### PR TITLE
feat: Add reputation_score to signed tokens

### DIFF
--- a/tests/test_signer_reputation.py
+++ b/tests/test_signer_reputation.py
@@ -1,0 +1,132 @@
+"""
+Tests for reputation integration in Signer.
+
+Tests the new reputation_score parameter in sign().
+"""
+
+import pytest
+from vouch.signer import Signer
+from vouch.verifier import Verifier
+from vouch.keys import generate_identity
+
+
+class TestSignerReputationManual:
+    """Tests for manually specifying reputation_score."""
+    
+    @pytest.fixture
+    def signer(self):
+        """Create a signer with generated keys."""
+        identity = generate_identity(domain="test-agent.com")
+        return Signer(
+            private_key=identity.private_key_jwk,
+            did=identity.did
+        ), identity.public_key_jwk
+    
+    def test_sign_without_reputation_backward_compatible(self, signer):
+        """Tokens without reputation should still work (backward compatible)."""
+        signer_obj, public_key = signer
+        token = signer_obj.sign({'action': 'read'})
+        
+        is_valid, passport = Verifier.verify(token, public_key_jwk=public_key)
+        
+        assert is_valid
+        assert passport.reputation_score is None  # No reputation included
+    
+    def test_sign_with_manual_reputation(self, signer):
+        """Should include reputation_score when manually specified."""
+        signer_obj, public_key = signer
+        token = signer_obj.sign({'action': 'read'}, reputation_score=85)
+        
+        is_valid, passport = Verifier.verify(token, public_key_jwk=public_key)
+        
+        assert is_valid
+        assert passport.reputation_score == 85
+    
+    def test_sign_with_zero_reputation(self, signer):
+        """Should handle zero reputation."""
+        signer_obj, public_key = signer
+        token = signer_obj.sign({'action': 'read'}, reputation_score=0)
+        
+        is_valid, passport = Verifier.verify(token, public_key_jwk=public_key)
+        
+        assert is_valid
+        assert passport.reputation_score == 0
+    
+    def test_sign_with_max_reputation(self, signer):
+        """Should handle 100 reputation."""
+        signer_obj, public_key = signer
+        token = signer_obj.sign({'action': 'read'}, reputation_score=100)
+        
+        is_valid, passport = Verifier.verify(token, public_key_jwk=public_key)
+        
+        assert is_valid
+        assert passport.reputation_score == 100
+    
+    def test_sign_clamps_reputation_above_100(self, signer):
+        """Should clamp reputation above 100 to 100."""
+        signer_obj, public_key = signer
+        token = signer_obj.sign({'action': 'read'}, reputation_score=150)
+        
+        is_valid, passport = Verifier.verify(token, public_key_jwk=public_key)
+        
+        assert is_valid
+        assert passport.reputation_score == 100  # Clamped
+    
+    def test_sign_clamps_reputation_below_0(self, signer):
+        """Should clamp reputation below 0 to 0."""
+        signer_obj, public_key = signer
+        token = signer_obj.sign({'action': 'read'}, reputation_score=-10)
+        
+        is_valid, passport = Verifier.verify(token, public_key_jwk=public_key)
+        
+        assert is_valid
+        assert passport.reputation_score == 0  # Clamped
+
+
+class TestPassportReputation:
+    """Tests for Passport reputation field."""
+    
+    def test_passport_reputation_in_raw_claims(self):
+        """Reputation should be accessible in raw_claims as well."""
+        identity = generate_identity(domain="test.com")
+        signer = Signer(
+            private_key=identity.private_key_jwk,
+            did=identity.did
+        )
+        
+        token = signer.sign({'action': 'test'}, reputation_score=75)
+        is_valid, passport = Verifier.verify(token, public_key_jwk=identity.public_key_jwk)
+        
+        assert is_valid
+        assert passport.reputation_score == 75
+        assert passport.raw_claims['vouch']['reputation_score'] == 75
+    
+    def test_passport_without_reputation_has_none(self):
+        """Passport should have None for reputation if not in token."""
+        identity = generate_identity(domain="test.com")
+        signer = Signer(
+            private_key=identity.private_key_jwk,
+            did=identity.did
+        )
+        
+        token = signer.sign({'action': 'test'})  # No reputation
+        is_valid, passport = Verifier.verify(token, public_key_jwk=identity.public_key_jwk)
+        
+        assert is_valid
+        assert passport.reputation_score is None
+        assert 'reputation_score' not in passport.raw_claims['vouch']
+    
+    def test_passport_reputation_different_values(self):
+        """Test various reputation values."""
+        identity = generate_identity(domain="test.com")
+        signer = Signer(
+            private_key=identity.private_key_jwk,
+            did=identity.did
+        )
+        
+        for expected_score in [25, 50, 75, 90, 100]:
+            token = signer.sign({'action': 'test'}, reputation_score=expected_score)
+            is_valid, passport = Verifier.verify(token, public_key_jwk=identity.public_key_jwk)
+            
+            assert is_valid
+            assert passport.reputation_score == expected_score

--- a/vouch/verifier.py
+++ b/vouch/verifier.py
@@ -32,6 +32,7 @@ class Passport:
         jti: JWT ID (unique nonce)
         payload: The signed intent/action data
         raw_claims: Full decoded JWT claims
+        reputation_score: Agent's reputation score (0-100) if included in token
     """
     sub: str
     iss: str
@@ -40,6 +41,7 @@ class Passport:
     jti: str
     payload: Dict[str, Any]
     raw_claims: Dict[str, Any]
+    reputation_score: Optional[int] = None
 
 
 class VerificationError(Exception):
@@ -152,6 +154,7 @@ class Verifier:
             # Extract vouch-specific payload
             vouch_data = claims.get('vouch', {})
             intent_payload = vouch_data.get('payload', {})
+            reputation_score = vouch_data.get('reputation_score')
             
             passport = Passport(
                 sub=claims.get('sub', ''),
@@ -160,7 +163,8 @@ class Verifier:
                 exp=exp,
                 jti=claims.get('jti', ''),
                 payload=intent_payload,
-                raw_claims=claims
+                raw_claims=claims,
+                reputation_score=reputation_score
             )
             
             return True, passport


### PR DESCRIPTION
## Summary

This PR adds the ability to include an agent's reputation score in signed tokens, allowing servers to see the agent's trustworthiness with each request.

## Changes

### Signer (vouch/signer.py)
- Added optional `reputation_score` parameter to `sign()` method
- Reputation score is clamped to 0-100 range
- Included in `vouch.reputation_score` claim when provided

### Verifier (vouch/verifier.py)
- Added `reputation_score: Optional[int]` field to `Passport` dataclass
- Extracts reputation from token during verification

### Tests (tests/test_signer_reputation.py)
- 9 new tests covering:
  - Backward compatibility (tokens without reputation work)
  - Manual reputation score inclusion
  - Edge cases (0, 100, clamping)
  - Passport field extraction

## Usage

```python
# Agent includes reputation in token
token = signer.sign({'action': 'read_data'}, reputation_score=85)

# Server checks reputation
is_valid, passport = Verifier.verify(token, public_key)
if passport.reputation_score and passport.reputation_score < 50:
    raise HTTPException(403, 'Agent reputation too low')
```

## Test Results

✅ All 107 tests passing (98 existing + 9 new)

## Closes

Closes #1