### PR TITLE
ci: Add DCO sign-off enforcement workflow

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,17 @@
+name: DCO Check
+
+on:
+  pull_request:
+    branches: [main]
+  pull_request_target:
+    branches: [main]
+
+jobs:
+  dco:
+    name: DCO Sign-off Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check DCO
+        uses: dkhamsing/check-dco@v1.2.3
+        with:
+          fail-on-missing: true


### PR DESCRIPTION
## Summary

Adds a GitHub Action to automatically check that all commits in a PR have DCO sign-off.

## Changes

- New workflow: `.github/workflows/dco.yml`
- Uses `dkhamsing/check-dco` action
- Fails PR if any commit lacks `Signed-off-by:` line

## How DCO Works

Contributors sign off commits with:
```bash
git commit -s -m "message"
```

This adds:
```
Signed-off-by: Name <email@example.com>
```

## OpenSSF/Linux Foundation Compliance

DCO is standard practice for Linux Foundation projects and recommended for OpenSSF Silver badge.

## Closes

Closes #13