### PR TITLE
feat: Implement Chain of Custody (Issue #18)

### DIFF
--- a/tests/test_delegation_chain.py
+++ b/tests/test_delegation_chain.py
@@ -1,0 +1,243 @@
+"""
+Tests for Chain of Custody (Delegation Chain) functionality.
+
+Tests the ability for agents to prove they are acting on behalf of 
+a user or another agent through recursive delegation chains.
+"""
+
+import pytest
+from vouch import Signer, Verifier, generate_identity, DelegationLink
+
+
+class TestDelegationChain:
+    """Test delegation chain functionality."""
+    
+    @pytest.fixture
+    def user_identity(self):
+        """Create a user identity."""
+        return generate_identity(domain="user.example.com")
+    
+    @pytest.fixture
+    def agent_a_identity(self):
+        """Create Agent A identity."""
+        return generate_identity(domain="agent-a.ai")
+    
+    @pytest.fixture
+    def agent_b_identity(self):
+        """Create Agent B identity."""
+        return generate_identity(domain="agent-b.ai")
+    
+    @pytest.fixture
+    def agent_c_identity(self):
+        """Create Agent C identity."""
+        return generate_identity(domain="agent-c.ai")
+    
+    def test_single_hop_no_delegation(self, user_identity):
+        """Test that tokens without delegation have empty chain."""
+        signer = Signer(
+            private_key=user_identity.private_key_jwk,
+            did=user_identity.did
+        )
+        
+        token = signer.sign({'action': 'read_file'})
+        
+        is_valid, passport = Verifier.verify(
+            token, 
+            public_key_jwk=user_identity.public_key_jwk
+        )
+        
+        assert is_valid
+        assert passport.delegation_chain == []
+        assert passport.iss == user_identity.did
+    
+    def test_two_hop_delegation(self, user_identity, agent_a_identity):
+        """Test User -> Agent A delegation chain."""
+        # User creates initial token authorizing Agent A
+        user_signer = Signer(
+            private_key=user_identity.private_key_jwk,
+            did=user_identity.did
+        )
+        user_token = user_signer.sign({'action': 'analyze_data'})
+        
+        # Agent A creates token with parent delegation
+        agent_a_signer = Signer(
+            private_key=agent_a_identity.private_key_jwk,
+            did=agent_a_identity.did
+        )
+        agent_a_token = agent_a_signer.sign(
+            {'action': 'query_database'},
+            parent_token=user_token
+        )
+        
+        # Verify Agent A's token
+        is_valid, passport = Verifier.verify(
+            agent_a_token,
+            public_key_jwk=agent_a_identity.public_key_jwk
+        )
+        
+        assert is_valid
+        assert len(passport.delegation_chain) == 1
+        assert passport.delegation_chain[0].iss == user_identity.did
+        assert passport.delegation_chain[0].sub == agent_a_identity.did
+    
+    def test_three_hop_delegation(self, user_identity, agent_a_identity, agent_b_identity):
+        """Test User -> Agent A -> Agent B (3-hop chain)."""
+        # Step 1: User authorizes Agent A
+        user_signer = Signer(
+            private_key=user_identity.private_key_jwk,
+            did=user_identity.did
+        )
+        user_token = user_signer.sign({'action': 'analyze_data'})
+        
+        # Step 2: Agent A delegates to Agent B
+        agent_a_signer = Signer(
+            private_key=agent_a_identity.private_key_jwk,
+            did=agent_a_identity.did
+        )
+        agent_a_token = agent_a_signer.sign(
+            {'action': 'fetch_records'},
+            parent_token=user_token
+        )
+        
+        # Step 3: Agent B acts with delegated authority
+        agent_b_signer = Signer(
+            private_key=agent_b_identity.private_key_jwk,
+            did=agent_b_identity.did
+        )
+        agent_b_token = agent_b_signer.sign(
+            {'action': 'query_api'},
+            parent_token=agent_a_token
+        )
+        
+        # Verify Agent B's token
+        is_valid, passport = Verifier.verify(
+            agent_b_token,
+            public_key_jwk=agent_b_identity.public_key_jwk
+        )
+        
+        assert is_valid
+        assert len(passport.delegation_chain) == 2
+        
+        # First link: User -> Agent A
+        assert passport.delegation_chain[0].iss == user_identity.did
+        assert passport.delegation_chain[0].sub == agent_a_identity.did
+        
+        # Second link: Agent A -> Agent B
+        assert passport.delegation_chain[1].iss == agent_a_identity.did
+        assert passport.delegation_chain[1].sub == agent_b_identity.did
+    
+    def test_max_depth_enforcement(
+        self, user_identity, agent_a_identity, agent_b_identity, agent_c_identity
+    ):
+        """Test that max chain depth (5) is enforced."""
+        # Build a chain of 6 agents (which creates 5 delegation links - the max)
+        identities = [
+            generate_identity(domain=f"agent-{i}.ai") 
+            for i in range(7)
+        ]
+        
+        # Start with first agent (no parent - no chain yet)
+        current_token = Signer(
+            private_key=identities[0].private_key_jwk,
+            did=identities[0].did
+        ).sign({'action': 'step_0'})
+        
+        # Build 5 more delegations (creates 5 links - the max allowed)
+        for i in range(1, 6):
+            current_token = Signer(
+                private_key=identities[i].private_key_jwk,
+                did=identities[i].did
+            ).sign({'action': f'step_{i}'}, parent_token=current_token)
+        
+        # This should work (5 links)
+        is_valid, passport = Verifier.verify(
+            current_token,
+            public_key_jwk=identities[5].public_key_jwk
+        )
+        assert is_valid
+        assert len(passport.delegation_chain) == 5  # Exactly at max
+        
+        # Trying to add 6th link should fail
+        with pytest.raises(ValueError, match="max depth"):
+            Signer(
+                private_key=identities[6].private_key_jwk,
+                did=identities[6].did
+            ).sign({'action': 'step_6'}, parent_token=current_token)
+    
+    def test_delegation_chain_with_reputation(self, user_identity, agent_a_identity):
+        """Test delegation chain combined with reputation score."""
+        user_signer = Signer(
+            private_key=user_identity.private_key_jwk,
+            did=user_identity.did
+        )
+        user_token = user_signer.sign(
+            {'action': 'authorize'},
+            reputation_score=90
+        )
+        
+        agent_a_signer = Signer(
+            private_key=agent_a_identity.private_key_jwk,
+            did=agent_a_identity.did
+        )
+        agent_a_token = agent_a_signer.sign(
+            {'action': 'execute'},
+            parent_token=user_token,
+            reputation_score=75
+        )
+        
+        is_valid, passport = Verifier.verify(
+            agent_a_token,
+            public_key_jwk=agent_a_identity.public_key_jwk
+        )
+        
+        assert is_valid
+        assert len(passport.delegation_chain) == 1
+        assert passport.reputation_score == 75
+    
+    def test_delegation_link_has_intent(self, user_identity, agent_a_identity):
+        """Test that delegation links capture the intent."""
+        user_signer = Signer(
+            private_key=user_identity.private_key_jwk,
+            did=user_identity.did
+        )
+        user_token = user_signer.sign({'action': 'manage_files'})
+        
+        agent_a_signer = Signer(
+            private_key=agent_a_identity.private_key_jwk,
+            did=agent_a_identity.did
+        )
+        intent = {'action': 'read_file', 'path': '/data/report.pdf'}
+        agent_a_token = agent_a_signer.sign(intent, parent_token=user_token)
+        
+        is_valid, passport = Verifier.verify(
+            agent_a_token,
+            public_key_jwk=agent_a_identity.public_key_jwk
+        )
+        
+        assert is_valid
+        assert len(passport.delegation_chain) == 1
+        
+        # The intent should be captured in the link
+        link = passport.delegation_chain[0]
+        assert 'read_file' in link.intent
+        assert '/data/report.pdf' in link.intent
+
+
+class TestDelegationLinkDataclass:
+    """Test DelegationLink dataclass."""
+    
+    def test_delegation_link_creation(self):
+        """Test creating a DelegationLink."""
+        link = DelegationLink(
+            iss="did:web:alice.com",
+            sub="did:web:agent.ai",
+            intent='{"action": "read"}',
+            iat=1704268800,
+            signature="abc123"
+        )
+        
+        assert link.iss == "did:web:alice.com"
+        assert link.sub == "did:web:agent.ai"
+        assert link.intent == '{"action": "read"}'
+        assert link.iat == 1704268800
+        assert link.signature == "abc123"

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -9,7 +9,7 @@ __version__ = "1.3.1"
 
 # Core signing/verification
 from .signer import Signer
-from .verifier import Verifier, Passport, VerificationError
+from .verifier import Verifier, Passport, VerificationError, DelegationLink
 from .auditor import Auditor
 
 # Key management
@@ -48,8 +48,8 @@ def __getattr__(name):
         from . import revocation
         return getattr(revocation, name)
     # Reputation
-    elif name in ("ReputationEngine", "ReputationScore", "ReputationEvent", 
-                  "MemoryReputationStore", "RedisReputationStore", 
+    elif name in ("ReputationEngine", "ReputationScore", "ReputationEvent",
+                  "MemoryReputationStore", "RedisReputationStore",
                   "KafkaReputationStore", "KafkaReputationConsumer"):
         from . import reputation
         return getattr(reputation, name)
@@ -67,6 +67,7 @@ __all__ = [
     "Verifier",
     "Passport",
     "VerificationError",
+    "DelegationLink",
     "Auditor",
     # Key management
     "generate_identity",

--- a/vouch/verifier.py
+++ b/vouch/verifier.py
@@ -8,8 +8,8 @@ validating signatures, timestamps, and extracting claims from tokens.
 import json
 import time
 import logging
-from typing import Tuple, Optional, Dict, Any, Union
-from dataclasses import dataclass
+from typing import Tuple, Optional, Dict, Any, Union, List
+from dataclasses import dataclass, field
 
 from jwcrypto import jwk, jws
 from jwcrypto.common import JWException
@@ -17,6 +17,25 @@ import httpx
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DelegationLink:
+    """
+    Represents a single link in a delegation chain.
+    
+    Attributes:
+        iss: Issuer - who delegated authority
+        sub: Subject - who received the delegation
+        intent: The intent/action that was authorized
+        iat: When the delegation was made
+        signature: Cryptographic signature of this delegation
+    """
+    iss: str
+    sub: str
+    intent: str
+    iat: int
+    signature: str
 
 
 @dataclass
@@ -33,6 +52,7 @@ class Passport:
         payload: The signed intent/action data
         raw_claims: Full decoded JWT claims
         reputation_score: Agent's reputation score (0-100) if included in token
+        delegation_chain: List of delegation links from root to current agent
     """
     sub: str
     iss: str
@@ -42,6 +62,7 @@ class Passport:
     payload: Dict[str, Any]
     raw_claims: Dict[str, Any]
     reputation_score: Optional[int] = None
+    delegation_chain: List[DelegationLink] = field(default_factory=list)
 
 
 class VerificationError(Exception):
@@ -64,11 +85,11 @@ class Verifier:
         >>> verifier = Verifier(trusted_roots={'did:web:agent.com': public_key_jwk})
         >>> valid, passport = verifier.check_vouch(token)
     """
-    
+
     # Cache for resolved DID public keys
     _key_cache: Dict[str, Tuple[jwk.JWK, float]] = {}
     _cache_ttl: int = 300  # 5 minutes
-    
+
     def __init__(
         self,
         trusted_roots: Optional[Dict[str, str]] = None,
@@ -86,14 +107,14 @@ class Verifier:
         self._trusted_roots: Dict[str, jwk.JWK] = {}
         self._allow_resolution = allow_did_resolution
         self._clock_skew = clock_skew_seconds
-        
+
         if trusted_roots:
             for did, key_json in trusted_roots.items():
                 try:
                     self._trusted_roots[did] = jwk.JWK.from_json(key_json)
                 except Exception as e:
                     logger.warning(f"Invalid key for {did}: {e}")
-    
+
     @staticmethod
     def verify(
         token: str,
@@ -114,48 +135,63 @@ class Verifier:
         """
         if not token:
             return False, None
-        
+
         try:
             # Parse the JWS
             jws_token = jws.JWS()
             jws_token.deserialize(token)
-            
+
             # Get the payload (without verification first, to extract claims)
             # This is safe because we verify the signature below
             payload_bytes = jws_token.objects.get('payload', b'')
             if isinstance(payload_bytes, str):
                 payload_bytes = payload_bytes.encode('utf-8')
-            
+
             claims = json.loads(payload_bytes.decode('utf-8'))
-            
+
             # Verify signature if public key provided
             if public_key_jwk:
                 key = jwk.JWK.from_json(public_key_jwk)
                 jws_token.verify(key)
-            
+
             # Validate timestamps
             now = int(time.time())
-            
+
             exp = claims.get('exp', 0)
             if exp and now > exp + clock_skew_seconds:
                 logger.debug(f"Token expired: exp={exp}, now={now}")
                 return False, None
-            
+
             nbf = claims.get('nbf', 0)
             if nbf and now < nbf - clock_skew_seconds:
                 logger.debug(f"Token not yet valid: nbf={nbf}, now={now}")
                 return False, None
-            
+
             iat = claims.get('iat', 0)
             if iat and now < iat - clock_skew_seconds:
                 logger.debug(f"Token issued in future: iat={iat}, now={now}")
                 return False, None
-            
+
             # Extract vouch-specific payload
             vouch_data = claims.get('vouch', {})
             intent_payload = vouch_data.get('payload', {})
             reputation_score = vouch_data.get('reputation_score')
             
+            # Extract delegation chain if present
+            delegation_chain = []
+            raw_chain = vouch_data.get('delegation_chain', [])
+            for link_data in raw_chain:
+                try:
+                    delegation_chain.append(DelegationLink(
+                        iss=link_data.get('iss', ''),
+                        sub=link_data.get('sub', ''),
+                        intent=link_data.get('intent', ''),
+                        iat=link_data.get('iat', 0),
+                        signature=link_data.get('sig', '')
+                    ))
+                except Exception as e:
+                    logger.debug(f"Invalid delegation link: {e}")
+
             passport = Passport(
                 sub=claims.get('sub', ''),
                 iss=claims.get('iss', ''),
@@ -164,11 +200,12 @@ class Verifier:
                 jti=claims.get('jti', ''),
                 payload=intent_payload,
                 raw_claims=claims,
-                reputation_score=reputation_score
+                reputation_score=reputation_score,
+                delegation_chain=delegation_chain
             )
-            
+
             return True, passport
-            
+
         except JWException as e:
             logger.debug(f"JWS verification failed: {e}")
             return False, None
@@ -178,7 +215,7 @@ class Verifier:
         except Exception as e:
             logger.debug(f"Verification error: {e}")
             return False, None
-    
+
     def check_vouch(self, token: str) -> Tuple[bool, Optional[Passport]]:
         """
         Verify a token using trusted roots or DID resolution.
@@ -191,58 +228,58 @@ class Verifier:
         """
         if not token:
             return False, None
-        
+
         try:
             # First, decode without verification to get the issuer
             jws_token = jws.JWS()
             jws_token.deserialize(token)
-            
+
             payload_bytes = jws_token.objects.get('payload', b'')
             if isinstance(payload_bytes, str):
                 payload_bytes = payload_bytes.encode('utf-8')
-            
+
             claims = json.loads(payload_bytes.decode('utf-8'))
             issuer_did = claims.get('iss', '')
-            
+
             # Get the public key
             public_key = self._get_public_key(issuer_did)
             if not public_key:
                 logger.warning(f"Could not resolve public key for: {issuer_did}")
                 return False, None
-            
+
             # Verify with the resolved key
             return Verifier.verify(
                 token,
                 public_key_jwk=public_key.export_public(),
                 clock_skew_seconds=self._clock_skew
             )
-            
+
         except Exception as e:
             logger.debug(f"check_vouch error: {e}")
             return False, None
-    
+
     def _get_public_key(self, did: str) -> Optional[jwk.JWK]:
         """Get public key from trusted roots or resolve from DID."""
-        
+
         # Check trusted roots first
         if did in self._trusted_roots:
             return self._trusted_roots[did]
-        
+
         # Check cache
         if did in self._key_cache:
             key, cached_at = self._key_cache[did]
             if time.time() - cached_at < self._cache_ttl:
                 return key
-        
+
         # Attempt DID resolution
         if self._allow_resolution and did.startswith('did:web:'):
             resolved_key = self._resolve_did_web(did)
             if resolved_key:
                 self._key_cache[did] = (resolved_key, time.time())
                 return resolved_key
-        
+
         return None
-    
+
     def _resolve_did_web(self, did: str) -> Optional[jwk.JWK]:
         """
         Resolve a did:web identifier to its public key.
@@ -260,47 +297,47 @@ class Verifier:
             parts = did.split(':')
             if len(parts) < 3:
                 return None
-            
+
             domain_and_path = ':'.join(parts[2:])
             path_parts = domain_and_path.split(':')
             domain = path_parts[0]
-            
+
             if len(path_parts) > 1:
                 path = '/'.join(path_parts[1:])
                 url = f"https://{domain}/{path}/did.json"
             else:
                 url = f"https://{domain}/.well-known/did.json"
-            
+
             # Fetch DID document
             with httpx.Client(timeout=10.0) as client:
                 response = client.get(url)
                 response.raise_for_status()
                 did_doc = response.json()
-            
+
             # Extract verification method
             verification_methods = did_doc.get('verificationMethod', [])
             if not verification_methods:
                 return None
-            
+
             # Get first Ed25519 key
             for method in verification_methods:
                 pub_key_jwk = method.get('publicKeyJwk', {})
                 if pub_key_jwk.get('kty') == 'OKP' and pub_key_jwk.get('crv') == 'Ed25519':
                     return jwk.JWK(**pub_key_jwk)
-            
+
             return None
-            
+
         except Exception as e:
             logger.debug(f"DID resolution failed for {did}: {e}")
             return None
-    
+
     def add_trusted_root(self, did: str, public_key_jwk: str) -> None:
         """Add a trusted DID and its public key."""
         try:
             self._trusted_roots[did] = jwk.JWK.from_json(public_key_jwk)
         except Exception as e:
             raise ValueError(f"Invalid JWK: {e}")
-    
+
     def clear_cache(self) -> None:
         """Clear the resolved key cache."""
         self._key_cache.clear()


### PR DESCRIPTION
## Summary

Implements Chain of Custody (recursive delegation chains) for multi-agent systems, allowing agents to prove they are acting on behalf of a user or another agent.

## Changes

### verifier.py
- Added `DelegationLink` dataclass with fields: `iss`, `sub`, `intent`, `iat`, `signature`
- Added `delegation_chain` field to `Passport` dataclass
- Updated `verify()` to extract delegation chains from tokens

### signer.py
- Added `parent_token` parameter to `sign()` method
- Added `_build_delegation_chain()` helper method
- Enforces max 5-hop chain depth

### __init__.py
- Exported `DelegationLink` from package

### tests/test_delegation_chain.py (NEW)
- 7 test cases covering:
  - Single hop (no delegation)
  - 2-hop chain
  - 3-hop chain
  - Max depth enforcement
  - Delegation with reputation
  - Intent capture
  - DelegationLink dataclass

## Example Usage

```python
# User creates token authorizing Agent A
user_token = user_signer.sign({'action': 'analyze_data'})

# Agent A creates token with parent delegation
agent_a_token = agent_a_signer.sign(
    {'action': 'query_database'},
    parent_token=user_token
)

# Verify and extract chain
is_valid, passport = Verifier.verify(agent_a_token, public_key)
print(passport.delegation_chain)  # [DelegationLink(iss=user, sub=agent_a, ...)]
```

## Verification

✅ All 114 tests pass
✅ 7 new delegation chain tests
✅ Max depth (5 hops) enforced

Closes #18