### PR TITLE
ci: Skip DCO check for bot accounts

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -10,6 +10,8 @@ jobs:
   dco:
     name: DCO Sign-off Check
     runs-on: ubuntu-latest
+    # Skip DCO check for bot accounts
+    if: github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]'
     steps:
       - name: Check DCO
         uses: dkhamsing/check-dco@v1.2.3


### PR DESCRIPTION
Allows Dependabot and other bot PRs to pass DCO check.

Bots don't sign commits, so DCO check was failing for automated PRs.