### PR TITLE
ci: Add code coverage reporting with Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,9 +27,20 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e ".[dev]"
     
-    - name: Run tests with pytest
+    - name: Run tests with coverage
       run: |
-        pytest tests/ -v --tb=short
+        pytest tests/ -v --tb=short --cov=vouch --cov-report=xml --cov-report=term-missing
+    
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == '3.11'
+      uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.xml
+        flags: unittests
+        name: codecov-vouch
+        fail_ci_if_error: false
+        verbose: true
     
     - name: Run security tests
       run: |

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <p align="center">
   <a href="https://github.com/vouch-protocol/vouch"><img src="https://img.shields.io/badge/Protected_by-Vouch_Protocol-00C853?style=flat&labelColor=333&logo=data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0Ij48cGF0aCBmaWxsPSIjMDBDODUzIiBkPSJNMTIgMjBMMiA0aDRsNiAxMC41TDE4IDRoNEwxMiAyMHoiLz48L3N2Zz4=" alt="Protected by Vouch"></a>
   <a href="https://www.bestpractices.dev/projects/11688"><img src="https://www.bestpractices.dev/projects/11688/badge" alt="OpenSSF Best Practices"></a>
+  <a href="https://codecov.io/gh/vouch-protocol/vouch"><img src="https://codecov.io/gh/vouch-protocol/vouch/branch/main/graph/badge.svg" alt="Code Coverage"></a>
   <a href="https://discord.gg/VxgYkjdph"><img src="https://img.shields.io/badge/Discord-Join_Community-7289da?logo=discord&logoColor=white" alt="Discord"></a>
 </p>
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,27 @@
+# Codecov configuration for Vouch Protocol
+# https://docs.codecov.com/docs/codecovyml-reference
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: 70%
+        threshold: 5%
+    patch:
+      default:
+        target: 60%
+        threshold: 10%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/**/*"
+  - "examples/**/*"
+  - "scripts/**/*"
+  - "docs/**/*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ media = [
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
+    "pytest-cov>=4.0.0",
     "black>=23.0.0",
     "mypy>=1.0.0",
     "ruff>=0.1.0",


### PR DESCRIPTION
Closes #11

## Changes
- Added `pytest-cov>=4.0.0` to dev dependencies
- Updated `test.yml` workflow with coverage reporting (`--cov=vouch`)
- Added Codecov integration (uploads on Python 3.11 only)
- Created `codecov.yml` with 70% target coverage
- Added coverage badge to README

## OpenSSF Compliance
This implements code coverage measurement for OpenSSF Silver badge compliance.

## Note
Requires setting up `CODECOV_TOKEN` secret in repository settings after connecting to Codecov.