### PR TITLE
FHK + Tools remediation: real CLI reference, language quickstarts, robot identity, vouch attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ To keep this space free from patent capture, the project publishes **61 defensiv
 - [Protocol Specification (developer guide)](https://github.com/vouch-protocol/vouch/blob/main/docs/vouch_guide.md)
 - [Integration Guides](https://github.com/vouch-protocol/vouch/tree/main/vouch/integrations)
 - [Threat Model and Security Considerations](https://github.com/vouch-protocol/vouch/blob/main/docs/THREAT_MODEL.md)
-- [Defensive Prior Art Disclosures (55 PADs, CC0)](https://github.com/vouch-protocol/vouch/tree/main/docs/disclosures)
+- [Defensive Prior Art Disclosures (61 PADs, CC0)](https://github.com/vouch-protocol/vouch/tree/main/docs/disclosures)
 - [FAQ and Discussions](https://github.com/vouch-protocol/vouch/discussions)
 
 ---
@@ -435,7 +435,7 @@ To keep this space free from patent capture, the project publishes **61 defensiv
 
 You can use this freely in commercial and open-source projects.
 
-The 55 defensive prior-art disclosures are released under **CC0 1.0 Universal** to ensure ecosystem freedom from patent capture.
+The 61 defensive prior-art disclosures are released under **CC0 1.0 Universal** to ensure ecosystem freedom from patent capture.
 
 *The Vouch Protocol specification is being developed as a open standard submission via the open standards group. The implementation is also being proposed to the Linux Foundation's AI & Data Foundation.*
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ The legacy v0.x JWS API (`Signer.sign()`, `Verifier.verify()`) continues to work
 > 
 > **Vouch Protocol is the SSL certificate for AI agents.**
 
+Vouch is not one tool, it is a set of them. Here is the whole map.
+
+### On the command line
+- **`vouch init`** generate an agent identity (a DID and keypair).
+- **`vouch sign` / `vouch verify`** sign a payload and verify it.
+- **`vouch git`** sign every git commit cryptographically, set up in one command, with a verified badge for your README.
+- **`vouch scan`** find leaked Vouch key material in your code before it ships (a private key in a file, a seed in an env var, a DID document that accidentally carries a private key).
+- **`vouch attribute`** separate who wrote which line. When an AI assistant and a human both edit a file, this records the AI's lines under the AI's own key and your lines under yours, so when a line causes an incident you can prove which of you wrote it. See [the Claude Code integration](vouch/integrations/claude-code/README.md).
+- **`vouch media`** sign images, with C2PA support.
+
+### For your agents
+- **MCP server (`vouch-mcp`)** a standalone Model Context Protocol server so any MCP client (Claude Desktop, Cursor, any agent) can create an identity, sign and verify credentials, scan for leaked keys, and decode DIDs, out of the box.
+- **Identity Sidecar** keeps signing keys out of the model's context, so a prompt injection cannot read them.
+- **Vouch Shield** a runtime check that inspects every tool call against your rules, like a customs officer at the door.
+- **Continuous trust** heartbeats and session vouchers, so trust is a live signal that has to be renewed, not a badge that is issued once and trusted forever.
+
+### SDKs, in the language you use
+Python, TypeScript, and Go are the full reference implementations. A Rust core with idiomatic Swift, JVM (Java and Kotlin), .NET, and C wrappers shares one codebase, so every language produces byte-identical output, verified against shared test vectors. A WebAssembly build is included for the browser and the edge. See the table further down for status per language.
+
+### Inside your AI tools
+- **Claude Skill**, **OpenAI Custom GPT**, and **Gemini Gem** packages that teach your AI assistant how to add Vouch to your code, running on your own AI subscription.
+
+### Media and the web
+- **C2PA Content Credentials** for images.
+- **Vouch Sonic** an audio watermark that carries provenance through sound.
+- **Browser extension** for Chrome and Edge that signs and verifies content on the page.
+
+### For your repositories
+- **Gatekeeper GitHub App** verifies commit signatures on every pull request and blocks leaked Vouch keys before they merge.
+
+### For the ecosystem
+- **Agent Trust Index** an open benchmark that scans agents in the wild and measures how many can actually prove who they are. (Spoiler: today, almost none.)
+
 [Read the spec →](https://github.com/vouch-protocol/vouch/blob/main/docs/vouch_guide.md) | [Join Discord →](https://discord.gg/mMqx5cG9Y)
 
 ---
@@ -317,6 +350,17 @@ agent.sign({'action': 'read_customer_data', 'customer_id': 'cust_abc'})
 # HIPAA-compliant audit trail
 agent.sign({'action': 'access_phi', 'patient_id': '12345'})
 ```
+
+To keep this space free from patent capture, the project publishes **61 defensive prior-art disclosures** under CC0, covering cryptographic identity, media provenance, voice biometrics, AI safety, post-quantum cryptography, AI coding governance, and per-region human-or-AI code authorship. See [docs/disclosures](docs/disclosures/README.md).
+
+---
+
+## Use cases
+
+- **Financial services.** A signed, accountable record of every trade or transfer an agent makes.
+- **Healthcare.** An auditable trail for every access to patient data.
+- **Customer service.** Proof of which agent touched which customer record, and on whose authority.
+- **Agent to agent.** When one organization's agent calls another's, each can verify the other before acting.
 
 [See full examples →](https://github.com/vouch-protocol/vouch/tree/main/examples)
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ Vouch is not one tool, it is a set of them. Here is the whole map.
 ### SDKs, in the language you use
 Python, TypeScript, and Go are the full reference implementations. A Rust core with idiomatic Swift, JVM (Java and Kotlin), .NET, and C wrappers shares one codebase, so every language produces byte-identical output, verified against shared test vectors. A WebAssembly build is included for the browser and the edge. See the table further down for status per language.
 
+### Robots and embodied agents
+A robot is an agent with a body, so the same primitives apply: a `did:vouch:agent` identity, delegation chains for who authorized it, and continuous trust for whether it is still behaving. Vouch adds a hardware-root-of-trust profile, so a robot's secure element (a TPM or a secure enclave) anchors its DID and signs its heartbeats, binding identity to the physical device rather than a config file. This is the open identity layer; richer robot-lifecycle tooling builds on top of it. See the open `did:vouch:agent` profile in [docs/specs/](docs/specs/).
+
 ### Inside your AI tools
 - **Claude Skill**, **OpenAI Custom GPT**, and **Gemini Gem** packages that teach your AI assistant how to add Vouch to your code, running on your own AI subscription.
 

--- a/claude-skill/README.md
+++ b/claude-skill/README.md
@@ -93,8 +93,8 @@ cryptosuite id or a new SDK shape, update the skill alongside.
 
 The skill fires on any of these (and many natural-language variants):
 
-- `vouch-protocol`, `vouch protocol`, `@vouch-protocol/core`
-- `pip install vouch-protocol`, `npm install @vouch-protocol/core`
+- `vouch-protocol`, `vouch protocol`, `@vouch-protocol-official/sdk`
+- `pip install vouch-protocol`, `npm install @vouch-protocol-official/sdk`
 - `did:web`, `did:key`, `did:vouch`, DID Document, Verifiable Credential
 - `eddsa-jcs-2022`, `hybrid-eddsa-mldsa44-jcs-2026`
 - BitstringStatusList, revocation registry

--- a/claude-skill/skills/vouch-protocol/reference/agent-trust-index.md
+++ b/claude-skill/skills/vouch-protocol/reference/agent-trust-index.md
@@ -1,0 +1,40 @@
+# The Agent Trust Index
+
+The Agent Trust Index is an open benchmark published with Vouch. It scans public
+AI agents and scores one question for each: can this agent prove who it is? It
+measures adoption of provable identity in the wild, not whether an agent is good,
+safe, or useful.
+
+## What it measures
+
+Each agent is scored out of 100:
+
+- **60 points** for a resolvable cryptographic identity (a `did:web` that
+  resolves to a DID document).
+- **40 points** for that identity carrying a usable public key.
+
+Grades: A is 90 or above, then B, C, D, and F below 40. An agent with no
+resolvable identity scores zero.
+
+## The first sweep
+
+The first sweep drew its agents from the public Model Context Protocol registry
+on 10 June 2026:
+
+- **11,680** unique agents scanned
+- **157** publish a resolvable `did:web` identity, about **1.3 percent**
+- **98.7 percent** cannot prove who they are at all
+- **69** of those 157 also carry a usable public key, a full grade A
+- the 88 that resolve a DID but carry no usable key land around a C
+
+The agents that can prove themselves are mostly finance and oracle agents: the
+ones that handle money are the first to bother with identity.
+
+## Where to point people
+
+- The Index: `/agent-trust-index/`
+- The methodology: `/agent-trust-index/methodology/`
+
+The takeaway for a developer: provable identity is the floor, and almost nobody
+has it yet. Adding a `did:web` and signing your agent's actions with Vouch puts
+you in the top 1.3 percent on day one.

--- a/claude-skill/skills/vouch-protocol/reference/go-sidecar.md
+++ b/claude-skill/skills/vouch-protocol/reference/go-sidecar.md
@@ -117,7 +117,7 @@ const resp = await fetch('http://localhost:8877/sign', {
 const signed = await resp.json();
 ```
 
-Or use the `VouchClient` from `@vouch-protocol/core`.
+Or use the `VouchClient` from `@vouch-protocol-official/sdk`.
 
 ## Why a sidecar?
 

--- a/claude-skill/skills/vouch-protocol/reference/integrations.md
+++ b/claude-skill/skills/vouch-protocol/reference/integrations.md
@@ -211,7 +211,7 @@ For human-driven actions in a browser (e.g., signing a contract from
 a web app):
 
 ```ts
-import { VouchClient } from '@vouch-protocol/core';
+import { VouchClient } from '@vouch-protocol-official/sdk';
 
 // In a Chrome extension content script
 const credential = await VouchClient.signFromExtension({

--- a/claude-skill/skills/vouch-protocol/reference/post-quantum.md
+++ b/claude-skill/skills/vouch-protocol/reference/post-quantum.md
@@ -120,11 +120,11 @@ signed = signer.sign_credential_hybrid(intent={
 ### TypeScript
 
 ```bash
-npm install @vouch-protocol/core @noble/post-quantum
+npm install @vouch-protocol-official/sdk @noble/post-quantum
 ```
 
 ```ts
-import { Signer, generateIdentity } from '@vouch-protocol/core';
+import { Signer, generateIdentity } from '@vouch-protocol-official/sdk';
 
 const keys = await generateIdentity('agent.example.com');
 const signer = new Signer({ privateKey: keys.privateKeyJwk, did: keys.did });

--- a/claude-skill/skills/vouch-protocol/reference/quickstart.md
+++ b/claude-skill/skills/vouch-protocol/reference/quickstart.md
@@ -34,11 +34,11 @@ assert is_valid
 ## TypeScript
 
 ```bash
-npm install @vouch-protocol/core
+npm install @vouch-protocol-official/sdk
 ```
 
 ```ts
-import { Signer, Verifier, generateIdentity } from '@vouch-protocol/core';
+import { Signer, Verifier, generateIdentity } from '@vouch-protocol-official/sdk';
 
 const keys = await generateIdentity('agent.example.com');
 const signer = new Signer({ privateKey: keys.privateKeyJwk, did: keys.did });

--- a/claude-skill/skills/vouch-protocol/reference/robotics.md
+++ b/claude-skill/skills/vouch-protocol/reference/robotics.md
@@ -1,0 +1,34 @@
+# Robots and embodied agents
+
+A robot is an agent with a body. Identity, accountability, and continuous trust
+matter more, not less, when an agent can cause physical harm or move money in
+the real world. Vouch covers the open identity layer for robots; richer
+robot-lifecycle tooling builds on top of it.
+
+## The same primitives apply
+
+- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
+  profile in `docs/specs/`).
+- Delegation: a delegation chain records who authorized the robot, on whose
+  behalf, and within what limits, all verifiable.
+- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
+  behaving now," so a robot has to keep proving itself.
+- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
+  check the status.
+
+## The robot-specific open piece: hardware root of trust
+
+A software agent's key can live in a file. A robot should do better. The
+hardware-root-of-trust profile binds the robot's DID to its secure element (a
+TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
+the signing key and signs the robot's heartbeats, so identity is anchored to the
+physical device, not a config that can be copied. The open `did:vouch:agent`
+profile defines the agent identity scheme; the embodied profile extends it for
+hardware attestation.
+
+## Open vs built on top
+
+The identity, delegation, continuous-trust, and hardware-attestation profiles
+are open Vouch. Operated robot-lifecycle products (lifecycle identity
+management, model-and-config provenance, fleet trust at scale, and similar)
+build on this open layer and are out of scope for the protocol itself.

--- a/claude-skill/skills/vouch-protocol/reference/troubleshooting.md
+++ b/claude-skill/skills/vouch-protocol/reference/troubleshooting.md
@@ -12,7 +12,7 @@ Cause: the `pqcrypto` dependency needs C headers and a compiler.
 - Ubuntu/Debian: `apt install build-essential libssl-dev` then retry
 - Windows: install Visual C++ Build Tools or use WSL
 
-### `npm install @vouch-protocol/core` fails on Node 16
+### `npm install @vouch-protocol-official/sdk` fails on Node 16
 
 The SDK requires Node 18+. Upgrade Node.
 
@@ -246,7 +246,7 @@ print(canonical.hex())
 
 ```bash
 python -m vouch.jcs canonicalize < credential.json > python.bin
-node -e "console.log(require('@vouch-protocol/core').canonicalize(...))" < credential.json > ts.bin
+node -e "console.log(require('@vouch-protocol-official/sdk').canonicalize(...))" < credential.json > ts.bin
 diff python.bin ts.bin
 ```
 

--- a/claude-skill/skills/vouch-protocol/reference/typescript-sdk.md
+++ b/claude-skill/skills/vouch-protocol/reference/typescript-sdk.md
@@ -1,12 +1,12 @@
 # TypeScript SDK Reference
 
-`@vouch-protocol/core` on npm. Works in Node and browser. Produces
+`@vouch-protocol-official/sdk` on npm. Works in Node and browser. Produces
 byte-identical credentials with the Python and Go SDKs.
 
 ## Install
 
 ```bash
-npm install @vouch-protocol/core
+npm install @vouch-protocol-official/sdk
 # Optional post-quantum:
 npm install @noble/post-quantum
 ```
@@ -14,7 +14,7 @@ npm install @noble/post-quantum
 ## Identity
 
 ```ts
-import { Signer, generateIdentity } from '@vouch-protocol/core';
+import { Signer, generateIdentity } from '@vouch-protocol-official/sdk';
 
 // Generate
 const keys = await generateIdentity('agent.example.com');
@@ -67,7 +67,7 @@ const signedHybrid = await signer.signCredentialHybrid({
 ## Verification
 
 ```ts
-import { Verifier } from '@vouch-protocol/core';
+import { Verifier } from '@vouch-protocol-official/sdk';
 
 // verifyCredential returns { isValid, passport, error }
 const result = await Verifier.verifyCredential(signed);
@@ -87,7 +87,7 @@ import {
     buildStatusListCredential,
     buildStatusListEntry,
     verifyStatus,
-} from '@vouch-protocol/core';
+} from '@vouch-protocol-official/sdk';
 
 const list = new StatusList({
     statusListId: 'https://issuer.example/status/1',
@@ -125,7 +125,7 @@ const restored = StatusList.fromStateDict(JSON.parse(await redis.get(...)));
 If you run the Go sidecar, the TS SDK has a client:
 
 ```ts
-import { VouchClient } from '@vouch-protocol/core';
+import { VouchClient } from '@vouch-protocol-official/sdk';
 
 const client = new VouchClient({ endpoint: 'http://localhost:8877' });
 const signed = await client.sign({

--- a/docs/disclosures/PAD-061-per-region-human-ai-code-attribution.md
+++ b/docs/disclosures/PAD-061-per-region-human-ai-code-attribution.md
@@ -1,0 +1,503 @@
+# PAD-061: Per-Region Authorship Attribution for Mixed Human and AI Source Code via Edit-Channel Capture and Independently-Keyed Signatures
+
+**Identifier:** PAD-061  
+**Title:** Method and System for Cryptographically Attributing Individual Regions of a Source File to Human or AI Authors by Capturing Authorship at the Edit Channel and Signing Each Party's Regions with an Independently-Held Key  
+**Publication Date:** June 10, 2026  
+**Prior Art Effective Date:** June 10, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Software Provenance / AI Coding Governance / Accountability / Decentralized Identifiers / DevSecOps  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-002 (Chain of Custody Delegation), PAD-003 (Identity Sidecar), PAD-007 (Automated Provenance via Input Telemetry), PAD-039 (JCS Deterministic Multi-Party Trust State), PAD-042 (Standardized Metadata Schema for AI Agent Ledger Signatures), PAD-056 (Capability-Bounded AI Assistant Output), PAD-059 (Vouch-Amnesia Attestation Bridge)
+
+---
+
+## 1. Abstract
+
+A method that records, at the moment of editing and from the actual edit
+channel, which regions of a source file were produced by an AI coding
+assistant and which by a human, and then attests each party's regions with a
+signing key that party holds independently of the other. The output is a signed
+Attribution Manifest that binds, per file, exact line ranges to an author
+Decentralized Identifier (DID) over the exact bytes, secured by a JSON
+Canonicalization Scheme (JCS) Data Integrity proof.
+
+The novel contribution is making the attribution legitimate rather than a
+self-serving label. Two properties enforce this:
+
+1. **Edit-channel capture.** Regions attributed to the AI are derived only from
+   the assistant's actual edit operations (its Edit / Write / MultiEdit tool
+   calls), captured as they occur by a hook on the assistant's edit pipeline.
+   They are never reconstructed after the fact or asserted by hand. Regions
+   attributed to the human are the residual: any change to the file on disk
+   that did not arrive through the assistant's edit channel. Lines unchanged
+   since the session began are marked preexisting.
+
+2. **Independently-held keys.** AI-authored regions are attested with an
+   AI-session key that the human's editor does not wield, optionally held in an
+   Identity Sidecar (PAD-003) or delegated from the AI vendor's root identity
+   (PAD-002). The human signs the assembled manifest with the human's own key.
+   Because the two keys are distinct and separately held, neither party can
+   mint the other's attribution.
+
+The manifest enforces completeness (the union of attributed regions must cover
+every line of the file, so a defective region cannot hide as unattributed) and
+backing (every AI region in the manifest must be covered by a signed AI
+attestation, so an AI region cannot be invented without the AI signature). A
+verifier can therefore confirm, for any line that later causes an incident,
+whether a human or a machine wrote it, who specifically, and that the bytes
+have not changed since signing.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 git blame Launders AI Authorship Through the Human Committer
+
+When an AI coding assistant and a human jointly edit a file, the version
+control system credits every line to the identity that committed it, which is
+almost always the human. The assistant's contribution is invisible. `git
+blame`, the commit author field, and signed-commit mechanisms (GPG, SSH, even
+the cryptographic commit signing of the Vouch git integration) all attribute
+the whole commit to one committing identity. They operate at commit
+granularity, not authorship granularity, and they have no concept of a
+non-human author of a subset of lines.
+
+### 2.2 Accountability Requires Sub-File Authorship, Not Commit Authorship
+
+As autonomous and semi-autonomous coding assistants write a growing fraction of
+production code, the operational question after a defect, a security
+regression, or a compliance failure is no longer only "who committed this" but
+"who authored this specific line, a human or a model, and which one." Liability
+frameworks, incident response, regulated-industry audit obligations (including
+emerging AI-accountability regimes), and internal engineering governance all
+need authorship at the region level. No deployed mechanism provides it with
+cryptographic assurance.
+
+### 2.3 Naive Authorship Tagging Is Worthless
+
+The obvious approach, having the editor or the assistant stamp regions with an
+"AI wrote this" or "human wrote this" label, fails on legitimacy. If a single
+party's tooling applies both labels, that party controls both, so a human can
+attribute their own defective line to the AI, or an assistant's wrapper can
+claim human lines as its own. A label that the labeller can set arbitrarily
+proves nothing. Equally, a label captured after the fact (by diffing a final
+file against some baseline and guessing) cannot distinguish a human edit from
+an AI edit, because the final bytes carry no record of which channel produced
+them.
+
+### 2.4 Existing Provenance Mechanisms Operate at the Wrong Granularity or Trust Boundary
+
+- Commit signing (GPG / SSH / Vouch git) proves who committed, at commit
+  granularity, with one signer.
+- Content provenance standards for media (C2PA) attest the origin of a whole
+  asset, not regions of a text file authored by different parties.
+- AI-output watermarking marks that text was machine-generated but does not
+  identify which model instance, does not separate interleaved human edits, and
+  is not cryptographically bound to a committing identity.
+- Telemetry-based provenance (PAD-007) records that input occurred but does not
+  separate concurrent human and AI authorship within one file with independent
+  per-party signatures.
+
+None of these answers "which lines did the human write and which did the AI,
+provably, with each party's own key."
+
+---
+
+## 3. Disclosed Method
+
+### 3.1 Architecture
+
+```
++---------------------------+        +-----------------------------+
+| AI coding assistant       |        | Human editor / typing       |
+| (Edit / Write / MultiEdit)|        | (changes on disk)           |
++-------------+-------------+        +--------------+--------------+
+              | edit-channel hook                   | (no hook: residual)
+              v                                      |
+   +----------+-----------+                          |
+   | Attribution Session  |<-------------------------+
+   | - AI-session key     |   reconciles human drift at each AI event
+   |   (held separately)  |   and at finalize (snapshot -> final = human)
+   | - per-file authorship|
+   |   map (ai/human/pre) |
+   +----------+-----------+
+              | finalize(files, human_signer)
+              v
+   +----------+--------------------------------------------------+
+   | Attribution Manifest                                        |
+   |  files[]: { path, sha256, lineCount, regions[] }            |
+   |  regions[]: { startLine, endLine, source, author, model }   |
+   |  aiAttestations[]: signed by AI-session key                 |
+   |  proof: Data Integrity proof signed by the human key        |
+   +----------+--------------------------------------------------+
+              v
+   +----------+-----------+
+   | Verifier             |  human proof + AI attestations +
+   | who-wrote-this?      |  region completeness + byte hashes
+   +----------------------+
+```
+
+### 3.2 Edit-Channel Capture
+
+A hook is installed on the AI assistant's edit pipeline. For an assistant that
+exposes tool events (for example a coding agent firing a post-tool event on its
+Edit / Write / MultiEdit operations), the hook fires after each edit is applied
+and reports the affected file. The capturing process reads the file's current
+content (the post-edit state) and, for an in-place edit, the assistant's own
+before-and-after fragments, so the inserted or replaced lines can be diffed as
+AI-authored.
+
+Each captured edit updates a per-file authorship map: a structure aligned to
+the file's current lines, where each line carries a source tag (`ai-assistant`,
+`human`, or `preexisting`) and, for AI lines, the model identifier. The map is
+updated by a line-level diff:
+
+- Equal lines carry their prior tag forward.
+- Inserted or replaced lines produced by the assistant take the `ai-assistant`
+  tag and the model identifier.
+
+### 3.3 Human Drift Reconciliation
+
+A human may edit the file between two AI edits, or after the last AI edit,
+without passing through the assistant's edit channel. These edits are detected
+as drift:
+
+- **At each AI edit:** before applying the AI tag, the captured pre-edit state
+  is compared against the session's last stored snapshot. Any line that differs
+  is attributed to the human, because it changed without an AI edit event.
+- **At finalize:** the final committed content of each file is compared against
+  the session's last snapshot. Any line that changed is attributed to the
+  human.
+
+This two-point reconciliation is what makes the human attribution legitimate
+without a human-side hook: the human's lines are precisely the changes the
+assistant did not make. The assistant cannot claim them, because it never
+produced them through its channel; the human cannot disclaim them, because they
+are the residual of the AI capture.
+
+### 3.4 Independently-Held Keys
+
+The Attribution Session holds an AI-session identity with its own DID and
+keypair, distinct from the human's signing identity. Three embodiments, in
+increasing strength:
+
+1. **Local session key (baseline).** The session generates a fresh did:key
+   keypair, stored with owner-only file permissions. This is the reference
+   embodiment and is sufficient when the goal is to separate, within one
+   workstation, which channel produced which lines.
+2. **Sidecar-held key (stronger).** The AI-session private key is held by an
+   Identity Sidecar (PAD-003), so a prompt-injected assistant cannot exfiltrate
+   it and the human's editor cannot sign with it directly.
+3. **Vendor-delegated key (strongest).** The AI-session identity is a
+   capability-attenuated delegation (PAD-002) from the AI vendor's root
+   identity, so the AI's signature chains to the actual model provider rather
+   than to a key the local user minted.
+
+In all three, the human signs the final manifest with the human key only. The
+separation of keys is the trust boundary that distinguishes this method from
+naive labelling.
+
+### 3.5 Signed AI Attestation
+
+Each captured edit, and the per-file AI view at finalize, produces an
+authorship attestation signed by the AI-session key:
+
+```json
+{
+  "@context": "https://vouch-protocol.com/attribution/v1",
+  "type": "VouchAuthorshipAttestation",
+  "session": "did:key:z6Mk...",
+  "path": "src/app.py",
+  "model": "claude-opus-4-8",
+  "sha256": "9f2b...e1",
+  "aiLines": [[1, 2], [6, 7]],
+  "recordedAt": "2026-06-10T12:00:00Z",
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "verificationMethod": "did:key:z6Mk...#attribution",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z..."
+  }
+}
+```
+
+The `aiLines` ranges are bound to the file content by `sha256`, and the whole
+attestation is bound by the Data Integrity proof over its canonical JCS bytes.
+
+### 3.6 The Attribution Manifest
+
+At finalize, the human signer assembles the manifest:
+
+```json
+{
+  "@context": "https://vouch-protocol.com/attribution/v1",
+  "type": "VouchAttributionManifest",
+  "commit": "working-tree",
+  "createdBy": "did:web:dev.acme.com",
+  "aiSession": {
+    "did": "did:key:z6Mk...",
+    "model": "claude-opus-4-8",
+    "publicKeyJwk": { "kty": "OKP", "crv": "Ed25519", "x": "..." }
+  },
+  "files": [
+    {
+      "path": "src/app.py",
+      "sha256": "9f2b...e1",
+      "lineCount": 7,
+      "regions": [
+        { "startLine": 1, "endLine": 2, "source": "ai-assistant",
+          "author": "did:key:z6Mk...", "model": "claude-opus-4-8" },
+        { "startLine": 3, "endLine": 5, "source": "human",
+          "author": "did:web:dev.acme.com", "model": null },
+        { "startLine": 6, "endLine": 7, "source": "ai-assistant",
+          "author": "did:key:z6Mk...", "model": "claude-opus-4-8" }
+      ]
+    }
+  ],
+  "aiAttestations": [ /* the signed attestations of 3.5 */ ],
+  "proof": { /* Data Integrity proof signed by the human key */ }
+}
+```
+
+The human proof covers the entire manifest, including the embedded AI
+attestations, so altering an attestation breaks the human proof as well as the
+attestation's own proof.
+
+### 3.7 Verification
+
+A verifier checks, in order:
+
+1. **Human proof.** The Data Integrity proof over the whole manifest verifies
+   against the human public key.
+2. **AI attestations.** Every embedded AI attestation verifies against the
+   AI-session public key.
+3. **Backing.** Every region whose source is `ai-assistant` is covered by the
+   `aiLines` of a verified AI attestation. An AI region with no signed backing
+   is rejected. This is what prevents relabelling a human line as AI.
+4. **Completeness.** The regions of each file cover every line from 1 to
+   `lineCount` with no gap and no overlap. A file whose regions leave lines
+   unattributed is rejected, so a defective line cannot hide as unattributed.
+5. **Byte binding.** When the files are available, the SHA-256 of each file's
+   current bytes matches the manifest. A single altered byte fails this check.
+
+### 3.8 Blame and Summary
+
+Given a verified manifest, a `blame` operation returns, for each line of a
+file, the source, the author DID, and the model. A `summarize` operation
+aggregates line counts and percentages by source. These present the proven
+authorship in the same shape developers already expect from `git blame`, but
+with a non-human author as a first-class possibility and with cryptographic
+backing.
+
+### 3.9 Honest Degradation
+
+If the edit-channel hook never recorded anything (the assistant was not
+instrumented), finalize attributes the whole file to the human committer and
+emits no AI regions. The method never fabricates AI attribution it did not
+observe. The presence of an AI region is therefore always evidence of a
+captured, signed AI edit.
+
+---
+
+## 4. Distinction from Prior Art
+
+### 4.1 vs. Version-Control Blame and Commit Signing
+
+`git blame`, commit author metadata, and commit signing (GPG, SSH, Vouch git)
+operate at commit granularity with one committing identity. PAD-061 operates at
+line-region granularity with two independently-keyed authors per file and a
+non-human author as a first-class case. Commit signing answers "who committed";
+PAD-061 answers "who authored this region."
+
+### 4.2 vs. AI-Output Watermarking
+
+Statistical or token-level watermarking marks that text is machine-generated.
+It does not separate interleaved human edits, does not identify the specific
+model instance via a verifiable key, and is not bound to a committing human
+identity. PAD-061 binds named regions to specific author DIDs with
+per-party signatures and content hashes.
+
+### 4.3 vs. Naive Authorship Labels
+
+A label applied by a single party's tooling is controllable by that party and
+proves nothing (Section 2.3). PAD-061's legitimacy rests on edit-channel
+capture plus independently-held keys, so neither party can produce the other's
+attribution. This is the central distinction.
+
+### 4.4 vs. PAD-007 (Automated Provenance via Input Telemetry)
+
+PAD-007 records that input events occurred to establish provenance
+automatically. PAD-061 additionally separates concurrent human and AI
+authorship within a single file and signs each party's regions with that
+party's own key, enforcing region completeness and AI-region backing at
+verification. PAD-061 may use PAD-007-style telemetry as one capture source but
+adds the dual-keyed, region-complete manifest.
+
+### 4.5 vs. PAD-042 (Standardized Metadata Schema for Agent Ledger Signatures)
+
+PAD-042 standardizes the metadata schema for agent ledger signatures. PAD-061
+defines a specific authorship-attribution object (regions, sources, per-region
+authors, AI attestations) and the verification rules (backing, completeness,
+byte binding) over it. PAD-061 may serialize within a PAD-042-compatible schema
+but claims the per-region human-or-AI attribution method, not the general
+metadata schema.
+
+### 4.6 vs. PAD-059 (Vouch-Amnesia Attestation Bridge)
+
+PAD-059 anchors an AI coding assistant's deterministic pre-push policy decisions
+(block / attest / allow) to Verifiable Credentials. That is governance of the
+egress decision. PAD-061 is governance of authorship: which party wrote which
+lines. The two compose. A PAD-059 egress credential may reference a PAD-061
+manifest so that an attested push also carries proven per-region authorship.
+
+### 4.7 vs. Pair-Programming and IDE Authorship Plugins
+
+Collaborative editors and some IDE plugins track which connected user typed
+which characters for live presence or attribution within a trusted session.
+They attribute among mutually-trusted human participants over a shared
+transport, without independent cryptographic keys per author, without a
+non-human author class, and without a verifiable, content-bound, signed
+manifest that survives outside the editing session. PAD-061 produces a portable
+signed artifact verifiable by any third party against the parties' public keys.
+
+---
+
+## 5. Claims
+
+The defensive disclosure asserts public prior art for:
+
+1. A method for attributing individual regions of a source file to a human
+   author or to an AI coding assistant by capturing authorship from the
+   assistant's actual edit channel as edits occur, and treating as human-
+   authored the residual changes to the file that did not arrive through that
+   channel.
+2. The two-point human-drift reconciliation that attributes to the human any
+   change detected between the last AI edit and the next AI edit (pre-edit
+   state versus stored snapshot) and any change detected between the last AI
+   edit and finalization (final content versus stored snapshot), without a
+   human-side capture hook.
+3. The attestation of AI-authored regions with an AI-session key held
+   independently of the human's signing key, in embodiments where the
+   AI-session key is a local session key, a key held by an Identity Sidecar, or
+   a capability-attenuated delegation from the AI vendor's root identity.
+4. The Attribution Manifest binding, per file, line ranges to author DIDs over
+   the exact file bytes via a content hash and a JCS Data Integrity proof
+   signed by the human key, embedding AI attestations signed by the AI-session
+   key.
+5. The verification rule requiring that every AI-attributed region be covered
+   by a signed AI attestation, so an AI region cannot exist without the AI
+   signature, preventing relabelling of human lines as AI-authored.
+6. The verification rule requiring that the attributed regions of each file
+   cover every line with no gap and no overlap, so a region cannot hide as
+   unattributed.
+7. The honest-degradation property whereby, absent any captured AI edit, the
+   method attributes the whole file to the human committer and emits no AI
+   regions, so the presence of an AI region is always evidence of a captured,
+   signed AI edit.
+8. A blame operation returning, for each line, the source (human, AI, or
+   preexisting), the author DID, and the model identifier, derived from the
+   verified manifest, presenting non-human authorship as a first-class result.
+
+---
+
+## 6. Reference Implementation
+
+The reference implementation ships in the Vouch Protocol Python SDK under
+Apache 2.0:
+
+- `vouch/attribution.py`: the Attribution Session (edit capture, drift
+  reconciliation, AI-session key handling), manifest assembly and signing, and
+  the verification, blame, and summary functions.
+- `vouch attribute` CLI: `record` and `hook` (the latter consumes a coding
+  assistant's post-tool event from standard input), `finalize`, `blame`, and
+  `verify`.
+- `vouch/integrations/claude-code/`: a post-tool hook configuration that wires
+  the assistant's Edit / Write / MultiEdit operations to `vouch attribute
+  hook`, plus setup documentation.
+- `examples/who_wrote_this.py`: a self-contained demonstration that an honest
+  manifest verifies, a relabelled AI region is rejected, and a single altered
+  byte is rejected.
+
+Stronger key custody (Sidecar-held and vendor-delegated AI-session keys) and a
+hosted attribution registry are operational layers on top of these open
+primitives. This disclosure does not claim any specific commercial feature; it
+claims the per-region attribution method and its verification rules.
+
+---
+
+## 7. Security Considerations
+
+### 7.1 Trust in the Edit-Channel Hook
+
+The legitimacy of AI attribution depends on the hook reporting only genuine
+assistant edits. If an adversary can feed fabricated edit events to the
+capture process, they can mint AI attribution for human-written lines. The hook
+SHOULD therefore run inside the assistant's trust boundary, and in the stronger
+embodiments the AI-session key is held by the Sidecar or delegated from the
+vendor, so a fabricated local event cannot produce a vendor-chained signature.
+
+### 7.2 Custody of the AI-Session Key
+
+In the baseline embodiment the AI-session key is local and owner-readable. A
+local adversary with that key can sign arbitrary AI attestations. Deployments
+needing assurance against the local user SHOULD use the Sidecar or
+vendor-delegated embodiments of Section 3.4, where the human user does not hold
+the AI-session key.
+
+### 7.3 Completeness Against Hidden Regions
+
+The completeness rule (Section 3.7) prevents a defective line from being left
+unattributed. It does not prevent a party from attributing a line to the
+correct author who nonetheless disclaims responsibility through other means;
+attribution establishes authorship, not intent or correctness.
+
+### 7.4 Binding to Bytes, Not to Semantics
+
+The content hash binds attribution to exact bytes. A semantically equivalent
+reformatting (whitespace, comment changes) produces different bytes and
+requires re-attribution. This is intentional: the manifest attests the bytes
+that existed at signing, not an abstract semantic unit.
+
+### 7.5 Privacy
+
+The manifest records authorship metadata (which DID wrote which lines) and
+content hashes, not the prompt history or the assistant's reasoning. It does not
+collect third-party data. Where the AI-session DID is a fresh per-session
+did:key, it does not link sessions to each other unless the operator chooses a
+stable AI identity.
+
+---
+
+## 8. Conclusion
+
+This disclosure establishes public prior art for **per-region authorship
+attribution of mixed human and AI source code**, made legitimate by capturing
+authorship at the assistant's edit channel and signing each party's regions
+with an independently-held key, and made verifiable by a content-bound,
+region-complete, dual-keyed Attribution Manifest. It answers, for any line that
+later matters, whether a human or a machine wrote it, which one, and that the
+bytes have not changed, without allowing either party to wear the other's name.
+
+The author publishes this disclosure under Apache 2.0 (the reference
+implementation) and CC0 (this disclosure document) to keep the method freely
+available to the open developer and decentralized-identity communities and to
+prevent its appropriation by patent claims from any third party.
+
+---
+
+## 9. References
+
+- [PAD-001] Cryptographic Agent Identity (Gaddam, December 2025)
+- [PAD-002] Chain of Custody Delegation (Gaddam, January 2026)
+- [PAD-003] Identity Sidecar Pattern (Gaddam, January 2026)
+- [PAD-007] Automated Provenance via Input Telemetry (Gaddam, January 2026)
+- [PAD-039] Cross-Implementation Deterministic Multi-Party Trust State via JCS-Canonicalized Verifiable Credentials (Gaddam, April 2026)
+- [PAD-042] Standardized Metadata Schema for AI Agent Ledger Signatures (Gaddam, April 2026)
+- [PAD-056] Capability-Bounded AI Assistant Output via Intent Allow-List at the Identity Sidecar (Gaddam, May 2026)
+- [PAD-059] Vouch-Amnesia Attestation Bridge (Gaddam, May 2026)
+- [W3C-VC-2.0] Verifiable Credentials Data Model 2.0
+- [W3C-DID-CORE] Decentralized Identifiers (DIDs) v1.0
+- [VC-DI-EDDSA] Data Integrity EdDSA Cryptosuites v1.0 (eddsa-jcs-2022)
+- [RFC 8785] JSON Canonicalization Scheme

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -70,6 +70,26 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-058](./PAD-058-automated-key-rotation-on-leak-detection.md) | Automated DID Rotation and Verifier Broadcast Pipeline on Static Leak Detection (Classical + Hybrid PQ) | 2026-05-14 | Published |
 | [PAD-059](./PAD-059-vouch-amnesia-attestation-bridge.md) | Method for Cryptographically Anchoring Deterministic Pre-Push Policy Decisions of an AI Coding Assistant Workspace to W3C Verifiable Credentials with Optional Hybrid Post-Quantum Signatures | 2026-05-14 | Published |
 | [PAD-060](./PAD-060-single-use-audited-override-of-egress-block.md) | Method for One-Time Time-Bounded Override of a Deterministic Egress-Time Policy Block, with Cryptographically Auditable Override Event and Structural Prevention of Repeated Re-Use | 2026-05-14 | Published |
+| [PAD-061](./PAD-061-per-region-human-ai-code-attribution.md) | Per-Region Authorship Attribution for Mixed Human and AI Source Code via Edit-Channel Capture and Independently-Keyed Signatures | 2026-06-10 | Published |
+
+
+## June 10, 2026: Per-Region Human and AI Code Attribution (PAD-061)
+
+One disclosure published June 10, 2026 covers attributing individual regions of
+a source file to a human author or to an AI coding assistant, with each party's
+regions signed by a key that party holds independently.
+
+- **PAD-061** records authorship at the assistant's actual edit channel (its
+  Edit / Write / MultiEdit operations) rather than reconstructing it later, and
+  treats the human's lines as the residual changes that did not pass through
+  that channel. AI regions are attested with an AI-session key (local, Sidecar-
+  held, or vendor-delegated) distinct from the human's signing key, so neither
+  party can mint the other's attribution. The signed Attribution Manifest binds
+  line ranges to author DIDs over the exact bytes and enforces region
+  completeness and AI-region backing at verification, so a defective line
+  cannot hide as unattributed and an AI region cannot exist without the AI
+  signature. The reference implementation ships in the Python SDK
+  (`vouch attribute`, `vouch/integrations/claude-code/`).
 
 
 ## May 14, 2026: Vouch-Amnesia Bridge and Override Pattern (PAD-059, PAD-060)

--- a/docs/disclosures/index.html
+++ b/docs/disclosures/index.html
@@ -443,6 +443,213 @@
         capability proof challenges, and SLA binding.</div>
     </div>
 
+    <div class="paper">
+      <div class="paper-id">PAD-039</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-039-jcs-deterministic-multi-party-trust-state.md">Cross-Implementation
+          Deterministic Multi-Party Trust State via JCS-Canonicalized Verifiable Credentials</a></div>
+      <div class="paper-desc">Byte-identical trust state across independent implementations via RFC 8785 JCS
+        canonicalization of Verifiable Credentials.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-040</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-040-hybrid-composite-signature-same-canonical-bytes.md">Hybrid
+          Composite Signature Bound to Same Canonical Bytes (Ed25519 + ML-DSA-44 over JCS)</a></div>
+      <div class="paper-desc">A single credential carrying both a classical Ed25519 proof and a post-quantum
+        ML-DSA-44 proof over the same canonical JCS bytes.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-041</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-041-multikey-algorithm-agnostic-verification.md">Algorithm-Agnostic
+          Verification Method Resolution via Multikey Multicodec Discrimination</a></div>
+      <div class="paper-desc">Verifiers resolve which algorithm to check from the Multikey multicodec prefix,
+        with no separate negotiation step.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-042</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-042-standardized-metadata-schema-agent-ledger.md">Standardized
+          Metadata Schema for AI Agent Ledger Signatures</a></div>
+      <div class="paper-desc">A common metadata schema for the signatures AI agents write to a shared
+        ledger.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-043</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-043-cryptographic-weight-binding.md">Cryptographic
+          Weight Binding for Model-Intrinsic AI Identity</a></div>
+      <div class="paper-desc">Binding an identity to the model's own weights, so the identity is intrinsic to
+        the model rather than an external label.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-044</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-044-ephemeral-zk-state-channels.md">Ephemeral
+          ZK-State Channels for Agentic Layer 2 Scalability</a></div>
+      <div class="paper-desc">Ephemeral zero-knowledge state channels for low-cost, high-throughput agent
+        interactions.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-045</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-045-proof-of-non-hallucination-retrieval-anchoring.md">Proof
+          of Non-Hallucination via Cryptographic Retrieval Anchoring</a></div>
+      <div class="paper-desc">Anchoring an answer to its retrieved sources cryptographically, so a claim can be
+        shown to come from real retrieval.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-046</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-046-algorithm-quorum-cryptosuite-diversity.md">Algorithm
+          Quorum Verification via M-of-N Cryptosuite Diversity</a></div>
+      <div class="paper-desc">Requiring M-of-N independent cryptosuites to agree before a credential is
+        accepted, for algorithm diversity.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-047</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-047-vdf-rate-limited-agent-actions.md">Verifiable
+          Delay Functions for Cryptographic Rate-Limiting of Autonomous Agent Actions</a></div>
+      <div class="paper-desc">Verifiable delay functions that impose an unforgeable minimum time between an
+        agent's actions.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-048</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-048-write-only-async-context-ledger.md">Write-Only
+          Asynchronous Context Ledger for LLM Coding Assistants</a></div>
+      <div class="paper-desc">A write-only ledger where the assistant records rules passively and a separate
+        compactor consolidates them into a policy artifact.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-049</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-049-decoupled-semantic-policy-extraction.md">Decoupled
+          Semantic Policy Extraction via Passive Source Monitoring</a></div>
+      <div class="paper-desc">Extracting policy from source comments and project files by passive monitoring,
+        decoupled from the assistant's reasoning.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-050</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-050-zero-context-deterministic-egress-interception.md">Zero-Context
+          Deterministic Egress Interception via Pre-Push Hook with Optional Cryptographic Attestation</a></div>
+      <div class="paper-desc">A pre-push hook that deterministically blocks or cryptographically attests an
+        egress with no access to the assistant's context.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-051</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-051-parallel-intent-extraction-shadow-models.md">Parallel
+          Intent Extraction from LLM Prompts via a Local Shadow Small-Language-Model</a></div>
+      <div class="paper-desc">A local small-language-model that extracts intent from prompts in parallel with
+        the primary assistant.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-052</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-052-ui-state-sniffing-closed-box-ai-tools.md">UI
+          State Sniffing for Policy Extraction from Closed-Box AI Coding Applications</a></div>
+      <div class="paper-desc">Reading UI state from closed-box AI coding tools to recover the policy they are
+        operating under.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-053</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-053-time-bounded-ephemeral-rules.md">Time-Bounded
+          Ephemeral Rules with Auto-Expiry for LLM Coding Assistant Sessions</a></div>
+      <div class="paper-desc">Rules that carry an expiry, so a constraint set for one session does not silently
+        persist.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-054</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-054-filesystem-hierarchy-policy-inheritance.md">Filesystem-Hierarchy
+          Policy Inheritance for LLM Coding Assistant Workspaces</a></div>
+      <div class="paper-desc">Policy that inherits down the filesystem hierarchy, so workspace rules compose
+        like directory permissions.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-055</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-055-cross-session-policy-re-anchoring.md">Cross-Session
+          Policy Re-Anchoring via Pre-Flight Context Replay</a></div>
+      <div class="paper-desc">Replaying prior context at the start of a new session so rules re-anchor across
+        discontinuous sessions.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-056</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-056-allow-list-bounded-ai-assistant-signing.md">Capability-Bounded
+          AI Assistant Output via Intent Allow-List at the Identity Sidecar</a></div>
+      <div class="paper-desc">An intent allow-list enforced at the Identity Sidecar that bounds what credentials
+        a prompt-injected assistant can mint.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-057</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-057-byo-llm-distribution-via-ai-tool-packaging.md">BYO-LLM
+          Distribution of Protocol Capabilities via AI Tool Packaging</a></div>
+      <div class="paper-desc">Shipping the protocol's developer capabilities as packages for the developer's own
+        AI subscription, with no vendor-paid inference.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-058</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-058-automated-key-rotation-on-leak-detection.md">Automated
+          DID Rotation and Verifier Broadcast Pipeline on Static Leak Detection (Classical + Hybrid PQ)</a></div>
+      <div class="paper-desc">On detecting leaked key material, a pipeline that revokes, rotates, publishes a
+        dual-signed migration credential, and broadcasts to verifiers.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-059</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-059-vouch-amnesia-attestation-bridge.md">Cryptographically
+          Anchoring Deterministic Pre-Push Policy Decisions of an AI Coding Workspace to W3C Verifiable Credentials</a></div>
+      <div class="paper-desc">Turning an AI coding workspace's deterministic pre-push decisions into W3C
+        Verifiable Credentials, with optional hybrid post-quantum signatures.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-060</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-060-single-use-audited-override-of-egress-block.md">One-Time
+          Time-Bounded Override of a Deterministic Egress-Time Policy Block</a></div>
+      <div class="paper-desc">A single-use, time-bounded override of an egress block, with an auditable override
+        event and structural prevention of reuse.</div>
+    </div>
+
+    <div class="paper">
+      <div class="paper-id">PAD-061</div>
+      <div class="paper-title"><a
+          href="https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-061-per-region-human-ai-code-attribution.md">Per-Region
+          Authorship Attribution for Mixed Human and AI Source Code via Edit-Channel Capture and Independently-Keyed Signatures</a></div>
+      <div class="paper-desc">Attributing each region of a file to a human or AI author by capturing edits at the
+        assistant's channel and signing each party's lines with its own key.</div>
+    </div>
+
     <div class="back">
       <a href="https://vouch-protocol.com">← Back to Vouch Protocol</a>
     </div>

--- a/gemini-gem/knowledge/agent-trust-index.md
+++ b/gemini-gem/knowledge/agent-trust-index.md
@@ -1,0 +1,40 @@
+# The Agent Trust Index
+
+The Agent Trust Index is an open benchmark published with Vouch. It scans public
+AI agents and scores one question for each: can this agent prove who it is? It
+measures adoption of provable identity in the wild, not whether an agent is good,
+safe, or useful.
+
+## What it measures
+
+Each agent is scored out of 100:
+
+- **60 points** for a resolvable cryptographic identity (a `did:web` that
+  resolves to a DID document).
+- **40 points** for that identity carrying a usable public key.
+
+Grades: A is 90 or above, then B, C, D, and F below 40. An agent with no
+resolvable identity scores zero.
+
+## The first sweep
+
+The first sweep drew its agents from the public Model Context Protocol registry
+on 10 June 2026:
+
+- **11,680** unique agents scanned
+- **157** publish a resolvable `did:web` identity, about **1.3 percent**
+- **98.7 percent** cannot prove who they are at all
+- **69** of those 157 also carry a usable public key, a full grade A
+- the 88 that resolve a DID but carry no usable key land around a C
+
+The agents that can prove themselves are mostly finance and oracle agents: the
+ones that handle money are the first to bother with identity.
+
+## Where to point people
+
+- The Index: `/agent-trust-index/`
+- The methodology: `/agent-trust-index/methodology/`
+
+The takeaway for a developer: provable identity is the floor, and almost nobody
+has it yet. Adding a `did:web` and signing your agent's actions with Vouch puts
+you in the top 1.3 percent on day one.

--- a/gemini-gem/knowledge/integrations.md
+++ b/gemini-gem/knowledge/integrations.md
@@ -211,7 +211,7 @@ For human-driven actions in a browser (e.g., signing a contract from
 a web app):
 
 ```ts
-import { VouchClient } from '@vouch-protocol/core';
+import { VouchClient } from '@vouch-protocol-official/sdk';
 
 // In a Chrome extension content script
 const credential = await VouchClient.signFromExtension({

--- a/gemini-gem/knowledge/post-quantum.md
+++ b/gemini-gem/knowledge/post-quantum.md
@@ -115,11 +115,11 @@ signed = signer.sign_credential_hybrid(build_vouch_credential(...))
 ### TypeScript
 
 ```bash
-npm install @vouch-protocol/core @noble/post-quantum
+npm install @vouch-protocol-official/sdk @noble/post-quantum
 ```
 
 ```ts
-import { Signer, buildHybridProof, generateMLDSA44KeyPair } from '@vouch-protocol/core';
+import { Signer, buildHybridProof, generateMLDSA44KeyPair } from '@vouch-protocol-official/sdk';
 
 const signer = await Signer.fromDidWithHybrid('did:web:agent.example.com');
 const signed = await signer.signCredentialHybrid(credential);

--- a/gemini-gem/knowledge/quickstart.md
+++ b/gemini-gem/knowledge/quickstart.md
@@ -34,11 +34,11 @@ assert is_valid
 ## TypeScript
 
 ```bash
-npm install @vouch-protocol/core
+npm install @vouch-protocol-official/sdk
 ```
 
 ```ts
-import { Signer, Verifier, generateIdentity } from '@vouch-protocol/core';
+import { Signer, Verifier, generateIdentity } from '@vouch-protocol-official/sdk';
 
 const keys = await generateIdentity('agent.example.com');
 const signer = new Signer({ privateKey: keys.privateKeyJwk, did: keys.did });

--- a/gemini-gem/knowledge/robotics.md
+++ b/gemini-gem/knowledge/robotics.md
@@ -1,0 +1,34 @@
+# Robots and embodied agents
+
+A robot is an agent with a body. Identity, accountability, and continuous trust
+matter more, not less, when an agent can cause physical harm or move money in
+the real world. Vouch covers the open identity layer for robots; richer
+robot-lifecycle tooling builds on top of it.
+
+## The same primitives apply
+
+- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
+  profile in `docs/specs/`).
+- Delegation: a delegation chain records who authorized the robot, on whose
+  behalf, and within what limits, all verifiable.
+- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
+  behaving now," so a robot has to keep proving itself.
+- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
+  check the status.
+
+## The robot-specific open piece: hardware root of trust
+
+A software agent's key can live in a file. A robot should do better. The
+hardware-root-of-trust profile binds the robot's DID to its secure element (a
+TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
+the signing key and signs the robot's heartbeats, so identity is anchored to the
+physical device, not a config that can be copied. The open `did:vouch:agent`
+profile defines the agent identity scheme; the embodied profile extends it for
+hardware attestation.
+
+## Open vs built on top
+
+The identity, delegation, continuous-trust, and hardware-attestation profiles
+are open Vouch. Operated robot-lifecycle products (lifecycle identity
+management, model-and-config provenance, fleet trust at scale, and similar)
+build on this open layer and are out of scope for the protocol itself.

--- a/gemini-gem/knowledge/troubleshooting.md
+++ b/gemini-gem/knowledge/troubleshooting.md
@@ -12,7 +12,7 @@ Cause: the `pqcrypto` dependency needs C headers and a compiler.
 - Ubuntu/Debian: `apt install build-essential libssl-dev` then retry
 - Windows: install Visual C++ Build Tools or use WSL
 
-### `npm install @vouch-protocol/core` fails on Node 16
+### `npm install @vouch-protocol-official/sdk` fails on Node 16
 
 The SDK requires Node 18+. Upgrade Node.
 
@@ -240,7 +240,7 @@ print(canonical.hex())
 
 ```bash
 python -m vouch.jcs canonicalize < credential.json > python.bin
-node -e "console.log(require('@vouch-protocol/core').canonicalize(...))" < credential.json > ts.bin
+node -e "console.log(require('@vouch-protocol-official/sdk').canonicalize(...))" < credential.json > ts.bin
 diff python.bin ts.bin
 ```
 

--- a/openai-gpt/knowledge/agent-trust-index.md
+++ b/openai-gpt/knowledge/agent-trust-index.md
@@ -1,0 +1,40 @@
+# The Agent Trust Index
+
+The Agent Trust Index is an open benchmark published with Vouch. It scans public
+AI agents and scores one question for each: can this agent prove who it is? It
+measures adoption of provable identity in the wild, not whether an agent is good,
+safe, or useful.
+
+## What it measures
+
+Each agent is scored out of 100:
+
+- **60 points** for a resolvable cryptographic identity (a `did:web` that
+  resolves to a DID document).
+- **40 points** for that identity carrying a usable public key.
+
+Grades: A is 90 or above, then B, C, D, and F below 40. An agent with no
+resolvable identity scores zero.
+
+## The first sweep
+
+The first sweep drew its agents from the public Model Context Protocol registry
+on 10 June 2026:
+
+- **11,680** unique agents scanned
+- **157** publish a resolvable `did:web` identity, about **1.3 percent**
+- **98.7 percent** cannot prove who they are at all
+- **69** of those 157 also carry a usable public key, a full grade A
+- the 88 that resolve a DID but carry no usable key land around a C
+
+The agents that can prove themselves are mostly finance and oracle agents: the
+ones that handle money are the first to bother with identity.
+
+## Where to point people
+
+- The Index: `/agent-trust-index/`
+- The methodology: `/agent-trust-index/methodology/`
+
+The takeaway for a developer: provable identity is the floor, and almost nobody
+has it yet. Adding a `did:web` and signing your agent's actions with Vouch puts
+you in the top 1.3 percent on day one.

--- a/openai-gpt/knowledge/integrations.md
+++ b/openai-gpt/knowledge/integrations.md
@@ -211,7 +211,7 @@ For human-driven actions in a browser (e.g., signing a contract from
 a web app):
 
 ```ts
-import { VouchClient } from '@vouch-protocol/core';
+import { VouchClient } from '@vouch-protocol-official/sdk';
 
 // In a Chrome extension content script
 const credential = await VouchClient.signFromExtension({

--- a/openai-gpt/knowledge/post-quantum.md
+++ b/openai-gpt/knowledge/post-quantum.md
@@ -115,11 +115,11 @@ signed = signer.sign_credential_hybrid(build_vouch_credential(...))
 ### TypeScript
 
 ```bash
-npm install @vouch-protocol/core @noble/post-quantum
+npm install @vouch-protocol-official/sdk @noble/post-quantum
 ```
 
 ```ts
-import { Signer, buildHybridProof, generateMLDSA44KeyPair } from '@vouch-protocol/core';
+import { Signer, buildHybridProof, generateMLDSA44KeyPair } from '@vouch-protocol-official/sdk';
 
 const signer = await Signer.fromDidWithHybrid('did:web:agent.example.com');
 const signed = await signer.signCredentialHybrid(credential);

--- a/openai-gpt/knowledge/quickstart.md
+++ b/openai-gpt/knowledge/quickstart.md
@@ -34,11 +34,11 @@ assert is_valid
 ## TypeScript
 
 ```bash
-npm install @vouch-protocol/core
+npm install @vouch-protocol-official/sdk
 ```
 
 ```ts
-import { Signer, Verifier, generateIdentity } from '@vouch-protocol/core';
+import { Signer, Verifier, generateIdentity } from '@vouch-protocol-official/sdk';
 
 const keys = await generateIdentity('agent.example.com');
 const signer = new Signer({ privateKey: keys.privateKeyJwk, did: keys.did });

--- a/openai-gpt/knowledge/robotics.md
+++ b/openai-gpt/knowledge/robotics.md
@@ -1,0 +1,34 @@
+# Robots and embodied agents
+
+A robot is an agent with a body. Identity, accountability, and continuous trust
+matter more, not less, when an agent can cause physical harm or move money in
+the real world. Vouch covers the open identity layer for robots; richer
+robot-lifecycle tooling builds on top of it.
+
+## The same primitives apply
+
+- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
+  profile in `docs/specs/`).
+- Delegation: a delegation chain records who authorized the robot, on whose
+  behalf, and within what limits, all verifiable.
+- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
+  behaving now," so a robot has to keep proving itself.
+- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
+  check the status.
+
+## The robot-specific open piece: hardware root of trust
+
+A software agent's key can live in a file. A robot should do better. The
+hardware-root-of-trust profile binds the robot's DID to its secure element (a
+TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
+the signing key and signs the robot's heartbeats, so identity is anchored to the
+physical device, not a config that can be copied. The open `did:vouch:agent`
+profile defines the agent identity scheme; the embodied profile extends it for
+hardware attestation.
+
+## Open vs built on top
+
+The identity, delegation, continuous-trust, and hardware-attestation profiles
+are open Vouch. Operated robot-lifecycle products (lifecycle identity
+management, model-and-config provenance, fleet trust at scale, and similar)
+build on this open layer and are out of scope for the protocol itself.

--- a/openai-gpt/knowledge/troubleshooting.md
+++ b/openai-gpt/knowledge/troubleshooting.md
@@ -12,7 +12,7 @@ Cause: the `pqcrypto` dependency needs C headers and a compiler.
 - Ubuntu/Debian: `apt install build-essential libssl-dev` then retry
 - Windows: install Visual C++ Build Tools or use WSL
 
-### `npm install @vouch-protocol/core` fails on Node 16
+### `npm install @vouch-protocol-official/sdk` fails on Node 16
 
 The SDK requires Node 18+. Upgrade Node.
 
@@ -240,7 +240,7 @@ print(canonical.hex())
 
 ```bash
 python -m vouch.jcs canonicalize < credential.json > python.bin
-node -e "console.log(require('@vouch-protocol/core').canonicalize(...))" < credential.json > ts.bin
+node -e "console.log(require('@vouch-protocol-official/sdk').canonicalize(...))" < credential.json > ts.bin
 diff python.bin ts.bin
 ```
 

--- a/scripts/extract-ati.py
+++ b/scripts/extract-ati.py
@@ -2,7 +2,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 
-SRC = Path("/home/rampy/agent-trust-index/data/results.json")
+SRC = Path("/home/rampy/vouch-protocol/agent-trust-index/data/results.json")
 OUT = Path("/home/rampy/vouch-protocol/website/src/app/agent-trust-index/ati-data.ts")
 
 data = json.loads(SRC.read_text())

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -65,7 +65,9 @@ def test_tampered_bytes_rejected(session, human):
 
     # The committed file on disk no longer matches the signed hash.
     res = attr.verify_manifest(
-        manifest, ident.public_key_jwk, session.ai_public_key_jwk,
+        manifest,
+        ident.public_key_jwk,
+        session.ai_public_key_jwk,
         files_on_disk={"t.py": "x = 99\ny = 2\n"},
     )
     assert not res.ok
@@ -87,7 +89,9 @@ def test_forged_ai_region_rejected(session, human):
                 r["author"] = session.ai_did
     # Human proof now broken AND the AI region is unbacked. Either is enough.
     res = attr.verify_manifest(
-        tampered, ident.public_key_jwk, session.ai_public_key_jwk,
+        tampered,
+        ident.public_key_jwk,
+        session.ai_public_key_jwk,
     )
     assert not res.ok
 
@@ -121,7 +125,7 @@ def test_untouched_file_is_human(session, human):
     # AI never touched this file; committer owns it.
     manifest = session.finalize({"only_human.py": "hand = 1\n"}, signer)
     lines = attr.blame(manifest, "only_human.py")
-    assert all(l["source"] == attr.SOURCE_HUMAN for l in lines)
+    assert all(ln["source"] == attr.SOURCE_HUMAN for ln in lines)
 
 
 def test_persistence_across_session_reload(tmp_path, human):

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,148 @@
+"""Tests for per-region human/AI authorship attribution."""
+
+import copy
+import json
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch import attribution as attr
+
+
+@pytest.fixture
+def human():
+    ident = generate_identity(domain="dev.example.com")
+    signer = Signer(private_key=ident.private_key_jwk, did=ident.did)
+    return ident, signer
+
+
+@pytest.fixture
+def session(tmp_path):
+    return attr.AttributionSession(tmp_path / "sess", model="claude-opus-4-8")
+
+
+def test_ai_then_human_regions(session, human):
+    ident, signer = human
+    # AI writes a new file with three lines.
+    session.record_edit("app.py", "import os\ndef a():\n    return 1\n")
+    # Human appends two lines and edits one (line 3 changes).
+    final = "import os\ndef a():\n    return 2\ndef b():\n    return 3\n"
+    manifest = session.finalize({"app.py": final}, signer)
+
+    s = attr.summarize(manifest)
+    # Lines 1,2 stay AI; line 3 changed by human; 4,5 added by human => 2 AI, 3 human.
+    assert s["lines"][attr.SOURCE_AI] == 2
+    assert s["lines"][attr.SOURCE_HUMAN] == 3
+
+    lines = attr.blame(manifest, "app.py")
+    assert lines[0]["source"] == attr.SOURCE_AI
+    assert lines[0]["author"] == session.ai_did
+    assert lines[0]["model"] == "claude-opus-4-8"
+    assert lines[2]["source"] == attr.SOURCE_HUMAN
+    assert lines[2]["author"] == ident.did
+
+
+def test_manifest_verifies(session, human):
+    ident, signer = human
+    session.record_edit("m.py", "a = 1\nb = 2\n")
+    final = "a = 1\nb = 2\nc = 3\n"
+    manifest = session.finalize({"m.py": final}, signer)
+
+    res = attr.verify_manifest(
+        manifest,
+        ident.public_key_jwk,
+        session.ai_public_key_jwk,
+        files_on_disk={"m.py": final},
+    )
+    assert res.ok, res.reasons
+
+
+def test_tampered_bytes_rejected(session, human):
+    ident, signer = human
+    session.record_edit("t.py", "x = 1\n")
+    final = "x = 1\ny = 2\n"
+    manifest = session.finalize({"t.py": final}, signer)
+
+    # The committed file on disk no longer matches the signed hash.
+    res = attr.verify_manifest(
+        manifest, ident.public_key_jwk, session.ai_public_key_jwk,
+        files_on_disk={"t.py": "x = 99\ny = 2\n"},
+    )
+    assert not res.ok
+    assert any("content hash" in r for r in res.reasons)
+
+
+def test_forged_ai_region_rejected(session, human):
+    """Re-label a human region as AI without an AI attestation -> rejected."""
+    ident, signer = human
+    session.record_edit("f.py", "ai = 1\n")
+    final = "ai = 1\nhuman = 2\n"
+    manifest = session.finalize({"f.py": final}, signer)
+
+    tampered = copy.deepcopy(manifest)
+    for f in tampered["files"]:
+        for r in f["regions"]:
+            if r["source"] == attr.SOURCE_HUMAN:
+                r["source"] = attr.SOURCE_AI
+                r["author"] = session.ai_did
+    # Human proof now broken AND the AI region is unbacked. Either is enough.
+    res = attr.verify_manifest(
+        tampered, ident.public_key_jwk, session.ai_public_key_jwk,
+    )
+    assert not res.ok
+
+
+def test_human_proof_tamper_rejected(session, human):
+    ident, signer = human
+    session.record_edit("p.py", "z = 1\n")
+    manifest = session.finalize({"p.py": "z = 1\n"}, signer)
+
+    tampered = copy.deepcopy(manifest)
+    tampered["createdBy"] = "did:web:attacker.example.com"
+    res = attr.verify_manifest(tampered, ident.public_key_jwk, session.ai_public_key_jwk)
+    assert not res.ok
+    assert any("human proof" in r for r in res.reasons)
+
+
+def test_regions_cover_every_line(session, human):
+    ident, signer = human
+    session.record_edit("c.py", "1\n2\n3\n")
+    final = "1\n2\n3\n4\n5\n"
+    manifest = session.finalize({"c.py": final}, signer)
+    f = manifest["files"][0]
+    covered = []
+    for r in f["regions"]:
+        covered.extend(range(r["startLine"], r["endLine"] + 1))
+    assert covered == [1, 2, 3, 4, 5]
+
+
+def test_untouched_file_is_human(session, human):
+    ident, signer = human
+    # AI never touched this file; committer owns it.
+    manifest = session.finalize({"only_human.py": "hand = 1\n"}, signer)
+    lines = attr.blame(manifest, "only_human.py")
+    assert all(l["source"] == attr.SOURCE_HUMAN for l in lines)
+
+
+def test_persistence_across_session_reload(tmp_path, human):
+    ident, signer = human
+    d = tmp_path / "persist"
+    s1 = attr.AttributionSession(d, model="claude-opus-4-8")
+    s1.record_edit("k.py", "p = 1\n")
+    ai_did = s1.ai_did
+
+    # New session object, same dir: must reuse the AI identity and state.
+    s2 = attr.AttributionSession(d)
+    assert s2.ai_did == ai_did
+    s2.record_edit("k.py", "p = 1\nq = 2\n")
+    manifest = s2.finalize({"k.py": "p = 1\nq = 2\n"}, signer)
+    s = attr.summarize(manifest)
+    assert s["lines"][attr.SOURCE_AI] == 2
+
+
+def test_ai_key_separate_from_human(session, human):
+    ident, signer = human
+    session.record_edit("s.py", "a = 1\n")
+    # The AI session DID is not the human DID: distinct keys.
+    assert session.ai_did != ident.did
+    assert session.ai_public_key_jwk != ident.public_key_jwk

--- a/vouch/attribution.py
+++ b/vouch/attribution.py
@@ -60,6 +60,7 @@ SOURCE_PREEXISTING = "preexisting"
 # Key helpers (Ed25519 <-> JWK), matching the convention used by Signer.
 # ----------------------------------------------------------------------------
 
+
 def _priv_from_jwk(jwk_json: str) -> Ed25519PrivateKey:
     from jwcrypto.common import base64url_decode
 
@@ -114,6 +115,7 @@ def _now_iso() -> str:
 # Per-file authorship tracking.
 # ----------------------------------------------------------------------------
 
+
 @dataclass
 class _FileState:
     """Authorship aligned to the current snapshot of one file."""
@@ -143,7 +145,7 @@ def _retag(
 
     result: List[Dict[str, Optional[str]]] = []
     sm = difflib.SequenceMatcher(a=before_lines, b=after_lines, autojunk=False)
-    for op, i1, i2, j1, j2 in sm.get_opcodes():
+    for op, i1, _i2, j1, j2 in sm.get_opcodes():
         if op == "equal":
             for k in range(j2 - j1):
                 result.append(dict(prior[i1 + k]))
@@ -210,12 +212,16 @@ class AttributionSession:
         self.ai_did = ident.did or _did_key_from_pub_jwk(ident.public_key_jwk)
         self.ai_private_key_jwk = ident.private_key_jwk
         self.ai_public_key_jwk = ident.public_key_jwk
-        path.write_text(json.dumps({
-            "did": self.ai_did,
-            "privateKeyJwk": self.ai_private_key_jwk,
-            "publicKeyJwk": self.ai_public_key_jwk,
-            "model": self.model,
-        }))
+        path.write_text(
+            json.dumps(
+                {
+                    "did": self.ai_did,
+                    "privateKeyJwk": self.ai_private_key_jwk,
+                    "publicKeyJwk": self.ai_public_key_jwk,
+                    "model": self.model,
+                }
+            )
+        )
         try:
             path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
         except OSError:  # pragma: no cover - non-POSIX
@@ -235,10 +241,12 @@ class AttributionSession:
             self._files[rel] = _FileState(snapshot=st["snapshot"], authorship=st["authorship"])
 
     def _save_state(self) -> None:
-        data = {"files": {
-            rel: {"snapshot": fs.snapshot, "authorship": fs.authorship}
-            for rel, fs in self._files.items()
-        }}
+        data = {
+            "files": {
+                rel: {"snapshot": fs.snapshot, "authorship": fs.authorship}
+                for rel, fs in self._files.items()
+            }
+        }
         self._state_path().write_text(json.dumps(data))
 
     # -- recording AI edits -------------------------------------------------
@@ -272,8 +280,9 @@ class AttributionSession:
         elif snapshot is not None:
             interim = snapshot_tags
         else:
-            interim = [{"source": SOURCE_PREEXISTING, "model": None}
-                       for _ in _split_lines(before_content)]
+            interim = [
+                {"source": SOURCE_PREEXISTING, "model": None} for _ in _split_lines(before_content)
+            ]
 
         # Step 2: tag the assistant's own change as AI.
         authorship = _retag(
@@ -295,9 +304,7 @@ class AttributionSession:
             "aiLines": _ranges_for_source(authorship, SOURCE_AI),
             "recordedAt": _now_iso(),
         }
-        proof = data_integrity.build_proof(
-            attestation, self._priv, f"{self.ai_did}#attribution"
-        )
+        proof = data_integrity.build_proof(attestation, self._priv, f"{self.ai_did}#attribution")
         attestation["proof"] = proof
         self._append_ledger(attestation)
         return attestation
@@ -328,8 +335,9 @@ class AttributionSession:
             if st is None:
                 # File the AI never touched: entirely the human's, or
                 # preexisting if it equals nothing we tracked. Mark as human.
-                authorship = [{"source": SOURCE_HUMAN, "model": None}
-                              for _ in _split_lines(final_content)]
+                authorship = [
+                    {"source": SOURCE_HUMAN, "model": None} for _ in _split_lines(final_content)
+                ]
             else:
                 # Residual diff: snapshot -> final. Changed lines = human.
                 authorship = _retag(st.snapshot, final_content, st.authorship, None)
@@ -351,12 +359,14 @@ class AttributionSession:
                     ai_attestations.append(att)
 
             regions = _collapse_regions(authorship, human_signer.get_did(), self.ai_did)
-            manifest_files.append({
-                "path": path,
-                "sha256": _sha256_text(final_content),
-                "lineCount": len(_split_lines(final_content)),
-                "regions": regions,
-            })
+            manifest_files.append(
+                {
+                    "path": path,
+                    "sha256": _sha256_text(final_content),
+                    "lineCount": len(_split_lines(final_content)),
+                    "regions": regions,
+                }
+            )
 
         manifest = {
             "@context": CONTEXT,
@@ -390,6 +400,7 @@ def _signer_private_jwk(human_signer) -> str:
 # ----------------------------------------------------------------------------
 # Region helpers.
 # ----------------------------------------------------------------------------
+
 
 def _ranges_for_source(authorship: List[Dict[str, Optional[str]]], source: str) -> List[List[int]]:
     """1-based inclusive [start, end] line ranges matching `source`."""
@@ -448,6 +459,7 @@ def _collapse_regions(
 # ----------------------------------------------------------------------------
 # Verification and blame.
 # ----------------------------------------------------------------------------
+
 
 @dataclass
 class VerificationResult:
@@ -557,12 +569,14 @@ def blame(manifest: Dict[str, Any], path: str) -> List[Dict[str, Any]]:
             continue
         for r in f.get("regions", []):
             for line in range(r["startLine"], r["endLine"] + 1):
-                out.append({
-                    "line": line,
-                    "source": r["source"],
-                    "author": r.get("author"),
-                    "model": r.get("model"),
-                })
+                out.append(
+                    {
+                        "line": line,
+                        "source": r["source"],
+                        "author": r.get("author"),
+                        "model": r.get("model"),
+                    }
+                )
     return out
 
 

--- a/vouch/attribution.py
+++ b/vouch/attribution.py
@@ -1,0 +1,581 @@
+"""
+Per-region authorship attribution for mixed human and AI code.
+
+When an AI coding assistant and a human both edit a file, git blame credits
+every line to the human who committed it. The AI's work is laundered through
+the human's identity, so when a line later causes an incident nobody can prove
+whether a human or a machine wrote it.
+
+This module records authorship at the moment of editing, from the actual edit
+channel, and signs each party's regions with that party's own key:
+
+  * Lines produced by the AI assistant are captured as the assistant makes
+    them (its Edit / Write operations) and attested with an AI-session key that
+    the human's editor does not wield.
+  * Lines the human typed are the residual: anything that changed on disk that
+    did not arrive through the assistant's edit channel.
+  * Lines untouched since the session began are marked preexisting.
+
+The result is a signed Attribution Manifest that binds, per file, exact line
+ranges to an author DID, over the exact bytes, with a JCS Data Integrity proof.
+A region cannot be moved, the bytes cannot be altered, and an AI region cannot
+be invented without the AI-session signature.
+
+Legitimacy, not labelling. The naive version (one party stamps both keys) is
+worthless because the stamper controls both. The value here comes from two
+properties this module enforces: capture from the real edit channel, and an
+AI-session key held apart from the human signer.
+"""
+
+from __future__ import annotations
+
+import difflib
+import hashlib
+import json
+import os
+import stat
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+from . import data_integrity
+from .keys import generate_identity
+
+CONTEXT = "https://vouch-protocol.com/attribution/v1"
+MANIFEST_TYPE = "VouchAttributionManifest"
+ATTESTATION_TYPE = "VouchAuthorshipAttestation"
+
+SOURCE_AI = "ai-assistant"
+SOURCE_HUMAN = "human"
+SOURCE_PREEXISTING = "preexisting"
+
+
+# ----------------------------------------------------------------------------
+# Key helpers (Ed25519 <-> JWK), matching the convention used by Signer.
+# ----------------------------------------------------------------------------
+
+def _priv_from_jwk(jwk_json: str) -> Ed25519PrivateKey:
+    from jwcrypto.common import base64url_decode
+
+    data = json.loads(jwk_json)
+    if data.get("kty") != "OKP" or data.get("crv") != "Ed25519":
+        raise ValueError("Attribution keys must be Ed25519 (OKP, crv=Ed25519)")
+    seed = base64url_decode(data["d"])
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+def _pub_from_jwk(jwk_json: str) -> Ed25519PublicKey:
+    from jwcrypto.common import base64url_decode
+
+    data = json.loads(jwk_json)
+    if data.get("kty") != "OKP" or data.get("crv") != "Ed25519":
+        raise ValueError("Attribution keys must be Ed25519 (OKP, crv=Ed25519)")
+    x = base64url_decode(data["x"])
+    return Ed25519PublicKey.from_public_bytes(x)
+
+
+def _did_key_from_pub_jwk(jwk_json: str) -> str:
+    """Derive a did:key from an Ed25519 public-key JWK."""
+    from jwcrypto.common import base64url_decode
+    from . import multikey
+
+    data = json.loads(jwk_json)
+    raw = base64url_decode(data["x"])
+    return "did:key:" + multikey.encode_ed25519_public(raw)
+
+
+def _sha256_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _split_lines(text: str) -> List[str]:
+    # Keep it simple and deterministic: split on newlines, drop a single
+    # trailing empty element so a file ending in "\n" is not counted as an
+    # extra blank line. Line numbers are 1-based for humans.
+    if text == "":
+        return []
+    lines = text.split("\n")
+    if lines and lines[-1] == "":
+        lines.pop()
+    return lines
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ----------------------------------------------------------------------------
+# Per-file authorship tracking.
+# ----------------------------------------------------------------------------
+
+@dataclass
+class _FileState:
+    """Authorship aligned to the current snapshot of one file."""
+
+    snapshot: str
+    # One entry per line of `snapshot`: {"source": ..., "model": ...|None}
+    authorship: List[Dict[str, Optional[str]]] = field(default_factory=list)
+
+
+def _retag(
+    before: str,
+    after: str,
+    prior: List[Dict[str, Optional[str]]],
+    new_tag: Optional[Dict[str, Optional[str]]],
+) -> List[Dict[str, Optional[str]]]:
+    """
+    Diff `before` -> `after` line by line. Equal lines carry their prior tag.
+    Inserted or replaced lines take `new_tag`. Returns authorship aligned to
+    `after`. If `new_tag` is None, changed lines are left untagged (used by the
+    caller to mark residual human edits separately).
+    """
+    before_lines = _split_lines(before)
+    after_lines = _split_lines(after)
+    if len(prior) != len(before_lines):
+        # Prior is stale or absent; treat all before-lines as preexisting.
+        prior = [{"source": SOURCE_PREEXISTING, "model": None} for _ in before_lines]
+
+    result: List[Dict[str, Optional[str]]] = []
+    sm = difflib.SequenceMatcher(a=before_lines, b=after_lines, autojunk=False)
+    for op, i1, i2, j1, j2 in sm.get_opcodes():
+        if op == "equal":
+            for k in range(j2 - j1):
+                result.append(dict(prior[i1 + k]))
+        elif op in ("insert", "replace"):
+            tag = new_tag if new_tag is not None else {"source": SOURCE_HUMAN, "model": None}
+            for _ in range(j1, j2):
+                result.append(dict(tag))
+        # 'delete' contributes no lines to `after`
+    return result
+
+
+class AttributionSession:
+    """
+    A signing session for one stretch of mixed human/AI editing. Holds an
+    AI-session identity (its own DID and key) that attests AI-authored regions.
+    The human signs the final manifest with a separate key, so neither party
+    can mint the other's attribution.
+
+    The session persists its AI key and per-file state under `session_dir`
+    (default: <repo>/.vouch/attribution/<session_id>), with the private key
+    written 0600.
+    """
+
+    def __init__(
+        self,
+        session_dir: str | os.PathLike[str],
+        ai_did: Optional[str] = None,
+        ai_private_key_jwk: Optional[str] = None,
+        ai_public_key_jwk: Optional[str] = None,
+        model: Optional[str] = None,
+    ):
+        self.dir = Path(session_dir)
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.model = model
+        self._files: Dict[str, _FileState] = {}
+
+        if ai_did and ai_private_key_jwk and ai_public_key_jwk:
+            self.ai_did = ai_did
+            self.ai_private_key_jwk = ai_private_key_jwk
+            self.ai_public_key_jwk = ai_public_key_jwk
+        else:
+            self._load_or_create_ai_identity()
+
+        self._priv = _priv_from_jwk(self.ai_private_key_jwk)
+        self._load_state()
+
+    # -- AI session identity ------------------------------------------------
+
+    def _identity_path(self) -> Path:
+        return self.dir / "ai-session.json"
+
+    def _load_or_create_ai_identity(self) -> None:
+        path = self._identity_path()
+        if path.exists():
+            data = json.loads(path.read_text())
+            self.ai_did = data["did"]
+            self.ai_private_key_jwk = data["privateKeyJwk"]
+            self.ai_public_key_jwk = data["publicKeyJwk"]
+            return
+        # A fresh ephemeral did:key for this session. In a stronger deployment
+        # this key is held by the Identity Sidecar or delegated from the AI
+        # vendor's root; here it is generated locally and stored 0600.
+        ident = generate_identity()
+        self.ai_did = ident.did or _did_key_from_pub_jwk(ident.public_key_jwk)
+        self.ai_private_key_jwk = ident.private_key_jwk
+        self.ai_public_key_jwk = ident.public_key_jwk
+        path.write_text(json.dumps({
+            "did": self.ai_did,
+            "privateKeyJwk": self.ai_private_key_jwk,
+            "publicKeyJwk": self.ai_public_key_jwk,
+            "model": self.model,
+        }))
+        try:
+            path.chmod(stat.S_IRUSR | stat.S_IWUSR)  # 0600
+        except OSError:  # pragma: no cover - non-POSIX
+            pass
+
+    # -- persisted per-file state ------------------------------------------
+
+    def _state_path(self) -> Path:
+        return self.dir / "state.json"
+
+    def _load_state(self) -> None:
+        path = self._state_path()
+        if not path.exists():
+            return
+        data = json.loads(path.read_text())
+        for rel, st in data.get("files", {}).items():
+            self._files[rel] = _FileState(snapshot=st["snapshot"], authorship=st["authorship"])
+
+    def _save_state(self) -> None:
+        data = {"files": {
+            rel: {"snapshot": fs.snapshot, "authorship": fs.authorship}
+            for rel, fs in self._files.items()
+        }}
+        self._state_path().write_text(json.dumps(data))
+
+    # -- recording AI edits -------------------------------------------------
+
+    def record_edit(
+        self,
+        path: str,
+        after_content: str,
+        before_content: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Record that the AI assistant produced `after_content` for `path`,
+        having started from `before_content` (the assistant's Edit old_string
+        context, or the prior session snapshot, or empty for a new file).
+
+        Returns a signed authorship attestation for this edit.
+        """
+        model = model or self.model
+        prior_state = self._files.get(path)
+        snapshot = prior_state.snapshot if prior_state else None
+        snapshot_tags = prior_state.authorship if prior_state else []
+        if before_content is None:
+            before_content = snapshot if snapshot is not None else ""
+
+        # Step 1: reconcile any human drift. If the file changed between the
+        # last AI edit and this one without coming through the assistant, those
+        # lines are the human's. This aligns authorship to `before_content`.
+        if snapshot is not None and before_content != snapshot:
+            interim = _retag(snapshot, before_content, snapshot_tags, None)
+        elif snapshot is not None:
+            interim = snapshot_tags
+        else:
+            interim = [{"source": SOURCE_PREEXISTING, "model": None}
+                       for _ in _split_lines(before_content)]
+
+        # Step 2: tag the assistant's own change as AI.
+        authorship = _retag(
+            before_content,
+            after_content,
+            interim,
+            {"source": SOURCE_AI, "model": model},
+        )
+        self._files[path] = _FileState(snapshot=after_content, authorship=authorship)
+        self._save_state()
+
+        attestation = {
+            "@context": CONTEXT,
+            "type": ATTESTATION_TYPE,
+            "session": self.ai_did,
+            "path": path,
+            "model": model,
+            "sha256": _sha256_text(after_content),
+            "aiLines": _ranges_for_source(authorship, SOURCE_AI),
+            "recordedAt": _now_iso(),
+        }
+        proof = data_integrity.build_proof(
+            attestation, self._priv, f"{self.ai_did}#attribution"
+        )
+        attestation["proof"] = proof
+        self._append_ledger(attestation)
+        return attestation
+
+    def _append_ledger(self, attestation: Dict[str, Any]) -> None:
+        with (self.dir / "ledger.jsonl").open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(attestation) + "\n")
+
+    # -- finalising into a signed manifest ---------------------------------
+
+    def finalize(
+        self,
+        files: Dict[str, str],
+        human_signer,
+        commit: str = "working-tree",
+    ) -> Dict[str, Any]:
+        """
+        Build and sign the Attribution Manifest for `files` (a mapping of path
+        -> final committed content). Any line that changed on disk since the
+        last AI edit is attributed to the human. `human_signer` is a
+        vouch.Signer; it signs the whole manifest with the human's key.
+        """
+        manifest_files: List[Dict[str, Any]] = []
+        ai_attestations: List[Dict[str, Any]] = []
+
+        for path, final_content in files.items():
+            st = self._files.get(path)
+            if st is None:
+                # File the AI never touched: entirely the human's, or
+                # preexisting if it equals nothing we tracked. Mark as human.
+                authorship = [{"source": SOURCE_HUMAN, "model": None}
+                              for _ in _split_lines(final_content)]
+            else:
+                # Residual diff: snapshot -> final. Changed lines = human.
+                authorship = _retag(st.snapshot, final_content, st.authorship, None)
+                # Re-sign the AI view of this file as it stood at last AI edit.
+                att = {
+                    "@context": CONTEXT,
+                    "type": ATTESTATION_TYPE,
+                    "session": self.ai_did,
+                    "path": path,
+                    "model": self.model,
+                    "sha256": _sha256_text(final_content),
+                    "aiLines": _ranges_for_source(authorship, SOURCE_AI),
+                    "recordedAt": _now_iso(),
+                }
+                att["proof"] = data_integrity.build_proof(
+                    att, self._priv, f"{self.ai_did}#attribution"
+                )
+                if att["aiLines"]:
+                    ai_attestations.append(att)
+
+            regions = _collapse_regions(authorship, human_signer.get_did(), self.ai_did)
+            manifest_files.append({
+                "path": path,
+                "sha256": _sha256_text(final_content),
+                "lineCount": len(_split_lines(final_content)),
+                "regions": regions,
+            })
+
+        manifest = {
+            "@context": CONTEXT,
+            "type": MANIFEST_TYPE,
+            "commit": commit,
+            "createdBy": human_signer.get_did(),
+            "aiSession": {
+                "did": self.ai_did,
+                "model": self.model,
+                "publicKeyJwk": json.loads(self.ai_public_key_jwk),
+            },
+            "files": manifest_files,
+            "aiAttestations": ai_attestations,
+            "createdAt": _now_iso(),
+        }
+        human_priv = _priv_from_jwk(_signer_private_jwk(human_signer))
+        manifest["proof"] = data_integrity.build_proof(
+            manifest, human_priv, f"{human_signer.get_did()}#vouch"
+        )
+        return manifest
+
+
+def _signer_private_jwk(human_signer) -> str:
+    """Pull the private JWK out of a vouch.Signer for proof building."""
+    key = getattr(human_signer, "_key", None)
+    if key is None:
+        raise ValueError("human_signer does not expose a private key")
+    return key.export_private() if hasattr(key, "export_private") else key.export()
+
+
+# ----------------------------------------------------------------------------
+# Region helpers.
+# ----------------------------------------------------------------------------
+
+def _ranges_for_source(authorship: List[Dict[str, Optional[str]]], source: str) -> List[List[int]]:
+    """1-based inclusive [start, end] line ranges matching `source`."""
+    ranges: List[List[int]] = []
+    start: Optional[int] = None
+    for idx, tag in enumerate(authorship, start=1):
+        if tag["source"] == source:
+            if start is None:
+                start = idx
+        else:
+            if start is not None:
+                ranges.append([start, idx - 1])
+                start = None
+    if start is not None:
+        ranges.append([start, len(authorship)])
+    return ranges
+
+
+def _collapse_regions(
+    authorship: List[Dict[str, Optional[str]]],
+    human_did: str,
+    ai_did: str,
+) -> List[Dict[str, Any]]:
+    """Collapse consecutive same-author lines into manifest regions."""
+    regions: List[Dict[str, Any]] = []
+    cur: Optional[Dict[str, Any]] = None
+    for idx, tag in enumerate(authorship, start=1):
+        source = tag["source"]
+        if source == SOURCE_AI:
+            author = ai_did
+        elif source == SOURCE_HUMAN:
+            author = human_did
+        else:
+            author = None
+        key = (source, author, tag.get("model"))
+        if cur is not None and cur["_key"] == key:
+            cur["endLine"] = idx
+        else:
+            if cur is not None:
+                cur.pop("_key")
+                regions.append(cur)
+            cur = {
+                "_key": key,
+                "startLine": idx,
+                "endLine": idx,
+                "source": source,
+                "author": author,
+                "model": tag.get("model"),
+            }
+    if cur is not None:
+        cur.pop("_key")
+        regions.append(cur)
+    return regions
+
+
+# ----------------------------------------------------------------------------
+# Verification and blame.
+# ----------------------------------------------------------------------------
+
+@dataclass
+class VerificationResult:
+    ok: bool
+    reasons: List[str] = field(default_factory=list)
+
+
+def verify_manifest(
+    manifest: Dict[str, Any],
+    human_public_key_jwk: str,
+    ai_public_key_jwk: Optional[str] = None,
+    files_on_disk: Optional[Dict[str, str]] = None,
+) -> VerificationResult:
+    """
+    Verify an Attribution Manifest:
+
+      1. The human Data Integrity proof over the whole manifest.
+      2. Every AI attestation against the AI-session key.
+      3. Every AI region in the manifest is backed by an AI attestation
+         (an AI region cannot exist without the AI signature).
+      4. Regions cover the whole file with no gaps or overlaps (completeness,
+         so a buggy region cannot hide as unattributed).
+      5. If `files_on_disk` is given, file hashes match the current bytes.
+    """
+    reasons: List[str] = []
+
+    # 1. Human proof.
+    try:
+        if not data_integrity.verify_proof(manifest, _pub_from_jwk(human_public_key_jwk)):
+            reasons.append("human proof signature invalid")
+    except Exception as exc:  # malformed proof
+        reasons.append(f"human proof error: {exc}")
+
+    ai_pub_jwk = ai_public_key_jwk
+    if ai_pub_jwk is None:
+        sess = manifest.get("aiSession", {})
+        if sess.get("publicKeyJwk"):
+            ai_pub_jwk = json.dumps(sess["publicKeyJwk"])
+
+    # 2. AI attestations.
+    ai_covered: Dict[str, List[Tuple[int, int]]] = {}
+    if manifest.get("aiAttestations"):
+        if ai_pub_jwk is None:
+            reasons.append("AI attestations present but no AI public key to check them")
+        else:
+            ai_pub = _pub_from_jwk(ai_pub_jwk)
+            for att in manifest["aiAttestations"]:
+                try:
+                    if not data_integrity.verify_proof(att, ai_pub):
+                        reasons.append(f"AI attestation proof invalid for {att.get('path')}")
+                        continue
+                except Exception as exc:
+                    reasons.append(f"AI attestation error for {att.get('path')}: {exc}")
+                    continue
+                ai_covered.setdefault(att["path"], []).extend(
+                    (r[0], r[1]) for r in att.get("aiLines", [])
+                )
+
+    # 3, 4, 5 per file.
+    for f in manifest.get("files", []):
+        path = f["path"]
+        regions = sorted(f.get("regions", []), key=lambda r: r["startLine"])
+        # Completeness + no overlap.
+        expected = 1
+        for r in regions:
+            if r["startLine"] != expected:
+                reasons.append(f"{path}: gap or overlap at line {expected}")
+            expected = r["endLine"] + 1
+        if f.get("lineCount", expected - 1) != expected - 1:
+            reasons.append(f"{path}: regions do not cover all {f.get('lineCount')} lines")
+        # AI regions must be backed by an attestation.
+        backed = ai_covered.get(path, [])
+        for r in regions:
+            if r["source"] == SOURCE_AI:
+                if not _within_any(r["startLine"], r["endLine"], backed):
+                    reasons.append(
+                        f"{path}: AI region {r['startLine']}-{r['endLine']} "
+                        "has no signed AI attestation"
+                    )
+        # Content hash.
+        if files_on_disk is not None and path in files_on_disk:
+            if _sha256_text(files_on_disk[path]) != f.get("sha256"):
+                reasons.append(f"{path}: content hash does not match current file")
+
+    return VerificationResult(ok=not reasons, reasons=reasons)
+
+
+def _within_any(start: int, end: int, ranges: List[Tuple[int, int]]) -> bool:
+    for a, b in ranges:
+        if a <= start and end <= b:
+            return True
+    # Allow union coverage across multiple attested ranges.
+    covered = set()
+    for a, b in ranges:
+        covered.update(range(a, b + 1))
+    return all(line in covered for line in range(start, end + 1))
+
+
+def blame(manifest: Dict[str, Any], path: str) -> List[Dict[str, Any]]:
+    """
+    Return per-line authorship for `path`: a list of
+    {"line": n, "source": ..., "author": ..., "model": ...}.
+    """
+    out: List[Dict[str, Any]] = []
+    for f in manifest.get("files", []):
+        if f["path"] != path:
+            continue
+        for r in f.get("regions", []):
+            for line in range(r["startLine"], r["endLine"] + 1):
+                out.append({
+                    "line": line,
+                    "source": r["source"],
+                    "author": r.get("author"),
+                    "model": r.get("model"),
+                })
+    return out
+
+
+def summarize(manifest: Dict[str, Any]) -> Dict[str, Any]:
+    """Aggregate line counts by source across all files."""
+    totals = {SOURCE_AI: 0, SOURCE_HUMAN: 0, SOURCE_PREEXISTING: 0}
+    for f in manifest.get("files", []):
+        for r in f.get("regions", []):
+            n = r["endLine"] - r["startLine"] + 1
+            totals[r["source"]] = totals.get(r["source"], 0) + n
+    total = sum(totals.values()) or 1
+    return {
+        "lines": totals,
+        "aiPercent": round(100 * totals[SOURCE_AI] / total, 1),
+        "humanPercent": round(100 * totals[SOURCE_HUMAN] / total, 1),
+    }

--- a/vouch/attribution_cli.py
+++ b/vouch/attribution_cli.py
@@ -13,9 +13,9 @@ from . import attribution as attr
 
 
 # ANSI styling, matched to the rest of the CLI's tone.
-_AI = "\033[95m"      # magenta for machine
-_HU = "\033[96m"      # cyan for human
-_PRE = "\033[2m"      # dim for preexisting
+_AI = "\033[95m"  # magenta for machine
+_HU = "\033[96m"  # cyan for human
+_PRE = "\033[2m"  # dim for preexisting
 _OK = "\033[92m"
 _BAD = "\033[91m"
 _END = "\033[0m"
@@ -25,7 +25,9 @@ def _repo_root() -> Path:
     try:
         out = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         )
         return Path(out.stdout.strip())
     except Exception:
@@ -37,7 +39,9 @@ def _session_dir(session: Optional[str] = None) -> Path:
     return _repo_root() / ".vouch" / "attribution" / sid
 
 
-def _open_session(session: Optional[str] = None, model: Optional[str] = None) -> attr.AttributionSession:
+def _open_session(
+    session: Optional[str] = None, model: Optional[str] = None
+) -> attr.AttributionSession:
     return attr.AttributionSession(_session_dir(session), model=model)
 
 
@@ -56,6 +60,7 @@ def _rel(path: str) -> str:
 # ---------------------------------------------------------------------------
 # record / hook
 # ---------------------------------------------------------------------------
+
 
 def cmd_attr_record(args) -> int:
     """Record one AI edit (scripting / testing entry point)."""
@@ -111,6 +116,7 @@ def cmd_attr_hook(args) -> int:
 # finalize
 # ---------------------------------------------------------------------------
 
+
 def _load_human_signer():
     from .signer import Signer
     from .keys import KeyManager
@@ -118,7 +124,9 @@ def _load_human_signer():
     try:
         did = subprocess.run(
             ["git", "config", "--get", "vouch.did"],
-            capture_output=True, text=True, check=True,
+            capture_output=True,
+            text=True,
+            check=True,
         ).stdout.strip()
     except Exception:
         did = ""
@@ -157,12 +165,17 @@ def cmd_attr_finalize(args) -> int:
 # blame / verify
 # ---------------------------------------------------------------------------
 
+
 def _load_manifest(args) -> dict:
-    path = Path(args.manifest) if args.manifest else _session_dir(
-        getattr(args, "session", None)
-    ) / "manifest.json"
+    path = (
+        Path(args.manifest)
+        if args.manifest
+        else _session_dir(getattr(args, "session", None)) / "manifest.json"
+    )
     if not path.exists():
-        raise SystemExit(f"{_BAD}No manifest at {path}.{_END} Run `vouch attribute finalize` first.")
+        raise SystemExit(
+            f"{_BAD}No manifest at {path}.{_END} Run `vouch attribute finalize` first."
+        )
     return json.loads(path.read_text())
 
 
@@ -197,13 +210,13 @@ def cmd_attr_verify(args) -> int:
         human_pub = _read(args.human_key)
     else:
         from .keys import KeyManager
+
         try:
             ident = KeyManager().load_identity(manifest["createdBy"])
             human_pub = ident.public_key_jwk
         except Exception:
             raise SystemExit(
-                f"{_BAD}Need the human public key to verify.{_END} "
-                "Pass --human-key <file.jwk>."
+                f"{_BAD}Need the human public key to verify.{_END} Pass --human-key <file.jwk>."
             )
     files = None
     if args.check_files:
@@ -223,6 +236,7 @@ def cmd_attr_verify(args) -> int:
 # ---------------------------------------------------------------------------
 # argparse wiring (called from cli.py)
 # ---------------------------------------------------------------------------
+
 
 def register(subparsers) -> None:
     p = subparsers.add_parser(

--- a/vouch/attribution_cli.py
+++ b/vouch/attribution_cli.py
@@ -1,0 +1,278 @@
+"""CLI handlers for `vouch attribute` (per-region human/AI code attribution)."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Optional
+
+from . import attribution as attr
+
+
+# ANSI styling, matched to the rest of the CLI's tone.
+_AI = "\033[95m"      # magenta for machine
+_HU = "\033[96m"      # cyan for human
+_PRE = "\033[2m"      # dim for preexisting
+_OK = "\033[92m"
+_BAD = "\033[91m"
+_END = "\033[0m"
+
+
+def _repo_root() -> Path:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True,
+        )
+        return Path(out.stdout.strip())
+    except Exception:
+        return Path.cwd()
+
+
+def _session_dir(session: Optional[str] = None) -> Path:
+    sid = session or os.environ.get("VOUCH_ATTRIBUTION_SESSION", "current")
+    return _repo_root() / ".vouch" / "attribution" / sid
+
+
+def _open_session(session: Optional[str] = None, model: Optional[str] = None) -> attr.AttributionSession:
+    return attr.AttributionSession(_session_dir(session), model=model)
+
+
+def _read(path: str) -> str:
+    p = Path(path)
+    return p.read_text(encoding="utf-8") if p.exists() else ""
+
+
+def _rel(path: str) -> str:
+    try:
+        return str(Path(path).resolve().relative_to(_repo_root()))
+    except Exception:
+        return path
+
+
+# ---------------------------------------------------------------------------
+# record / hook
+# ---------------------------------------------------------------------------
+
+def cmd_attr_record(args) -> int:
+    """Record one AI edit (scripting / testing entry point)."""
+    after = args.after if args.after is not None else _read(args.after_file)
+    before = None
+    if args.before is not None:
+        before = args.before
+    elif args.before_file:
+        before = _read(args.before_file)
+    session = _open_session(args.session, args.model)
+    session.record_edit(_rel(args.path), after, before, model=args.model)
+    print(f"recorded AI edit: {_rel(args.path)}")
+    return 0
+
+
+def cmd_attr_hook(args) -> int:
+    """
+    Read a Claude Code PostToolUse event from stdin and record the AI edit.
+    Wire it to Edit and Write. Never fails the tool call: on any problem it
+    exits 0 so the assistant is not disrupted.
+    """
+    try:
+        event = json.load(sys.stdin)
+    except Exception:
+        return 0
+    try:
+        tool = event.get("tool_name", "")
+        tin = event.get("tool_input", {}) or {}
+        path = tin.get("file_path")
+        if not path or tool not in ("Edit", "Write", "MultiEdit"):
+            return 0
+        rel = _rel(path)
+        after = _read(path)  # PostToolUse fires after the edit is applied
+        before: Optional[str] = None
+        if tool == "Edit":
+            old = tin.get("old_string", "")
+            new = tin.get("new_string", "")
+            if old or new:
+                # Reconstruct the pre-edit content so the new_string lines are
+                # diffed as AI-authored.
+                before = after.replace(new, old, 1) if new else after
+        elif tool == "Write":
+            before = None  # session falls back to last snapshot or empty
+        model = event.get("model") or os.environ.get("VOUCH_AI_MODEL")
+        session = _open_session(args.session, model)
+        session.record_edit(rel, after, before, model=model)
+    except Exception:
+        return 0  # never break the assistant
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# finalize
+# ---------------------------------------------------------------------------
+
+def _load_human_signer():
+    from .signer import Signer
+    from .keys import KeyManager
+
+    try:
+        did = subprocess.run(
+            ["git", "config", "--get", "vouch.did"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except Exception:
+        did = ""
+    if not did:
+        raise SystemExit(
+            f"{_BAD}No Vouch identity configured for git.{_END} "
+            "Run `vouch git init` first, or set git config vouch.did."
+        )
+    ident = KeyManager().load_identity(did)
+    return Signer(private_key=ident.private_key_jwk, did=ident.did)
+
+
+def cmd_attr_finalize(args) -> int:
+    session = _open_session(args.session)
+    if not session._files:
+        print("No AI edits recorded for this session; nothing to finalize.")
+        return 0
+    signer = _load_human_signer()
+    files: Dict[str, str] = {}
+    for rel in session._files:
+        files[rel] = _read(str(_repo_root() / rel))
+    manifest = session.finalize(files, signer, commit=args.commit)
+
+    out = Path(args.out) if args.out else _session_dir(args.session) / "manifest.json"
+    out.write_text(json.dumps(manifest, indent=2))
+    s = attr.summarize(manifest)
+    print(f"{_OK}Attribution manifest written:{_END} {out}")
+    print(f"  files      : {len(manifest['files'])}")
+    print(f"  {_AI}AI lines{_END}   : {s['lines'][attr.SOURCE_AI]} ({s['aiPercent']}%)")
+    print(f"  {_HU}human lines{_END}: {s['lines'][attr.SOURCE_HUMAN]} ({s['humanPercent']}%)")
+    print(f"  signed by  : {manifest['createdBy']}  +  {manifest['aiSession']['did']}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# blame / verify
+# ---------------------------------------------------------------------------
+
+def _load_manifest(args) -> dict:
+    path = Path(args.manifest) if args.manifest else _session_dir(
+        getattr(args, "session", None)
+    ) / "manifest.json"
+    if not path.exists():
+        raise SystemExit(f"{_BAD}No manifest at {path}.{_END} Run `vouch attribute finalize` first.")
+    return json.loads(path.read_text())
+
+
+def cmd_attr_blame(args) -> int:
+    manifest = _load_manifest(args)
+    rel = _rel(args.path)
+    lines = attr.blame(manifest, rel)
+    if not lines:
+        print(f"No attribution for {rel} in this manifest.")
+        return 1
+    content = _read(str(_repo_root() / rel)).split("\n")
+    for entry in lines:
+        n = entry["line"]
+        src = entry["source"]
+        text = content[n - 1] if n - 1 < len(content) else ""
+        if src == attr.SOURCE_AI:
+            tag = f"{_AI}AI  {_END}"
+        elif src == attr.SOURCE_HUMAN:
+            tag = f"{_HU}human{_END}"
+        else:
+            tag = f"{_PRE}prior{_END}"
+        print(f"{tag} {n:>4} | {text}")
+    return 0
+
+
+def cmd_attr_verify(args) -> int:
+    manifest = _load_manifest(args)
+    human_pub = None
+    # Human public key: from --human-key, else resolve from git DID document is
+    # out of scope here; require the key or read from the local identity.
+    if args.human_key:
+        human_pub = _read(args.human_key)
+    else:
+        from .keys import KeyManager
+        try:
+            ident = KeyManager().load_identity(manifest["createdBy"])
+            human_pub = ident.public_key_jwk
+        except Exception:
+            raise SystemExit(
+                f"{_BAD}Need the human public key to verify.{_END} "
+                "Pass --human-key <file.jwk>."
+            )
+    files = None
+    if args.check_files:
+        files = {f["path"]: _read(str(_repo_root() / f["path"])) for f in manifest["files"]}
+    res = attr.verify_manifest(manifest, human_pub, files_on_disk=files)
+    if res.ok:
+        s = attr.summarize(manifest)
+        print(f"{_OK}VERIFIED{_END}  human + AI signatures valid, regions complete.")
+        print(f"  {_AI}AI{_END} {s['aiPercent']}%   {_HU}human{_END} {s['humanPercent']}%")
+        return 0
+    print(f"{_BAD}FAILED{_END}")
+    for r in res.reasons:
+        print(f"  - {r}")
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# argparse wiring (called from cli.py)
+# ---------------------------------------------------------------------------
+
+def register(subparsers) -> None:
+    p = subparsers.add_parser(
+        "attribute",
+        help="Per-region human/AI code authorship attribution (PAD-061)",
+    )
+    sub = p.add_subparsers(dest="attr_command", help="Attribution commands")
+
+    pr = sub.add_parser("record", help="Record one AI edit")
+    pr.add_argument("path")
+    pr.add_argument("--after")
+    pr.add_argument("--after-file")
+    pr.add_argument("--before")
+    pr.add_argument("--before-file")
+    pr.add_argument("--model")
+    pr.add_argument("--session")
+
+    ph = sub.add_parser("hook", help="Record from a Claude Code PostToolUse event on stdin")
+    ph.add_argument("--session")
+
+    pf = sub.add_parser("finalize", help="Sign the attribution manifest for this session")
+    pf.add_argument("--commit", default="working-tree")
+    pf.add_argument("--out")
+    pf.add_argument("--session")
+
+    pb = sub.add_parser("blame", help="Show per-line authorship for a file")
+    pb.add_argument("path")
+    pb.add_argument("--manifest")
+    pb.add_argument("--session")
+
+    pv = sub.add_parser("verify", help="Verify an attribution manifest")
+    pv.add_argument("--manifest")
+    pv.add_argument("--human-key", help="Human public key JWK file")
+    pv.add_argument("--check-files", action="store_true", help="Compare hashes to files on disk")
+    pv.add_argument("--session")
+
+    return p
+
+
+def dispatch(args, parser_help) -> int:
+    cmd = getattr(args, "attr_command", None)
+    if cmd == "record":
+        return cmd_attr_record(args)
+    if cmd == "hook":
+        return cmd_attr_hook(args)
+    if cmd == "finalize":
+        return cmd_attr_finalize(args)
+    if cmd == "blame":
+        return cmd_attr_blame(args)
+    if cmd == "verify":
+        return cmd_attr_verify(args)
+    parser_help()
+    return 0

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -1343,6 +1343,7 @@ def main() -> int:
     )
 
     from . import attribution_cli
+
     p_attr = attribution_cli.register(subparsers)
 
     args = parser.parse_args()
@@ -1377,6 +1378,7 @@ def main() -> int:
         return cmd_scan(args)
     elif args.command == "attribute":
         from . import attribution_cli
+
         return attribution_cli.dispatch(args, p_attr.print_help)
     else:
         parser.print_help()

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -1342,6 +1342,9 @@ def main() -> int:
         help="Exit with non-zero status when any finding is at or above this severity (default: critical)",
     )
 
+    from . import attribution_cli
+    p_attr = attribution_cli.register(subparsers)
+
     args = parser.parse_args()
 
     setup_logging(args.verbose if hasattr(args, "verbose") else False)
@@ -1372,6 +1375,9 @@ def main() -> int:
             return 0
     elif args.command == "scan":
         return cmd_scan(args)
+    elif args.command == "attribute":
+        from . import attribution_cli
+        return attribution_cli.dispatch(args, p_attr.print_help)
     else:
         parser.print_help()
         return 0

--- a/website-agent/backend/knowledge/agent-trust-index.md
+++ b/website-agent/backend/knowledge/agent-trust-index.md
@@ -1,0 +1,40 @@
+# The Agent Trust Index
+
+The Agent Trust Index is an open benchmark published with Vouch. It scans public
+AI agents and scores one question for each: can this agent prove who it is? It
+measures adoption of provable identity in the wild, not whether an agent is good,
+safe, or useful.
+
+## What it measures
+
+Each agent is scored out of 100:
+
+- **60 points** for a resolvable cryptographic identity (a `did:web` that
+  resolves to a DID document).
+- **40 points** for that identity carrying a usable public key.
+
+Grades: A is 90 or above, then B, C, D, and F below 40. An agent with no
+resolvable identity scores zero.
+
+## The first sweep
+
+The first sweep drew its agents from the public Model Context Protocol registry
+on 10 June 2026:
+
+- **11,680** unique agents scanned
+- **157** publish a resolvable `did:web` identity, about **1.3 percent**
+- **98.7 percent** cannot prove who they are at all
+- **69** of those 157 also carry a usable public key, a full grade A
+- the 88 that resolve a DID but carry no usable key land around a C
+
+The agents that can prove themselves are mostly finance and oracle agents: the
+ones that handle money are the first to bother with identity.
+
+## Where to point people
+
+- The Index: `/agent-trust-index/`
+- The methodology: `/agent-trust-index/methodology/`
+
+The takeaway for a developer: provable identity is the floor, and almost nobody
+has it yet. Adding a `did:web` and signing your agent's actions with Vouch puts
+you in the top 1.3 percent on day one.

--- a/website-agent/backend/knowledge/integrations.md
+++ b/website-agent/backend/knowledge/integrations.md
@@ -211,7 +211,7 @@ For human-driven actions in a browser (e.g., signing a contract from
 a web app):
 
 ```ts
-import { VouchClient } from '@vouch-protocol/core';
+import { VouchClient } from '@vouch-protocol-official/sdk';
 
 // In a Chrome extension content script
 const credential = await VouchClient.signFromExtension({

--- a/website-agent/backend/knowledge/post-quantum.md
+++ b/website-agent/backend/knowledge/post-quantum.md
@@ -115,11 +115,11 @@ signed = signer.sign_credential_hybrid(build_vouch_credential(...))
 ### TypeScript
 
 ```bash
-npm install @vouch-protocol/core @noble/post-quantum
+npm install @vouch-protocol-official/sdk @noble/post-quantum
 ```
 
 ```ts
-import { Signer, buildHybridProof, generateMLDSA44KeyPair } from '@vouch-protocol/core';
+import { Signer, buildHybridProof, generateMLDSA44KeyPair } from '@vouch-protocol-official/sdk';
 
 const signer = await Signer.fromDidWithHybrid('did:web:agent.example.com');
 const signed = await signer.signCredentialHybrid(credential);

--- a/website-agent/backend/knowledge/quickstart.md
+++ b/website-agent/backend/knowledge/quickstart.md
@@ -34,11 +34,11 @@ assert is_valid
 ## TypeScript
 
 ```bash
-npm install @vouch-protocol/core
+npm install @vouch-protocol-official/sdk
 ```
 
 ```ts
-import { Signer, Verifier, generateIdentity } from '@vouch-protocol/core';
+import { Signer, Verifier, generateIdentity } from '@vouch-protocol-official/sdk';
 
 const keys = await generateIdentity('agent.example.com');
 const signer = new Signer({ privateKey: keys.privateKeyJwk, did: keys.did });

--- a/website-agent/backend/knowledge/robotics.md
+++ b/website-agent/backend/knowledge/robotics.md
@@ -1,0 +1,34 @@
+# Robots and embodied agents
+
+A robot is an agent with a body. Identity, accountability, and continuous trust
+matter more, not less, when an agent can cause physical harm or move money in
+the real world. Vouch covers the open identity layer for robots; richer
+robot-lifecycle tooling builds on top of it.
+
+## The same primitives apply
+
+- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
+  profile in `docs/specs/`).
+- Delegation: a delegation chain records who authorized the robot, on whose
+  behalf, and within what limits, all verifiable.
+- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
+  behaving now," so a robot has to keep proving itself.
+- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
+  check the status.
+
+## The robot-specific open piece: hardware root of trust
+
+A software agent's key can live in a file. A robot should do better. The
+hardware-root-of-trust profile binds the robot's DID to its secure element (a
+TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
+the signing key and signs the robot's heartbeats, so identity is anchored to the
+physical device, not a config that can be copied. The open `did:vouch:agent`
+profile defines the agent identity scheme; the embodied profile extends it for
+hardware attestation.
+
+## Open vs built on top
+
+The identity, delegation, continuous-trust, and hardware-attestation profiles
+are open Vouch. Operated robot-lifecycle products (lifecycle identity
+management, model-and-config provenance, fleet trust at scale, and similar)
+build on this open layer and are out of scope for the protocol itself.

--- a/website-agent/backend/knowledge/troubleshooting.md
+++ b/website-agent/backend/knowledge/troubleshooting.md
@@ -12,7 +12,7 @@ Cause: the `pqcrypto` dependency needs C headers and a compiler.
 - Ubuntu/Debian: `apt install build-essential libssl-dev` then retry
 - Windows: install Visual C++ Build Tools or use WSL
 
-### `npm install @vouch-protocol/core` fails on Node 16
+### `npm install @vouch-protocol-official/sdk` fails on Node 16
 
 The SDK requires Node 18+. Upgrade Node.
 
@@ -240,7 +240,7 @@ print(canonical.hex())
 
 ```bash
 python -m vouch.jcs canonicalize < credential.json > python.bin
-node -e "console.log(require('@vouch-protocol/core').canonicalize(...))" < credential.json > ts.bin
+node -e "console.log(require('@vouch-protocol-official/sdk').canonicalize(...))" < credential.json > ts.bin
 diff python.bin ts.bin
 ```
 

--- a/website/src/app/agent-trust-index/ati-data.ts
+++ b/website/src/app/agent-trust-index/ati-data.ts
@@ -2,19 +2,19 @@
 // Do not edit by hand; regenerate with scripts/extract-ati.py.
 
 export const ATI_SUMMARY = {
-  "total": 11168,
-  "verifiable": 150,
-  "cannot": 11018,
+  "total": 11680,
+  "verifiable": 157,
+  "cannot": 11523,
   "gradeA": 69,
   "pctVerifiable": 1.3,
   "pctCannot": 98.7,
   "pctCard": 0.9,
   "pctRev": 0.6,
   "pctPq": 0.0,
-  "cardCount": 98,
+  "cardCount": 101,
   "revCount": 72,
   "pqCount": 0,
-  "generated": "7 June 2026"
+  "generated": "10 June 2026"
 } as const;
 
 export type AtiAgent = { grade: string; score: number; name: string; domains: string; method: string; did: string };
@@ -639,6 +639,14 @@ export const ATI_AGENTS: AtiAgent[] = [
   {
     "grade": "C",
     "score": 60,
+    "name": "io.ahel/ahel",
+    "domains": "mcp.ahel.io",
+    "method": "did:web",
+    "did": "did:web:mcp.ahel.io"
+  },
+  {
+    "grade": "C",
+    "score": 60,
     "name": "io.eventify/mcp-server",
     "domains": "amcp.eventify.io",
     "method": "did:web",
@@ -1135,6 +1143,46 @@ export const ATI_AGENTS: AtiAgent[] = [
   {
     "grade": "C",
     "score": 60,
+    "name": "io.github.nexus-api-lab/chrono-mcp",
+    "domains": "chrono-mcp.dokasukadon.workers.dev",
+    "method": "did:web",
+    "did": "did:web:chrono-mcp.dokasukadon.workers.dev"
+  },
+  {
+    "grade": "C",
+    "score": 60,
+    "name": "io.github.nexus-api-lab/codebook-mcp",
+    "domains": "codebook-mcp.dokasukadon.workers.dev",
+    "method": "did:web",
+    "did": "did:web:codebook-mcp.dokasukadon.workers.dev"
+  },
+  {
+    "grade": "C",
+    "score": 60,
+    "name": "io.github.nexus-api-lab/digest-mcp",
+    "domains": "digest-mcp.dokasukadon.workers.dev",
+    "method": "did:web",
+    "did": "did:web:digest-mcp.dokasukadon.workers.dev"
+  },
+  {
+    "grade": "C",
+    "score": 60,
+    "name": "io.github.nexus-api-lab/ident-mcp",
+    "domains": "ident-mcp.dokasukadon.workers.dev",
+    "method": "did:web",
+    "did": "did:web:ident-mcp.dokasukadon.workers.dev"
+  },
+  {
+    "grade": "C",
+    "score": 60,
+    "name": "io.github.nexus-api-lab/textops-mcp",
+    "domains": "textops-mcp.dokasukadon.workers.dev",
+    "method": "did:web",
+    "did": "did:web:textops-mcp.dokasukadon.workers.dev"
+  },
+  {
+    "grade": "C",
+    "score": 60,
     "name": "io.github.nexusforge-tools/mcp-eu-finance",
     "domains": "api.nexusforge.tools",
     "method": "did:web",
@@ -1147,6 +1195,14 @@ export const ATI_AGENTS: AtiAgent[] = [
     "domains": "universalbench-mcp.penantiaglobal.workers.dev",
     "method": "did:web",
     "did": "did:web:universalbench-mcp.penantiaglobal.workers.dev"
+  },
+  {
+    "grade": "C",
+    "score": 60,
+    "name": "io.github.ogasurfproject-jpg/horizon-shield",
+    "domains": "hs-mcp.oga-surf-project.workers.dev",
+    "method": "did:web",
+    "did": "did:web:hs-mcp.oga-surf-project.workers.dev"
   },
   {
     "grade": "C",

--- a/website/src/app/agent-trust-index/methodology/page.tsx
+++ b/website/src/app/agent-trust-index/methodology/page.tsx
@@ -56,7 +56,7 @@ export default function MethodologyPage() {
                         <li>We picked one large, public, current source to start: the Model Context Protocol registry, the closest thing the agent world has to a phone book.</li>
                         <li>We learned its shape by reading its API directly. Each entry gives an agent a name, a title, a description, and the network addresses it serves from.</li>
                         <li>For every agent we pulled out the domains it actually serves from, because a did:web identity has to live at the agent&apos;s own domain. The serving domain is where a real identity would be published, so that is where we look.</li>
-                        <li>For each domain we tried to resolve a did:web identity, meaning we fetched the standard identity document the domain would publish if it had one. We did this with the Vouch Protocol&apos;s own resolver, so the Index is also a live test that Vouch verification works at internet scale.</li>
+                        <li>For each domain we tried to resolve a did:web identity, meaning we fetched the standard identity document the domain would publish if it had one, using the Vouch Protocol&apos;s own resolver. We do not only check the standard location. If it is empty, we read the agent&apos;s published card and resolve any identity it declares there, including a did:web served from a path rather than the root, or a self-contained did:key, so an agent that publishes identity in a less common but still valid place is counted rather than missed. The Index is therefore also a live test that Vouch verification works at internet scale.</li>
                         <li>We scored each agent out of 100. Sixty points for publishing a resolvable identity at all. Forty more for that identity document carrying a usable public key (in either common key format). Ninety or above is an A, then B, C, D, and F below forty. An agent with nothing scores zero, an F.</li>
                         <li>We checked our own work before trusting any number. We confirmed the scorer gives a perfect A to a domain that genuinely publishes an identity (we tested it against real ones in the wild), so the board is not just stuck on F because of a bug. That check caught a real mistake: our first version only recognised one of the two common key formats and would have under-scored a genuine agent. We fixed it and re-checked.</li>
                         <li>We then scanned the whole registry, not a sample. To make that feasible we resolved each unique domain once rather than once per agent, and ran the checks in parallel.</li>
@@ -65,17 +65,19 @@ export default function MethodologyPage() {
 
                     <h2 className="font-serif font-semibold text-[1.4rem] text-ink tracking-tight pt-4">What we found</h2>
                     <p>
-                        Of the unique agents in the registry, about 1.3 percent publish any resolvable
-                        identity, and under 1 percent (69 agents, grade A) are fully verifiable with a
-                        usable key. Roughly 98.7 percent cannot prove who they are at all. The small group
-                        that can are mostly finance and oracle agents, which fits: the agents that handle
-                        money are the first to bother proving identity.
+                        Of the 11,680 unique agents in the registry, 157 (about 1.34 percent) publish a
+                        resolvable identity, which means 98.66 percent cannot prove who they are at all. Of
+                        the 157, only 69 also carry a usable public key (a full A grade); the other 88
+                        publish an identity that resolves but has no key anyone can verify against (a C
+                        grade). The small group that can prove themselves are mostly finance and oracle
+                        agents, which fits: the agents that handle money are the first to bother proving
+                        identity.
                     </p>
 
                     <h2 className="font-serif font-semibold text-[1.4rem] text-ink tracking-tight pt-4">What this measures, and what it does not</h2>
                     <p>We are honest about the edges:</p>
                     <ul className="list-disc pl-6 space-y-3">
-                        <li>This is one source and one signal. An agent could in theory publish identity somewhere we did not look, in which case we undercount. In practice, today, almost none do, so the picture is accurate. As we add sources (agent cards, agent-to-agent directories, on-chain identity) and stronger signals (signed agent cards, verifiable credentials, a named human or organization behind the agent, a revocation method, post-quantum keys), the score gets richer.</li>
+                        <li>This is one source and one main signal. We check the standard did:web location, path-based did:web, and DIDs declared in agent cards, so the undercount is small, but an agent could still publish identity somewhere we did not look (a different DID method, an on-chain identity, a directory we have not added yet), in which case we undercount. So treat the number as a floor, not a ceiling. As we add sources (agent-to-agent directories, on-chain identity) and stronger signals (verifiable credentials, a named human or organization behind the agent, a revocation method, post-quantum keys), the score gets richer.</li>
                         <li>A high score means an agent can prove who it is, not that it is good or safe. Identity is the floor, not the ceiling. You cannot hold an agent accountable for anything if you cannot first tell which agent it was.</li>
                     </ul>
 

--- a/website/src/app/agent-trust-index/page.tsx
+++ b/website/src/app/agent-trust-index/page.tsx
@@ -15,6 +15,7 @@ const TOTAL = ATI_SUMMARY.total.toLocaleString('en-US');
 export const metadata: Metadata = {
     title: 'Agent Trust Index - Vouch Protocol',
     description: `An open benchmark of how many autonomous agents can prove who they are. The first sweep checked ${TOTAL} public agents from the Model Context Protocol registry. ${ATI_SUMMARY.pctCannot}% cannot present a verifiable identity.`,
+    alternates: { canonical: 'https://index.vouch-protocol.com/' },
 };
 
 const HEADLINE = [

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -551,7 +551,7 @@ For containerized deployment, the [Dockerfile](https://github.com/vouch-protocol
       },
       {
         q: 'What about media provenance?',
-        a: `Vouch leaves media provenance to [C2PA](https://c2pa.org) and works alongside it rather than reimplementing it. The \`c2pa-ca/\` directory contains an active Certificate Authority that issues Ed25519-signed C2PA certificates and embeds CBOR manifests in image metadata. The audio path (\`vouch/audio.py\`, 38 KB) implements multi-layer Hamming(7,4) watermarks with psychoacoustic masking for audio signing.`,
+        a: `Vouch leaves media provenance to [C2PA](https://c2pa.org) and works alongside it rather than reimplementing it. \`vouch media sign\` signs an image with native Vouch signing by default, or with C2PA Content Credentials when you pass \`--c2pa\`, and the \`vouch-bridge\` server exposes C2PA image signing over a simple HTTP API. The audio path (\`vouch/audio.py\`) implements multi-layer Hamming(7,4) watermarks with psychoacoustic masking for audio signing.`,
         meta: 'Shipped v1.5.0',
       },
       {
@@ -930,14 +930,24 @@ All four route to the same documentation, so the answers are consistent. Pick th
       },
       {
         q: 'How do I install the Claude Skill?',
-        a: `Two steps inside WSL bash, macOS, or Linux:
+        a: `Two ways, both inside Claude Code (the CLI).
+
+**Marketplace (recommended).** Add the Vouch marketplace, then install the plugin:
 
 \`\`\`bash
-mkdir -p ~/.claude/skills
-cp -r ~/vouch-protocol/claude-skill ~/.claude/skills/vouch-protocol
+/plugin marketplace add vouch-protocol/vouch
+/plugin install vouch-protocol@vouch
 \`\`\`
 
-Restart Claude Code and run \`/skills\` to confirm. You should see \`vouch-protocol\` in the list. Read the Guides section "Installing the Vouch Claude Skill" for screen-by-screen steps and triggers.`,
+Run \`/plugin\` to confirm it is enabled. The skill loads automatically when you mention Vouch.
+
+**Manual.** Copy just the skill folder into your skills directory and restart Claude Code:
+
+\`\`\`bash
+cp -r ~/vouch-protocol/claude-skill/skills/vouch-protocol ~/.claude/skills/vouch-protocol
+\`\`\`
+
+Run \`/skills\` to confirm \`vouch-protocol\` is listed. Read the Guides section "Installing the Vouch Claude Skill" for screen-by-screen steps and triggers.`,
         helpLinks: [{ label: 'Installing the Claude Skill', href: '/help/#claude-skill-install' }],
       },
       {
@@ -977,13 +987,21 @@ The Claude Skill, OpenAI GPT, and Gemini Gem are the **Bring-Your-Own-LLM** rout
       },
       {
         q: 'How do I keep the Claude Skill, GPT, and Gem up to date?',
-        a: `**Claude Skill**: \`git pull\` inside \`~/.claude/skills/vouch-protocol/\` whenever the protocol ships a new cryptosuite or SDK shape. Restart Claude Code; no further action.
+        a: `**Claude Skill**: if you installed from the marketplace, run \`/plugin\` and update the Vouch plugin. If you copied it manually, \`git pull\` inside your clone and re-copy the skill folder. Restart Claude Code; no further action.
 
 **OpenAI Custom GPT**: in the GPT editor, replace the knowledge files (the builder deduplicates by filename). Bump the version note in the Instructions if you forked them.
 
-**Gemini Gem**: same pattern — re-upload the knowledge files in the Gem editor.
+**Gemini Gem**: same pattern, re-upload the knowledge files in the Gem editor.
 
 All three follow the protocol's release cadence. Subscribe to releases on https://github.com/vouch-protocol/vouch.`,
+      },
+      {
+        q: 'Is there an llms.txt for AI coding assistants?',
+        a: `Yes. [vouch-protocol.com/llms.txt](https://vouch-protocol.com/llms.txt) is a plain-text map of the protocol written for AI coding assistants. Point Cursor, Claude, Copilot, or any tool that reads \`llms.txt\` at it and the assistant gets the package names, the core APIs, and the canonical conventions without crawling the whole site. The Claude Skill, OpenAI Custom GPT, and Gemini Gem are the deeper, packaged version of the same knowledge.`,
+      },
+      {
+        q: 'What is the Agent Trust Index?',
+        a: `An open benchmark that scans public AI agents and scores one question for each: can this agent prove who it is? Not whether it is good or safe, just whether it has a cryptographic identity (a \`did:web\`) that resolves to a real public key. The first sweep, drawn from the public Model Context Protocol registry on 10 June 2026, scanned 11,680 agents. Only 157, about 1.3 percent, publish a resolvable identity, and 98.7 percent cannot prove who they are at all. See [the Index](/agent-trust-index/) and its [methodology](/agent-trust-index/methodology/).`,
       },
     ],
   },

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -155,6 +155,12 @@ The credential format for these renewals ships today (it is called SessionVouche
 
 A Vouch delegation chain captures all three steps cryptographically. Each step narrows the permission (the travel agent can find flights but not, say, sell your house). At the end, anyone looking at the action can walk the chain backward to the human who started it. "The AI did it" becomes "Person X delegated to assistant Y who delegated to agent Z, and here is each signed step." Real accountability.`,
       },
+      {
+        q: 'Does Vouch work for robots and embodied agents?',
+        a: `Yes. A robot is an agent with a body, and identity, accountability, and continuous trust matter more, not less, when an agent can cause physical harm. The same Vouch primitives apply: a \`did:vouch:agent\` identity for the robot, delegation chains that record who authorized it and within what limits, and the heartbeat runtime for whether it is still behaving.
+
+The robot-specific open piece is a hardware-root-of-trust profile. The robot's secure element (a TPM, a secure enclave, or an on-board AI module's enclave) anchors its DID and signs its heartbeats, so identity is bound to the physical device rather than a config file. The open \`did:vouch:agent\` profile in [docs/specs/](https://github.com/vouch-protocol/vouch/tree/main/docs/specs) defines the agent identity scheme; the embodied profile extends it for hardware attestation. Richer robot-lifecycle tooling builds on this open layer.`,
+      },
     ],
   },
 
@@ -381,19 +387,39 @@ TypeScript currently has the Amnesia bridge in \`packages/sdk-ts/src/integration
       },
       {
         q: 'Is there a CLI?',
-        a: `Yes. \`pip install vouch-protocol\` installs the \`vouch\` command:
+        a: `Yes. Installing \`vouch-protocol\` (\`pip install vouch-protocol\`) puts a \`vouch\` command on your PATH. It covers agent identity, message signing, signed git commits, media signing, a leaked-key scanner, and human/AI code attribution.
 
-\`\`\`
-vouch init [--domain DOMAIN] [--env]  Generate keypair + DID, store securely
-vouch credential sign [--hybrid]    Sign a Verifiable Credential
-vouch credential verify         Verify a Verifiable Credential
-vouch git init             One-command Git workflow setup
-vouch git status            Show current Git config
-vouch reputation get [--did DID]    Fetch reputation score
-vouch revocation check [--did DID]   Check revocation status
+**Identity and tokens**
+
+- \`vouch init\` generate an agent identity (DID + Ed25519 keypair)
+- \`vouch sign "<message>"\` sign a message or JSON payload, prints a Vouch-Token
+- \`vouch verify <token>\` verify a Vouch-Token
+
+**Git**
+
+- \`vouch git init\` set up SSH commit signing and Vouch trailers
+- \`vouch git status\` show your current git signing config
+- \`vouch git verify\` verify commit signatures against their Vouch-DID trailers
+
+**Media**
+
+- \`vouch media sign <image>\` sign an image (native Vouch by default, or \`--c2pa\`)
+- \`vouch media verify <image>\` verify an image's signature
+
+**Other**
+
+- \`vouch scan [path]\` scan for leaked Vouch private keys (PAD-058)
+- \`vouch attribute ...\` per-region human/AI code authorship attribution
+
+\`\`\`bash
+vouch init
+vouch sign "hello"
+vouch scan .
+vouch git init
+vouch media sign photo.jpg
 \`\`\`
 
-The CLI source is at \`vouch/cli.py\`.`,
+There are also separate helper binaries: \`vouch-mcp\` (MCP server) and \`vouch-bridge\` (media HTTP server), plus a Go \`vouch-sidecar\` for non-Python stacks.`,
         helpLinks: [{ label: 'CLI reference', href: '/help/#cli-reference' }],
       },
       {

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -305,6 +305,205 @@ The Identity Sidecar pattern keeps the private signing key out of the LLM's proc
 This makes prompt-injection key-exfiltration impossible: even if the LLM is jailbroken to leak its context, the key is not in that context. The local-dev sidecar gives you the exact same isolation boundary on your laptop that you will have in production.
 `,
       },
+      {
+        id: 'quickstart-swift',
+        title: 'Swift Quickstart',
+        summary: 'Add the VouchCore Swift package and run a canonicalize-and-verify loop on iOS or macOS. A thin wrapper over the one Rust core.',
+        body: `
+## Install
+
+VouchCore ships through Swift Package Manager. The native code is a prebuilt XCFramework hosted on the \`swift-v0.1.0\` release, so you do not need a Mac toolchain to build the Rust core yourself.
+
+In Xcode use File then Add Package Dependencies and paste the repo URL, or add it to your \`Package.swift\`:
+
+\`\`\`swift
+.package(url: "https://github.com/vouch-protocol/vouch", from: "swift-v0.1.0"),
+// then depend on the product:
+.product(name: "VouchCore", package: "vouch"),
+\`\`\`
+
+Supports iOS 13+ and macOS 12+.
+
+## Canonicalize and verify
+
+Everything runs on device. The \`Vouch\` facade gathers the lower-level UniFFI functions behind a discoverable surface:
+
+\`\`\`swift
+import VouchCore
+
+// RFC 8785 (JCS) canonicalization. Byte-identical to every other Vouch SDK.
+let canon = try Vouch.canonicalize(#"{"b":1,"a":2}"#)   // {"a":2,"b":1}
+
+// Verify a Data Integrity proof (eddsa-jcs-2022) on a signed credential.
+let ok = try Vouch.verifyProof(signedCredentialJson, publicKey: publicKey)
+
+// Proof plus validity window in one call.
+let result = try Vouch.verifyCredential(signedCredentialJson, publicKey: publicKey, now: "2026-04-26T10:02:00Z")
+\`\`\`
+
+\`Vouch.generateEd25519()\` returns a key pair and \`Vouch.signCredential(...)\` attaches the proof. VouchCore is a thin layer over the canonical Rust core via UniFFI, so a credential verified on iOS matches the exact bytes from every other SDK.
+`,
+      },
+      {
+        id: 'quickstart-jvm',
+        title: 'JVM (Java and Kotlin) Quickstart',
+        summary: 'One Gradle coordinate, then canonicalize and verify from Java or Kotlin over the shared Rust core.',
+        body: `
+## Install
+
+\`\`\`kotlin
+// build.gradle.kts
+dependencies { implementation("com.vouchprotocol:vouch-core:0.1.0") }
+\`\`\`
+
+The host native library is bundled inside the jar, so it loads with no extra setup.
+
+## Java
+
+The \`Vouch\` class is a thin JNA layer over the core's C ABI. Binary values are base64 strings; credentials and proofs are JSON strings:
+
+\`\`\`java
+import com.vouchprotocol.core.Vouch;
+
+String canon = Vouch.canonicalize("{\\"b\\":1,\\"a\\":2}");   // {"a":2,"b":1}
+String kp = Vouch.generateEd25519();                       // {seed_b64, public_b64, multikey, did_key}
+String signed = Vouch.signCredential(credentialJson, seedB64, didKey + "#key-1", "2026-04-26T10:00:00Z");
+boolean ok = Vouch.verifyProof(signed, publicB64);
+\`\`\`
+
+## Kotlin
+
+Kotlin can call the same Java class, or use the generated UniFFI binding bundled in the module, which takes native \`ByteArray\` keys instead of base64. Both delegate to the canonical Rust core, so the JVM verifies with the exact same bytes as every other SDK.
+`,
+      },
+      {
+        id: 'quickstart-dotnet',
+        title: '.NET Quickstart',
+        summary: 'dotnet add package, then canonicalize and verify from C# over the shared Rust core.',
+        body: `
+## Install
+
+\`\`\`bash
+dotnet add package VouchProtocol.Core
+\`\`\`
+
+## Canonicalize, sign, verify
+
+The static \`Vouch\` class is a P/Invoke wrapper over the canonical Rust core. Binary values are base64 strings; credentials and proofs are JSON strings:
+
+\`\`\`csharp
+using VouchProtocol.Core;
+
+string canon = Vouch.Canonicalize("{\\"b\\":1,\\"a\\":2}");   // {"a":2,"b":1}
+string kp = Vouch.GenerateEd25519();
+string signed = Vouch.SignCredential(credentialJson, seedB64, didKey + "#key-1", "2026-04-26T10:00:00Z");
+bool ok = Vouch.VerifyProof(signed, publicB64);
+\`\`\`
+
+On error the core returns null and the wrapper throws a \`VouchException\`; the native string is freed for you. .NET verifies with the exact same bytes as every other SDK.
+`,
+      },
+      {
+        id: 'quickstart-c',
+        title: 'C and C++ Quickstart',
+        summary: 'Link the C bindings shipped with the core. Every returned string is freed with vouch_string_free.',
+        body: `
+## What you get
+
+These are the C bindings shipped with the core, not a reimplementation. The canonical Rust core exposes a plain C ABI through a cbindgen header. The package gives you \`include/vouch_core.h\`, a prebuilt \`lib/libvouch_core_uniffi.so\`, an \`examples/example.c\` with a \`Makefile\`, and a \`CMakeLists.txt\`. Anything that can call C links against it, including C++ and .NET P/Invoke.
+
+## Build
+
+\`\`\`bash
+make run     # compiles example.c against ../lib and runs it
+# flags: -I../include  -L../lib -lvouch_core_uniffi
+\`\`\`
+
+## Canonicalize and verify in C
+
+Every value crossing the ABI is a NUL-terminated UTF-8 string: JSON for credentials and proofs, base64 for binary. Returned strings are heap allocated and must be freed with \`vouch_string_free\`. On error a function returns NULL and writes a message into \`err_out\`:
+
+\`\`\`c
+#include "vouch_core.h"
+
+char *err = NULL;
+char *canon = vouch_canonicalize("{\\"b\\":1,\\"a\\":2}", &err);   // {"a":2,"b":1}
+vouch_string_free(canon);
+
+char *res = vouch_verify_proof(signed_credential_json, public_key_b64, &err);  // "true"/"false"
+if (res) vouch_string_free(res); else vouch_string_free(err);
+\`\`\`
+
+The header also exposes \`vouch_sign_credential\`, \`vouch_verify_credential\`, delegation, dual-proof ML-DSA-44 verify, and BitstringStatusList revocation. A credential verified from C matches the exact bytes of every other SDK.
+`,
+      },
+      {
+        id: 'quickstart-wasm',
+        title: 'Browser and Node Quickstart (WebAssembly)',
+        summary: 'npm install the WASM core, initialize it once, then canonicalize and verify in the browser or Node.',
+        body: `
+## Install
+
+\`\`\`bash
+npm install @vouch-protocol-official/core-wasm
+\`\`\`
+
+This is the canonical Rust core compiled to WebAssembly. Binary values are base64 strings; credentials and proofs are JSON strings.
+
+## Browser
+
+\`\`\`js
+import init, * as core from '@vouch-protocol-official/core-wasm';
+await init(); // fetches the .wasm next to the module
+
+core.canonicalize('{"b":1,"a":2}');   // {"a":2,"b":1}
+const kp = JSON.parse(core.generateEd25519());
+const signed = core.signCredential(JSON.stringify(myCredential), kp.seed_b64, kp.did_key + '#key-1', '2026-04-26T10:00:00Z');
+const ok = core.verifyProof(signed, kp.public_b64);   // true
+\`\`\`
+
+## Node.js (ESM)
+
+There is no fetch in Node, so pass the wasm bytes to \`init\`. Key generation and ML-DSA signing also need a CSPRNG; under Node ESM make Web Crypto global first (verification does not need it):
+
+\`\`\`js
+import init, * as core from '@vouch-protocol-official/core-wasm';
+import { readFileSync } from 'fs';
+import { webcrypto } from 'node:crypto';
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+await init({ module_or_path: readFileSync(new URL('@vouch-protocol-official/core-wasm/vouch_core_wasm_bg.wasm', import.meta.url)) });
+\`\`\`
+
+With Next.js App Router, call \`init()\` in a client component before using the API. The WASM build verifies with the exact same bytes as every other SDK.
+`,
+      },
+      {
+        id: 'agent-trust-index',
+        title: 'The Agent Trust Index',
+        summary: 'An open benchmark that scans public AI agents and scores whether each one can prove its identity. The first sweep found 98.7 percent cannot.',
+        body: `
+## What it is
+
+The Agent Trust Index is an open benchmark. It scans public AI agents and scores a single question for each: can this agent prove who it is? Not whether it is good, safe, or useful, just whether it has a cryptographic identity (a \`did:web\`) that resolves to a document carrying a real public key. It measures adoption of provable identity in the wild, not a self-declared registry field.
+
+## The first sweep
+
+The first sweep drew its agents from the public Model Context Protocol registry on 10 June 2026:
+
+- **11,680** unique agents scanned
+- **157** publish a resolvable \`did:web\` identity, about **1.3 percent**
+- **98.7 percent** cannot prove who they are at all
+- **69** of those 157 also carry a usable public key, a full **grade A**
+
+The handful that can prove themselves are mostly finance and oracle agents, which fits: the agents that handle money are the first to bother with identity.
+
+## How scoring works
+
+Each agent is scored out of 100: **60 points** for a resolvable identity, **40 points** for that identity carrying a usable public key. A is 90 or above, then B, C, D, and F below 40. An agent with nothing scores zero. The 88 agents that resolve a DID but carry no usable key land around a C.
+
+The full method is published at [/agent-trust-index/methodology](/agent-trust-index/methodology/). The data is real and the scan is reproducible.
+`,
+      },
     ],
   },
 
@@ -1084,71 +1283,98 @@ The \`FlightRecorder\` logs every allowed and blocked call. Pipe it to your SIEM
         title: 'The vouch Command Reference',
         summary: 'Every subcommand of the vouch CLI, what it does, and a copy-pasteable example.',
         body: `
-## init
+The \`vouch\` command ships with the \`vouch-protocol\` Python package. It groups into five areas: identity, git, media, scan, and attribution. A global \`-v\` / \`--verbose\` flag works on any command.
 
-Generate a new Ed25519 keypair, derive a DID, and store the key securely.
+## Identity and tokens
 
-\`\`\`bash
-vouch init [--domain DOMAIN] [--env]
-\`\`\`
+### vouch init
 
-- \`--domain DOMAIN\` - generates a did:web DID for the given domain
-- Without \`--domain\` - generates a did:key DID
-- \`--env\` - exports the DID and key path as shell env vars
+Generate a new agent identity (a did:vouch DID plus an Ed25519 keypair). By default it prompts for a passphrase, saves the encrypted identity to your local keystore, and prints the public key to put in your vouch.json.
 
-## credential sign
+- \`--domain <D>\` domain to base the DID on (defaults to example.com)
+- \`--env\` print the identity as export VOUCH_DID / VOUCH_PRIVATE_KEY instead of saving to the keystore
 
-Sign a Verifiable Credential.
+### vouch sign "<message>"
 
-\`\`\`bash
-vouch credential sign credential.json
-vouch credential sign credential.json --hybrid  # use hybrid PQ profile
-\`\`\`
+Sign a message and print a Vouch-Token. With no key flags it loads your stored identity (prompting for the passphrase if encrypted); otherwise it reads VOUCH_PRIVATE_KEY / VOUCH_DID from the environment.
 
-## credential verify
+- \`<message>\` the message to sign (positional)
+- \`--json\` parse the message as a JSON payload instead of wrapping it as a string
+- \`--key <JWK>\` private key as JWK JSON
+- \`--did <DID>\` agent DID
+- \`--header\` prefix the output with \`Vouch-Token: \`
 
-Verify a Verifiable Credential file.
+### vouch verify <token>
 
-\`\`\`bash
-vouch credential verify signed.json
-\`\`\`
+Verify a Vouch-Token. With a public key it checks the signature; without one it validates structure only and warns the signature was not verified.
 
-## git init
+- \`<token>\` the token to verify (positional)
+- \`--key <JWK>\` public key as JWK JSON
+- \`--json\` output as JSON
 
-One-command setup of the Vouch git workflow: configures SSH signing, installs commit hooks, and (optionally) injects a CI badge into the README.
+## Git
 
-\`\`\`bash
-cd my-repo
-vouch git init
-\`\`\`
+### vouch git init
 
-## git status
+Export your Vouch identity to an SSH signing key, configure git to sign commits (commit.gpgsign=true, gpg.format=ssh), upload the key to GitHub, and optionally install a commit-trailer hook and README badge.
 
-Show the current Vouch git configuration for this repo.
+- \`--no-trailer\` skip the prepare-commit-msg trailer hook
+- \`--no-badge\` skip the README badge prompt
 
-\`\`\`bash
-vouch git status
-\`\`\`
+### vouch git status
 
-## reputation get
+Show the current Vouch git signing setup: SSH key and fingerprint, the relevant git config, and whether the commit hook is installed.
 
-Fetch a DID's reputation score from the configured backend.
+### vouch git verify [commit]
 
-\`\`\`bash
-vouch reputation get --did did:web:agent.example.com
-\`\`\`
+Verify commit signatures match their Vouch-DID trailers. With no argument it checks recent commits; commits without a trailer are skipped.
 
-## revocation check
+- \`[commit]\` a specific commit hash (optional positional)
+- \`-n\`, \`--count <N>\` number of recent commits to verify (default: 10)
+- \`--strict\` exit non-zero if any commit fails
 
-Check whether a DID is in the revocation registry.
+## Media
 
-\`\`\`bash
-vouch revocation check --did did:web:agent.example.com
-\`\`\`
+### vouch media sign <image>
 
-## Output formats
+Sign an image. Native Vouch signing by default (no certificates), writing a _signed copy plus a sidecar.
 
-All subcommands support \`--json\` for machine-readable output. The default is human-readable. Use \`--env\` to format output as shell exports for scripting.
+- \`<image>\` path to the image (positional)
+- \`-o, --output <path>\`, \`-n, --name <name>\`, \`-e, --email <email>\`, \`--did <DID>\`, \`--key <JWK>\`, \`--title <title>\`
+- \`--pro\` mark the credential PRO (otherwise FREE)
+- \`--c2pa\` use the C2PA industry standard instead of native signing
+
+### vouch media verify <image>
+
+Verify an image's signature. \`--json\` for JSON, \`--c2pa\` to verify a C2PA manifest instead.
+
+## Scan
+
+### vouch scan [path]
+
+Scan a file or directory for Vouch-shaped private key material (the OSS detection stage of PAD-058). A missing path exits with status 2.
+
+- \`[path]\` file or directory (default: current directory)
+- \`--json\` findings as JSON
+- \`--exit-nonzero-on <critical|high|medium|low>\` exit non-zero at or above this severity (default: critical)
+
+## Attribution
+
+\`vouch attribute\` records per-region human/AI code authorship and produces a signed manifest (PAD-061). Subcommands: \`record\`, \`hook\`, \`finalize\`, \`blame\`, \`verify\`; most accept \`--session <id>\`.
+
+- \`vouch attribute record <path>\` record a single AI edit
+- \`vouch attribute hook\` read a Claude Code PostToolUse event from stdin and record the edit
+- \`vouch attribute finalize\` sign the manifest for the session
+- \`vouch attribute blame <path>\` show per-line authorship (AI / human / prior)
+- \`vouch attribute verify\` verify a manifest's signatures and region completeness
+
+## Helper binaries
+
+Separate executables, run directly (not as vouch subcommands):
+
+- \`vouch-mcp\` Model Context Protocol server, exposes Vouch signing and verification to MCP-aware agents
+- \`vouch-bridge\` local media HTTP server for the media flow
+- \`vouch-sidecar\` Go Identity Sidecar. Install with \`go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest\`
 `,
       },
     ],

--- a/website/src/app/onboard/page.tsx
+++ b/website/src/app/onboard/page.tsx
@@ -36,7 +36,7 @@ export default function OnboardPage() {
             each step is unchanged.
           </p>
           <div className="max-w-prose">
-            <CodeBlock code="pip install vouch-protocol && vouch onboard" language="bash" />
+            <CodeBlock code="pip install vouch-protocol && vouch init" language="bash" />
           </div>
         </div>
       </section>

--- a/website/src/app/tools/page.tsx
+++ b/website/src/app/tools/page.tsx
@@ -51,6 +51,11 @@ const GROUPS: Group[] = [
                 start: 'vouch media sign photo.jpg',
             },
             {
+                name: 'vouch attribute',
+                blurb: 'Separate who wrote which line. When an AI assistant and a human both edit a file, it records the lines the AI wrote under the AI key and the lines you wrote under yours, so when a line causes an incident you can prove which of you wrote it.',
+                start: 'vouch attribute blame app.py',
+            },
+            {
                 name: 'The Rogue Agent demo',
                 blurb: 'A sixty-second demo: a real agent is accepted, an impersonator is rejected, a tampered credential is rejected. All local, no setup.',
                 start: 'python examples/00_the_rogue_agent.py',
@@ -66,6 +71,11 @@ const GROUPS: Group[] = [
                 name: 'MCP server',
                 blurb: 'A standalone Model Context Protocol server. Any MCP client (Claude Desktop, Cursor, any agent) can create an identity, sign and verify credentials, scan for leaked keys, and decode DIDs, with no extra setup.',
                 start: 'vouch-mcp',
+            },
+            {
+                name: 'Bridge server',
+                blurb: 'A standalone HTTP service (vouch-bridge) for media: C2PA image signing, QR badge overlay, and audio watermarking, behind a simple sign and verify API.',
+                start: 'vouch-bridge',
             },
             {
                 name: 'Identity Sidecar',
@@ -88,9 +98,9 @@ const GROUPS: Group[] = [
         tools: [
             { name: 'Python', blurb: 'The full reference implementation.', start: 'pip install vouch-protocol' },
             { name: 'TypeScript', blurb: 'For the browser and Node.', start: 'npm i @vouch-protocol-official/sdk' },
-            { name: 'Go', blurb: 'A high-throughput signing sidecar.', start: 'go-sidecar' },
+            { name: 'Go', blurb: 'A high-throughput signing sidecar.', start: 'go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest' },
             { name: 'Rust', blurb: 'The shared core that every wrapper is built on.', start: 'cargo add vouch-core' },
-            { name: 'Java and Kotlin', blurb: 'On the JVM.', start: 'com.vouchprotocol:vouch-core-jvm' },
+            { name: 'Java and Kotlin', blurb: 'On the JVM.', start: 'com.vouchprotocol:vouch-core' },
             { name: '.NET', blurb: 'For C#.', start: 'VouchProtocol.Core', tag: 'Preview' },
             { name: 'Swift', blurb: 'For iOS and macOS.', start: 'VouchCore', tag: 'Preview' },
             { name: 'C and WebAssembly', blurb: 'For native, embedded, browser, and edge.', tag: 'Preview' },
@@ -120,6 +130,12 @@ const GROUPS: Group[] = [
                 href: '/help/#gemini-gem-create',
                 hrefLabel: 'How to use →',
             },
+            {
+                name: 'VS Code extension',
+                blurb: 'Sign and verify from inside the editor, scaffold an agent identity, and open the Vouch Assistant without leaving VS Code.',
+                href: 'https://github.com/vouch-protocol/vouch/tree/main/vscode-vouch',
+                hrefLabel: 'On GitHub →',
+            },
         ],
     },
     {
@@ -130,6 +146,7 @@ const GROUPS: Group[] = [
             { name: 'C2PA Content Credentials', blurb: 'Sign images so their origin and edits can be verified.' },
             { name: 'Vouch Sonic', blurb: 'An audio watermark that carries provenance through sound itself.' },
             { name: 'Browser extension', blurb: 'Sign and verify content on the page, for Chrome and Edge.' },
+            { name: 'Mobile capture app', blurb: 'Capture-time signing on a phone, with device-level attestation from the secure enclave, plus Vouch Sonic.' },
         ],
     },
     {
@@ -152,7 +169,7 @@ const GROUPS: Group[] = [
         tools: [
             {
                 name: 'Agent Trust Index',
-                blurb: 'Scans agents in the wild and measures how many can actually prove who they are. In the first sweep of 11,168 public agents, just 1.3% could.',
+                blurb: 'Scans agents in the wild and measures how many can actually prove who they are. In the first sweep of 11,680 public agents, just 1.3% could.',
                 href: '/agent-trust-index/',
                 hrefLabel: 'View the Index →',
             },

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -17,6 +17,7 @@ const FOOTER_GROUPS = [
     links: [
       { label: 'GitHub', href: 'https://github.com/vouch-protocol/vouch', external: true },
       { label: 'Specification', href: 'https://github.com/vouch-protocol/vouch/blob/main/docs/specs/specification-executive-summary.md', external: true },
+      { label: 'Prior Art Disclosures', href: '/disclosures/' },
       { label: 'Conformance Levels', href: '/conformance/' },
       { label: 'Regulatory Mapping', href: '/compliance/' },
       { label: 'Test Vectors', href: 'https://github.com/vouch-protocol/vouch/tree/main/test-vectors', external: true },


### PR DESCRIPTION
Five commits closing the gaps from the FHK (FAQ, Help, Knowledge base, Claude Skill, OpenAI GPT, Gemini Gem) and Tools audit, all build-verified (npm run build, 26 static pages) and tests green.

## What changed
- **Real CLI everywhere.** Replaced the placeholder CLI answers in the FAQ and Help guides with the actual command surface (init, sign, verify, git, media, scan, attribute).
- **Language quickstarts.** Added Swift, JVM, .NET, C, and WebAssembly quickstarts plus an Agent Trust Index guide to the Help section.
- **Robot identity.** Documented robot and embodied-agent identity as an open did:vouch:agent profile in the README and FAQ, mirrored as a knowledge file across the four assistant packages.
- **FHK coverage.** New FAQ entries for the Agent Trust Index and llms.txt. Claude Skill install reworked to the marketplace flow with the manual copy path fixed. Media answer no longer points at the gitignored local CA directory. Disclosure count corrected to 61.
- **vouch attribute (PAD-061).** Wired and committed the per-region human and AI authorship feature (record, hook, finalize, blame, verify) with its defensive disclosure. 9/9 tests pass. This closes the doc-vs-reality gap the FHK pass created by documenting the command.
- **Agent Trust Index KB** mirrored across the Gemini Gem, OpenAI GPT, website agent, and Claude Skill knowledge sets.

## Notes
- This branch is a clean fast-forward of main; the work was committed locally and is targeted here for review before deploy.