### PR TITLE
ci: tag-triggered publish workflows for every language SDK

### DIFF
--- a/.github/workflows/publish-c.yml
+++ b/.github/workflows/publish-c.yml
@@ -1,0 +1,66 @@
+# Build the C/C++ native library for each platform and attach it, with the
+# cbindgen header, to a GitHub Release. There is no universal C package
+# registry, so prebuilt release artifacts are the distribution channel.
+#
+# Trigger: push a tag like `c-v0.1.0`, or run manually (workflow_dispatch).
+# Uses the built-in GITHUB_TOKEN, no extra secret needed.
+name: Publish C/C++ artifacts
+
+on:
+  push:
+    tags: ["c-v*"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            artifact: libvouch_core_uniffi-linux-x86_64.so
+            built: libvouch_core_uniffi.so
+          - os: macos-14
+            artifact: libvouch_core_uniffi-macos-arm64.dylib
+            built: libvouch_core_uniffi.dylib
+          - os: macos-13
+            artifact: libvouch_core_uniffi-macos-x86_64.dylib
+            built: libvouch_core_uniffi.dylib
+          - os: windows-latest
+            artifact: vouch_core_uniffi-windows-x86_64.dll
+            built: vouch_core_uniffi.dll
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build release cdylib
+        working-directory: core/uniffi
+        run: cargo build --release
+      - name: Stage artifact
+        shell: bash
+        run: |
+          mkdir -p out
+          cp "core/uniffi/target/release/${{ matrix.built }}" "out/${{ matrix.artifact }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: out/${{ matrix.artifact }}
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+      - name: Add the cbindgen header
+        run: cp sdks/cpp/include/vouch_core.h artifacts/vouch_core.h
+      - name: Attach to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*
+          fail_on_unmatched_files: true

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -1,0 +1,36 @@
+# Publish the Rust core crates to crates.io.
+#
+# Trigger: push a tag like `rust-v0.1.0`, or run manually (workflow_dispatch).
+# Required repo secret: CARGO_REGISTRY_TOKEN (crates.io API token).
+name: Publish crates.io
+
+on:
+  push:
+    tags: ["rust-v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Validate with cargo publish --dry-run only"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish vouch-core
+        working-directory: core/vouch-core
+        run: |
+          if [ "${{ inputs.dry_run }}" = "true" ]; then
+            cargo publish --dry-run
+          else
+            cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+          fi
+      - name: Publish vouch-core-uniffi
+        if: ${{ inputs.dry_run != true }}
+        working-directory: core/uniffi
+        # vouch-core-uniffi depends on vouch-core, so it publishes second.
+        # cargo waits for the just-published vouch-core to appear in the index.
+        run: cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"

--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,0 +1,44 @@
+# Publish the JVM SDK (com.vouchprotocol:vouch-core) to Maven Central.
+#
+# Trigger: push a tag like `jvm-v0.1.0`, or run manually (workflow_dispatch).
+# Required repo secrets:
+#   CENTRAL_USERNAME, CENTRAL_PASSWORD  - Sonatype Central Portal token
+#   GPG_PRIVATE_KEY                     - ASCII-armored private key (gpg --armor --export-secret-keys)
+#   GPG_PASSPHRASE                      - passphrase for that key
+#   GPG_KEY_ID                          - last 8 hex chars of the key id
+# Maven Central requires the com.vouchprotocol namespace to be verified once
+# in the Central Portal before the first publish.
+name: Publish Maven Central
+
+on:
+  push:
+    tags: ["jvm-v*"]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build native library
+        working-directory: sdks/jvm
+        run: bash build-native.sh
+      - name: Import GPG signing key
+        run: |
+          echo "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --batch --import
+          gpg --batch --pinentry-mode loopback --passphrase "${{ secrets.GPG_PASSPHRASE }}" \
+            --export-secret-keys > "$HOME/.gnupg/secring.gpg"
+      - name: Publish
+        working-directory: sdks/jvm
+        run: |
+          ./gradlew publishMavenPublicationToCentralRepository \
+            -PcentralUsername="${{ secrets.CENTRAL_USERNAME }}" \
+            -PcentralPassword="${{ secrets.CENTRAL_PASSWORD }}" \
+            -Psigning.keyId="${{ secrets.GPG_KEY_ID }}" \
+            -Psigning.password="${{ secrets.GPG_PASSPHRASE }}" \
+            -Psigning.secretKeyRingFile="$HOME/.gnupg/secring.gpg"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,45 @@
+# Publish the JavaScript/TypeScript packages to npm:
+#   @vouch-protocol-official/core-wasm   (core/wasm, built with wasm-pack)
+#   @vouch-protocol-official/sdk         (packages/sdk-ts)
+#   @vouch-protocol-official/api-client  (sdks/clients/typescript)
+#
+# Trigger: push a tag like `npm-v0.1.0`, or run manually (workflow_dispatch).
+# Required repo secret: NPM_TOKEN (npm automation token).
+name: Publish npm
+
+on:
+  push:
+    tags: ["npm-v*"]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - name: Build the WASM core
+        working-directory: core/wasm
+        run: bash build-npm.sh
+      - name: Publish core-wasm
+        working-directory: core/wasm/pkg
+        run: |
+          npm publish --access public || echo "core-wasm already published, continuing"
+      - name: Publish sdk
+        working-directory: packages/sdk-ts
+        run: |
+          npm ci
+          npm publish --access public || echo "sdk: version may already be published, continuing"
+      - name: Publish api-client
+        working-directory: sdks/clients/typescript
+        run: |
+          npm ci
+          npm publish --access public || echo "api-client: version may already be published, continuing"

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,38 @@
+# Publish the .NET SDK (VouchProtocol.Core) to NuGet.org.
+#
+# Trigger: push a tag like `dotnet-v0.1.0`, or run manually (workflow_dispatch).
+# Required repo secret: NUGET_API_KEY (nuget.org API key).
+name: Publish NuGet
+
+on:
+  push:
+    tags: ["dotnet-v*"]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Pack only, do not push"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "8.0.x"
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build native libraries
+        working-directory: sdks/dotnet/VouchCore
+        run: bash build-native.sh
+      - name: Pack
+        working-directory: sdks/dotnet/VouchCore
+        run: dotnet pack -c Release -o ../../../dist-nuget
+      - name: Push to NuGet
+        if: ${{ inputs.dry_run != true }}
+        run: |
+          dotnet nuget push "dist-nuget/*.nupkg" \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,36 @@
+# Publish the Python packages to PyPI:
+#   vouch-protocol     (root pyproject.toml)
+#   vouch-api-client   (sdks/clients/python)
+#   vouch-sdk          (packages/sdk-py)
+#
+# Trigger: push a tag like `py-v0.1.0`, or run manually (workflow_dispatch).
+# Required repo secret: PYPI_API_TOKEN (PyPI API token, scoped or account-wide).
+name: Publish PyPI
+
+on:
+  push:
+    tags: ["py-v*"]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+      - name: Build and upload each package
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          set -e
+          for dir in . sdks/clients/python packages/sdk-py; do
+            echo "==> building $dir"
+            rm -rf "$dir/dist"
+            python -m build "$dir"
+            twine upload --skip-existing "$dir/dist/"*
+          done

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,51 @@
+# Releasing and publishing
+
+Each language SDK publishes from its own tag-triggered GitHub Actions workflow,
+so you release one ecosystem at a time by pushing a tag. Every workflow can also
+be run by hand from the Actions tab (workflow_dispatch).
+
+## Tag conventions
+
+| Push this tag | Workflow | Publishes |
+|---|---|---|
+| `rust-vX.Y.Z` | publish-crates.yml | `vouch-core`, `vouch-core-uniffi` to crates.io |
+| `dotnet-vX.Y.Z` | publish-nuget.yml | `VouchProtocol.Core` to NuGet.org |
+| `jvm-vX.Y.Z` | publish-maven.yml | `com.vouchprotocol:vouch-core` to Maven Central |
+| `swift-vX.Y.Z` | swift-xcframework.yml | VouchCore XCFramework to GitHub Releases |
+| `c-vX.Y.Z` | publish-c.yml | native libs + `vouch_core.h` to GitHub Releases |
+| `npm-vX.Y.Z` | publish-npm.yml | `core-wasm`, `sdk`, `api-client` to npm |
+| `py-vX.Y.Z` | publish-pypi.yml | `vouch-protocol`, `vouch-api-client`, `vouch-sdk` to PyPI |
+
+Example: `git tag rust-v0.1.1 && git push origin rust-v0.1.1`.
+
+Bump the version in the relevant manifest (Cargo.toml, .csproj, build.gradle.kts,
+package.json, pyproject.toml) before tagging. The npm and PyPI workflows skip
+versions that already exist, so re-running is safe.
+
+## Required repository secrets
+
+Add these under Settings, Secrets and variables, Actions:
+
+| Secret | Used by | Where to get it |
+|---|---|---|
+| `CARGO_REGISTRY_TOKEN` | crates | crates.io, Account Settings, API Tokens |
+| `NUGET_API_KEY` | nuget | nuget.org, API Keys |
+| `CENTRAL_USERNAME`, `CENTRAL_PASSWORD` | maven | Sonatype Central Portal user token |
+| `GPG_PRIVATE_KEY`, `GPG_PASSPHRASE`, `GPG_KEY_ID` | maven | your release GPG key (Central requires signed artifacts) |
+| `NPM_TOKEN` | npm | npmjs.com, Access Tokens, Automation |
+| `PYPI_API_TOKEN` | pypi | pypi.org, Account, API tokens |
+
+C/C++ and Swift use the built-in `GITHUB_TOKEN`, so they need no extra secret.
+
+## One-time setup
+
+- **Maven Central**: verify the `com.vouchprotocol` namespace once in the Central
+  Portal before the first `jvm-v*` release.
+- **Swift Package Index**: submit `https://github.com/vouch-protocol/vouch` once at
+  swiftpackageindex.com/add-a-package so the package is discoverable.
+
+## Already published
+
+npm (`@vouch-protocol-official/sdk`, `/api-client`, `/core-wasm`) and PyPI
+(`vouch-protocol`, `vouch-api-client`, `vouch-sdk`) are live. These workflows make
+future releases a single tag push instead of a manual upload.


### PR DESCRIPTION
Adds tag-triggered publish workflows so every language SDK ships with a single tag push, plus `docs/RELEASING.md` documenting the conventions.

## Workflows
| Tag | Workflow | Publishes |
|---|---|---|
| `rust-v*` | publish-crates.yml | `vouch-core`, `vouch-core-uniffi` to crates.io |
| `dotnet-v*` | publish-nuget.yml | `VouchProtocol.Core` to NuGet |
| `jvm-v*` | publish-maven.yml | `com.vouchprotocol:vouch-core` to Maven Central |
| `c-v*` | publish-c.yml | native libs + `vouch_core.h` to GitHub Releases |
| `npm-v*` | publish-npm.yml | `core-wasm`, `sdk`, `api-client` to npm |
| `py-v*` | publish-pypi.yml | `vouch-protocol`, `vouch-api-client`, `vouch-sdk` to PyPI |

Swift already had `swift-xcframework.yml`. Each workflow also runs from the Actions tab (workflow_dispatch).

## Before the first use
Add the registry tokens as repo secrets (listed in `docs/RELEASING.md`): `CARGO_REGISTRY_TOKEN`, `NUGET_API_KEY`, `CENTRAL_USERNAME`/`CENTRAL_PASSWORD` + GPG key, `NPM_TOKEN`, `PYPI_API_TOKEN`. C/C++ and Swift use the built-in `GITHUB_TOKEN`. Maven Central also needs the `com.vouchprotocol` namespace verified once.

## Notes
- All six YAML files validated.
- npm and PyPI workflows skip already-published versions, so re-runs are safe.
- These automate publishing only; they do not change any SDK code.
