### PR TITLE
feat: Gemini CLI extension (cherry-picked from #38)

### DIFF
--- a/gemini-extension/GEMINI.md
+++ b/gemini-extension/GEMINI.md
@@ -1,0 +1,51 @@
+# Vouch Protocol extension
+
+This extension gives Gemini cryptographic identity tools for AI agents,
+backed by the Vouch Protocol. Vouch is the open standard for AI agent
+identity and provenance: agents get a Decentralized Identifier (DID) and
+every sensitive action becomes a signed Verifiable Credential.
+
+## Tools available via the `vouch` MCP server
+
+- `sign_action` — Generate a signed Vouch token for an intent before an
+  authenticated API call. Args: `intent` (required, e.g. `read_email`,
+  `send_payment`), `target` (optional resource/service).
+- `get_identity` — Return the current agent DID, auto-sign status, and
+  session state.
+- `create_session` — Mint a session token valid for multiple actions so
+  each individual call need not be signed separately. Arg: `purpose`.
+
+The MCP server signs locally using `VOUCH_PRIVATE_KEY` / `VOUCH_DID` from
+the environment. **No private key material is ever sent to the model.**
+If those env vars are unset, signing tools return a configuration error —
+tell the user to run `vouch init --env` and export the values.
+
+## How to behave
+
+1. Before drafting code that performs a sensitive action (payment, email
+   send, data access), offer to sign the intent with `sign_action` and
+   show where the resulting `Vouch-Token` header attaches.
+2. When asked "what is my identity / DID", call `get_identity`.
+3. Never ask the user to paste a private key, JWK, or seed phrase into
+   the chat. The key lives in the environment, not the conversation. If a
+   user pastes one, advise rotation and refuse to operate on it.
+4. Be terse and technical. Lead with the command or result, not preamble.
+5. Do not invent SDK method names, field names, or cryptosuite ids. The
+   default cryptosuite is `eddsa-jcs-2022`; the optional hybrid
+   post-quantum profile is `hybrid-eddsa-mldsa44-jcs-2026`.
+
+## Decision rules
+
+- did:web for production agents with a public domain; did:key for
+  short-lived test agents.
+- Hybrid PQ if the audit horizon is past 2030 or a regulated PQ mandate
+  applies; otherwise classical Ed25519 (~60x faster per signature).
+- Use `create_session` when an agent will perform many actions in one
+  task; use `sign_action` for one-off high-stakes intents.
+
+## Links
+
+- Repo: https://github.com/vouch-protocol/vouch
+- Spec: https://vouch-protocol.com/specs/SPEC/
+- Issues: https://github.com/vouch-protocol/vouch/issues
+- Discord: https://discord.gg/mMqx5cG9Y

--- a/gemini-extension/README.md
+++ b/gemini-extension/README.md
@@ -1,0 +1,111 @@
+# Vouch Protocol Gemini Extension
+
+A [Gemini CLI extension](https://github.com/google-gemini/gemini-cli) that
+gives Gemini cryptographic identity tools for AI agents, backed by the
+Vouch Protocol. It bundles the `vouch-mcp` MCP server, a context file, and
+custom `/vouch:*` commands.
+
+## What this is — and what it is not
+
+Gemini has several "extension"-shaped surfaces. They are not the same
+thing, and only one of them is something a project can ship itself:
+
+| Surface | Self-serve? | What you build |
+|---|---|---|
+| **Gemini CLI extension** (this folder) | ✅ Yes | `gemini-extension.json` + MCP server + commands |
+| **Gemini API / Vertex AI function calling** | ✅ Yes | An OpenAPI/function spec your *own* app passes to the model — see `../openai-gpt/actions.yaml` |
+| **Gemini Gem** | ✅ Yes | Persona + knowledge, no API calls — see `../gemini-gem/` |
+| **Consumer Gemini app `@`-extension / "Connected Apps"** | ❌ No | Google-curated business partnership; there is no developer console to upload an OpenAPI spec and get a public `@Vouch` toggle |
+
+This package is the **Gemini CLI extension**: the genuine, file-based,
+self-serve "Gemini Extension." It lets a developer install Vouch into
+their Gemini CLI and invoke it through the bundled MCP tools and commands.
+
+## Files
+
+- `gemini-extension.json` — the extension manifest (name, version, the
+  `vouch` MCP server, and the context file name)
+- `GEMINI.md` — context injected into the model so Gemini knows the tools,
+  the safety rules, and the decision rules
+- `commands/vouch/*.toml` — custom slash commands: `/vouch:sign`,
+  `/vouch:identity`, `/vouch:session`
+
+## Prerequisites
+
+```bash
+pip install vouch-protocol   # installs the `vouch` CLI and `vouch-mcp` server
+vouch init --env             # prints VOUCH_DID and VOUCH_PRIVATE_KEY exports
+```
+
+Export the two values in the shell that launches Gemini CLI (or set them
+in your shell profile). The MCP server signs locally with these; **no key
+material is sent to the model.** Without them the signing tools return a
+configuration error and the read-only `get_identity` tool reports
+"Not configured."
+
+## Install
+
+Install from this directory (local checkout):
+
+```bash
+gemini extensions install /path/to/vouch/gemini-extension
+```
+
+Or from the repository:
+
+```bash
+gemini extensions install https://github.com/vouch-protocol/vouch \
+  --path gemini-extension
+```
+
+Then start Gemini CLI. Confirm the extension loaded:
+
+```bash
+gemini extensions list
+```
+
+## Use
+
+```text
+/vouch:identity                         # show your agent DID and status
+/vouch:sign send_payment to acme.example   # sign an action intent
+/vouch:session email_management         # mint a multi-action session token
+```
+
+Or just ask in natural language — the model has the tools and will call
+them, e.g. *"Sign my intent to read the calendar before we make the API
+call."*
+
+## MCP tools exposed
+
+| Tool | Purpose |
+|---|---|
+| `sign_action` | Sign an `intent` (+ optional `target`) → `Vouch-Token` header |
+| `get_identity` | Report the agent DID, auto-sign status, session state |
+| `create_session` | Mint a session token for a multi-action `purpose` |
+
+These come from the `vouch-mcp` server defined at
+`vouch/integrations/mcp/server.py` and exposed via the `vouch-mcp` console
+script (`pyproject.toml` → `[project.scripts]`).
+
+## Updating
+
+When the protocol, SDK, or MCP tools change:
+
+1. Bump `version` in `gemini-extension.json`.
+2. Refresh tool descriptions in `GEMINI.md` to match
+   `vouch/integrations/mcp/server.py`.
+3. Re-run `gemini extensions install --force` (or `update`).
+
+## Downstream subscriber
+
+a downstream product is a separate product that subscribes to Vouch's CA; it is
+not part of this repository. To give downstream the same Gemini CLI extension,
+replicate this folder in the downstream repo, point `mcpServers` at downstream's own
+MCP server, and adapt `GEMINI.md` to downstream's tool surface.
+
+## Links
+
+- Gemini CLI: https://github.com/google-gemini/gemini-cli
+- MCP quickstart: ../docs/mcp-quickstart.md
+- Repo: https://github.com/vouch-protocol/vouch

--- a/gemini-extension/commands/vouch/identity.toml
+++ b/gemini-extension/commands/vouch/identity.toml
@@ -1,0 +1,11 @@
+description = "Show the current Vouch agent identity (DID) and status"
+
+prompt = """
+Call the `get_identity` tool and report the agent's DID, auto-sign
+status, and whether a session is active.
+
+If the DID is not configured, explain that the extension needs
+VOUCH_PRIVATE_KEY and VOUCH_DID in the environment: run `vouch init --env`,
+export the two values, and restart Gemini CLI. Never request the private
+key in the chat.
+"""

--- a/gemini-extension/commands/vouch/session.toml
+++ b/gemini-extension/commands/vouch/session.toml
@@ -1,0 +1,16 @@
+description = "Create a Vouch session token for a multi-action task"
+
+prompt = """
+The user wants a session token covering multiple actions in one task.
+
+Purpose provided by the user: {{args}}
+
+Steps:
+1. If no purpose was given, ask for one (e.g. `calendar_access`,
+   `email_management`) and stop.
+2. Call the `create_session` tool with `purpose`.
+3. Show the returned session token and explain that subsequent actions in
+   this task can reuse it instead of signing each one individually.
+4. If the tool reports the identity is not configured, tell the user to
+   run `vouch init --env`, export the values, and restart Gemini CLI.
+"""

--- a/gemini-extension/commands/vouch/sign.toml
+++ b/gemini-extension/commands/vouch/sign.toml
@@ -1,0 +1,18 @@
+description = "Sign an agent action intent as a Vouch credential"
+
+prompt = """
+The user wants to sign an action intent with Vouch.
+
+Intent (and optional target) provided by the user: {{args}}
+
+Steps:
+1. Parse the intent from the arguments. If no intent was given, ask for
+   one (e.g. `read_email`, `send_payment`, `access_database`) and stop.
+2. Call the `sign_action` tool with `intent` (and `target` if the user
+   named a resource).
+3. Show the returned `Vouch-Token` and exactly where it attaches:
+   as the `Vouch-Token:` HTTP header on the corresponding request.
+4. If the tool reports that VOUCH_PRIVATE_KEY / VOUCH_DID are unset, tell
+   the user to run `vouch init --env`, export the printed values, and
+   restart Gemini CLI. Do not ask them to paste the key into the chat.
+"""

--- a/gemini-extension/gemini-extension.json
+++ b/gemini-extension/gemini-extension.json
@@ -1,0 +1,16 @@
+{
+  "name": "vouch",
+  "version": "1.0.0",
+  "description": "Cryptographic identity for AI agents. Sign agent actions as Verifiable Credentials and inspect your did:web/did:key identity, directly from Gemini CLI.",
+  "contextFileName": "GEMINI.md",
+  "mcpServers": {
+    "vouch": {
+      "command": "vouch-mcp",
+      "env": {
+        "VOUCH_PRIVATE_KEY": "${VOUCH_PRIVATE_KEY}",
+        "VOUCH_DID": "${VOUCH_DID}",
+        "VOUCH_AUTO_SIGN": "${VOUCH_AUTO_SIGN}"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Cherry-picks just the **gemini-extension/** package from #38 onto current main, leaving the rest of that large, conflict-heavy PR behind.

## What this is
A Gemini CLI extension (6 files) that wires the  MCP server with , , and  slash commands. It signs locally from / and never sends key material to the model.

## Verified against current main (nothing breaks)
- The slash commands call MCP tools , , , which the current  all expose.
- References the real commands: ,  (both exist on main).
- gemini-extension.json is valid JSON. No Cygn/Aign, no em-dashes, no stale package names.

## What was intentionally dropped from #38
The ~600 other files (a generated docs/_next dump, lock files, and stale forks of faq-data/help-data/cli.py/README that would regress the recent PAD-061 / Agent Trust Index / robot-identity / canonical-npm-name work). Only the clean, additive extension is taken here.