### PR TITLE
security: SSRF guard, proof binding, bounded cache, key hardening (cherry-picked from #40)

### DIFF
--- a/core/vouch-core/Cargo.lock
+++ b/core/vouch-core/Cargo.lock
@@ -476,6 +476,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "zeroize",
 ]
 
 [[package]]

--- a/core/vouch-core/Cargo.toml
+++ b/core/vouch-core/Cargo.toml
@@ -16,13 +16,15 @@ serde_json = { version = "1", features = ["preserve_order"] }
 # ECMAScript-compliant float formatting (RFC 8785 number serialization), so JCS
 # matches JavaScript's Number.prototype.toString byte-for-byte.
 ryu-js = "1"
-ed25519-dalek = "2"
+# "zeroize" wipes the SigningKey's secret seed from memory on drop.
+ed25519-dalek = { version = "2", features = ["zeroize"] }
 fips204 = "0.4"
 sha2 = "0.10"
 bs58 = "0.5"
 base64 = "0.22"
 flate2 = "1"
 getrandom = "0.2"
+zeroize = "1"
 
 [dev-dependencies]
 hex = "0.4"

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,0 +1,65 @@
+"""
+Focused tests for the cherry-picked security hardening: the SSRF guard used by
+did:web resolution, and the path-traversal-safe key filename derivation.
+
+The proof-binding and bounded-cache additions in the verifier are exercised
+indirectly by the full existing suite (which still passes); these tests pin the
+two guards that are cleanly unit-testable.
+"""
+
+import os
+
+import pytest
+
+from vouch.ssrf import validate_url, SSRFError
+from vouch.keys import KeyManager
+
+
+# --- SSRF guard -------------------------------------------------------------
+
+
+def test_ssrf_rejects_non_https():
+    with pytest.raises(SSRFError):
+        validate_url("http://8.8.8.8")
+
+
+def test_ssrf_rejects_loopback():
+    with pytest.raises(SSRFError):
+        validate_url("https://127.0.0.1")
+
+
+def test_ssrf_rejects_cloud_metadata():
+    # 169.254.169.254 is the link-local cloud-metadata endpoint.
+    with pytest.raises(SSRFError):
+        validate_url("https://169.254.169.254")
+
+
+def test_ssrf_rejects_private_range():
+    with pytest.raises(SSRFError):
+        validate_url("https://10.0.0.1")
+
+
+def test_ssrf_allows_public_https():
+    # 8.8.8.8 is a public address literal (no DNS lookup needed); must not raise.
+    validate_url("https://8.8.8.8")
+
+
+# --- Key filename path traversal -------------------------------------------
+
+
+def test_keys_path_traversal_is_contained():
+    km = KeyManager()
+    path = km._get_filename("did:web:../../etc/passwd")
+    # The crafted DID must not escape the key directory. Path separators are
+    # stripped, so any residual dots are literal filename characters, not
+    # traversal; the real guarantee is that the resolved file stays in key_dir.
+    assert os.path.dirname(os.path.realpath(path)) == os.path.realpath(km.key_dir)
+    assert "/" not in os.path.basename(path)
+    assert os.sep not in os.path.basename(path)
+
+
+def test_keys_normal_did_filename_preserved():
+    km = KeyManager()
+    path = km._get_filename("did:web:example.com")
+    # Historic scheme preserved for ordinary DIDs (':' becomes '-').
+    assert os.path.basename(path) == "did-web-example.com.json"

--- a/vouch/did_web.py
+++ b/vouch/did_web.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 
 import httpx
 
+from . import ssrf
+
 
 @dataclass
 class VerificationMethod:
@@ -209,8 +211,11 @@ async def resolve_did_web(
       httpx.HTTPError: If the request fails
     """
     url = did_web_to_url(did)
+    ssrf.validate_url(url)  # https-only, public IPs only (blocks SSRF)
 
-    async with httpx.AsyncClient(timeout=timeout, verify=verify_ssl) as client:
+    async with httpx.AsyncClient(
+        timeout=timeout, verify=verify_ssl, follow_redirects=False
+    ) as client:
         response = await client.get(
             url,
             headers={
@@ -234,8 +239,9 @@ def resolve_did_web_sync(
     For use in non-async contexts.
     """
     url = did_web_to_url(did)
+    ssrf.validate_url(url)  # https-only, public IPs only (blocks SSRF)
 
-    with httpx.Client(timeout=timeout, verify=verify_ssl) as client:
+    with httpx.Client(timeout=timeout, verify=verify_ssl, follow_redirects=False) as client:
         response = client.get(
             url,
             headers={

--- a/vouch/keys.py
+++ b/vouch/keys.py
@@ -6,15 +6,19 @@ Uses Scrypt for key derivation and ChaCha20Poly1305 for authenticated encryption
 """
 
 import os
+import re
 import json
 import base64
 import glob
+import logging
 from dataclasses import dataclass, asdict
 from typing import Optional, List, Dict, Any
 
 from jwcrypto import jwk
 from cryptography.hazmat.primitives.kdf.scrypt import Scrypt
 from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+
+logger = logging.getLogger(__name__)
 
 # Constants
 VOUCH_DIR = os.path.expanduser("~/.vouch")
@@ -43,9 +47,20 @@ class KeyManager:
             os.makedirs(self.key_dir, mode=0o700, exist_ok=True)
 
     def _get_filename(self, did: str) -> str:
-        """Convert DID to filename (replace : with -)."""
-        safe_name = did.replace(":", "-")
-        return os.path.join(self.key_dir, f"{safe_name}.json")
+        """
+        Convert a DID to a safe filename. Whitelists filename characters so a
+        crafted DID (containing '/', '\\', or '..') cannot escape the key
+        directory via path traversal. For normal DIDs this matches the historic
+        scheme (':' becomes '-'), so existing files keep their names.
+        """
+        safe_name = re.sub(r"[^A-Za-z0-9._-]", "-", did).strip(".")
+        if not safe_name:
+            raise ValueError(f"DID does not yield a safe filename: {did!r}")
+        path = os.path.join(self.key_dir, f"{safe_name}.json")
+        # Defense in depth: the resolved path must stay inside key_dir.
+        if os.path.dirname(os.path.realpath(path)) != os.path.realpath(self.key_dir):
+            raise ValueError(f"unsafe key path for DID {did!r}")
+        return path
 
     def save_identity(self, identity: KeyPair, password: Optional[str] = None):
         """
@@ -103,15 +118,24 @@ class KeyManager:
                 "ciphertext": base64.b64encode(ciphertext).decode("utf-8"),
             }
         else:
-            # Warning: Plain text storage
+            # Plaintext storage: discouraged. The private key sits unencrypted
+            # on disk; prefer passing a password.
+            logger.warning(
+                "Saving identity %s WITHOUT a password: the private key is "
+                "stored in plaintext. Provide a password to encrypt it.",
+                identity.did,
+            )
             data["private_key"] = identity.private_key_jwk
 
-        # Write to file
-        with open(filename, "w") as f:
-            json.dump(data, f, indent=2)
-
-        # Set restricted permissions (Read/Write for user only)
-        os.chmod(filename, 0o600)
+        # Write with 0o600 at creation so there is no window where the file is
+        # world/group-readable (umask only removes permission bits, never adds
+        # them). chmod afterwards also tightens a pre-existing looser file.
+        fd = os.open(filename, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump(data, f, indent=2)
+        finally:
+            os.chmod(filename, 0o600)
 
     def load_identity(self, did: str, password: Optional[str] = None) -> KeyPair:
         """

--- a/vouch/ssrf.py
+++ b/vouch/ssrf.py
@@ -1,0 +1,85 @@
+"""
+SSRF protection for outbound fetches (did:web resolution, revocation lists,
+status lists).
+
+A verifier fetches URLs derived from attacker-controlled input (an issuer DID,
+a credentialStatus entry). Without a guard, an attacker can point those at
+internal services or the cloud metadata endpoint (169.254.169.254). This module
+validates that a URL is https and resolves only to public, routable addresses,
+and the callers disable redirects so a public host cannot 302 to an internal
+one.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.parse
+from typing import List
+
+
+class SSRFError(Exception):
+    """Raised when a URL is not safe to fetch (non-https or non-public host)."""
+
+
+def _ip_is_public(ip_str: str) -> bool:
+    """True only for globally routable unicast addresses."""
+    try:
+        addr = ipaddress.ip_address(ip_str)
+    except ValueError:
+        return False
+    if (
+        addr.is_private
+        or addr.is_loopback
+        or addr.is_link_local  # blocks 169.254.0.0/16 incl. cloud metadata
+        or addr.is_multicast
+        or addr.is_reserved
+        or addr.is_unspecified
+    ):
+        return False
+    # IPv4-mapped / 6to4 / Teredo can smuggle private targets through IPv6.
+    if isinstance(addr, ipaddress.IPv6Address):
+        if addr.ipv4_mapped is not None:
+            return _ip_is_public(str(addr.ipv4_mapped))
+        if addr.sixtofour is not None:
+            return _ip_is_public(str(addr.sixtofour))
+    return addr.is_global
+
+
+def _resolved_ips(host: str, port: int) -> List[str]:
+    """Resolve a host to its IP literals, or return [host] if already an IP."""
+    try:
+        ipaddress.ip_address(host)
+        return [host]
+    except ValueError:
+        pass
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as e:
+        raise SSRFError(f"cannot resolve host: {host}") from e
+    return [info[4][0] for info in infos]
+
+
+def validate_url(url: str, *, allow_http: bool = False) -> None:
+    """
+    Validate that `url` is safe to fetch. Raises SSRFError otherwise.
+
+    - Scheme must be https (http only if allow_http is explicitly set).
+    - The host must resolve exclusively to public, routable IP addresses.
+      Every resolved address is checked to defend against a hostname that
+      resolves to a mix of public and private addresses.
+    """
+    parsed = urllib.parse.urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme != "https" and not (allow_http and scheme == "http"):
+        raise SSRFError(f"scheme not allowed: {scheme!r}")
+    host = parsed.hostname
+    if not host:
+        raise SSRFError("URL has no host")
+    port = parsed.port or (443 if scheme == "https" else 80)
+    ips = _resolved_ips(host, port)
+    if not ips:
+        raise SSRFError(f"host did not resolve: {host}")
+    for ip in ips:
+        if not _ip_is_public(ip):
+            raise SSRFError(f"host {host} resolves to non-public address {ip}")

--- a/vouch/verifier.py
+++ b/vouch/verifier.py
@@ -159,6 +159,9 @@ class Verifier:
     # Cache for resolved DID public keys
     _key_cache: Dict[str, Tuple[jwk.JWK, float]] = {}
     _cache_ttl: int = 300  # 5 minutes
+    # Bound the cache so distinct attacker-supplied DIDs cannot grow it without
+    # limit (memory DoS).
+    _key_cache_max: int = 1024
 
     def __init__(
         self,
@@ -345,6 +348,10 @@ class Verifier:
         if self._allow_resolution and did.startswith("did:web:"):
             resolved_key = self._resolve_did_web(did)
             if resolved_key:
+                if len(self._key_cache) >= self._key_cache_max and did not in self._key_cache:
+                    # Evict the oldest entry to keep the cache bounded.
+                    oldest = min(self._key_cache, key=lambda d: self._key_cache[d][1])
+                    del self._key_cache[oldest]
                 self._key_cache[did] = (resolved_key, time.time())
                 return resolved_key
 
@@ -472,6 +479,27 @@ class Verifier:
                 return False, None
             except InvalidSignature:
                 return False, None
+
+        # Bind the proof to the issuer and enforce its purpose. A signature is
+        # only meaningful if the key that made it is the issuer's key, used for
+        # the right purpose. Without this, a key trusted for issuer A could sign
+        # a credential claiming issuer B (cross-issuer reuse), and a proof made
+        # for an unrelated purpose could be replayed as an assertion.
+        proof = cred.get("proof")
+        if isinstance(proof, dict):
+            if proof.get("proofPurpose") != "assertionMethod":
+                logger.debug("Proof proofPurpose is not assertionMethod")
+                return False, None
+            issuer = cred.get("issuer")
+            issuer_did = issuer[0] if isinstance(issuer, list) and issuer else issuer
+            vm = proof.get("verificationMethod")
+            if isinstance(issuer_did, str) and issuer_did:
+                if not isinstance(vm, str) or not vm:
+                    logger.debug("Proof missing verificationMethod")
+                    return False, None
+                if vm.split("#", 1)[0] != issuer_did:
+                    logger.debug("verificationMethod does not belong to issuer")
+                    return False, None
 
         # Validate temporal claims
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
Cherry-picks the genuinely-complete security hardening from #40 onto current main, ported onto main's current files and tested. Leaves #40 itself (and its disjoint history, generated docs dump, stale forks, and incomplete v1.7 attenuation) behind.

## What's included
- **SSRF guard** (`vouch/ssrf.py` + did:web resolver): outbound did:web fetches are https-only, must resolve to public IPs (blocks loopback / private ranges / the cloud-metadata endpoint), and do not follow redirects.
- **Proof binding** (`verifier.py`): a Data Integrity proof must use `proofPurpose: assertionMethod` and a `verificationMethod` whose DID matches the credential issuer. Blocks cross-issuer key reuse and proof-purpose replay.
- **Bounded key cache** (`verifier.py`): the resolved-DID cache is capped at 1024 entries with oldest-entry eviction, so attacker-supplied DIDs cannot grow memory without limit.
- **Key storage hardening** (`keys.py`): filenames derived through a character whitelist with a realpath containment check (path-traversal-safe), a warning on plaintext key storage, and `0o600` at file creation (no permission-race window).
- **Rust** (`core/vouch-core/Cargo.toml`): `ed25519-dalek` `zeroize` feature + the `zeroize` crate, wiping the secret seed from memory on drop.

## Verification
- **571 Python tests pass** (564 existing, unchanged + 7 new in `tests/test_security_hardening.py`), zero regressions.
- `ruff check` and `ruff format --check` clean across vouch/, tests/, examples/.
- `cargo check` green with the zeroize feature.

## Deliberately left out of #40
- The incomplete v1.7 capability-attenuation (`validate_delegation_chain` references `VerifierBudget` / `AttenuationResult` that are never defined, the F821 that fails #40's lint). That needs the attenuation module finished first.
- The revocation-registry fail-closed gate, which is entangled with revocation.py / status_list.py / async_verifier.py changes and warrants its own tested pass.
