### PR TITLE
feat(sdk-ts): TypeScript sidecar with byte-identical cross-language interop

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -39,6 +39,9 @@
  "main": "./dist/index.js",
  "module": "./dist/index.mjs",
  "types": "./dist/index.d.ts",
+ "bin": {
+  "vouch-sidecar-ts": "./dist/sidecar/cli.js"
+ },
  "exports": {
   ".": {
    "import": {
@@ -67,7 +70,7 @@
   "README.md"
  ],
  "scripts": {
-  "build": "tsup src/index.ts src/portable.ts --format cjs,esm --dts --clean",
+  "build": "tsup src/index.ts src/portable.ts src/sidecar/cli.ts src/sidecar/server.ts --format cjs,esm --dts --clean",
   "prepublishOnly": "npm run build",
   "typecheck": "tsc --noEmit",
   "lint": "eslint src --ext .ts",

--- a/packages/sdk-ts/src/sidecar/cli.ts
+++ b/packages/sdk-ts/src/sidecar/cli.ts
@@ -1,0 +1,92 @@
+#!/usr/bin/env node
+/**
+ * CLI entry point for the TypeScript Vouch sidecar.
+ *
+ * Mirrors the Go sidecar's developer ergonomics: a required `--did`, an
+ * optional `--port` (default 8877), and an Ed25519 seed loaded from the
+ * `VOUCH_ED25519_SEED` environment variable (base64 or hex, 32 bytes). When
+ * no seed is supplied an ephemeral one is generated and a warning is printed
+ * to stderr, matching the Go sidecar's development behavior.
+ *
+ *   vouch-sidecar-ts --did did:web:agent.example.com --port 8877
+ */
+
+import { webcrypto } from 'node:crypto';
+
+import { createSidecarServer } from './server';
+
+interface CliArgs {
+  did: string;
+  port: number;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  let did = '';
+  let port = 8877;
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--did') {
+      did = argv[++i] ?? '';
+    } else if (arg === '--port') {
+      const raw = argv[++i] ?? '';
+      const parsed = Number.parseInt(raw, 10);
+      if (Number.isNaN(parsed)) {
+        process.stderr.write(`error: invalid --port value: ${raw}\n`);
+        process.exit(1);
+      }
+      port = parsed;
+    }
+  }
+
+  if (did === '') {
+    process.stderr.write('error: --did is required\n');
+    process.exit(1);
+  }
+
+  return { did, port };
+}
+
+/** Decode a 32-byte Ed25519 seed from a base64 or hex string. */
+function decodeSeed(raw: string): Uint8Array {
+  const trimmed = raw.trim();
+
+  // Hex: exactly 64 hex chars.
+  if (/^[0-9a-fA-F]{64}$/.test(trimmed)) {
+    return new Uint8Array(Buffer.from(trimmed, 'hex'));
+  }
+
+  // Otherwise treat as base64 (standard or url-safe).
+  const seed = new Uint8Array(Buffer.from(trimmed, 'base64'));
+  if (seed.length !== 32) {
+    throw new Error(
+      `VOUCH_ED25519_SEED must decode to 32 bytes (base64 or hex), got ${seed.length}`
+    );
+  }
+  return seed;
+}
+
+function loadSeed(): Uint8Array {
+  const fromEnv = process.env.VOUCH_ED25519_SEED;
+  if (fromEnv && fromEnv.trim() !== '') {
+    return decodeSeed(fromEnv);
+  }
+  process.stderr.write(
+    'warning: no VOUCH_ED25519_SEED set, generating ephemeral keys\n'
+  );
+  const seed = new Uint8Array(32);
+  webcrypto.getRandomValues(seed);
+  return seed;
+}
+
+function main(): void {
+  const { did, port } = parseArgs(process.argv.slice(2));
+  const seed = loadSeed();
+
+  const server = createSidecarServer({ did, seed });
+  server.listen(port, () => {
+    process.stdout.write(`vouch-sidecar-ts listening on :${port}\n`);
+  });
+}
+
+main();

--- a/packages/sdk-ts/src/sidecar/server.ts
+++ b/packages/sdk-ts/src/sidecar/server.ts
@@ -1,0 +1,145 @@
+/**
+ * Standalone TypeScript Vouch sidecar HTTP server.
+ *
+ * The TypeScript counterpart to the Go sidecar at
+ * `go-sidecar/cmd/vouch-sidecar/main.go`. Signs Vouch Credentials with the
+ * `eddsa-jcs-2022` Data Integrity cryptosuite using the raw-seed portable
+ * signing primitive, so its output is BYTE-IDENTICAL to the Python, Go, and
+ * Rust sidecars for the same inputs.
+ *
+ * Endpoints:
+ *   - POST /sign   : sign a supplied credential as-is, or build one from an
+ *                    intent and sign it. Returns the signed credential JSON.
+ *   - GET  /health : liveness/identity probe.
+ */
+
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
+
+import { buildProofPortable } from '../data-integrity-portable';
+import { buildVouchCredential, type Intent } from '../vc';
+
+const CRYPTOSUITE_LABEL = 'standard (eddsa-jcs-2022)';
+
+export interface SidecarConfig {
+  /** Agent DID used as the credential issuer and verification method base. */
+  did: string;
+  /** 32-byte raw Ed25519 seed used to sign credentials. */
+  seed: Uint8Array;
+}
+
+interface SignRequestBody {
+  intent?: Intent;
+  credential?: Record<string, unknown>;
+  validSeconds?: number;
+  validFrom?: string;
+  created?: string;
+}
+
+/**
+ * Create (but do not start) a Node HTTP server exposing the sidecar API.
+ * The caller is responsible for `.listen()` and `.close()`.
+ */
+export function createSidecarServer(config: SidecarConfig): Server {
+  const verificationMethod = config.did + '#key-1';
+
+  return createServer((req: IncomingMessage, res: ServerResponse) => {
+    const url = req.url ?? '/';
+
+    if (url === '/health') {
+      if (req.method !== 'GET') {
+        return sendError(res, 405, 'method not allowed');
+      }
+      return sendJson(res, 200, {
+        status: 'operational',
+        did: config.did,
+        mode: CRYPTOSUITE_LABEL,
+      });
+    }
+
+    if (url === '/sign') {
+      if (req.method !== 'POST') {
+        return sendError(res, 405, 'method not allowed');
+      }
+      return readBody(req, (err, raw) => {
+        if (err) {
+          return sendError(res, 400, 'failed to read request body');
+        }
+        let body: SignRequestBody;
+        try {
+          body = raw.length === 0 ? {} : (JSON.parse(raw) as SignRequestBody);
+        } catch {
+          return sendError(res, 400, 'invalid JSON body');
+        }
+        try {
+          const signed = signCredential(config, verificationMethod, body);
+          return sendJson(res, 200, signed);
+        } catch (e) {
+          return sendError(res, 400, (e as Error).message);
+        }
+      });
+    }
+
+    return sendError(res, 404, 'not found');
+  });
+}
+
+function signCredential(
+  config: SidecarConfig,
+  verificationMethod: string,
+  body: SignRequestBody
+): Record<string, unknown> {
+  const created = body.created ? new Date(body.created) : undefined;
+
+  let credential: Record<string, unknown>;
+  if (body.credential !== undefined) {
+    if (typeof body.credential !== 'object' || body.credential === null) {
+      throw new Error('credential must be an object');
+    }
+    // Sign the supplied credential AS-IS. Do not rebuild it: the interop
+    // contract depends on the exact bytes the caller provided.
+    credential = body.credential;
+  } else if (body.intent !== undefined) {
+    credential = buildVouchCredential({
+      issuerDid: config.did,
+      intent: body.intent,
+      validSeconds: body.validSeconds,
+      validFrom: body.validFrom ? new Date(body.validFrom) : undefined,
+    }) as unknown as Record<string, unknown>;
+  } else {
+    throw new Error('request must provide either `credential` or `intent`');
+  }
+
+  const proof = buildProofPortable(credential, {
+    rawPrivateKey: config.seed,
+    verificationMethod,
+    created,
+  });
+
+  return { ...credential, proof };
+}
+
+function readBody(
+  req: IncomingMessage,
+  cb: (err: Error | null, raw: string) => void
+): void {
+  const chunks: Buffer[] = [];
+  let done = false;
+  const finish = (err: Error | null, raw: string): void => {
+    if (done) return;
+    done = true;
+    cb(err, raw);
+  };
+  req.on('data', (chunk: Buffer) => chunks.push(chunk));
+  req.on('end', () => finish(null, Buffer.concat(chunks).toString('utf8')));
+  req.on('error', (err: Error) => finish(err, ''));
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  const out = JSON.stringify(payload);
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(out);
+}
+
+function sendError(res: ServerResponse, status: number, message: string): void {
+  sendJson(res, status, { error: message });
+}

--- a/packages/sdk-ts/tests/sidecar-interop.test.ts
+++ b/packages/sdk-ts/tests/sidecar-interop.test.ts
@@ -1,0 +1,98 @@
+import { readFileSync } from 'node:fs';
+import { type AddressInfo } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import * as ed25519 from '@noble/ed25519';
+import { sha512 } from '@noble/hashes/sha512';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createSidecarServer } from '../src/sidecar/server';
+import { verifyProofPortable } from '../src/data-integrity-portable';
+
+// @noble/ed25519 v3 sync APIs need sha512 wired in (same as the SDK does).
+(ed25519 as { hashes: { sha512?: (m: Uint8Array) => Uint8Array } }).hashes.sha512 = sha512;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const VECTOR_PATH = resolve(
+  __dirname,
+  '../../../test-vectors/data-integrity-eddsa-jcs-2022/vector.json'
+);
+
+interface InteropVector {
+  ed25519: { seed_b64: string };
+  verificationMethod: string;
+  created: string;
+  unsigned_credential: Record<string, unknown>;
+  proofValue: string;
+}
+
+const vector: InteropVector = JSON.parse(readFileSync(VECTOR_PATH, 'utf8'));
+const seed = new Uint8Array(Buffer.from(vector.ed25519.seed_b64, 'base64'));
+const publicKey = ed25519.getPublicKey(seed);
+const DID = 'did:web:test.example.com';
+
+let server: ReturnType<typeof createSidecarServer>;
+let baseUrl: string;
+
+beforeAll(async () => {
+  server = createSidecarServer({ did: DID, seed });
+  await new Promise<void>((res) => server.listen(0, res));
+  const { port } = server.address() as AddressInfo;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((res, rej) =>
+    server.close((err) => (err ? rej(err) : res()))
+  );
+});
+
+async function postSign(body: unknown): Promise<Record<string, unknown>> {
+  const resp = await fetch(`${baseUrl}/sign`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  expect(resp.status).toBe(200);
+  expect(resp.headers.get('content-type')).toContain('application/json');
+  return (await resp.json()) as Record<string, unknown>;
+}
+
+describe('TS sidecar eddsa-jcs-2022 interop', () => {
+  it('reproduces the shared vector proofValue EXACTLY', async () => {
+    const signed = await postSign({
+      credential: vector.unsigned_credential,
+      created: vector.created,
+    });
+    const proof = signed.proof as { proofValue: string };
+    expect(proof.proofValue).toBe(vector.proofValue);
+  });
+
+  it('round-trips an intent-built credential that verifies', async () => {
+    const signed = await postSign({
+      intent: {
+        action: 'read_database',
+        target: 'users_table',
+        resource: 'https://api.example.com/v1/users',
+      },
+    });
+    const proof = signed.proof as { type: string; cryptosuite: string };
+    expect(proof.type).toBe('DataIntegrityProof');
+    expect(proof.cryptosuite).toBe('eddsa-jcs-2022');
+    expect(verifyProofPortable(signed, publicKey)).toBe(true);
+  });
+
+  it('/health reports operational', async () => {
+    const resp = await fetch(`${baseUrl}/health`);
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      status: string;
+      did: string;
+      mode: string;
+    };
+    expect(body.status).toBe('operational');
+    expect(body.did).toBe(DID);
+    expect(body.mode).toBe('standard (eddsa-jcs-2022)');
+  });
+});


### PR DESCRIPTION
Adds a real TypeScript sidecar to `@vouch-protocol-official/sdk`, the counterpart to the Go sidecar, with a cross-language interop contract test that passes. This is the sidecar the docs referenced but that did not exist.

## What's included
- `packages/sdk-ts/src/sidecar/server.ts`: `createSidecarServer({ did, seed })` returning a Node http server with `POST /sign` (accepts `{ intent }` to build a credential, or `{ credential }` to sign a provided one; optional `validFrom` / `validSeconds` / `created`) and `GET /health`. Signs with `buildProofPortable` (the raw-seed eddsa-jcs-2022 primitive shared with the SDK).
- `packages/sdk-ts/src/sidecar/cli.ts`: a `vouch-sidecar-ts` bin. `--did` (required) and `--port` (default 8877), seed from `VOUCH_ED25519_SEED` (base64 or hex) or an ephemeral dev seed, mirroring the Go sidecar.
- `packages/sdk-ts/tests/sidecar-interop.test.ts`: the contract test.
- `package.json`: `bin` + tsup build entries for the sidecar.

## Byte-identical interop (verified)
The contract test feeds the sidecar the shared vector's inputs (`test-vectors/data-integrity-eddsa-jcs-2022/vector.json`) and asserts the response `proof.proofValue` equals the vector's `proofValue` **exactly**, the same value the Rust core, Python, and Go reproduce. Plus a round-trip test (`verifyProofPortable`) and a /health check.

- `npm run build` succeeds (emits `dist/sidecar/cli.js` + `server.js`).
- `npx vitest run tests/sidecar-interop.test.ts`: **3 passed** (interop, round-trip, health).

## Follow-up (separate)
The sidecar-tier docs reference `packages/sdk-ts/sidecar/` and a `test-vectors/sidecar-contract/` suite. The real paths are `packages/sdk-ts/src/sidecar/` and this interop test; a docs reconciliation will follow so the guides match.
