### PR TITLE
Release v1.6.1: per-region human and AI code attribution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Vouch Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-06-14
+
+### Added
+
+#### Per-region human and AI code attribution (PAD-061)
+
+`vouch attribute` records which lines an AI coding assistant wrote and which a
+human wrote, signing each party's regions with that party's own key. Authorship
+is captured from the assistant's actual edit channel (a Claude Code hook on
+Edit / Write / MultiEdit); the human's lines are the residual. The signed
+Attribution Manifest binds line ranges to author DIDs over the exact bytes, and
+verification enforces region completeness and AI-region backing. Includes the
+`vouch/integrations/claude-code/` hook, the `who_wrote_this` example, and the
+PAD-061 defensive disclosure.
+
 ## [Unreleased]
 
 ### Added

--- a/examples/who_wrote_this.py
+++ b/examples/who_wrote_this.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Who Wrote This: a demo of per-region human/AI code attribution.
+
+Run it:
+
+    pip install vouch-protocol
+    python who_wrote_this.py
+
+An AI assistant and a human edit the same file. git blame would credit every
+line to the human who committed it. Vouch records who actually wrote each line,
+signs the AI's lines with the AI's own key and the human's with the human's,
+and lets anyone verify it. Then it shows that you cannot forge an AI line or
+alter a single byte without breaking the proof.
+
+Everything runs locally in a temporary directory. No servers, no setup.
+"""
+
+import copy
+import tempfile
+
+from vouch import Signer, generate_identity
+from vouch import attribution as attr
+
+G = "\033[92m"; R = "\033[91m"; AI = "\033[95m"; HU = "\033[96m"
+DIM = "\033[2m"; BOLD = "\033[1m"; END = "\033[0m"
+
+
+def line(char="-", n=64):
+    print(DIM + char * n + END)
+
+
+def main() -> None:
+    tmp = tempfile.mkdtemp()
+    print()
+    print(f"{BOLD}WHO WROTE THIS{END}  {DIM}a Vouch Protocol demo{END}")
+    line("=")
+
+    # The human's identity, and a session that holds the AI's separate key.
+    human = generate_identity(domain="dev.acme.com")
+    human_signer = Signer(private_key=human.private_key_jwk, did=human.did)
+    session = attr.AttributionSession(tmp, model="claude-opus-4-8")
+    print(f"{HU}human{END} : {human.did}")
+    print(f"{AI}AI   {END} : {session.ai_did}")
+    print(f"{DIM}Two separate keys. Neither party can sign as the other.{END}")
+    print()
+
+    # Act 1: the AI writes the first version.
+    print(f"{BOLD}Act 1.{END} The AI assistant writes a handler.")
+    line()
+    v1 = (
+        "import os\n"
+        "def handler(event):\n"
+        "    return event[\"id\"]\n"
+    )
+    session.record_edit("app.py", v1)
+    print(f"{AI}AI wrote 3 lines.{END}")
+    print()
+
+    # Act 2: the human edits one line and adds two, without the AI.
+    print(f"{BOLD}Act 2.{END} The human fixes a bug and adds an audit function.")
+    line()
+    v2 = (
+        "import os\n"
+        "def handler(event):\n"
+        "    return event[\"order_id\"]\n"   # human fixes the key
+        "def audit(event):\n"               # human adds
+        "    log(event)\n"                   # human adds
+    )
+    # The human's edit did not come through the assistant. It is the residual.
+
+    # Act 3: the AI adds one more function on top of the human's version.
+    print(f"{BOLD}Act 3.{END} The AI adds a retry helper.")
+    line()
+    v3 = v2 + "def retry(event):\n    return handler(event)\n"
+    session.record_edit("app.py", v3, before_content=v2)
+    print(f"{AI}AI wrote 2 more lines.{END}")
+    print()
+
+    # Finalize: the human signs the manifest; the AI's regions carry the AI key.
+    manifest = session.finalize({"app.py": v3}, human_signer)
+
+    print(f"{BOLD}The signed attribution:{END}")
+    line()
+    content = v3.split("\n")
+    for entry in attr.blame(manifest, "app.py"):
+        n = entry["line"]
+        text = content[n - 1] if n - 1 < len(content) else ""
+        if entry["source"] == attr.SOURCE_AI:
+            tag = f"{AI}AI   {END}"
+        elif entry["source"] == attr.SOURCE_HUMAN:
+            tag = f"{HU}human{END}"
+        else:
+            tag = f"{DIM}prior{END}"
+        print(f"  {tag} {n} | {text}")
+    s = attr.summarize(manifest)
+    print()
+    print(f"  {AI}AI{END} {s['aiPercent']}%    {HU}human{END} {s['humanPercent']}%")
+    print()
+
+    # Verify the honest manifest.
+    ok = attr.verify_manifest(
+        manifest, human.public_key_jwk, session.ai_public_key_jwk,
+        files_on_disk={"app.py": v3},
+    )
+    print(f"{BOLD}Verify the real manifest:{END} ", end="")
+    print(f"{G}{BOLD}VERIFIED{END}" if ok.ok else f"{R}{BOLD}FAILED{END}")
+
+    # Attack 1: relabel the human's bug-fix line as AI-written.
+    forged = copy.deepcopy(manifest)
+    for f in forged["files"]:
+        for r in f["regions"]:
+            if r["source"] == attr.SOURCE_HUMAN:
+                r["source"] = attr.SOURCE_AI
+                r["author"] = session.ai_did
+    forged_ok = attr.verify_manifest(forged, human.public_key_jwk, session.ai_public_key_jwk)
+    print(f"{BOLD}Blame the AI for a human line:{END} ", end="")
+    print(f"{R}{BOLD}REJECTED{END}" if not forged_ok.ok else f"{G}ACCEPTED{END}")
+
+    # Attack 2: change one byte of the committed file.
+    tampered_bytes = v3.replace("order_id", "evil_id")
+    tampered_ok = attr.verify_manifest(
+        manifest, human.public_key_jwk, session.ai_public_key_jwk,
+        files_on_disk={"app.py": tampered_bytes},
+    )
+    print(f"{BOLD}Alter one byte after signing:{END} ", end="")
+    print(f"{R}{BOLD}REJECTED{END}" if not tampered_ok.ok else f"{G}ACCEPTED{END}")
+
+    print()
+    line("=")
+    invariant = ok.ok and (not forged_ok.ok) and (not tampered_ok.ok)
+    if invariant:
+        print(f"{G}{BOLD}Every line has an author you can prove. Nobody can wear the other's name.{END}")
+    else:
+        print(f"{R}Demo invariant failed.{END}")
+    print(f"{DIM}This is Vouch Protocol attribution. See vouch/integrations/claude-code/.{END}")
+    print()
+    raise SystemExit(0 if invariant else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/who_wrote_this.py
+++ b/examples/who_wrote_this.py
@@ -22,8 +22,13 @@ import tempfile
 from vouch import Signer, generate_identity
 from vouch import attribution as attr
 
-G = "\033[92m"; R = "\033[91m"; AI = "\033[95m"; HU = "\033[96m"
-DIM = "\033[2m"; BOLD = "\033[1m"; END = "\033[0m"
+G = "\033[92m"
+R = "\033[91m"
+AI = "\033[95m"
+HU = "\033[96m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+END = "\033[0m"
 
 
 def line(char="-", n=64):
@@ -48,11 +53,7 @@ def main() -> None:
     # Act 1: the AI writes the first version.
     print(f"{BOLD}Act 1.{END} The AI assistant writes a handler.")
     line()
-    v1 = (
-        "import os\n"
-        "def handler(event):\n"
-        "    return event[\"id\"]\n"
-    )
+    v1 = 'import os\ndef handler(event):\n    return event["id"]\n'
     session.record_edit("app.py", v1)
     print(f"{AI}AI wrote 3 lines.{END}")
     print()
@@ -63,9 +64,9 @@ def main() -> None:
     v2 = (
         "import os\n"
         "def handler(event):\n"
-        "    return event[\"order_id\"]\n"   # human fixes the key
-        "def audit(event):\n"               # human adds
-        "    log(event)\n"                   # human adds
+        '    return event["order_id"]\n'  # human fixes the key
+        "def audit(event):\n"  # human adds
+        "    log(event)\n"  # human adds
     )
     # The human's edit did not come through the assistant. It is the residual.
 
@@ -100,7 +101,9 @@ def main() -> None:
 
     # Verify the honest manifest.
     ok = attr.verify_manifest(
-        manifest, human.public_key_jwk, session.ai_public_key_jwk,
+        manifest,
+        human.public_key_jwk,
+        session.ai_public_key_jwk,
         files_on_disk={"app.py": v3},
     )
     print(f"{BOLD}Verify the real manifest:{END} ", end="")
@@ -120,7 +123,9 @@ def main() -> None:
     # Attack 2: change one byte of the committed file.
     tampered_bytes = v3.replace("order_id", "evil_id")
     tampered_ok = attr.verify_manifest(
-        manifest, human.public_key_jwk, session.ai_public_key_jwk,
+        manifest,
+        human.public_key_jwk,
+        session.ai_public_key_jwk,
         files_on_disk={"app.py": tampered_bytes},
     )
     print(f"{BOLD}Alter one byte after signing:{END} ", end="")
@@ -130,7 +135,9 @@ def main() -> None:
     line("=")
     invariant = ok.ok and (not forged_ok.ok) and (not tampered_ok.ok)
     if invariant:
-        print(f"{G}{BOLD}Every line has an author you can prove. Nobody can wear the other's name.{END}")
+        print(
+            f"{G}{BOLD}Every line has an author you can prove. Nobody can wear the other's name.{END}"
+        )
     else:
         print(f"{R}Demo invariant failed.{END}")
     print(f"{DIM}This is Vouch Protocol attribution. See vouch/integrations/claude-code/.{END}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "1.6.0"
+version = "1.6.1"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/vouch/integrations/claude-code/README.md
+++ b/vouch/integrations/claude-code/README.md
@@ -1,0 +1,64 @@
+# Vouch attribution for Claude Code
+
+Separate who wrote which line. When Claude Code and a human both edit a file,
+git blame credits every line to the human who committed it. This hook records
+the assistant's edits as they happen, so the AI's lines can be attributed to
+the AI's own key and the human's lines to the human's key. When a line later
+causes an incident, you can prove which of you wrote it.
+
+This is the reference implementation of the per-region authorship attribution
+described in [PAD-061](../../../docs/disclosures/README.md).
+
+## Why this is legitimate and not just labelling
+
+Two properties make the attribution trustworthy:
+
+1. **Capture from the real edit channel.** The hook fires on the assistant's
+   actual `Edit` / `Write` / `MultiEdit` operations. AI lines come only from
+   edits the assistant truly made, not from a label anyone chose afterward.
+2. **A separate AI-session key.** Recorded edits are attested with an
+   AI-session key (`.vouch/attribution/<session>/ai-session.json`, written
+   0600) that is distinct from the key you sign commits with. The human signs
+   the final manifest with the human key. Neither party can mint the other's
+   attribution.
+
+The human's lines are the residual: anything that changed on disk that did not
+arrive through the assistant's edit channel. Unchanged lines are marked
+preexisting. Every region is bound to the exact bytes by a SHA-256 hash and a
+JCS Data Integrity proof, so a region cannot be moved and the bytes cannot be
+altered without breaking verification.
+
+## Setup
+
+```bash
+pip install vouch-protocol
+vouch git init          # configures your human signing identity
+```
+
+Merge the `hooks` block from [`settings.hooks.json`](settings.hooks.json) into
+your `.claude/settings.json` (project) or `~/.claude/settings.json` (global).
+
+That is all. From now on, every assistant edit is recorded automatically.
+
+## Using it
+
+```bash
+# After a session of mixed editing, before or at commit time:
+vouch attribute finalize
+
+# See who wrote what:
+vouch attribute blame src/app.py
+
+# Verify the manifest (signatures, region completeness, byte hashes):
+vouch attribute verify --check-files
+```
+
+`finalize` writes a signed manifest to
+`.vouch/attribution/<session>/manifest.json`. Commit it alongside your code if
+you want the attribution to travel with the repository.
+
+## Honest degradation
+
+Run `finalize` without the hook ever having recorded anything and the manifest
+simply attributes everything to the human committer. The tool never invents AI
+attribution it did not observe.

--- a/vouch/integrations/claude-code/settings.hooks.json
+++ b/vouch/integrations/claude-code/settings.hooks.json
@@ -1,0 +1,16 @@
+{
+  "//": "Vouch attribution hook for Claude Code. Merge the `hooks` block into your project's .claude/settings.json (or ~/.claude/settings.json). It records every Edit/Write the assistant makes so the AI's lines can be attributed to the AI's own key. Requires `pip install vouch-protocol`.",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "vouch attribute hook"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Release v1.6.1

Cuts the 1.6.1 release for the per-region human and AI code attribution feature
(`vouch attribute`, PAD-061). The attribution core landed on main in #41; this
release adds the pieces that were missing and bumps the version.

### What this adds
- Version bump to 1.6.1 in `pyproject.toml`.
- The `who_wrote_this` example so the feature has a runnable demo.
- The Claude Code integration (`vouch/integrations/claude-code/`): the PostToolUse
  hook config and a setup guide, so an assistant's edits are recorded automatically.
- A CHANGELOG entry for 1.6.1.

### Status
- PyPI 1.6.1 is already published (manually via twine, because the repo's
  `PYPI_API_TOKEN` secret returns 403 and the tag-triggered CI publish failed at
  upload). Fixing that secret is a separate follow-up so future tag releases
  publish automatically.
- Tag `py-v1.6.1` is pushed.

### Notes
- No new wire formats, so no new interop vectors needed.
- The full test suite passes.
