### PR TITLE
Phase 1: reference validator transport + callable trust check

### DIFF
--- a/tests/test_trust_check.py
+++ b/tests/test_trust_check.py
@@ -59,8 +59,10 @@ def test_fresh_voucher_meets_threshold(agent):
         valid_seconds=120,
     )
     v = verify_agent_call(
-        cred, public_key=signer.get_public_key_multikey(),
-        session_voucher=voucher, trust_threshold=0.5,
+        cred,
+        public_key=signer.get_public_key_multikey(),
+        session_voucher=voucher,
+        trust_threshold=0.5,
     )
     assert v.ok is True
     assert v.trust_ok is True
@@ -81,8 +83,11 @@ def test_decayed_voucher_below_threshold_fails(agent):
     # Evaluate far in the future: trust has decayed well below the threshold.
     future = datetime.now(timezone.utc) + timedelta(hours=10)
     v = verify_agent_call(
-        cred, public_key=signer.get_public_key_multikey(),
-        session_voucher=voucher, trust_threshold=0.5, at_time=future,
+        cred,
+        public_key=signer.get_public_key_multikey(),
+        session_voucher=voucher,
+        trust_threshold=0.5,
+        at_time=future,
     )
     assert v.ok is False
     assert v.trust_ok is False

--- a/tests/test_trust_check.py
+++ b/tests/test_trust_check.py
@@ -1,0 +1,109 @@
+"""Tests for the composed agent-call trust check (vouch/trust_check.py)."""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.vc import build_session_voucher
+from vouch.revocation import RevocationRegistry, MemoryRevocationStore
+from vouch.trust_check import verify_agent_call, verify_agent_call_async
+
+INTENT = {"action": "read", "target": "order:1", "resource": "https://api.example.com/orders/1"}
+
+
+@pytest.fixture
+def agent():
+    ident = generate_identity(domain="caller.example.com")
+    signer = Signer(private_key=ident.private_key_jwk, did=ident.did)
+    cred = signer.sign_credential(intent=INTENT, valid_seconds=300)
+    return ident, signer, cred
+
+
+def test_valid_call_passes(agent):
+    ident, signer, cred = agent
+    v = verify_agent_call(cred, public_key=signer.get_public_key_multikey())
+    assert v.ok is True
+    assert v.identity_ok is True
+    assert v.revoked is False
+    assert v.reasons == []
+
+
+def test_no_key_means_identity_not_established(agent):
+    _, _, cred = agent
+    v = verify_agent_call(cred, public_key=None)
+    # Without a key only structural checks run; identity cannot be relied on.
+    assert v.identity_ok is False
+    assert v.ok is False
+    assert "no_public_key" in v.reasons
+
+
+def test_revoked_caller_fails(agent):
+    ident, signer, cred = agent
+    v = verify_agent_call(cred, public_key=signer.get_public_key_multikey(), revoked=True)
+    assert v.ok is False
+    assert v.revoked is True
+    assert "issuer_revoked" in v.reasons
+
+
+def test_fresh_voucher_meets_threshold(agent):
+    ident, signer, cred = agent
+    voucher = build_session_voucher(
+        subject_did=ident.did,
+        validator_dids=["did:web:v.example.com"],
+        decay_lambda=0.01,
+        initial_trust=1.0,
+        max_ttl_seconds=3600,
+        scope=["agent_actions"],
+        valid_seconds=120,
+    )
+    v = verify_agent_call(
+        cred, public_key=signer.get_public_key_multikey(),
+        session_voucher=voucher, trust_threshold=0.5,
+    )
+    assert v.ok is True
+    assert v.trust_ok is True
+    assert v.trust is not None and v.trust > 0.5
+
+
+def test_decayed_voucher_below_threshold_fails(agent):
+    ident, signer, cred = agent
+    voucher = build_session_voucher(
+        subject_did=ident.did,
+        validator_dids=["did:web:v.example.com"],
+        decay_lambda=0.01,
+        initial_trust=1.0,
+        max_ttl_seconds=3600,
+        scope=["agent_actions"],
+        valid_seconds=120,
+    )
+    # Evaluate far in the future: trust has decayed well below the threshold.
+    future = datetime.now(timezone.utc) + timedelta(hours=10)
+    v = verify_agent_call(
+        cred, public_key=signer.get_public_key_multikey(),
+        session_voucher=voucher, trust_threshold=0.5, at_time=future,
+    )
+    assert v.ok is False
+    assert v.trust_ok is False
+    assert any("trust_below_threshold" in r for r in v.reasons)
+
+
+def test_async_checks_revocation_registry(agent):
+    ident, signer, cred = agent
+    registry = RevocationRegistry(local_store=MemoryRevocationStore(), check_remote=False)
+
+    async def run():
+        # Not revoked yet.
+        v1 = await verify_agent_call_async(
+            cred, public_key=signer.get_public_key_multikey(), revocation=registry
+        )
+        assert v1.ok is True and v1.revoked is False
+        # Revoke the issuer, then re-check.
+        await registry.revoke(did=ident.did, reason="leaked")
+        v2 = await verify_agent_call_async(
+            cred, public_key=signer.get_public_key_multikey(), revocation=registry
+        )
+        assert v2.ok is False and v2.revoked is True
+
+    asyncio.run(run())

--- a/tests/test_validator_server.py
+++ b/tests/test_validator_server.py
@@ -1,6 +1,8 @@
 """Tests for the reference validator HTTP transport (vouch/validator_server.py)."""
 
 import pytest
+
+pytest.importorskip("fastapi", reason="fastapi not installed")
 from fastapi.testclient import TestClient
 
 from vouch import Signer, generate_identity

--- a/tests/test_validator_server.py
+++ b/tests/test_validator_server.py
@@ -1,0 +1,124 @@
+"""Tests for the reference validator HTTP transport (vouch/validator_server.py)."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from vouch import Signer, generate_identity
+from vouch.heartbeat import HeartbeatSession, HeartbeatValidator
+from vouch.quorum import HeartbeatQuorum, QuorumValidator
+from vouch import data_integrity
+from vouch.attribution import _pub_from_jwk  # reuse the Ed25519 JWK -> pubkey helper
+from vouch.validator_server import create_validator_app
+
+AGENT_DID = "did:web:agent.example.com"
+
+
+@pytest.fixture
+def signer_identity():
+    ident = generate_identity(domain="validator.example.com")
+    return ident, Signer(private_key=ident.private_key_jwk, did=ident.did)
+
+
+def _quorum():
+    validators = [
+        QuorumValidator(validator=HeartbeatValidator(validator_did=f"did:web:v{i}.example.com"))
+        for i in range(1, 4)
+    ]
+    return HeartbeatQuorum(validators=validators, threshold=2)  # 2-of-3
+
+
+@pytest.fixture
+def client(signer_identity):
+    _, signer = signer_identity
+    app = create_validator_app(coordinator=_quorum(), signer=signer)
+    return TestClient(app)
+
+
+def test_healthz(client):
+    r = client.get("/healthz")
+    assert r.status_code == 200 and r.json()["ok"] is True
+
+
+def test_heartbeat_issues_signed_voucher(client, signer_identity):
+    ident, _ = signer_identity
+    req = HeartbeatSession(subject_did=AGENT_DID).build_request().to_dict()
+    r = client.post("/heartbeat", json=req)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["ok"] is True
+    voucher = body["session_voucher"]
+    assert "proof" in voucher
+    # The voucher proof verifies against the validator server's public key.
+    assert data_integrity.verify_proof(voucher, _pub_from_jwk(ident.public_key_jwk))
+    assert len(body["approving_dids"]) >= 2  # 2-of-3 quorum met
+
+
+def test_voucher_published_with_cache_headers(client):
+    req = HeartbeatSession(subject_did=AGENT_DID).build_request().to_dict()
+    client.post("/heartbeat", json=req)
+    r = client.get(f"/vouchers/{AGENT_DID}/{req['session_id']}")
+    assert r.status_code == 200
+    assert "ETag" in r.headers
+    assert "max-age" in r.headers.get("Cache-Control", "")
+    # Conditional GET returns 304.
+    etag = r.headers["ETag"]
+    r2 = client.get(
+        f"/vouchers/{AGENT_DID}/{req['session_id']}",
+        headers={"If-None-Match": etag},
+    )
+    assert r2.status_code == 304
+
+
+def test_voucher_404_when_absent(client):
+    r = client.get(f"/vouchers/{AGENT_DID}/no-such-session")
+    assert r.status_code == 404
+
+
+def test_session_status_reflects_voucher(client):
+    req = HeartbeatSession(subject_did=AGENT_DID).build_request().to_dict()
+    sid = req["session_id"]
+    before = client.get(f"/sessions/{AGENT_DID}/{sid}").json()
+    assert before["has_active_voucher"] is False
+    client.post("/heartbeat", json=req)
+    after = client.get(f"/sessions/{AGENT_DID}/{sid}").json()
+    assert after["has_active_voucher"] is True
+    assert after["revoked"] is False
+
+
+def test_revoked_did_is_blocked(client):
+    sess = HeartbeatSession(subject_did=AGENT_DID)
+    # First heartbeat works.
+    assert client.post("/heartbeat", json=sess.build_request().to_dict()).json()["ok"]
+    # Revoke the agent.
+    rv = client.post("/revoke", json={"did": AGENT_DID, "reason": "key leaked"})
+    assert rv.status_code == 200 and rv.json()["revoked"] is True
+    # Next heartbeat is refused with 403.
+    r = client.post("/heartbeat", json=sess.build_request().to_dict())
+    assert r.status_code == 403 and r.json()["revoked"] is True
+
+
+def test_missing_fields_rejected(client):
+    r = client.post("/heartbeat", json={"foo": "bar"})
+    assert r.status_code == 400
+
+
+def test_replayed_heartbeat_rejected(client):
+    req = HeartbeatSession(subject_did=AGENT_DID).build_request().to_dict()
+    assert client.post("/heartbeat", json=req).json()["ok"] is True
+    # Replaying the exact same request is stale; quorum should not approve.
+    replay = client.post("/heartbeat", json=req)
+    assert replay.status_code == 200
+    assert replay.json()["ok"] is False
+
+
+def test_single_validator_coordinator(signer_identity):
+    _, signer = signer_identity
+    app = create_validator_app(
+        coordinator=HeartbeatValidator(validator_did="did:web:solo.example.com"),
+        signer=signer,
+    )
+    c = TestClient(app)
+    req = HeartbeatSession(subject_did=AGENT_DID).build_request().to_dict()
+    body = c.post("/heartbeat", json=req).json()
+    assert body["ok"] is True
+    assert "reasons" in body  # single-validator result shape

--- a/vouch/trust_check.py
+++ b/vouch/trust_check.py
@@ -1,0 +1,166 @@
+"""
+One callable trust check for an incoming agent call.
+
+MCP tool calls and Agent2Agent (A2A) calls both need to answer the same
+question before acting on a request from another agent: is the caller who it
+claims to be, was it allowed to do this, has it been revoked, and is its trust
+still live right now. This module composes the existing primitives (credential
+verification including the delegation chain, revocation, and trust-entropy
+decay) into a single verdict so every transport checks trust the same way.
+
+The integration packages (MCP, A2A) call `verify_agent_call` rather than
+re-implementing the composition. Keep the composition here, once.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+from .verifier import Verifier
+from .trust_entropy import evaluate_trust
+
+
+@dataclass
+class TrustVerdict:
+    """
+    The outcome of checking an incoming agent call.
+
+    Attributes:
+      ok: True only if identity verified, not revoked, and (when a voucher is
+        supplied) current trust meets the threshold.
+      identity_ok: The credential's Data Integrity proof, timing, resource
+        binding, and delegation chain all verified.
+      revoked: The issuer DID was reported revoked by the caller.
+      trust: Current decayed trust from the SessionVoucher, or None if no
+        voucher was supplied.
+      trust_ok: Whether `trust` met the threshold, or None if no voucher.
+      reasons: Structured failure reasons; empty when ok=True.
+      passport: The CredentialPassport from verification, or None.
+    """
+
+    ok: bool
+    identity_ok: bool
+    revoked: bool
+    trust: Optional[float] = None
+    trust_ok: Optional[bool] = None
+    reasons: List[str] = field(default_factory=list)
+    passport: Optional[Any] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "identity_ok": self.identity_ok,
+            "revoked": self.revoked,
+            "trust": self.trust,
+            "trust_ok": self.trust_ok,
+            "reasons": list(self.reasons),
+        }
+
+
+def verify_agent_call(
+    credential: Union[Dict[str, Any], str],
+    *,
+    public_key: Optional[Union[str, Any]] = None,
+    revoked: bool = False,
+    session_voucher: Optional[Dict[str, Any]] = None,
+    trust_threshold: float = 0.0,
+    at_time: Optional[datetime] = None,
+    clock_skew_seconds: int = 30,
+) -> TrustVerdict:
+    """
+    Check an incoming agent call end to end (synchronous).
+
+    Args:
+      credential: the caller's Vouch credential (dict or JSON string). Its
+        delegation chain, if present, is verified by `verify_credential`.
+      public_key: the issuer's Ed25519 public key (Multikey string or key
+        object). If None, only structural and temporal checks run, so
+        identity_ok cannot be relied on.
+      revoked: whether the issuer DID is revoked. Callers that have a
+        revocation registry should pass the result of `is_revoked`, or use
+        `verify_agent_call_async` which checks it for them.
+      session_voucher: an optional current-trust SessionVoucher. When present,
+        the call is only ok if decayed trust meets `trust_threshold`.
+      trust_threshold: minimum current trust required when a voucher is given.
+      at_time: evaluation time for trust decay (defaults to now).
+      clock_skew_seconds: allowed clock drift for credential timing.
+    """
+    reasons: List[str] = []
+
+    structurally_valid, passport = Verifier.verify_credential(
+        credential, public_key=public_key, clock_skew_seconds=clock_skew_seconds
+    )
+    # Identity is only established when a key was supplied AND the proof verified.
+    # With no key, verify_credential runs structural and temporal checks only, so
+    # it cannot be treated as proof of who signed the credential.
+    if public_key is None:
+        identity_ok = False
+        reasons.append("no_public_key")
+    elif not structurally_valid:
+        identity_ok = False
+        reasons.append("credential_invalid")
+    else:
+        identity_ok = True
+
+    if revoked:
+        reasons.append("issuer_revoked")
+
+    trust: Optional[float] = None
+    trust_ok: Optional[bool] = None
+    if session_voucher is not None:
+        evaluation = evaluate_trust(session_voucher, trust_threshold, at_time)
+        trust = evaluation.trust
+        trust_ok = evaluation.passed
+        if not evaluation.passed:
+            reasons.append(f"trust_below_threshold:{trust:.4f}<{trust_threshold}")
+
+    ok = identity_ok and (not revoked) and (trust_ok is not False)
+    return TrustVerdict(
+        ok=ok,
+        identity_ok=identity_ok,
+        revoked=revoked,
+        trust=trust,
+        trust_ok=trust_ok,
+        reasons=reasons,
+        passport=passport,
+    )
+
+
+async def verify_agent_call_async(
+    credential: Union[Dict[str, Any], str],
+    *,
+    public_key: Optional[Union[str, Any]] = None,
+    revocation: Optional[Any] = None,
+    issuer_did: Optional[str] = None,
+    session_voucher: Optional[Dict[str, Any]] = None,
+    trust_threshold: float = 0.0,
+    at_time: Optional[datetime] = None,
+    clock_skew_seconds: int = 30,
+) -> TrustVerdict:
+    """
+    Same as `verify_agent_call`, but checks revocation against a registry.
+
+    Args:
+      revocation: a RevocationRegistry (or anything with async is_revoked).
+      issuer_did: DID to check for revocation. Defaults to the credential's
+        `issuer` field.
+    """
+    revoked = False
+    if revocation is not None:
+        did = issuer_did
+        if did is None and isinstance(credential, dict):
+            did = credential.get("issuer")
+        if did:
+            revoked = await revocation.is_revoked(did)
+
+    return verify_agent_call(
+        credential,
+        public_key=public_key,
+        revoked=revoked,
+        session_voucher=session_voucher,
+        trust_threshold=trust_threshold,
+        at_time=at_time,
+        clock_skew_seconds=clock_skew_seconds,
+    )

--- a/vouch/validator_server.py
+++ b/vouch/validator_server.py
@@ -1,0 +1,193 @@
+"""
+Reference validator transport for the Heartbeat Protocol (Specification §11.3).
+
+A single-region HTTP server that puts the existing continuous-trust runtime
+(HeartbeatValidator, HeartbeatQuorum) on the wire so an agent can renew trust,
+read its session status, fetch its published SessionVoucher, and so an authority
+can revoke a DID. It is a clean reference, not production infrastructure: storage
+is the existing pluggable in-memory store, and there is no Raft, no multi-region,
+no multi-tenancy, and no hosting. Those belong to the commercial layer.
+
+Endpoints:
+  POST /heartbeat                     submit a signed heartbeat, get a signed voucher
+  GET  /sessions/{did}/{session_id}   session status
+  GET  /vouchers/{did}/{session_id}   the last issued voucher (cache-friendly)
+  POST /revoke                        revoke a DID
+  GET  /healthz                       liveness
+
+The coordinator is either a HeartbeatValidator (single validator) or a
+HeartbeatQuorum (M-of-N). Both expose validate(request); this server normalizes
+their result shapes and signs the issued voucher with the server's own key.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from typing import Any, Dict, Optional, Tuple, Union
+
+from fastapi import FastAPI, Request, Response
+from fastapi.responses import JSONResponse
+
+from . import data_integrity
+from .heartbeat import HeartbeatValidator
+from .quorum import HeartbeatQuorum
+from .revocation import MemoryRevocationStore, RevocationRegistry
+
+Coordinator = Union[HeartbeatValidator, HeartbeatQuorum]
+
+
+class VoucherStore:
+    """In-memory cache of the last issued voucher per (subject_did, session_id)."""
+
+    def __init__(self) -> None:
+        self._data: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        self._lock = threading.Lock()
+
+    def put(self, did: str, session_id: str, voucher: Dict[str, Any]) -> None:
+        with self._lock:
+            self._data[(did, session_id)] = voucher
+
+    def get(self, did: str, session_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._data.get((did, session_id))
+
+
+def _etag(payload: Dict[str, Any]) -> str:
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return '"' + hashlib.sha256(raw).hexdigest()[:32] + '"'
+
+
+def _normalize(result: Any) -> Dict[str, Any]:
+    """Flatten a HeartbeatValidationResult or QuorumResult into a dict."""
+    out: Dict[str, Any] = {"ok": bool(result.ok), "session_voucher": result.session_voucher}
+    # Single-validator result carries reasons; quorum result carries the tally.
+    if hasattr(result, "reasons"):
+        out["reasons"] = list(result.reasons)
+    if hasattr(result, "rejections"):
+        out["rejections"] = dict(result.rejections)
+        out["threshold"] = result.threshold
+        out["votes_for"] = result.votes_for
+        out["approving_dids"] = list(result.approving_dids)
+    return out
+
+
+def create_validator_app(
+    coordinator: Coordinator,
+    signer: Any,
+    revocation: Optional[RevocationRegistry] = None,
+    voucher_store: Optional[VoucherStore] = None,
+) -> FastAPI:
+    """
+    Build the validator FastAPI app.
+
+    Args:
+      coordinator: a HeartbeatValidator or HeartbeatQuorum.
+      signer: a vouch.Signer used to sign issued vouchers.
+      revocation: a RevocationRegistry. Defaults to a local-only memory registry
+        (no remote .well-known lookups) so the reference server is self-contained.
+      voucher_store: where issued vouchers are cached for GET /vouchers.
+    """
+    if revocation is None:
+        revocation = RevocationRegistry(local_store=MemoryRevocationStore(), check_remote=False)
+    if voucher_store is None:
+        voucher_store = VoucherStore()
+
+    if signer is None or getattr(signer, "_raw_priv", None) is None:
+        raise ValueError("validator server requires a Signer with an Ed25519 key")
+
+    app = FastAPI(title="Vouch Validator", version="1")
+
+    def _sign_voucher(voucher: Dict[str, Any]) -> Dict[str, Any]:
+        signed = dict(voucher)
+        signed["proof"] = data_integrity.build_proof(
+            signed, signer._raw_priv, signer.verification_method_id()
+        )
+        return signed
+
+    @app.get("/healthz")
+    async def healthz() -> Dict[str, Any]:
+        return {"ok": True, "validator": signer.get_did()}
+
+    @app.post("/heartbeat")
+    async def heartbeat(request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"ok": False, "reasons": ["body_not_json"]}, status_code=400)
+        if not isinstance(body, dict):
+            return JSONResponse({"ok": False, "reasons": ["body_not_object"]}, status_code=400)
+
+        did = body.get("subject_did")
+        session_id = body.get("session_id")
+        if not did or not session_id:
+            return JSONResponse(
+                {"ok": False, "reasons": ["missing_subject_did_or_session_id"]},
+                status_code=400,
+            )
+
+        if await revocation.is_revoked(did):
+            return JSONResponse({"ok": False, "revoked": True}, status_code=403)
+
+        result = _normalize(coordinator.validate(body))
+        if not result["ok"]:
+            # A rejected heartbeat is a valid, expected outcome, not a server error.
+            return JSONResponse(result, status_code=200)
+
+        voucher = _sign_voucher(result["session_voucher"])
+        voucher_store.put(did, session_id, voucher)
+        result["session_voucher"] = voucher
+        return JSONResponse(result, status_code=200)
+
+    @app.get("/sessions/{did}/{session_id}")
+    async def session_status(did: str, session_id: str) -> Dict[str, Any]:
+        voucher = voucher_store.get(did, session_id)
+        return {
+            "subject_did": did,
+            "session_id": session_id,
+            "has_active_voucher": voucher is not None,
+            "revoked": await revocation.is_revoked(did),
+        }
+
+    @app.get("/vouchers/{did}/{session_id}")
+    async def get_voucher(did: str, session_id: str, request: Request) -> Response:
+        voucher = voucher_store.get(did, session_id)
+        if voucher is None:
+            return JSONResponse({"error": "no_voucher_for_session"}, status_code=404)
+        etag = _etag(voucher)
+        if request.headers.get("if-none-match") == etag:
+            return Response(status_code=304, headers={"ETag": etag})
+        return JSONResponse(
+            voucher,
+            headers={
+                "ETag": etag,
+                # The voucher is short-lived; let caches hold it briefly but
+                # revalidate against the ETag.
+                "Cache-Control": "public, max-age=30, must-revalidate",
+            },
+        )
+
+    @app.post("/revoke")
+    async def revoke(request: Request) -> JSONResponse:
+        try:
+            body = await request.json()
+        except Exception:
+            return JSONResponse({"error": "body_not_json"}, status_code=400)
+        did = (body or {}).get("did")
+        if not did:
+            return JSONResponse({"error": "missing_did"}, status_code=400)
+        record = await revocation.revoke(
+            did=did,
+            reason=(body.get("reason") or "unspecified"),
+            revoked_by=body.get("revoked_by"),
+        )
+        return JSONResponse(
+            {"revoked": True, "did": did, "revoked_at": record.revoked_at}, status_code=200
+        )
+
+    # Expose the wiring for tests and embedding.
+    app.state.coordinator = coordinator
+    app.state.revocation = revocation
+    app.state.voucher_store = voucher_store
+    return app


### PR DESCRIPTION
## Phase 1: reference validator transport and a callable trust check

Open-source backlog Phase 1. Protocol primitives and reference implementations
only, no hosted or productized pieces.

### 1.1 Reference validator transport (`vouch/validator_server.py`)
A single-region HTTP server that puts the existing continuous-trust runtime on
the wire:
- `POST /heartbeat`: runs the request through the M-of-N quorum (or a single
  validator) and returns a signed SessionVoucher.
- `GET /sessions/{did}/{session_id}`: session status.
- `GET /vouchers/{did}/{session_id}`: the last issued voucher, with ETag and
  cache headers, and a 304 on a matching `If-None-Match`.
- `POST /revoke`: revoke a DID via the existing revocation registry.
- `GET /healthz`.

It is a clean reference: storage is the existing in-memory store, there is no
Raft, no multi-region, no multi-tenancy, and no hosting. Those belong to the
commercial layer.

### 1.2 / 1.3 One callable trust check (`vouch/trust_check.py`)
MCP tool calls and Agent2Agent calls need the same check before acting on a
request from another agent: is the caller who it claims to be, was it allowed,
is it revoked, is its trust still live. `verify_agent_call` composes credential
verification (including the delegation chain), revocation, and trust-entropy
decay into one verdict, plus an async variant that checks a revocation registry.
The MCP and A2A integration packages should call this rather than re-implement
the composition.

A note on a fix this surfaced: with no public key, `verify_credential` returns
structurally-valid, which would read as identity established. `verify_agent_call`
treats no key as identity not established, so a missing key cannot pass as
verified identity.

### Tests
15 new tests (9 for the validator server, 6 for the trust check). The full suite
passes. No new wire formats, so no new interop vectors needed.
