### PR TITLE
feat(website): OS-tabbed code blocks (macOS/Linux + Windows) for cross-platform commands

### DIFF
--- a/agents-and-skills/FAQ-DRAFT.md
+++ b/agents-and-skills/FAQ-DRAFT.md
@@ -132,9 +132,18 @@ reference file before answering Vouch questions, instead of guessing.
 **Q: How do I install the Claude Skill?**
 A: Copy the `claude-skill/` directory into your Claude skills folder:
 
+**macOS / Linux**
+
 ```bash
 mkdir -p ~/.claude/skills
 cp -r claude-skill ~/.claude/skills/vouch-protocol
+```
+
+**Windows (PowerShell)**
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
+Copy-Item -Recurse "claude-skill" "$env:USERPROFILE\.claude\skills\vouch-protocol"
 ```
 
 Restart Claude Code and run `/skills`. You should see `vouch-protocol`

--- a/agents-and-skills/HELP-GUIDE-DRAFT.md
+++ b/agents-and-skills/HELP-GUIDE-DRAFT.md
@@ -74,8 +74,16 @@ three on every commit.
 The HTTP API is identical, so an agent that talks to the Python sidecar
 can talk to the Go sidecar with one env-var change:
 
+**macOS / Linux**
+
 ```bash
 export VOUCH_SIDECAR_URL=http://localhost:8877  # same on all three
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$env:VOUCH_SIDECAR_URL = "http://localhost:8877"  # same on all three
 ```
 
 The agent code does not change. The DID changes (production agents use
@@ -157,8 +165,17 @@ on your team's terminology.
 
 ### Updating
 
+**macOS / Linux**
+
 ```bash
 cd ~/.claude/skills/vouch-protocol
+git pull
+```
+
+**Windows (PowerShell)**
+
+```powershell
+cd $env:USERPROFILE\.claude\skills\vouch-protocol
 git pull
 ```
 
@@ -209,24 +226,56 @@ page and on the homepage. On the mobile app, it's the Help tab.
 
 ### Self-host the agent locally
 
-Three processes, three terminals:
+Three processes, three terminals.
+
+**Terminal 1: dev sidecar (ephemeral key, dev only)**
+
+macOS / Linux
 
 ```bash
-# Terminal 1: dev sidecar (ephemeral key — dev only)
 cd ~/vouch-protocol/website-agent/backend
 python -m vouch_agent.dev_sidecar --did did:web:agent.example.com --port 8877
 ```
 
+Windows (PowerShell)
+
+```powershell
+cd $env:USERPROFILE\vouch-protocol\website-agent\backend
+python -m vouch_agent.dev_sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Terminal 2: agent backend**
+
+macOS / Linux
+
 ```bash
-# Terminal 2: agent backend
 cd ~/vouch-protocol/website-agent/backend
 cp ../.env.example ../.env   # then edit ../.env to add your LLM key
 uvicorn vouch_agent.main:app --host 127.0.0.1 --port 8000
 ```
 
+Windows (PowerShell)
+
+```powershell
+cd $env:USERPROFILE\vouch-protocol\website-agent\backend
+Copy-Item ..\.env.example ..\.env   # then edit ..\.env to add your LLM key
+uvicorn vouch_agent.main:app --host 127.0.0.1 --port 8000
+```
+
+**Terminal 3: chat widget (standalone harness)**
+
+macOS / Linux
+
 ```bash
-# Terminal 3: chat widget (standalone harness)
 cd ~/vouch-protocol/website-agent/standalone
+npm install
+npm run dev   # http://localhost:3200
+```
+
+Windows (PowerShell)
+
+```powershell
+cd $env:USERPROFILE\vouch-protocol\website-agent\standalone
 npm install
 npm run dev   # http://localhost:3200
 ```
@@ -244,6 +293,8 @@ reverse proxy with TLS.
 
 The agent backend supports three:
 
+**macOS / Linux**
+
 ```bash
 # Anthropic (default)
 export VOUCH_LLM_PROVIDER=anthropic
@@ -256,6 +307,22 @@ export OPENAI_API_KEY=sk-...
 # Google Gemini
 export VOUCH_LLM_PROVIDER=gemini
 export GEMINI_API_KEY=...
+```
+
+**Windows (PowerShell)**
+
+```powershell
+# Anthropic (default)
+$env:VOUCH_LLM_PROVIDER = "anthropic"
+$env:ANTHROPIC_API_KEY = "sk-ant-..."
+
+# OpenAI
+$env:VOUCH_LLM_PROVIDER = "openai"
+$env:OPENAI_API_KEY = "sk-..."
+
+# Google Gemini
+$env:VOUCH_LLM_PROVIDER = "gemini"
+$env:GEMINI_API_KEY = "..."
 ```
 
 Or set them in `website-agent/.env` (auto-loaded on backend start).

--- a/agents-and-skills/TESTING.md
+++ b/agents-and-skills/TESTING.md
@@ -9,9 +9,18 @@ assumes you are inside `~/vouch-protocol/` on Linux/WSL/macOS.
 
 ### Install locally
 
+**macOS / Linux**
+
 ```bash
 mkdir -p ~/.claude/skills
 cp -r claude-skill ~/.claude/skills/vouch-protocol
+```
+
+**Windows (PowerShell)**
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
+Copy-Item -Recurse "claude-skill" "$env:USERPROFILE\.claude\skills\vouch-protocol"
 ```
 
 ### Verify Claude Code picks it up
@@ -88,6 +97,8 @@ vouch-bridge --did did:web:agent.vouch-protocol.org --port 8877
 
 **Terminal 2: Agent backend**
 
+**macOS / Linux**
+
 ```bash
 cd website-agent/backend
 export ANTHROPIC_API_KEY=sk-ant-...
@@ -95,7 +106,18 @@ export VOUCH_SIDECAR_URL=http://localhost:8877
 uvicorn vouch_agent.main:app --reload --port 8000
 ```
 
+**Windows (PowerShell)**
+
+```powershell
+cd website-agent/backend
+$env:ANTHROPIC_API_KEY = "sk-ant-..."
+$env:VOUCH_SIDECAR_URL = "http://localhost:8877"
+uvicorn vouch_agent.main:app --reload --port 8000
+```
+
 **Terminal 3: Smoke checks**
+
+**macOS / Linux**
 
 ```bash
 # Health check
@@ -133,12 +155,55 @@ curl -s http://localhost:8000/audit | jq
 # Expect: at least one entry from the previous sign request
 ```
 
+**Windows (PowerShell)**
+
+```powershell
+# Health check
+Invoke-RestMethod "http://localhost:8000/healthz"
+# Expect: ok=True, sidecar_ok=True, knowledge_chunks > 0
+
+# Chat (no signing)
+$chatBody = @{ message = "What is the Vouch protocol?" } | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri "http://localhost:8000/chat" -ContentType "application/json" -Body $chatBody
+# Expect: SSE stream with event: meta, event: token... , event: done
+
+# Sign an allow-listed intent
+$signBody = @{
+    intent = @{
+        action   = "answer_question"
+        target   = "session:abc"
+        resource = "https://vouch-protocol.org/help"
+    }
+} | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri "http://localhost:8000/sign" -ContentType "application/json" -Body $signBody
+# Expect: a credential object plus an audit object
+
+# Reject a disallowed action
+$rejectBody = @{
+    intent = @{ action = "exfiltrate_keys"; target = "x"; resource = "x" }
+} | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri "http://localhost:8000/sign" -ContentType "application/json" -Body $rejectBody
+# Expect: HTTP 400 with detail "action 'exfiltrate_keys' not in allow-list"
+
+# Audit log
+Invoke-RestMethod "http://localhost:8000/audit"
+# Expect: at least one entry from the previous sign request
+```
+
 ### Frontend widget test
 
 In the existing Next.js website:
 
+**macOS / Linux**
+
 ```bash
 cp -r website-agent/frontend/components website/components/vouch-chat
+```
+
+**Windows (PowerShell)**
+
+```powershell
+Copy-Item -Recurse "website-agent\frontend\components" "website\components\vouch-chat"
 ```
 
 Add a temporary test page:

--- a/claude-skill/README.md
+++ b/claude-skill/README.md
@@ -80,8 +80,18 @@ better at the protocol.
 
 ## Updating
 
+**macOS / Linux**
+
 ```bash
 cd ~/.claude/skills/vouch-protocol
+git pull   # if you cloned the vouch-protocol repo
+# or re-copy from a fresh clone
+```
+
+**Windows (PowerShell)**
+
+```powershell
+cd $env:USERPROFILE\.claude\skills\vouch-protocol
 git pull   # if you cloned the vouch-protocol repo
 # or re-copy from a fresh clone
 ```

--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -122,9 +122,18 @@ See `reference/post-quantum.md` for the migration narrative.
 Use the Identity Sidecar pattern: a separate process holds the key, the
 LLM never sees it.
 
+**macOS / Linux**
+
 ```bash
 cd go-sidecar && go build ./cmd/vouch-sidecar
 ./vouch-sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+cd go-sidecar; go build ./cmd/vouch-sidecar
+.\vouch-sidecar.exe --did did:web:agent.example.com --port 8877
 ```
 
 The agent's code calls `POST http://localhost:8877/sign` with the

--- a/claude-skill/skills/vouch-protocol/reference/go-sidecar.md
+++ b/claude-skill/skills/vouch-protocol/reference/go-sidecar.md
@@ -19,8 +19,16 @@ go build ./cmd/vouch-sidecar
 
 ## Run
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com --port 8877
 ```
 
 Flags:

--- a/claude-skill/skills/vouch-protocol/reference/post-quantum.md
+++ b/claude-skill/skills/vouch-protocol/reference/post-quantum.md
@@ -141,8 +141,16 @@ const signed = await signer.signCredentialHybrid({
 
 Hybrid signing is built into the sidecar:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com --hybrid --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com --hybrid --port 8877
 ```
 
 All `/sign` requests now produce hybrid credentials.

--- a/claude-skill/skills/vouch-protocol/reference/quickstart.md
+++ b/claude-skill/skills/vouch-protocol/reference/quickstart.md
@@ -64,6 +64,8 @@ go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 vouch-sidecar --did did:web:agent.example.com --port 8877
 ```
 
+**macOS / Linux**
+
 ```bash
 curl -X POST http://localhost:8877/sign \
     -H 'content-type: application/json' \
@@ -74,6 +76,20 @@ curl -X POST http://localhost:8877/sign \
             "resource": "https://insurance.example.com/claims/HC-001"
         }
     }'
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$body = @{
+    intent = @{
+        action   = "submit_claim"
+        target   = "claim:HC-001"
+        resource = "https://insurance.example.com/claims/HC-001"
+    }
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:8877/sign" -ContentType "application/json" -Body $body
 ```
 
 ## Hosting a did:web DID Document

--- a/claude-skill/skills/vouch-protocol/reference/sidecar.md
+++ b/claude-skill/skills/vouch-protocol/reference/sidecar.md
@@ -48,9 +48,18 @@ Even if the LLM is fully compromised, it cannot leak a key it never had.
 `go-sidecar/cmd/vouch-sidecar` is the reference implementation. Small
 binary, low memory, fast startup, no GIL.
 
+**macOS / Linux**
+
 ```bash
 go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 ./vouch-sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
+.\vouch-sidecar.exe --did did:web:agent.example.com --port 8877
 ```
 
 See `reference/go-sidecar.md` for the full HTTP API and deployment patterns.
@@ -123,10 +132,20 @@ spec:
 For production, the sidecar shouldn't even hold a raw key file. Point
 it at AWS KMS / GCP KMS / Azure Key Vault:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com \
                 --kms-provider aws \
                 --kms-key-id alias/vouch-agent
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com `
+                    --kms-provider aws `
+                    --kms-key-id alias/vouch-agent
 ```
 
 The sidecar holds a session token, not the underlying private key.
@@ -144,8 +163,16 @@ If the path from sidecar to caller is over a network (e.g., calling
 from a separate service), enable `--sensitive` to wrap responses in
 JWE so the credential is encrypted in flight:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did ... --sensitive
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did ... --sensitive
 ```
 
 Caller decrypts with its pre-shared key. Typically used in

--- a/docs/mcp-quickstart.md
+++ b/docs/mcp-quickstart.md
@@ -27,10 +27,16 @@ pip install vouch-protocol
 vouch init --env
 ```
 
-**Output:**
+**Output (macOS / Linux):**
 ```bash
 export VOUCH_DID='did:vouch:abc123...'
 export VOUCH_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+```
+
+**Output (Windows / PowerShell):**
+```powershell
+$env:VOUCH_DID = "did:vouch:abc123..."
+$env:VOUCH_PRIVATE_KEY = '{"kty":"OKP","crv":"Ed25519",...}'
 ```
 
 > 💡 Copy these values - you'll paste them in the next step!
@@ -90,11 +96,22 @@ Your keys aren't being passed to the server. Check:
 
 ### Test the server manually
 
+**macOS / Linux**
+
 ```bash
 export VOUCH_DID='did:vouch:test'
 export VOUCH_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519","x":"...","d":"..."}'
 
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | vouch-mcp
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$env:VOUCH_DID = "did:vouch:test"
+$env:VOUCH_PRIVATE_KEY = '{"kty":"OKP","crv":"Ed25519","x":"...","d":"..."}'
+
+'{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | vouch-mcp
 ```
 
 ---

--- a/docs/mcp-tutorial.md
+++ b/docs/mcp-tutorial.md
@@ -299,6 +299,8 @@ if __name__ == "__main__":
 
 ### Step 4: Test It
 
+**macOS / Linux**
+
 ```bash
 # Set your identity (from vouch init --env)
 export VOUCH_DID='did:vouch:abc123'
@@ -306,6 +308,17 @@ export VOUCH_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
 
 # Test sending a signed email
 echo '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_email","arguments":{"to":"alice@example.com","subject":"Hello","body":"Test"}}}' | python my_vouch_mcp_server.py
+```
+
+**Windows (PowerShell)**
+
+```powershell
+# Set your identity (from vouch init --env)
+$env:VOUCH_DID = "did:vouch:abc123"
+$env:VOUCH_PRIVATE_KEY = '{"kty":"OKP","crv":"Ed25519",...}'
+
+# Test sending a signed email
+'{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"send_email","arguments":{"to":"alice@example.com","subject":"Hello","body":"Test"}}}' | python my_vouch_mcp_server.py
 ```
 
 **Output:**

--- a/gemini-gem/knowledge/post-quantum.md
+++ b/gemini-gem/knowledge/post-quantum.md
@@ -129,8 +129,16 @@ const signed = await signer.signCredentialHybrid(credential);
 
 Hybrid signing is built into the sidecar:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com --hybrid --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com --hybrid --port 8877
 ```
 
 All `/sign` requests now produce hybrid credentials.

--- a/gemini-gem/knowledge/quickstart.md
+++ b/gemini-gem/knowledge/quickstart.md
@@ -64,6 +64,8 @@ go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 vouch-sidecar --did did:web:agent.example.com --port 8877
 ```
 
+**macOS / Linux**
+
 ```bash
 curl -X POST http://localhost:8877/sign \
     -H 'content-type: application/json' \
@@ -74,6 +76,20 @@ curl -X POST http://localhost:8877/sign \
             "resource": "https://insurance.example.com/claims/HC-001"
         }
     }'
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$body = @{
+    intent = @{
+        action   = "submit_claim"
+        target   = "claim:HC-001"
+        resource = "https://insurance.example.com/claims/HC-001"
+    }
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:8877/sign" -ContentType "application/json" -Body $body
 ```
 
 ## Hosting a did:web DID Document

--- a/gemini-gem/knowledge/sidecar.md
+++ b/gemini-gem/knowledge/sidecar.md
@@ -48,9 +48,18 @@ Even if the LLM is fully compromised, it cannot leak a key it never had.
 `go-sidecar/cmd/vouch-sidecar` is the reference implementation. Small
 binary, low memory, fast startup, no GIL.
 
+**macOS / Linux**
+
 ```bash
 go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 ./vouch-sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
+.\vouch-sidecar.exe --did did:web:agent.example.com --port 8877
 ```
 
 See `reference/go-sidecar.md` for the full HTTP API and deployment patterns.
@@ -123,10 +132,20 @@ spec:
 For production, the sidecar shouldn't even hold a raw key file. Point
 it at AWS KMS / GCP KMS / Azure Key Vault:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com \
                 --kms-provider aws \
                 --kms-key-id alias/vouch-agent
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com `
+                    --kms-provider aws `
+                    --kms-key-id alias/vouch-agent
 ```
 
 The sidecar holds a session token, not the underlying private key.
@@ -144,8 +163,16 @@ If the path from sidecar to caller is over a network (e.g., calling
 from a separate service), enable `--sensitive` to wrap responses in
 JWE so the credential is encrypted in flight:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did ... --sensitive
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did ... --sensitive
 ```
 
 Caller decrypts with its pre-shared key. Typically used in

--- a/openai-gpt/knowledge/post-quantum.md
+++ b/openai-gpt/knowledge/post-quantum.md
@@ -129,8 +129,16 @@ const signed = await signer.signCredentialHybrid(credential);
 
 Hybrid signing is built into the sidecar:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com --hybrid --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com --hybrid --port 8877
 ```
 
 All `/sign` requests now produce hybrid credentials.

--- a/openai-gpt/knowledge/quickstart.md
+++ b/openai-gpt/knowledge/quickstart.md
@@ -64,6 +64,8 @@ go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 vouch-sidecar --did did:web:agent.example.com --port 8877
 ```
 
+**macOS / Linux**
+
 ```bash
 curl -X POST http://localhost:8877/sign \
     -H 'content-type: application/json' \
@@ -74,6 +76,20 @@ curl -X POST http://localhost:8877/sign \
             "resource": "https://insurance.example.com/claims/HC-001"
         }
     }'
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$body = @{
+    intent = @{
+        action   = "submit_claim"
+        target   = "claim:HC-001"
+        resource = "https://insurance.example.com/claims/HC-001"
+    }
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:8877/sign" -ContentType "application/json" -Body $body
 ```
 
 ## Hosting a did:web DID Document

--- a/openai-gpt/knowledge/sidecar.md
+++ b/openai-gpt/knowledge/sidecar.md
@@ -48,9 +48,18 @@ Even if the LLM is fully compromised, it cannot leak a key it never had.
 `go-sidecar/cmd/vouch-sidecar` is the reference implementation. Small
 binary, low memory, fast startup, no GIL.
 
+**macOS / Linux**
+
 ```bash
 go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 ./vouch-sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
+.\vouch-sidecar.exe --did did:web:agent.example.com --port 8877
 ```
 
 See `reference/go-sidecar.md` for the full HTTP API and deployment patterns.
@@ -123,10 +132,20 @@ spec:
 For production, the sidecar shouldn't even hold a raw key file. Point
 it at AWS KMS / GCP KMS / Azure Key Vault:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com \
                 --kms-provider aws \
                 --kms-key-id alias/vouch-agent
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com `
+                    --kms-provider aws `
+                    --kms-key-id alias/vouch-agent
 ```
 
 The sidecar holds a session token, not the underlying private key.
@@ -144,8 +163,16 @@ If the path from sidecar to caller is over a network (e.g., calling
 from a separate service), enable `--sensitive` to wrap responses in
 JWE so the credential is encrypted in flight:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did ... --sensitive
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did ... --sensitive
 ```
 
 Caller decrypts with its pre-shared key. Typically used in

--- a/website-agent/backend/knowledge/ai-assistants.md
+++ b/website-agent/backend/knowledge/ai-assistants.md
@@ -22,9 +22,18 @@ Claude reads the matching file before answering Vouch questions.
 
 ### Install
 
+**macOS / Linux**
+
 ```bash
 mkdir -p ~/.claude/skills
 cp -r ~/vouch-protocol/claude-skill ~/.claude/skills/vouch-protocol
+```
+
+**Windows (PowerShell)**
+
+```powershell
+New-Item -ItemType Directory -Force "$env:USERPROFILE\.claude\skills"
+Copy-Item -Recurse "$env:USERPROFILE\vouch-protocol\claude-skill" "$env:USERPROFILE\.claude\skills\vouch-protocol"
 ```
 
 Restart Claude Code and run `/skills` to confirm. You should see
@@ -47,8 +56,17 @@ Eleven reference files: `python-sdk.md`, `typescript-sdk.md`,
 
 ### Updating
 
+**macOS / Linux**
+
 ```bash
 cd ~/.claude/skills/vouch-protocol
+git pull
+```
+
+**Windows (PowerShell)**
+
+```powershell
+cd $env:USERPROFILE\.claude\skills\vouch-protocol
 git pull
 ```
 

--- a/website-agent/backend/knowledge/post-quantum.md
+++ b/website-agent/backend/knowledge/post-quantum.md
@@ -129,8 +129,16 @@ const signed = await signer.signCredentialHybrid(credential);
 
 Hybrid signing is built into the sidecar:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com --hybrid --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com --hybrid --port 8877
 ```
 
 All `/sign` requests now produce hybrid credentials.

--- a/website-agent/backend/knowledge/quickstart.md
+++ b/website-agent/backend/knowledge/quickstart.md
@@ -64,6 +64,8 @@ go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 vouch-sidecar --did did:web:agent.example.com --port 8877
 ```
 
+**macOS / Linux**
+
 ```bash
 curl -X POST http://localhost:8877/sign \
     -H 'content-type: application/json' \
@@ -74,6 +76,20 @@ curl -X POST http://localhost:8877/sign \
             "resource": "https://insurance.example.com/claims/HC-001"
         }
     }'
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$body = @{
+    intent = @{
+        action   = "submit_claim"
+        target   = "claim:HC-001"
+        resource = "https://insurance.example.com/claims/HC-001"
+    }
+} | ConvertTo-Json
+
+Invoke-RestMethod -Method Post -Uri "http://localhost:8877/sign" -ContentType "application/json" -Body $body
 ```
 
 ## Hosting a did:web DID Document

--- a/website-agent/backend/knowledge/sidecar-tiers.md
+++ b/website-agent/backend/knowledge/sidecar-tiers.md
@@ -64,8 +64,16 @@ rejects the same inputs and emits semantically equivalent credentials.
 The HTTP API is identical. An agent that talks to the Python sidecar
 can talk to the Go sidecar with one env-var change:
 
+**macOS / Linux**
+
 ```bash
 export VOUCH_SIDECAR_URL=http://localhost:8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+$env:VOUCH_SIDECAR_URL = "http://localhost:8877"
 ```
 
 The agent code does not change. The DID changes (production agents

--- a/website-agent/backend/knowledge/sidecar.md
+++ b/website-agent/backend/knowledge/sidecar.md
@@ -48,9 +48,18 @@ Even if the LLM is fully compromised, it cannot leak a key it never had.
 `go-sidecar/cmd/vouch-sidecar` is the reference implementation. Small
 binary, low memory, fast startup, no GIL.
 
+**macOS / Linux**
+
 ```bash
 go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
 ./vouch-sidecar --did did:web:agent.example.com --port 8877
+```
+
+**Windows (PowerShell)**
+
+```powershell
+go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest
+.\vouch-sidecar.exe --did did:web:agent.example.com --port 8877
 ```
 
 See `reference/go-sidecar.md` for the full HTTP API and deployment patterns.
@@ -123,10 +132,20 @@ spec:
 For production, the sidecar shouldn't even hold a raw key file. Point
 it at AWS KMS / GCP KMS / Azure Key Vault:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did did:web:agent.example.com \
                 --kms-provider aws \
                 --kms-key-id alias/vouch-agent
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did did:web:agent.example.com `
+                    --kms-provider aws `
+                    --kms-key-id alias/vouch-agent
 ```
 
 The sidecar holds a session token, not the underlying private key.
@@ -144,8 +163,16 @@ If the path from sidecar to caller is over a network (e.g., calling
 from a separate service), enable `--sensitive` to wrap responses in
 JWE so the credential is encrypted in flight:
 
+**macOS / Linux**
+
 ```bash
 ./vouch-sidecar --did ... --sensitive
+```
+
+**Windows (PowerShell)**
+
+```powershell
+.\vouch-sidecar.exe --did ... --sensitive
 ```
 
 Caller decrypts with its pre-shared key. Typically used in

--- a/website/src/app/faq/FAQClient.tsx
+++ b/website/src/app/faq/FAQClient.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo } from 'react';
 import Link from 'next/link';
 import type { FAQSection } from './faq-data';
 import CodeBlock from '@/components/CodeBlock';
+import OSCodeBlock from '@/components/OSCodeBlock';
 
 /**
  * Render a FAQ answer. Supports code fences (extracted first so internal
@@ -34,10 +35,33 @@ function renderAnswer(text: string): React.ReactNode {
     }
 
     const out: React.ReactNode[] = [];
-    segments.forEach((seg, si) => {
+    const isUnix = (l?: string) =>
+        ['bash', 'sh', 'shell', 'console', 'zsh'].includes((l || '').toLowerCase());
+    const isWin = (l?: string) =>
+        ['powershell', 'pwsh', 'ps1', 'ps'].includes((l || '').toLowerCase());
+    for (let si = 0; si < segments.length; si++) {
+        const seg = segments[si];
         if (seg.kind === 'code') {
+            if (isUnix(seg.lang)) {
+                let j = si + 1;
+                if (
+                    j < segments.length &&
+                    segments[j].kind === 'text' &&
+                    segments[j].content.trim() === ''
+                ) {
+                    j++;
+                }
+                const next = segments[j];
+                if (next && next.kind === 'code' && isWin(next.lang)) {
+                    out.push(
+                        <OSCodeBlock key={`s${si}`} unix={seg.content} windows={next.content} />
+                    );
+                    si = j;
+                    continue;
+                }
+            }
             out.push(<CodeBlock key={`s${si}`} code={seg.content} language={seg.lang} />);
-            return;
+            continue;
         }
         const paragraphs = seg.content.split(/\n\n+/).map((p) => p.trim()).filter(Boolean);
         paragraphs.forEach((paragraph, pi) => {
@@ -67,7 +91,7 @@ function renderAnswer(text: string): React.ReactNode {
                 </p>
             );
         });
-    });
+    }
     return out;
 }
 

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -947,6 +947,10 @@ Run \`/plugin\` to confirm it is enabled. The skill loads automatically when you
 cp -r ~/vouch-protocol/claude-skill/skills/vouch-protocol ~/.claude/skills/vouch-protocol
 \`\`\`
 
+\`\`\`powershell
+Copy-Item -Recurse "$env:USERPROFILE\\vouch-protocol\\claude-skill\\skills\\vouch-protocol" "$env:USERPROFILE\\.claude\\skills\\vouch-protocol"
+\`\`\`
+
 Run \`/skills\` to confirm \`vouch-protocol\` is listed. Read the Guides section "Installing the Vouch Claude Skill" for screen-by-screen steps and triggers.`,
         helpLinks: [{ label: 'Installing the Claude Skill', href: '/help/#claude-skill-install' }],
       },

--- a/website/src/app/help/HelpClient.tsx
+++ b/website/src/app/help/HelpClient.tsx
@@ -4,6 +4,7 @@ import React, { useState, useMemo } from 'react';
 import Link from 'next/link';
 import type { HelpSection } from './help-data';
 import CodeBlock from '@/components/CodeBlock';
+import OSCodeBlock from '@/components/OSCodeBlock';
 
 /**
  * Render markdown-lite content: paragraphs, **bold**, `code`, code fences,
@@ -36,19 +37,46 @@ function renderBody(body: string): React.ReactNode {
         segments.push({ kind: 'text', content: trimmed });
     }
 
+    const isUnix = (l?: string) =>
+        ['bash', 'sh', 'shell', 'console', 'zsh'].includes((l || '').toLowerCase());
+    const isWin = (l?: string) =>
+        ['powershell', 'pwsh', 'ps1', 'ps'].includes((l || '').toLowerCase());
+
     const out: React.ReactNode[] = [];
-    segments.forEach((seg, si) => {
+    for (let si = 0; si < segments.length; si++) {
+        const seg = segments[si];
         if (seg.kind === 'code') {
+            // OS-paired block: a macOS/Linux fence immediately followed by a
+            // Windows (PowerShell) fence (ignoring a whitespace-only gap)
+            // renders as one tabbed block.
+            if (isUnix(seg.lang)) {
+                let j = si + 1;
+                if (
+                    j < segments.length &&
+                    segments[j].kind === 'text' &&
+                    segments[j].content.trim() === ''
+                ) {
+                    j++;
+                }
+                const next = segments[j];
+                if (next && next.kind === 'code' && isWin(next.lang)) {
+                    out.push(
+                        <OSCodeBlock key={`s${si}`} unix={seg.content} windows={next.content} />
+                    );
+                    si = j;
+                    continue;
+                }
+            }
             out.push(
                 <CodeBlock key={`s${si}`} code={seg.content} language={seg.lang} />
             );
-            return;
+            continue;
         }
         const blocks = seg.content.split(/\n\n+/).map((b) => b.trim()).filter(Boolean);
         blocks.forEach((block, bi) => {
             out.push(renderTextBlock(block, `s${si}-b${bi}`));
         });
-    });
+    }
     return out;
 }
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -262,6 +262,10 @@ Run it locally with a placeholder DID. The sidecar binds to localhost only by de
 ./vouch-sidecar --did did:web:localhost --port 8877
 \`\`\`
 
+\`\`\`powershell
+.\\vouch-sidecar.exe --did did:web:localhost --port 8877
+\`\`\`
+
 Optional flags:
 
 - \`--sensitive\` or \`-s\` - wrap the response in a JWE so the credential is encrypted in flight
@@ -284,6 +288,19 @@ curl -X POST http://localhost:8877/sign \\
     },
     "validSeconds": 300
   }'
+\`\`\`
+
+\`\`\`powershell
+$body = @{
+  subjectDid = "did:web:localhost"
+  intent = @{
+    action   = "submit_claim"
+    target   = "claim:HC-001"
+    resource = "https://insurance.example.com/claims/HC-001"
+  }
+  validSeconds = 300
+} | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri http://localhost:8877/sign -ContentType 'application/json' -Body $body
 \`\`\`
 
 The response is the full signed Verifiable Credential. Pipe it into your Python or TypeScript verifier (configured with \`trusted_roots\` / \`trustedRoots\` pointing at the sidecar's public key, fetched from \`GET http://localhost:8877/.well-known/did.json\`) to close the loop.
@@ -1598,14 +1615,10 @@ Run \`/plugin\` to confirm it is enabled. The skill loads automatically when you
 
 Prefer to drop it in by hand? Copy the skill folder into your skills directory.
 
-Linux / macOS / WSL:
-
 \`\`\`bash
 git clone https://github.com/vouch-protocol/vouch
 cp -r vouch/claude-skill/skills/vouch-protocol ~/.claude/skills/vouch-protocol
 \`\`\`
-
-Windows PowerShell:
 
 \`\`\`powershell
 git clone https://github.com/vouch-protocol/vouch
@@ -1755,6 +1768,20 @@ export OPENAI_API_KEY=sk-...
 # Google Gemini
 export VOUCH_LLM_PROVIDER=gemini
 export GEMINI_API_KEY=...
+\`\`\`
+
+\`\`\`powershell
+# Anthropic (default)
+$env:VOUCH_LLM_PROVIDER = "anthropic"
+$env:ANTHROPIC_API_KEY = "sk-ant-..."
+
+# OpenAI
+$env:VOUCH_LLM_PROVIDER = "openai"
+$env:OPENAI_API_KEY = "sk-..."
+
+# Google Gemini
+$env:VOUCH_LLM_PROVIDER = "gemini"
+$env:GEMINI_API_KEY = "..."
 \`\`\`
 
 Or set them in \`website-agent/.env\` (auto-loaded on backend start).

--- a/website/src/components/CodeBlock.tsx
+++ b/website/src/components/CodeBlock.tsx
@@ -9,6 +9,8 @@ type Props = {
     language?: string;
     /** Override Tailwind classes on the <pre>. */
     className?: string;
+    /** Drop the default vertical margin (used when a parent owns the spacing, e.g. OSCodeBlock tabs). */
+    bare?: boolean;
 };
 
 /**
@@ -17,7 +19,7 @@ type Props = {
  * numbers cannot pollute the clipboard. Icon flips to a checkmark for
  * ~1.6 seconds after a successful copy.
  */
-export default function CodeBlock({ code, language, className = '' }: Props) {
+export default function CodeBlock({ code, language, className = '', bare = false }: Props) {
     const [copied, setCopied] = useState(false);
 
     async function copy() {
@@ -31,7 +33,7 @@ export default function CodeBlock({ code, language, className = '' }: Props) {
     }
 
     return (
-        <div className="relative group my-4">
+        <div className={`relative group ${bare ? '' : 'my-4'}`}>
             {language && (
                 <div className="absolute top-2 left-3 flex items-center gap-2 pointer-events-none">
                     <span className="font-mono uppercase text-[0.62rem] tracking-[0.18em] text-parchment/50">

--- a/website/src/components/OSCodeBlock.tsx
+++ b/website/src/components/OSCodeBlock.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import CodeBlock from './CodeBlock';
+
+/**
+ * A code block with macOS/Linux and Windows (PowerShell) variants behind tabs.
+ * The chosen OS is shared across every OSCodeBlock on the page and persisted to
+ * localStorage, so a developer picks their OS once and every command follows.
+ *
+ * macOS and Linux share a tab because the command text is identical on both.
+ */
+
+type OS = 'unix' | 'windows';
+const STORAGE_KEY = 'vouch-os-pref';
+
+// Module-level current selection + subscribers, so all instances stay in sync.
+let current: OS = 'unix';
+const listeners = new Set<(os: OS) => void>();
+
+function setGlobalOS(os: OS): void {
+  current = os;
+  try {
+    localStorage.setItem(STORAGE_KEY, os);
+  } catch {
+    /* storage unavailable */
+  }
+  listeners.forEach((fn) => fn(os));
+}
+
+type Props = {
+  /** macOS / Linux command text. */
+  unix: string;
+  /** Windows (PowerShell) command text. */
+  windows: string;
+  /** Optional className forwarded to the inner <pre>. */
+  className?: string;
+};
+
+export default function OSCodeBlock({ unix, windows, className }: Props) {
+  const [os, setOs] = useState<OS>(current);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as OS | null;
+      if (stored === 'unix' || stored === 'windows') {
+        current = stored;
+      }
+    } catch {
+      /* storage unavailable */
+    }
+    setOs(current);
+    const listener = (next: OS) => setOs(next);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  function tab(label: string, value: OS) {
+    const active = os === value;
+    return (
+      <button
+        type="button"
+        onClick={() => setGlobalOS(value)}
+        aria-pressed={active}
+        className={`font-mono uppercase text-[0.62rem] tracking-[0.16em] px-3 py-1.5 border-b-2 transition-colors ${
+          active
+            ? 'border-burgundy text-ink'
+            : 'border-transparent text-ink-faint hover:text-ink-soft'
+        }`}
+      >
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <div className="my-4">
+      <div className="flex gap-1 border-b border-rule">
+        {tab('macOS / Linux', 'unix')}
+        {tab('Windows', 'windows')}
+      </div>
+      <CodeBlock code={os === 'windows' ? windows : unix} className={className} bare />
+    </div>
+  );
+}


### PR DESCRIPTION
First slice of cross-platform command coverage: a website component plus the Help quickstarts, so developers on Windows get PowerShell commands, not just Linux ones.

## What this adds
- **OSCodeBlock** component: macOS/Linux and Windows (PowerShell) tabs. The choice syncs across every block on the page and persists (localStorage), so a developer picks their OS once and every command follows. macOS and Linux share a tab because the command text is identical on both.
- The Help markdown renderer now pairs a bash fence immediately followed by a powershell fence into one tabbed block (no new syntax to author).
- Applied to the Help commands that actually differ by OS: the Claude Skill manual install (cp -r vs Copy-Item), the LLM-provider env config (export vs :), and the Go sidecar run + request (./vouch-sidecar + curl vs .exe + Invoke-RestMethod).

Commands identical on every OS (pip install, npm i, cargo add, every vouch CLI command) are left as plain blocks, no needless tabs.

## Rollout plan (this is slice 1)
Next: the FAQ, onboard page, then the markdown surfaces (README + the six FHKCOG knowledge bases) using labeled "macOS / Linux" + "Windows (PowerShell)" blocks since markdown cannot host interactive tabs. As I touch each command I verify it runs (the Linux side of the docs-vs-reality sweep).

Build-verified (npm run build, 25 static pages). No SDK or CLI code changed.
