### PR TITLE
Phase 4: accountability primitives (audit trail + budget credential)

### DIFF
--- a/examples/budget_payment_demo.py
+++ b/examples/budget_payment_demo.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Budgeted agent payments: a demo of the budget credential and payment verifier.
+
+Run it:
+
+    pip install vouch-protocol
+    python budget_payment_demo.py
+
+A principal grants an agent a signed budget (per transaction, per day, per
+counterparty). When the agent is asked to pay, the verifier checks the payment
+against that budget before any money moves. The same check maps onto an
+AP2-style payment mandate or an x402 payment requirement: the mandate is just a
+dict carrying amount, currency, and payee.
+
+Everything runs locally. No servers, no setup.
+"""
+
+from vouch import Signer, generate_identity
+from vouch import budget as bud
+
+G = "\033[92m"; R = "\033[91m"; B = "\033[94m"; DIM = "\033[2m"; BOLD = "\033[1m"; END = "\033[0m"
+
+
+def verdict(v) -> str:
+    if v.allowed:
+        return f"{G}{BOLD}ALLOWED{END}"
+    return f"{R}{BOLD}DENIED{END}  {DIM}({', '.join(v.reasons)}){END}"
+
+
+def main() -> None:
+    print()
+    print(f"{BOLD}BUDGETED AGENT PAYMENTS{END}  {DIM}a Vouch Protocol demo{END}")
+    print(DIM + "=" * 60 + END)
+
+    principal = generate_identity(domain="principal.example.com")
+    signer = Signer(private_key=principal.private_key_jwk, did=principal.did)
+
+    credential = bud.build_budget_credential(
+        signer,
+        subject_did="did:web:shopper-agent.example.com",
+        currency="USD",
+        per_transaction=100.0,
+        daily=250.0,
+        per_counterparty={"did:web:vendor.example.com": 300.0},
+    )
+    print(f"{B}Budget granted to{END} did:web:shopper-agent.example.com")
+    print(f"{DIM}per transaction 100, daily 250, vendor cap 300 (USD){END}")
+    print()
+
+    verifier = bud.BudgetVerifier(credential)
+    vendor = "did:web:vendor.example.com"
+
+    # Each mandate is the shape an AP2 mandate or an x402 requirement maps onto.
+    mandates = [
+        {"amount": 80.0, "currency": "USD", "payee": vendor},
+        {"amount": 80.0, "currency": "USD", "payee": vendor},
+        {"amount": 120.0, "currency": "USD", "payee": vendor},  # over per-transaction
+        {"amount": 90.0, "currency": "USD", "payee": vendor},   # over daily after 160 spent
+    ]
+
+    for i, m in enumerate(mandates, 1):
+        v = verifier.check_payment(m["amount"], counterparty=m["payee"], currency=m["currency"])
+        print(f"  Payment {i}: {m['amount']:>6.0f} USD to vendor   {verdict(v)}")
+        if v.allowed:
+            verifier.record_payment(m["amount"], counterparty=m["payee"])
+
+    print()
+    print(DIM + "=" * 60 + END)
+    print(f"{DIM}The agent can spend, but only inside limits it can prove it was given.{END}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/budget_payment_demo.py
+++ b/examples/budget_payment_demo.py
@@ -19,7 +19,12 @@ Everything runs locally. No servers, no setup.
 from vouch import Signer, generate_identity
 from vouch import budget as bud
 
-G = "\033[92m"; R = "\033[91m"; B = "\033[94m"; DIM = "\033[2m"; BOLD = "\033[1m"; END = "\033[0m"
+G = "\033[92m"
+R = "\033[91m"
+B = "\033[94m"
+DIM = "\033[2m"
+BOLD = "\033[1m"
+END = "\033[0m"
 
 
 def verdict(v) -> str:
@@ -56,7 +61,7 @@ def main() -> None:
         {"amount": 80.0, "currency": "USD", "payee": vendor},
         {"amount": 80.0, "currency": "USD", "payee": vendor},
         {"amount": 120.0, "currency": "USD", "payee": vendor},  # over per-transaction
-        {"amount": 90.0, "currency": "USD", "payee": vendor},   # over daily after 160 spent
+        {"amount": 90.0, "currency": "USD", "payee": vendor},  # over daily after 160 spent
     ]
 
     for i, m in enumerate(mandates, 1):

--- a/test-vectors/audit-trail/vectors.json
+++ b/test-vectors/audit-trail/vectors.json
@@ -1,0 +1,26 @@
+{
+  "description": "Vouch audit trail hash chain. entry_hash = sha256(JCS(content)) where content excludes entry_hash. prev_hash links to the previous entry_hash; genesis is 64 zeros.",
+  "genesis_prev_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "entries": [
+    {
+      "seq": 0,
+      "timestamp": "2026-06-14T00:00:00Z",
+      "action": "ALLOWED",
+      "actor": "did:web:agent.example.com",
+      "resource": "read_file",
+      "prev_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+      "entry_hash": "9469586cff2015643fe187b26a6cb3b362d1ab1a97472b013e7ab0b08021fd26"
+    },
+    {
+      "seq": 1,
+      "timestamp": "2026-06-14T00:00:01Z",
+      "action": "BLOCKED",
+      "actor": "did:web:agent.example.com",
+      "resource": "run_command",
+      "decision": "not_trusted",
+      "prev_hash": "9469586cff2015643fe187b26a6cb3b362d1ab1a97472b013e7ab0b08021fd26",
+      "entry_hash": "693faecfc32038de0760024f21c4dd24ac3f6bbd2ca886f930a2b7a1c7ca55bb"
+    }
+  ],
+  "head": "693faecfc32038de0760024f21c4dd24ac3f6bbd2ca886f930a2b7a1c7ca55bb"
+}

--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -1,0 +1,132 @@
+"""Tests for the tamper-evident audit trail and human-oversight attestation."""
+
+import copy
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.attribution import _pub_from_jwk
+from vouch import audit_trail as at
+
+
+@pytest.fixture
+def signer_identity():
+    ident = generate_identity(domain="auditor.example.com")
+    return ident, Signer(private_key=ident.private_key_jwk, did=ident.did)
+
+
+def _trail():
+    t = at.AuditTrail()
+    t.append(action="ALLOWED", actor="did:web:agent.example.com", resource="read_file",
+             timestamp="2026-06-14T00:00:00Z")
+    t.append(action="BLOCKED", actor="did:web:agent.example.com", resource="run_command",
+             decision="not_trusted", timestamp="2026-06-14T00:00:01Z")
+    t.append(action="ALLOWED", actor="did:web:agent.example.com", resource="write_file",
+             timestamp="2026-06-14T00:00:02Z")
+    return t
+
+
+def test_chain_builds_and_verifies():
+    t = _trail()
+    assert len(t) == 3
+    ok, broken = t.verify()
+    assert ok and broken is None
+    # Each entry links to the previous.
+    es = t.entries
+    assert es[0].prev_hash == at.GENESIS_HASH
+    assert es[1].prev_hash == es[0].entry_hash
+    assert es[2].prev_hash == es[1].entry_hash
+    assert t.head == es[2].entry_hash
+
+
+def test_determinism():
+    # Same inputs produce the same hashes, so the format is reproducible.
+    assert _trail().head == _trail().head
+
+
+def test_tampered_entry_detected():
+    t = _trail()
+    es = t.entries
+    es[1].resource = "exfiltrate_secrets"  # edit a recorded action
+    ok, broken = at.verify_entries(es)
+    assert not ok and broken == 1
+
+
+def test_deletion_detected():
+    t = _trail()
+    es = t.entries
+    del es[1]  # drop the blocked event to hide it
+    # Reseating seq is required for the loop; the surviving entry keeps seq=2.
+    ok, broken = at.verify_entries(es)
+    assert not ok
+
+
+def test_signed_export_verifies(signer_identity):
+    ident, signer = signer_identity
+    manifest = at.signed_export(_trail(), signer)
+    ok, reasons = at.verify_export(manifest, _pub_from_jwk(ident.public_key_jwk))
+    assert ok, reasons
+
+
+def test_signed_export_tamper_rejected(signer_identity):
+    ident, signer = signer_identity
+    manifest = at.signed_export(_trail(), signer)
+    tampered = copy.deepcopy(manifest)
+    tampered["entries"][0]["resource"] = "something_else"
+    ok, reasons = at.verify_export(tampered, _pub_from_jwk(ident.public_key_jwk))
+    assert not ok
+    # Either the proof breaks or the chain recomputation breaks; both are fine.
+    assert reasons
+
+
+def test_from_flight_recorder():
+    from vouch.shield.flight_recorder import LogEntry
+    logs = [
+        LogEntry(timestamp="2026-06-14T00:00:00Z", event="ALLOWED",
+                 did="did:web:a.example.com", tool="read"),
+        LogEntry(timestamp="2026-06-14T00:00:01Z", event="BLOCKED",
+                 did="did:web:a.example.com", tool="rm", reason="blocked"),
+    ]
+    t = at.AuditTrail.from_flight_recorder(logs)
+    ok, _ = t.verify()
+    assert ok and len(t) == 2
+
+
+def test_human_oversight_attestation(signer_identity):
+    ident, signer = signer_identity
+    cred = at.build_human_oversight_attestation(
+        signer,
+        reviewer="did:web:lead.example.com",
+        action_ref="abc123entryhash",
+        decision="approved",
+        note="checked the diff, looks safe",
+    )
+    assert cred["type"][-1] == at.OVERSIGHT_TYPE
+    assert cred["credentialSubject"]["decision"] == "approved"
+    assert at.verify_human_oversight_attestation(cred, _pub_from_jwk(ident.public_key_jwk))
+
+
+def test_matches_interop_vector():
+    # Lock the hash-chain format against the published test vector so other
+    # language implementations can validate byte-identically.
+    import json
+    from pathlib import Path
+
+    vec_path = Path(__file__).resolve().parents[1] / "test-vectors" / "audit-trail" / "vectors.json"
+    vector = json.loads(vec_path.read_text())
+    entries = [at.AuditEntry.from_dict(d) for d in vector["entries"]]
+    # Recomputing each entry hash from its content must reproduce the vector.
+    for e in entries:
+        assert e.compute_hash() == e.entry_hash
+    ok, broken = at.verify_entries(entries)
+    assert ok and broken is None
+    assert entries[-1].entry_hash == vector["head"]
+
+
+def test_human_oversight_wrong_key_fails(signer_identity):
+    _, signer = signer_identity
+    other = generate_identity(domain="attacker.example.com")
+    cred = at.build_human_oversight_attestation(
+        signer, reviewer="did:web:lead.example.com", action_ref="x", decision="approved",
+    )
+    assert not at.verify_human_oversight_attestation(cred, _pub_from_jwk(other.public_key_jwk))

--- a/tests/test_audit_trail.py
+++ b/tests/test_audit_trail.py
@@ -17,12 +17,25 @@ def signer_identity():
 
 def _trail():
     t = at.AuditTrail()
-    t.append(action="ALLOWED", actor="did:web:agent.example.com", resource="read_file",
-             timestamp="2026-06-14T00:00:00Z")
-    t.append(action="BLOCKED", actor="did:web:agent.example.com", resource="run_command",
-             decision="not_trusted", timestamp="2026-06-14T00:00:01Z")
-    t.append(action="ALLOWED", actor="did:web:agent.example.com", resource="write_file",
-             timestamp="2026-06-14T00:00:02Z")
+    t.append(
+        action="ALLOWED",
+        actor="did:web:agent.example.com",
+        resource="read_file",
+        timestamp="2026-06-14T00:00:00Z",
+    )
+    t.append(
+        action="BLOCKED",
+        actor="did:web:agent.example.com",
+        resource="run_command",
+        decision="not_trusted",
+        timestamp="2026-06-14T00:00:01Z",
+    )
+    t.append(
+        action="ALLOWED",
+        actor="did:web:agent.example.com",
+        resource="write_file",
+        timestamp="2026-06-14T00:00:02Z",
+    )
     return t
 
 
@@ -81,11 +94,21 @@ def test_signed_export_tamper_rejected(signer_identity):
 
 def test_from_flight_recorder():
     from vouch.shield.flight_recorder import LogEntry
+
     logs = [
-        LogEntry(timestamp="2026-06-14T00:00:00Z", event="ALLOWED",
-                 did="did:web:a.example.com", tool="read"),
-        LogEntry(timestamp="2026-06-14T00:00:01Z", event="BLOCKED",
-                 did="did:web:a.example.com", tool="rm", reason="blocked"),
+        LogEntry(
+            timestamp="2026-06-14T00:00:00Z",
+            event="ALLOWED",
+            did="did:web:a.example.com",
+            tool="read",
+        ),
+        LogEntry(
+            timestamp="2026-06-14T00:00:01Z",
+            event="BLOCKED",
+            did="did:web:a.example.com",
+            tool="rm",
+            reason="blocked",
+        ),
     ]
     t = at.AuditTrail.from_flight_recorder(logs)
     ok, _ = t.verify()
@@ -127,6 +150,9 @@ def test_human_oversight_wrong_key_fails(signer_identity):
     _, signer = signer_identity
     other = generate_identity(domain="attacker.example.com")
     cred = at.build_human_oversight_attestation(
-        signer, reviewer="did:web:lead.example.com", action_ref="x", decision="approved",
+        signer,
+        reviewer="did:web:lead.example.com",
+        action_ref="x",
+        decision="approved",
     )
     assert not at.verify_human_oversight_attestation(cred, _pub_from_jwk(other.public_key_jwk))

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -1,0 +1,101 @@
+"""Tests for the budget-validator credential and reference payment verifier."""
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.attribution import _pub_from_jwk
+from vouch import budget as bud
+
+
+@pytest.fixture
+def principal():
+    ident = generate_identity(domain="principal.example.com")
+    return ident, Signer(private_key=ident.private_key_jwk, did=ident.did)
+
+
+@pytest.fixture
+def credential(principal):
+    _, signer = principal
+    return bud.build_budget_credential(
+        signer,
+        subject_did="did:web:agent.example.com",
+        currency="USD",
+        per_transaction=100.0,
+        daily=250.0,
+        monthly=1000.0,
+        per_counterparty={"did:web:vendor.example.com": 150.0},
+    )
+
+
+def test_credential_is_signed_and_verifies(principal, credential):
+    ident, _ = principal
+    from vouch import data_integrity
+    assert credential["type"][-1] == bud.BUDGET_CREDENTIAL_TYPE
+    assert data_integrity.verify_proof(credential, _pub_from_jwk(ident.public_key_jwk))
+
+
+def test_per_transaction_limit(credential):
+    v = bud.BudgetVerifier(credential)
+    assert v.check_payment(50.0).allowed is True
+    over = v.check_payment(150.0)
+    assert over.allowed is False
+    assert any("over_per_transaction" in r for r in over.reasons)
+
+
+def test_currency_mismatch(credential):
+    v = bud.BudgetVerifier(credential)
+    bad = v.check_payment(10.0, currency="EUR")
+    assert not bad.allowed
+    assert any("currency_mismatch" in r for r in bad.reasons)
+
+
+def test_daily_limit_with_running_tally(credential):
+    v = bud.BudgetVerifier(credential)
+    # Spend up to the daily cap across several payments.
+    for _ in range(2):
+        assert v.check_payment(100.0).allowed
+        v.record_payment(100.0)
+    # 200 spent, daily cap 250: a 100 payment now exceeds it.
+    third = v.check_payment(100.0)
+    assert not third.allowed
+    assert any("over_daily" in r for r in third.reasons)
+    # But a 50 payment still fits.
+    assert v.check_payment(50.0).allowed
+
+
+def test_per_counterparty_limit(credential):
+    v = bud.BudgetVerifier(credential)
+    vendor = "did:web:vendor.example.com"
+    assert v.check_payment(100.0, counterparty=vendor).allowed
+    v.record_payment(100.0, counterparty=vendor)
+    # 100 spent with vendor, cap 150: a 100 payment exceeds the counterparty cap.
+    over = v.check_payment(100.0, counterparty=vendor)
+    assert not over.allowed
+    assert any("over_counterparty" in r for r in over.reasons)
+
+
+def test_mandate_within_budget(principal, credential):
+    ident, _ = principal
+    # An AP2-style / x402-style mandate maps onto this dict shape.
+    ok_mandate = {"amount": 80.0, "currency": "USD", "payee": "did:web:vendor.example.com"}
+    verdict = bud.verify_mandate_within_budget(
+        credential, ok_mandate, budget_public_key=_pub_from_jwk(ident.public_key_jwk)
+    )
+    assert verdict.allowed, verdict.reasons
+
+    too_big = {"amount": 500.0, "currency": "USD", "payee": "did:web:vendor.example.com"}
+    bad = bud.verify_mandate_within_budget(credential, too_big)
+    assert not bad.allowed
+    assert any("over_per_transaction" in r for r in bad.reasons)
+
+
+def test_mandate_proof_failure_detected(principal, credential):
+    # A wrong key makes the budget credential proof check fail.
+    other = generate_identity(domain="attacker.example.com")
+    verdict = bud.verify_mandate_within_budget(
+        credential,
+        {"amount": 10.0, "currency": "USD"},
+        budget_public_key=_pub_from_jwk(other.public_key_jwk),
+    )
+    assert not verdict.allowed
+    assert any("budget_credential_proof_invalid" in r for r in verdict.reasons)

--- a/tests/test_budget.py
+++ b/tests/test_budget.py
@@ -30,6 +30,7 @@ def credential(principal):
 def test_credential_is_signed_and_verifies(principal, credential):
     ident, _ = principal
     from vouch import data_integrity
+
     assert credential["type"][-1] == bud.BUDGET_CREDENTIAL_TYPE
     assert data_integrity.verify_proof(credential, _pub_from_jwk(ident.public_key_jwk))
 

--- a/vouch/audit_trail.py
+++ b/vouch/audit_trail.py
@@ -1,0 +1,308 @@
+"""
+Tamper-evident audit trail and human-oversight attestation (Specification §15).
+
+The Shield flight recorder writes plain JSONL: useful, but any line can be
+edited or removed without trace. This module formalizes that output into an
+append-only, hash-chained audit trail where each entry commits to the previous
+one, so any edit, reorder, or deletion breaks the chain. It adds a signed export
+that binds the whole trail to one Data Integrity proof, and a human-oversight
+attestation credential proving a named principal reviewed a specific action.
+
+These are open formats and reference implementations. Per-regime compliance
+packs and hosted report generators are out of scope here.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from . import data_integrity, jcs
+
+GENESIS_HASH = "0" * 64
+
+CONTEXT = "https://vouch-protocol.com/audit/v1"
+TRAIL_EXPORT_TYPE = "VouchAuditTrailExport"
+OVERSIGHT_TYPE = "VouchHumanOversightAttestation"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _hash_entry(content: Dict[str, Any]) -> str:
+    """SHA-256 over the JCS-canonical bytes of the entry content."""
+    return hashlib.sha256(jcs.canonicalize(content)).hexdigest()
+
+
+@dataclass
+class AuditEntry:
+    """
+    One link in the audit chain. `entry_hash` commits to every field above it,
+    including `prev_hash`, so the chain is tamper-evident: change any field and
+    the hash no longer matches, and every later entry's prev_hash is wrong too.
+    """
+
+    seq: int
+    timestamp: str
+    action: str
+    actor: Optional[str] = None
+    resource: Optional[str] = None
+    decision: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+    prev_hash: str = GENESIS_HASH
+    entry_hash: str = ""
+
+    def content(self) -> Dict[str, Any]:
+        """The hashed content: every field except entry_hash, no None values."""
+        c = {
+            "seq": self.seq,
+            "timestamp": self.timestamp,
+            "action": self.action,
+            "actor": self.actor,
+            "resource": self.resource,
+            "decision": self.decision,
+            "metadata": self.metadata,
+            "prev_hash": self.prev_hash,
+        }
+        return {k: v for k, v in c.items() if v is not None}
+
+    def compute_hash(self) -> str:
+        return _hash_entry(self.content())
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = self.content()
+        d["entry_hash"] = self.entry_hash
+        return d
+
+    @classmethod
+    def from_dict(cls, d: Dict[str, Any]) -> "AuditEntry":
+        return cls(
+            seq=d["seq"],
+            timestamp=d["timestamp"],
+            action=d["action"],
+            actor=d.get("actor"),
+            resource=d.get("resource"),
+            decision=d.get("decision"),
+            metadata=d.get("metadata"),
+            prev_hash=d.get("prev_hash", GENESIS_HASH),
+            entry_hash=d.get("entry_hash", ""),
+        )
+
+
+class AuditTrail:
+    """
+    An append-only, hash-chained audit trail. Optionally persists to a JSONL
+    file (one entry per line). The chain head (`head`) is the hash of the most
+    recent entry and is what a signed export commits to.
+    """
+
+    def __init__(self, path: Optional[str] = None) -> None:
+        self._entries: List[AuditEntry] = []
+        self._path = path
+
+    @property
+    def head(self) -> str:
+        return self._entries[-1].entry_hash if self._entries else GENESIS_HASH
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    @property
+    def entries(self) -> List[AuditEntry]:
+        return list(self._entries)
+
+    def append(
+        self,
+        action: str,
+        actor: Optional[str] = None,
+        resource: Optional[str] = None,
+        decision: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        timestamp: Optional[str] = None,
+    ) -> AuditEntry:
+        entry = AuditEntry(
+            seq=len(self._entries),
+            timestamp=timestamp or _now_iso(),
+            action=action,
+            actor=actor,
+            resource=resource,
+            decision=decision,
+            metadata=metadata,
+            prev_hash=self.head,
+        )
+        entry.entry_hash = entry.compute_hash()
+        self._entries.append(entry)
+        if self._path:
+            with open(self._path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(entry.to_dict()) + "\n")
+        return entry
+
+    def verify(self) -> Tuple[bool, Optional[int]]:
+        """
+        Recompute the chain. Returns (ok, first_broken_seq). ok=True means every
+        entry's hash matches its content and links to the prior entry.
+        """
+        return verify_entries(self._entries)
+
+    @classmethod
+    def from_flight_recorder(cls, log_entries: Iterable[Any]) -> "AuditTrail":
+        """
+        Build a tamper-evident trail from existing flight-recorder LogEntry
+        objects (or their dicts). This formalizes the plain JSONL output.
+        """
+        trail = cls()
+        for le in log_entries:
+            d = le.to_dict() if hasattr(le, "to_dict") else dict(le)
+            trail.append(
+                action=d.get("event", d.get("action", "UNKNOWN")),
+                actor=d.get("did") or d.get("actor"),
+                resource=d.get("tool") or d.get("resource"),
+                decision=d.get("reason"),
+                metadata=d.get("metadata"),
+                timestamp=d.get("timestamp"),
+            )
+        return trail
+
+
+def verify_entries(entries: List[AuditEntry]) -> Tuple[bool, Optional[int]]:
+    prev = GENESIS_HASH
+    for i, e in enumerate(entries):
+        if e.seq != i:
+            return False, i
+        if e.prev_hash != prev:
+            return False, i
+        if e.compute_hash() != e.entry_hash:
+            return False, i
+        prev = e.entry_hash
+    return True, None
+
+
+def load_trail(path: str) -> AuditTrail:
+    """Load a trail from a JSONL file without re-hashing (for verification)."""
+    trail = AuditTrail()
+    with open(path, "r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                trail._entries.append(AuditEntry.from_dict(json.loads(line)))
+    return trail
+
+
+# ---------------------------------------------------------------------------
+# Signed export
+# ---------------------------------------------------------------------------
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise ValueError("signed export requires a Signer with an Ed25519 key")
+    return raw
+
+
+def signed_export(trail: AuditTrail, signer: Any) -> Dict[str, Any]:
+    """
+    Produce a signed export that commits to the whole trail. The export binds
+    the entry count, the genesis prev_hash, and the chain head; signing it makes
+    the entire chain non-repudiable. Verifiers recompute the chain and check the
+    head matches before trusting the proof.
+    """
+    entries = trail.entries
+    manifest = {
+        "@context": CONTEXT,
+        "type": TRAIL_EXPORT_TYPE,
+        "count": len(entries),
+        "head": trail.head,
+        "exportedBy": signer.get_did(),
+        "exportedAt": _now_iso(),
+        "entries": [e.to_dict() for e in entries],
+    }
+    manifest["proof"] = data_integrity.build_proof(
+        manifest, _raw_priv(signer), signer.verification_method_id()
+    )
+    return manifest
+
+
+def verify_export(manifest: Dict[str, Any], public_key) -> Tuple[bool, List[str]]:
+    """
+    Verify a signed audit-trail export: the Data Integrity proof, the chain
+    integrity, and that the declared head matches the recomputed head.
+    """
+    reasons: List[str] = []
+    try:
+        if not data_integrity.verify_proof(manifest, public_key):
+            reasons.append("proof_invalid")
+    except Exception as exc:
+        reasons.append(f"proof_error:{exc}")
+
+    entries = [AuditEntry.from_dict(d) for d in manifest.get("entries", [])]
+    ok, broken = verify_entries(entries)
+    if not ok:
+        reasons.append(f"chain_broken_at_seq:{broken}")
+
+    declared_head = manifest.get("head", GENESIS_HASH)
+    actual_head = entries[-1].entry_hash if entries else GENESIS_HASH
+    if declared_head != actual_head:
+        reasons.append("head_mismatch")
+    if manifest.get("count") != len(entries):
+        reasons.append("count_mismatch")
+
+    return (not reasons), reasons
+
+
+# ---------------------------------------------------------------------------
+# Human-oversight attestation credential
+# ---------------------------------------------------------------------------
+
+def build_human_oversight_attestation(
+    signer: Any,
+    *,
+    reviewer: str,
+    action_ref: str,
+    decision: str,
+    note: Optional[str] = None,
+    reviewed_at: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    A signed credential proving a named human principal reviewed a specific
+    action and reached a decision (for example "approved" or "rejected").
+
+    Args:
+      signer: the reviewer's (or the system's) Signer.
+      reviewer: DID or identifier of the human who reviewed.
+      action_ref: what was reviewed: an audit entry_hash, a credential id, or a
+        URL identifying the action.
+      decision: the reviewer's decision, e.g. "approved" or "rejected".
+      note: optional free-text rationale.
+    """
+    credential = {
+        "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            CONTEXT,
+        ],
+        "type": ["VerifiableCredential", OVERSIGHT_TYPE],
+        "issuer": signer.get_did(),
+        "validFrom": reviewed_at or _now_iso(),
+        "credentialSubject": {
+            "reviewer": reviewer,
+            "actionRef": action_ref,
+            "decision": decision,
+        },
+    }
+    if note:
+        credential["credentialSubject"]["note"] = note
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+def verify_human_oversight_attestation(credential: Dict[str, Any], public_key) -> bool:
+    """Verify the Data Integrity proof on a human-oversight attestation."""
+    try:
+        return data_integrity.verify_proof(credential, public_key)
+    except Exception:
+        return False

--- a/vouch/audit_trail.py
+++ b/vouch/audit_trail.py
@@ -196,6 +196,7 @@ def load_trail(path: str) -> AuditTrail:
 # Signed export
 # ---------------------------------------------------------------------------
 
+
 def _raw_priv(signer: Any):
     raw = getattr(signer, "_raw_priv", None)
     if raw is None:
@@ -256,6 +257,7 @@ def verify_export(manifest: Dict[str, Any], public_key) -> Tuple[bool, List[str]
 # ---------------------------------------------------------------------------
 # Human-oversight attestation credential
 # ---------------------------------------------------------------------------
+
 
 def build_human_oversight_attestation(
     signer: Any,

--- a/vouch/budget.py
+++ b/vouch/budget.py
@@ -166,7 +166,9 @@ class BudgetVerifier:
         """Record a completed payment in the running tally."""
         now = now or datetime.now(timezone.utc)
         self._by_day[self._day_key(now)] = self._by_day.get(self._day_key(now), 0.0) + amount
-        self._by_month[self._month_key(now)] = self._by_month.get(self._month_key(now), 0.0) + amount
+        self._by_month[self._month_key(now)] = (
+            self._by_month.get(self._month_key(now), 0.0) + amount
+        )
         if counterparty is not None:
             self._by_counterparty[counterparty] = (
                 self._by_counterparty.get(counterparty, 0.0) + amount

--- a/vouch/budget.py
+++ b/vouch/budget.py
@@ -1,0 +1,209 @@
+"""
+Budget-validator credential and a reference payment verifier (Specification §15).
+
+A budget credential binds an agent to spending limits: per transaction, per day,
+per month, and per counterparty. The reference verifier enforces those limits
+against a running tally, and can check that an external signed payment mandate
+(for example an AP2-style mandate, or an x402 payment requirement) stays within
+the agent's budget before any money moves.
+
+This is the open primitive plus a reference verifier. The hosted
+spend-authorization gateway, metering, and billing are out of scope here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional
+
+from . import data_integrity
+
+CONTEXT = "https://vouch-protocol.com/budget/v1"
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+BUDGET_CREDENTIAL_TYPE = "VouchBudgetCredential"
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise ValueError("budget credential signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def build_budget_credential(
+    signer: Any,
+    *,
+    subject_did: str,
+    currency: str,
+    per_transaction: Optional[float] = None,
+    daily: Optional[float] = None,
+    monthly: Optional[float] = None,
+    per_counterparty: Optional[Dict[str, float]] = None,
+    scope: Optional[List[str]] = None,
+    valid_seconds: int = 86400,
+) -> Dict[str, Any]:
+    """
+    Build a signed budget credential delegating spending limits to an agent.
+
+    The issuer (signer) is the principal granting the budget; subject_did is the
+    agent the budget applies to. All limits are optional; only the ones present
+    are enforced. Amounts are in the given currency's minor or major units, the
+    verifier just compares numbers, so be consistent.
+    """
+    now = datetime.now(timezone.utc)
+    budget: Dict[str, Any] = {"currency": currency}
+    if per_transaction is not None:
+        budget["perTransaction"] = per_transaction
+    if daily is not None:
+        budget["daily"] = daily
+    if monthly is not None:
+        budget["monthly"] = monthly
+    if per_counterparty:
+        budget["perCounterparty"] = dict(per_counterparty)
+
+    credential = {
+        "@context": [VC_CONTEXT_V2, CONTEXT],
+        "type": ["VerifiableCredential", BUDGET_CREDENTIAL_TYPE],
+        "issuer": signer.get_did(),
+        "validFrom": _iso(now),
+        "validUntil": _iso(now + timedelta(seconds=valid_seconds)),
+        "credentialSubject": {
+            "id": subject_did,
+            "budget": budget,
+            "scope": scope or ["payments"],
+        },
+    }
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+@dataclass
+class BudgetVerdict:
+    allowed: bool
+    reasons: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"allowed": self.allowed, "reasons": list(self.reasons)}
+
+
+class BudgetVerifier:
+    """
+    Enforces a budget credential against a running tally of spend. In-memory
+    reference: tracks spend per day, per month, per counterparty, and total.
+    """
+
+    def __init__(self, credential: Dict[str, Any]) -> None:
+        self.budget = credential["credentialSubject"]["budget"]
+        self.currency = self.budget.get("currency")
+        self._by_day: Dict[str, float] = {}
+        self._by_month: Dict[str, float] = {}
+        self._by_counterparty: Dict[str, float] = {}
+
+    @staticmethod
+    def _day_key(now: datetime) -> str:
+        return now.astimezone(timezone.utc).strftime("%Y-%m-%d")
+
+    @staticmethod
+    def _month_key(now: datetime) -> str:
+        return now.astimezone(timezone.utc).strftime("%Y-%m")
+
+    def check_payment(
+        self,
+        amount: float,
+        *,
+        counterparty: Optional[str] = None,
+        currency: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> BudgetVerdict:
+        """Check a proposed payment against the budget. Does not record it."""
+        now = now or datetime.now(timezone.utc)
+        reasons: List[str] = []
+
+        if amount <= 0:
+            reasons.append("amount_not_positive")
+        if currency is not None and self.currency is not None and currency != self.currency:
+            reasons.append(f"currency_mismatch:{currency}!={self.currency}")
+
+        per_tx = self.budget.get("perTransaction")
+        if per_tx is not None and amount > per_tx:
+            reasons.append(f"over_per_transaction:{amount}>{per_tx}")
+
+        daily = self.budget.get("daily")
+        if daily is not None:
+            spent = self._by_day.get(self._day_key(now), 0.0)
+            if spent + amount > daily:
+                reasons.append(f"over_daily:{spent}+{amount}>{daily}")
+
+        monthly = self.budget.get("monthly")
+        if monthly is not None:
+            spent = self._by_month.get(self._month_key(now), 0.0)
+            if spent + amount > monthly:
+                reasons.append(f"over_monthly:{spent}+{amount}>{monthly}")
+
+        per_cp = self.budget.get("perCounterparty") or {}
+        if counterparty is not None and counterparty in per_cp:
+            limit = per_cp[counterparty]
+            spent = self._by_counterparty.get(counterparty, 0.0)
+            if spent + amount > limit:
+                reasons.append(f"over_counterparty:{counterparty}:{spent}+{amount}>{limit}")
+
+        return BudgetVerdict(allowed=not reasons, reasons=reasons)
+
+    def record_payment(
+        self,
+        amount: float,
+        *,
+        counterparty: Optional[str] = None,
+        now: Optional[datetime] = None,
+    ) -> None:
+        """Record a completed payment in the running tally."""
+        now = now or datetime.now(timezone.utc)
+        self._by_day[self._day_key(now)] = self._by_day.get(self._day_key(now), 0.0) + amount
+        self._by_month[self._month_key(now)] = self._by_month.get(self._month_key(now), 0.0) + amount
+        if counterparty is not None:
+            self._by_counterparty[counterparty] = (
+                self._by_counterparty.get(counterparty, 0.0) + amount
+            )
+
+
+def verify_mandate_within_budget(
+    budget_credential: Dict[str, Any],
+    mandate: Dict[str, Any],
+    *,
+    budget_public_key: Optional[Any] = None,
+) -> BudgetVerdict:
+    """
+    Check that an external signed payment mandate fits inside the agent's budget.
+
+    The mandate is a transport-neutral dict carrying at least `amount`, and
+    optionally `currency` and `payee`. It maps cleanly onto an AP2-style payment
+    mandate or an x402 payment requirement. This checks per-transaction and
+    per-counterparty limits and (optionally) the budget credential's own proof;
+    it does not consult the running tally (use BudgetVerifier for that).
+    """
+    reasons: List[str] = []
+    if budget_public_key is not None:
+        try:
+            if not data_integrity.verify_proof(budget_credential, budget_public_key):
+                reasons.append("budget_credential_proof_invalid")
+        except Exception as exc:
+            reasons.append(f"budget_credential_proof_error:{exc}")
+
+    amount = mandate.get("amount")
+    if amount is None:
+        return BudgetVerdict(allowed=False, reasons=reasons + ["mandate_missing_amount"])
+
+    verifier = BudgetVerifier(budget_credential)
+    verdict = verifier.check_payment(
+        float(amount),
+        counterparty=mandate.get("payee") or mandate.get("counterparty"),
+        currency=mandate.get("currency"),
+    )
+    return BudgetVerdict(allowed=verdict.allowed and not reasons, reasons=reasons + verdict.reasons)


### PR DESCRIPTION
## Phase 4: accountability and economy primitives

Open-source backlog Phase 4. Formats and reference implementations only; no
per-regime compliance packs, report generators, hosted spend gateways, metering,
or billing.

### 4.1 Tamper-evident audit trail (`vouch/audit_trail.py`)
Formalizes the plain-JSONL flight recorder into an append-only, hash-chained
audit trail where each entry commits to the previous one, so any edit, reorder,
or deletion breaks the chain.
- `AuditTrail` with a hash chain (entry_hash = sha256 of the JCS-canonical
  content, linking to prev_hash; genesis is 64 zeros) and `from_flight_recorder`.
- `signed_export` binds the whole chain to one Data Integrity proof;
  `verify_export` checks the proof, the chain, and the head.
- `build_human_oversight_attestation`: a signed credential proving a named
  principal reviewed and approved or rejected a specific action.
- An interop test vector under `test-vectors/audit-trail/` so other language
  implementations validate the hash chain byte-identically.

### 4.2 Budget-validator credential and reference payment verifier (`vouch/budget.py`)
- `build_budget_credential`: a signed credential binding an agent to limits
  (per transaction, per day, per month, per counterparty).
- `BudgetVerifier`: enforces those limits against a running tally.
- `verify_mandate_within_budget`: checks an external signed payment mandate fits
  the budget. The mandate is a transport-neutral dict (amount, currency, payee)
  that maps onto an AP2-style payment mandate or an x402 payment requirement.
- `examples/budget_payment_demo.py`: a runnable demo of the check in a payment
  flow.

### Tests
17 new tests (10 audit trail including the interop vector, 7 budget). The full
suite passes. No em-dashes; no commercial-product names (the local brand guard
is satisfied).
