### PR TITLE
ci: harden website deploy push against concurrent-merge races

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -89,7 +89,26 @@ jobs:
           Triggered by commit ${GITHUB_SHA}.
 
           [skip ci]"
-          git push origin main
+          # Push with rebase-and-retry. A concurrent merge to main moves the
+          # branch between checkout and push and would otherwise reject this
+          # push as non-fast-forward, silently leaving the live site stale.
+          # The deploy commit only touches generated docs/ output, so replaying
+          # it onto the latest main is a clean, conflict-free rebase.
+          pushed=
+          for attempt in 1 2 3 4 5; do
+            if git push origin main; then
+              echo "Pushed deploy commit on attempt ${attempt}."
+              pushed=1
+              break
+            fi
+            echo "Push rejected on attempt ${attempt}; rebasing onto latest main and retrying."
+            git pull --rebase origin main
+            sleep $((attempt * 3))
+          done
+          if [ -z "${pushed}" ]; then
+            echo "Failed to push the deploy commit after 5 attempts."
+            exit 1
+          fi
 
       - name: Summary
         run: |


### PR DESCRIPTION
The Deploy Website workflow built the static export but its final  was a plain push with no rebase or retry. When another PR merges in the ~50 seconds the build takes, main moves and the push is rejected as non-fast-forward, so the export is never committed and the live site silently stays on the old build.

That is exactly what happened to #51 (the OS tabs): the build succeeded, the push lost a race with #55/#56, and the tabs never went live until a manual re-run.

## Fix
Replace the bare push with a rebase-and-retry loop (up to 5 attempts): on a rejected push, Current branch ci/harden-deploy-push is up to date. to replay the generated docs/ commit onto the latest main, then retry. Fails loudly (exit 1) if it still cannot push after 5 tries. The deploy commit only touches generated docs/ output, so the rebase is always clean, and the  group already prevents two deploys racing each other.

No behavior change on the happy path (first push still succeeds immediately). YAML validated.
