### PR TITLE
Add robotics primitives, /robotics page, and PAD-064 through 070

### DIFF
--- a/docs/disclosures/PAD-064-hardware-rooted-robot-identity.md
+++ b/docs/disclosures/PAD-064-hardware-rooted-robot-identity.md
@@ -1,0 +1,151 @@
+# PAD-064: Hardware-Rooted Verifiable Robot Identity and Lifecycle Credential
+
+**Identifier:** PAD-064  
+**Title:** Method for Binding a Robot's Software Identity Key to a Hardware Root of Trust via an Attested Verifiable Lifecycle Credential, as a Vendor-Neutral Robot Identity  
+**Publication Date:** June 14, 2026  
+**Prior Art Effective Date:** June 14, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Hardware Root of Trust / Verifiable Credentials / Device Identity / AI Safety  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-018 (Model Lineage Provenance), PAD-065 (Model and Config Provenance), PAD-068 (Kill-Switch Credential)  
+
+---
+
+## 1. Abstract
+
+A method for giving a physical robot a verifiable identity in which the robot's
+software identity key (a Vouch Ed25519 key used to sign actions) is
+cryptographically bound to a hardware root of trust (a TPM or a secure element)
+through an attested, verifiable lifecycle credential. The hardware root signs a
+canonical binding over the robot's decentralized identifier and its software
+public key; that attestation is embedded in a Verifiable Credential carrying the
+robot's make, model, serial, and lifecycle history. A verifier checks both the
+credential's own proof (the software key) and the hardware attestation (the root
+key), so the identity cannot be cloned to other hardware.
+
+Key innovations:
+
+- **Dual-proof identity.** The identity verifies only when both the software-key
+  credential proof and the hardware-root attestation over the (DID, key) binding
+  verify, tying the portable software identity to one physical device.
+- **Vendor-neutral, open profile.** The identity is an open Verifiable Credential
+  profile, not a proprietary or state-run registry, so any manufacturer or owner
+  can issue and any party can verify it.
+- **Pluggable hardware root.** A single interface (public key plus a
+  sign-over-digest operation) is satisfied by a TPM attestation key, a
+  secure-element device key, or a software reference for development, so the same
+  credential format serves every backend.
+- **Lifecycle history in-credential.** Manufacture, commissioning, ownership
+  transfer, and decommissioning are recorded as a lifecycle history on the
+  identity, making provenance auditable.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Robot identity today is proprietary or absent
+
+Robots are identified by vendor serial numbers, cloud-account bindings, or
+closed/state-run registries. None give a portable, cryptographically verifiable,
+vendor-neutral identity that an arbitrary third party can check offline.
+
+### 2.2 A software key alone can be copied to other hardware
+
+If a robot's identity is just a software key, that key can be exfiltrated and run
+on different hardware, impersonating the robot. Identity must be anchored to the
+specific device.
+
+### 2.3 No open binding between a verifiable credential and a hardware root
+
+Verifiable Credentials and DIDs provide portable software identity; TPMs and
+secure elements provide hardware anchoring. No open method binds the two so that
+a robot's verifiable identity is provably resident on one device, with a
+lifecycle history.
+
+---
+
+## 3. Solution (The Invention)
+
+At commissioning, the robot mints a RobotIdentityCredential:
+
+1. The robot's software signer computes its public key in multibase form and its
+   DID.
+2. The hardware root signs a canonical binding `B = JCS({"key": robotKeyMultibase,
+   "robotDid": robotDid})`, producing an attestation signature.
+3. The credential's subject carries `make`, `model`, `serial`, a `lifecycle`
+   array, and a `hardwareRoot` block `{ kind, publicKeyMultibase, attestation }`.
+4. The robot self-issues the credential with its software key (an eddsa-jcs-2022
+   Data Integrity proof).
+
+To verify, a party:
+
+1. verifies the credential's Data Integrity proof against the robot's software
+   public key,
+2. decodes the hardware-root public key from `hardwareRoot.publicKeyMultibase`,
+3. recomputes the binding `B` from the credential subject's DID and the software
+   key, and
+4. verifies the hardware-root attestation over `B`.
+
+Acceptance requires both. Because the binding includes both the DID and the
+software key, and the attestation is produced by a hardware-resident key, the
+credential proves the software identity is anchored to that hardware. The
+`HardwareRootOfTrust` interface (public key plus sign-over-digest) is satisfied by
+a TPM attestation key, a secure element, or a software reference for testing.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **TPM remote attestation / DICE / IDevID (IEEE 802.1AR).** Provide hardware
+  device identity but are not expressed as open, portable Verifiable Credentials
+  carrying make/model/serial and a lifecycle history that any party can verify
+  with the same tooling used for agent credentials.
+- **Proprietary robot fleet identity (vendor clouds).** Closed and account-bound;
+  not vendor-neutral or third-party-verifiable offline.
+- **PAD-001 (Cryptographic Agent Identity).** Establishes software agent identity;
+  the present method adds the hardware-root binding and the robot lifecycle
+  profile, which PAD-001 does not cover.
+- **DID methods (did:web, did:key).** Provide software-key identity but no binding
+  to a hardware root or a device lifecycle.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `HardwareRootOfTrust` (the pluggable
+interface), `SoftwareRootOfTrust` (development reference), `mint_robot_identity`,
+`verify_robot_identity`, and `lifecycle_event`. A TPM or secure-element backend
+subclasses the interface, signing the binding with its hardware-resident
+attestation key without exposing the key. The binding and the credential reuse the
+shared JCS canonicalization, multikey encoding, and eddsa-jcs-2022 proof, so the
+robot identity verifies with the same cross-language SDKs as agent credentials. An
+interop vector pins the binding bytes.
+
+---
+
+## 6. Claims Summary
+
+1. A method for a robot's verifiable identity in which a hardware root of trust
+   signs a canonical binding over the robot's decentralized identifier and its
+   software identity public key, the attestation embedded in a Verifiable
+   Credential, such that verification requires both the credential proof and the
+   hardware attestation.
+2. The method of claim 1 wherein the credential carries make, model, serial, and a
+   lifecycle history of the robot.
+3. The method of claim 1 wherein the hardware root is accessed through a single
+   interface satisfied by a TPM attestation key, a secure-element device key, or a
+   software reference.
+4. The method of claim 1 wherein the binding includes both the identifier and the
+   key, so the credential cannot be re-bound to a different key or device.
+5. The method of claim 1 wherein the identity is an open, vendor-neutral Verifiable
+   Credential profile verifiable by any party without a central registry.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the broader robotics community.

--- a/docs/disclosures/PAD-065-model-config-provenance-attestation.md
+++ b/docs/disclosures/PAD-065-model-config-provenance-attestation.md
@@ -1,0 +1,131 @@
+# PAD-065: Re-Signable Model-and-Config Provenance Attestation for Embodied Agents
+
+**Identifier:** PAD-065  
+**Title:** Method for a Signed, Chained Provenance Attestation of the Model, Weights Hash, Safety Policy, and Configuration Running on a Robot, Re-Signed on Each Over-the-Air Update  
+**Publication Date:** June 14, 2026  
+**Prior Art Effective Date:** June 14, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Model Provenance / AI Safety / Supply Chain / Verifiable Credentials  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-018 (Model Lineage Provenance), PAD-043 (Cryptographic Weight Binding), PAD-064 (Hardware-Rooted Robot Identity), PAD-068 (Kill-Switch Credential)  
+
+---
+
+## 1. Abstract
+
+A method for attesting, in a signed and verifiable record, exactly which
+Vision-Language-Action (VLA) model, model-weights hash, safety policy, and runtime
+configuration are running on a physical robot at a given time, and for re-signing
+that record on each over-the-air (OTA) update so that the sequence of attestations
+forms a tamper-evident chain of what software the robot ran and when. The record
+records the configuration as a hash of its canonical form, so a verifier can
+confirm the exact configuration without the configuration's contents being
+re-derived.
+
+Key innovations:
+
+- **Single attestation binds model, weights, policy, and config.** One signed
+  record ties the model identity, the weights hash, the active safety policy, and
+  the configuration hash to the robot's identity.
+- **OTA re-signing with a supersedes link.** Each update issues a new attestation
+  that references the attestation it replaces, so the chain answers "what was
+  running at time T" for any past T.
+- **Canonical config hashing.** The configuration hash is the multibase SHA-256 of
+  the JCS-canonical configuration, reproducible by any verifier in any language.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 No verifiable record of what software a robot runs
+
+After deployment and OTA updates, there is no standard, verifiable way to know
+which model weights and safety policy a robot is actually running. Logs are
+mutable and vendor-specific.
+
+### 2.2 OTA updates erase history
+
+An OTA update replaces the running software, and the prior state is typically
+gone. For incident investigation and regulatory audit, the question "what model
+and policy were active when this incident occurred" must be answerable after the
+fact.
+
+### 2.3 Config drift is invisible
+
+A safety-relevant configuration parameter can change without a verifiable record,
+so a robot's behavior can change without an auditable cause.
+
+---
+
+## 3. Solution (The Invention)
+
+A ModelProvenanceAttestation is a Verifiable Credential whose subject carries a
+`vla` block:
+
+```
+{ "modelName", "weightsHash", "safetyPolicy", "version", "configHash" }
+```
+
+where `weightsHash` is the multibase SHA-256 of the weights artifact (supplied by
+the builder), `safetyPolicy` identifies or hashes the active policy, and
+`configHash` is the multibase SHA-256 of the JCS-canonical runtime configuration,
+computed by the issuer. The credential is signed (eddsa-jcs-2022).
+
+On each OTA update, the deployer issues a new attestation whose subject includes a
+`supersedes` reference to the prior attestation's identifier or hash, forming a
+chain. A verifier confirms each attestation's proof, and may recompute the config
+hash from a supplied configuration to confirm the exact configuration matches the
+signed record. Following the supersedes links reconstructs the full history of
+which software the robot ran and when.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **Software bill of materials (SBOM), in-toto, Sigstore.** Attest software supply
+  chains at build time but are not a robot-resident, re-signable record of the
+  running model, weights, policy, and config tied to the robot's identity and
+  chained across OTA updates.
+- **PAD-018 (Model Lineage Provenance) / PAD-043 (Cryptographic Weight Binding).**
+  Address model lineage and weight binding; the present method adds the
+  robot-resident, OTA-re-signable attestation that jointly binds model, weights,
+  safety policy, and configuration to the robot, with a supersedes chain.
+- **Secure boot / measured boot.** Attest the boot chain, not the
+  application-level VLA model, safety policy, and configuration as a verifiable,
+  queryable, re-signable credential.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `config_hash`, `build_provenance_attestation`
+(with optional `supersedes`), and `verify_provenance_attestation` (with optional
+config re-hash check). The attestation reuses the shared JCS and eddsa-jcs-2022
+primitives, so it verifies cross-language, and an interop vector pins the config
+hash.
+
+---
+
+## 6. Claims Summary
+
+1. A method for attesting, in a signed Verifiable Credential bound to a robot's
+   identity, the model name, weights hash, safety policy, and configuration hash
+   of the software running on the robot.
+2. The method of claim 1 wherein the configuration hash is the multibase SHA-256
+   of the canonical configuration, reproducible by any verifier.
+3. The method of claim 1 wherein each over-the-air update issues a new attestation
+   referencing the attestation it supersedes, forming a tamper-evident chain.
+4. The method of claim 3 wherein following the supersedes chain answers which
+   model, policy, and configuration were active at any past time.
+5. The method of claim 1 wherein a verifier recomputes the configuration hash from
+   a supplied configuration to confirm an exact match with the signed record.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the robotics community.

--- a/docs/disclosures/PAD-066-physical-capability-scope-attenuation.md
+++ b/docs/disclosures/PAD-066-physical-capability-scope-attenuation.md
@@ -1,0 +1,137 @@
+# PAD-066: Physical Capability Scope as Cryptographically Enforceable Attenuation
+
+**Identifier:** PAD-066  
+**Title:** Method for Expressing and Enforcing a Robot's Physical Action Limits (Force, Speed, Proximity-to-Human Speed, Zones, Shift Windows) as a Cryptographically Signed, Monotonically Attenuating Capability Scope  
+**Publication Date:** June 14, 2026  
+**Prior Art Effective Date:** June 14, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Physical Safety / Capability Attenuation / Verifiable Credentials / AI Safety  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-021 (Inverse Capability Protocol), PAD-022 (Swarm Limits Protocol), PAD-064 (Hardware-Rooted Robot Identity), PAD-068 (Kill-Switch Credential)  
+
+---
+
+## 1. Abstract
+
+A method for extending the capability-attenuation model of delegated authority
+from the digital domain (action, target, resource, time, rate, policy) into the
+physical domain, by expressing a robot's permitted physical envelope as a signed
+capability scope: maximum force, maximum speed, a separate lower maximum speed
+when near humans, the set of allowed zones, and the permitted shift windows. The
+scope is carried in a Verifiable Credential and checked before each actuation, and
+when authority is delegated the child scope must attenuate (narrow, never broaden)
+its parent on every physical dimension.
+
+Key innovations:
+
+- **Physical dimensions as first-class capability attenuation.** Force, speed,
+  near-human speed, zones, and shift windows join the existing attenuation
+  dimensions, so a physical envelope can be delegated and narrowed with the same
+  cryptographic rule as a digital capability.
+- **Proximity-aware speed cap.** A distinct, lower speed limit applies when the
+  robot is near a human, enforced as part of the signed scope.
+- **Pre-actuation enforcement.** A proposed physical action (its force, speed,
+  near-human flag, zone, and time) is checked against the scope and refused before
+  the actuator moves.
+- **Monotone narrowing on delegation.** A delegated scope is valid only if it is
+  not broader than its parent on any physical dimension (caps may only shrink,
+  allowed zones may only be a subset, shift windows must fit inside parent
+  windows).
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Physical limits are not part of any verifiable authority model
+
+A robot's force and speed limits live in firmware or controller configuration,
+not in a verifiable, delegable credential. There is no cryptographic way to grant
+a robot a narrower physical envelope for a particular task and prove it.
+
+### 2.2 Delegation does not constrain the physical world
+
+When a robot's authority is delegated (to a sub-task, a teleoperator, a cooperating
+robot), there is no mechanism ensuring the delegate's physical envelope is no
+broader than the delegator's.
+
+### 2.3 Near-human operation needs a distinct, enforceable limit
+
+Safety standards require slower operation near people, but that limit is not
+expressed as a signed, verifiable, enforceable capability that travels with the
+robot's authority.
+
+---
+
+## 3. Solution (The Invention)
+
+A PhysicalCapabilityScope credential carries a `physicalScope` object:
+
+```
+{ "maxForceN", "maxSpeedMps", "maxSpeedNearHumansMps",
+  "allowedZones": [...], "shiftWindows": [{"start","end"}, ...] }
+```
+
+signed (eddsa-jcs-2022). Before actuating, the controller evaluates a proposed
+physical action (force, speed, a near-human flag, a zone, a time) against the
+scope: the force must not exceed `maxForceN`; the speed must not exceed
+`maxSpeedMps`, or `maxSpeedNearHumansMps` when the near-human flag is set; the zone
+must be in `allowedZones`; the time must fall in a shift window. Any violation
+refuses the action.
+
+When authority is delegated, the child scope is accepted only if it attenuates the
+parent: each numeric cap is less than or equal to the parent's, the allowed zones
+are a subset, and each child shift window fits inside some parent window. This is
+the same monotone-narrowing discipline as digital capability attenuation, extended
+to physical dimensions.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **Safety-rated controllers / speed-and-separation monitoring (ISO/TS 15066).**
+  Define physical safety behavior but not a signed, delegable, attenuating
+  capability credential that expresses and enforces the envelope as verifiable
+  authority.
+- **Object-capability and macaroon attenuation.** Attenuate digital authority; do
+  not model physical force/speed/zone/shift dimensions.
+- **PAD-021 (Inverse Capability) / PAD-022 (Swarm Limits).** Govern autonomy
+  budgets and swarm limits; the present method adds the physical-envelope
+  dimensions to the cryptographic attenuation model and the pre-actuation check.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_physical_scope_credential`,
+`check_physical_action` (pre-actuation enforcement), and `attenuates`
+(delegation-narrowing check), reusing the eddsa-jcs-2022 credential format. The
+near-human speed cap is selected automatically when the action is flagged
+near-human.
+
+---
+
+## 6. Claims Summary
+
+1. A method for expressing a robot's permitted physical envelope (maximum force,
+   maximum speed, a lower maximum speed near humans, allowed zones, and shift
+   windows) as a signed capability scope in a Verifiable Credential.
+2. The method of claim 1 wherein a proposed physical action is checked against the
+   scope and refused before actuation.
+3. The method of claim 1 wherein a lower speed limit is enforced when the robot is
+   near a human.
+4. The method of claim 1 wherein a delegated scope is valid only if it does not
+   broaden the parent on any physical dimension, caps may only shrink, allowed
+   zones may only be a subset, and shift windows must fit inside parent windows.
+5. The method of claim 1 wherein the physical dimensions are added to a digital
+   capability-attenuation model so physical and digital authority attenuate by the
+   same rule.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the robotics community.

--- a/docs/disclosures/PAD-067-robot-to-robot-bounded-trust-handshake.md
+++ b/docs/disclosures/PAD-067-robot-to-robot-bounded-trust-handshake.md
@@ -1,0 +1,127 @@
+# PAD-067: Robot-to-Robot Bounded-Trust Handshake Across Trust Domains
+
+**Identifier:** PAD-067  
+**Title:** Method for Two Robots in Different Trust Domains to Authenticate and Establish a Scope-Bounded Cooperation Session via a Three-Message Signed Handshake with Scope Intersection  
+**Publication Date:** June 14, 2026  
+**Prior Art Effective Date:** June 14, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Multi-Agent Systems / Cross-Domain Trust / Authenticated Key/Scope Agreement / AI Safety  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-063 (Live Trust-Standing Propagation), PAD-064 (Hardware-Rooted Robot Identity), PAD-066 (Physical Capability Scope)  
+
+---
+
+## 1. Abstract
+
+A method by which two robots that belong to different trust domains establish a
+bounded-trust cooperation session before acting jointly, using a three-message
+signed handshake. The initiator sends a signed HELLO carrying its identity, a
+fresh nonce, and the scope it proposes. The responder verifies the initiator's
+identity, checks the initiator's trust domain against the responder's policy, and
+signs an ACCEPT carrying the **intersection** of the proposed scope with what the
+responder is willing to grant, bound to the nonce. The initiator verifies the
+ACCEPT and signs a CONFIRM. The agreed session scope is therefore never broader
+than what either robot grants.
+
+Key innovations:
+
+- **Scope intersection as bounded trust.** The cooperation scope is the
+  intersection of the two robots' offered scopes, so neither side is exposed to
+  more than it agreed to.
+- **Domain-policy gate.** The responder accepts only if the initiator's trust
+  domain (its did:web domain) is permitted by the responder's policy, enabling
+  cross-domain cooperation under explicit policy.
+- **Nonce-bound three-message exchange.** A fresh nonce binds the HELLO, ACCEPT,
+  and CONFIRM into one session, preventing replay and binding the agreed scope to
+  the exchange.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Cooperating robots from different operators lack a trust-establishment step
+
+When two robots from different fleets or vendors must cooperate, there is no
+standard, identity-authenticated, scope-bounded handshake that establishes how
+much each will trust the other and for what.
+
+### 2.2 Authentication without bounded scope is unsafe
+
+Authenticating the peer is not enough; a cooperation session must bound what the
+peer is allowed to do, derived from what each side is willing to grant.
+
+### 2.3 Cross-domain policy is not expressed at the handshake
+
+The decision to cooperate with a peer from another trust domain should be a policy
+decision made at the handshake, not an implicit consequence of mere reachability.
+
+---
+
+## 3. Solution (The Invention)
+
+Each message is a signed (eddsa-jcs-2022) object:
+
+1. **HELLO** (initiator A): `{ from: A, to: B?, nonce, proposedScope, issuedAt }`.
+2. **ACCEPT** (responder B): B verifies HELLO's signature, checks A's domain
+   against B's trust policy (a set of trusted did:web domains, or accept-unknown),
+   computes `boundedScope = proposedScope intersect offeredScope`, and signs
+   `{ from: B, sessionId, nonce, boundedScope, validUntil }`.
+3. **CONFIRM** (A): A verifies ACCEPT, confirms the nonce echoes, and signs
+   `{ from: A, sessionId, nonce, acceptedScope }`.
+
+Both parties now hold the same bounded session: an identifier, the two DIDs, the
+intersected scope, the nonce, and an expiry. The scope is the meet of the two
+offers, so cooperation is bounded by mutual consent. The trust-domain check makes
+cross-domain cooperation an explicit policy decision.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **TLS / Noise / authenticated key exchange.** Establish a secure channel and
+  authenticate peers but do not negotiate a bounded authorization scope as the
+  intersection of two offered capability sets, nor gate on a cross-domain trust
+  policy expressed in robot identity terms.
+- **OAuth scopes.** Are granted by an authorization server to a client; they are
+  not the mutually-intersected scope of two peer robots established in a direct
+  handshake.
+- **PAD-063 (Live Trust-Standing Propagation).** Carries a caller's trust into a
+  call; the present method is a symmetric, scope-bounding handshake between two
+  robots in different domains, which PAD-063 does not address.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_hello`, `build_accept` (with the trust
+policy check and scope intersection), `verify_accept`, `build_confirm`, and
+`verify_confirm`, plus a `TrustPolicy` over did:web domains and a `BoundedSession`
+result. Each message reuses the eddsa-jcs-2022 signing, so the handshake verifies
+with the cross-language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for two robots in different trust domains to establish a cooperation
+   session via a three-message signed handshake in which the agreed scope is the
+   intersection of the two robots' offered scopes.
+2. The method of claim 1 wherein the responder accepts only if the initiator's
+   trust domain is permitted by the responder's policy.
+3. The method of claim 1 wherein a fresh nonce binds the three messages into one
+   session and prevents replay.
+4. The method of claim 1 wherein the bounded session carries the two identities,
+   the intersected scope, and an expiry, and neither robot is exposed beyond the
+   intersected scope.
+5. The method of claim 1 wherein the offered scopes and the intersection include
+   physical capability dimensions (force, speed, zones, shift windows).
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the robotics community.

--- a/docs/disclosures/PAD-068-kill-switch-credential.md
+++ b/docs/disclosures/PAD-068-kill-switch-credential.md
@@ -1,0 +1,130 @@
+# PAD-068: Verifiable Kill-Switch Credential with Attested-Authority Enforcement
+
+**Identifier:** PAD-068  
+**Title:** Method for a Verifiable Emergency-Stop (Kill-Switch) Credential Proving the Issuing Authority of a Robot Stop Command, Enforceable so that Only an Attested Authority Can Trigger It  
+**Publication Date:** June 14, 2026  
+**Prior Art Effective Date:** June 14, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Physical Safety / Emergency Stop / Verifiable Credentials / Authorization  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-064 (Hardware-Rooted Robot Identity), PAD-066 (Physical Capability Scope), PAD-067 (Robot-to-Robot Handshake)  
+
+---
+
+## 1. Abstract
+
+A method for issuing and enforcing an emergency-stop ("kill-switch") command to a
+robot as a verifiable credential that proves who issued the stop, what it targets,
+and why, and that is enforceable so that **only an attested authority** can trigger
+it. A robot (or a fleet controller) accepts a stop command only when it is a
+validly signed KillSwitchCredential whose issuer is in the robot's set of attested
+emergency-stop authorities, so a forged or unauthorized stop command is rejected,
+and a genuine stop is non-repudiably attributable to its issuer.
+
+Key innovations:
+
+- **Stop command as a verifiable, attributable credential.** The emergency stop is
+  not an anonymous signal but a signed credential proving the issuer, target, and
+  reason, giving non-repudiation for both issuing and withholding a stop.
+- **Attested-authority allowlist enforcement.** Acceptance requires the issuer to
+  be in the robot's set of attested stop authorities, so only an authorized party
+  can stop the robot, while still allowing any party to verify that a stop was
+  legitimately issued.
+- **Targetable scope.** A stop can target a single robot, a fleet, or a zone, and
+  carry an optional scope, so emergency authority is expressible at the right
+  granularity.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Emergency-stop signals are unauthenticated
+
+A physical e-stop or a network stop signal typically carries no proof of who
+issued it. This permits both malicious denial-of-service (an attacker halting a
+fleet) and unaccountable stops (no record of who stopped a robot or why).
+
+### 2.2 No verifiable record of stop authority
+
+After an incident, "who stopped the robot, and were they authorized" must be
+answerable. Unsigned signals leave no verifiable record.
+
+### 2.3 Authorization and verifiability are conflated
+
+A system that restricts who can stop a robot often does so by a closed channel
+that no third party can verify. The two properties (only an authority can trigger;
+anyone can verify a stop was legitimate) should be separable.
+
+---
+
+## 3. Solution (The Invention)
+
+A KillSwitchCredential is a Verifiable Credential whose subject carries:
+
+```
+{ "id": <target robot/fleet/zone>, "command": "emergency_stop",
+  "reason": <text>, "issuedBy": <authority DID>, "scope"?: [...] }
+```
+
+signed (eddsa-jcs-2022) by the issuing authority. To act on a stop, the robot or
+controller:
+
+1. verifies the credential's Data Integrity proof, and
+2. checks that the issuer DID is a member of the robot's configured set of
+   attested emergency-stop authorities.
+
+Both are required for the stop to take effect, so an unauthorized signer cannot
+halt the robot. Independently, any third party can verify the credential to
+confirm that a stop was legitimately issued by a named authority, giving
+non-repudiation. The target field allows a single robot, a fleet, or a zone, and
+the optional scope narrows the stop where needed.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **Hardware e-stop / safety PLC / ISO 13850.** Provide reliable physical stopping
+  but no cryptographic proof of who issued the stop and no attested-authority
+  authorization verifiable by third parties.
+- **Network kill commands (fleet management).** Typically rely on channel
+  authentication, not on a portable, verifiable, attributable credential that any
+  party can check and that enforces an attested-authority allowlist.
+- **PAD-064 / PAD-066.** Establish robot identity and physical scope; the present
+  method adds the verifiable, attested-authority-enforced emergency-stop credential.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_killswitch_credential` and
+`verify_killswitch_credential` (with an optional `trusted_authorities` allowlist),
+reusing the eddsa-jcs-2022 credential format so the stop credential verifies with
+the cross-language SDKs. The robot enforces the allowlist locally; verification of
+issuance is open to any party.
+
+---
+
+## 6. Claims Summary
+
+1. A method for an emergency-stop command to a robot expressed as a signed
+   Verifiable Credential proving the issuing authority, the target, and the reason.
+2. The method of claim 1 wherein the stop takes effect only when the issuer is a
+   member of the robot's set of attested emergency-stop authorities, so an
+   unauthorized party cannot stop the robot.
+3. The method of claim 1 wherein any third party can verify the credential to
+   confirm a stop was legitimately issued, giving non-repudiation.
+4. The method of claim 1 wherein the target is a single robot, a fleet, or a zone,
+   with an optional scope.
+5. The method of claim 1 wherein the authorization (only an attested authority may
+   trigger) and the verifiability (anyone may confirm legitimacy) are separable
+   properties of the same credential.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the robotics community.

--- a/docs/disclosures/PAD-069-confidential-tamper-evident-robot-blackbox.md
+++ b/docs/disclosures/PAD-069-confidential-tamper-evident-robot-blackbox.md
@@ -1,0 +1,144 @@
+# PAD-069: Confidential, Tamper-Evident Robot Black-Box with Separable Confidentiality and Integrity
+
+**Identifier:** PAD-069  
+**Title:** Method for a Robot Flight-Recorder Log Whose Entry Payloads Are Encrypted While the Log's Integrity Is Independently Verifiable Without the Decryption Key, with a Signable Chain Head Anchoring the Whole Log  
+**Publication Date:** June 15, 2026  
+**Prior Art Effective Date:** June 15, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Tamper-Evident Logging / Encrypted Audit / Verifiable Credentials  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-064 (Hardware-Rooted Robot Identity), PAD-065 (Model and Config Provenance), PAD-068 (Kill-Switch Credential)  
+
+---
+
+## 1. Abstract
+
+A method for a robot black-box (flight recorder) in which each event entry's
+payload is encrypted with AES-256-GCM and hash-linked to the previous entry, so
+the log is at once confidential and tamper-evident, and crucially the two
+properties are **separable**: any party can verify the integrity of the entire
+chain over the encrypted entries **without the decryption key**, while only a
+holder of the black-box key can read the payloads. The current chain head can be
+signed to anchor an arbitrarily long log to an identity and a point in time with
+a single signature.
+
+Key innovations:
+
+- **Separable confidentiality and integrity.** Integrity verification (the hash
+  chain over encrypted entries) requires no key; only reading a payload requires
+  the key. A forensic investigator, regulator, or counterparty can prove the log
+  was not altered without being given access to its sensitive contents.
+- **Encrypted-yet-verifiable entries.** Each entry's hash is computed over the
+  encrypted body (sequence number, timestamp, event label, ciphertext, and link
+  to the prior entry), so tampering with the ciphertext, reordering entries, or
+  dropping one is detected without ever decrypting.
+- **Single-signature anchoring of the whole log.** Signing only the current chain
+  head anchors every prior entry, so a long-running recorder does not need a
+  signature per entry to be attributable and time-anchored.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Robot logs must be both private and tamper-evident
+
+A robot flight recorder captures operational data that is often sensitive
+(proprietary sensor streams, internal state, customer-site detail) yet must be
+trustworthy after an incident. Encrypting the log normally makes independent
+integrity verification impossible without sharing the key; leaving it in
+plaintext for verifiability exposes the sensitive content. These goals appear to
+conflict.
+
+### 2.2 Third parties cannot verify an encrypted log without the key
+
+After an incident, an investigator or counterparty must be able to confirm "this
+log was not altered" without the operator handing over a key that also reveals
+everything in the log.
+
+### 2.3 Anchoring a long log is expensive
+
+Attributing and time-anchoring a long log typically requires a signature per
+entry, or reliance on a trusted external logging service.
+
+---
+
+## 3. Solution (The Invention)
+
+A `BlackBoxLog` holds a 32-byte key. Each `append(event, payload)`:
+
+```
+entry = {
+  "version", "seq", "timestamp", "event",
+  "ciphertext": multibase( nonce || AES-256-GCM(payload) ),
+  "prevHash":  <entryHash of the previous entry, or genesis>,
+}
+entry["entryHash"] = multibase( SHA-256( JCS(entry without entryHash) ) )
+```
+
+Two independent operations follow:
+
+1. **Integrity, no key required.** `verify_blackbox_chain(entries)` walks the
+   entries checking sequence monotonicity, that each `prevHash` links to the prior
+   `entryHash`, and that each `entryHash` recomputes over the (still encrypted)
+   body. Any tampering, reordering, or omission fails. The verifier never needs
+   the key.
+2. **Confidentiality, key required.** `open_entry(entry, key)` decrypts a single
+   payload. Only a key holder can read content.
+
+The current `head()` hash can be signed with a Vouch signer (eddsa-jcs-2022) to
+anchor the entire log to an identity and time in one signature. Because the chain
+and anchor use the shared JCS plus SHA-256 primitives, they verify byte-identically
+across the language SDKs.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **Tamper-evident / Merkle / append-only logs.** Provide integrity but generally
+  over plaintext, or require the verifier to see the content. The present method
+  verifies integrity over ciphertext, decoupled from read access.
+- **Encrypted databases and WORM storage.** Provide confidentiality and
+  append-only behavior but no portable, key-free integrity proof a third party can
+  check independently.
+- **Aircraft FDR/CVR.** Provide physical tamper resistance, not cryptographic
+  proof, and no separable confidentiality/integrity for third parties.
+- **PAD-068 (kill switch).** Shares the module and the credential format but
+  addresses emergency-stop authorization, a distinct method.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `BlackBoxLog` (`append`, `head`, `entries`,
+`open_entry`), the module-level `open_entry`, and `verify_blackbox_chain`, using
+AES-256-GCM, multibase encoding, and the shared JCS plus SHA-256 hashing. This
+ships the formats and reference library; hosted black-box storage and fleet-scale
+infrastructure are out of scope and left to the deployer.
+
+---
+
+## 6. Claims Summary
+
+1. A method for a robot event log wherein each entry's payload is encrypted and
+   hash-linked to the prior entry, such that the integrity of the whole chain is
+   verifiable without the decryption key.
+2. The method of claim 1 wherein only a holder of the key can decrypt payloads, so
+   confidentiality and integrity are separable properties of the same log.
+3. The method of claim 1 wherein each entry's hash is computed over the encrypted
+   entry body, so ciphertext tampering, reordering, or omission is detected without
+   decryption.
+4. The method of claim 1 wherein signing the current chain head anchors the entire
+   log to an identity and time with a single signature.
+5. The method of claim 1 wherein the chain and anchor use canonicalization and
+   hashing primitives shared across language SDKs, so the log verifies
+   cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the robotics community.

--- a/docs/disclosures/PAD-070-scannable-offline-robot-passport.md
+++ b/docs/disclosures/PAD-070-scannable-offline-robot-passport.md
@@ -1,0 +1,140 @@
+# PAD-070: Self-Contained, Offline-Verifiable Robot Passport for Physical-World Scanning
+
+**Identifier:** PAD-070  
+**Title:** Method for a Self-Contained Robot Passport Encoded into a Scannable (QR/NFC) URI Carrying the Full Signed Credential, Conveying Owner, Authorized Physical Actions, Certification, and Live Standing, Verifiable Offline  
+**Publication Date:** June 15, 2026  
+**Prior Art Effective Date:** June 15, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Offline Verification / Physical-World Credentials / QR-NFC  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-064 (Hardware-Rooted Robot Identity), PAD-066 (Physical Capability Scope), PAD-069 (Robot Black-Box)  
+
+---
+
+## 1. Abstract
+
+A method for a robot "passport": a compact signed Verifiable Credential conveying
+a robot's identity, owner, authorized physical actions, certification, and current
+operational standing (active, suspended, or decommissioned), encoded into a
+scannable URI (a `vouch-passport:` URI carrying the multibase canonical bytes of
+the credential) so that any bystander or inspector can scan a QR code or NFC tag
+and verify the credential's signature and contents **fully offline**, with no
+network round-trip and no issuer lookup at scan time.
+
+Key innovations:
+
+- **Self-contained scannable credential for an embodied agent.** The QR/NFC
+  payload carries the entire signed credential, not a URL to be resolved, so a
+  person can verify a physical robot on the spot with no connectivity.
+- **Embodied-agent passport semantics.** The credential subject is robot-specific:
+  owner, the **authorized physical actions** the robot may perform, certification,
+  and a live **standing** field, so the scan answers "is this robot legitimate,
+  whose is it, what may it do, and is it currently in good standing."
+- **Composition with the robot identity and capability system.** The passport is
+  built on the same credential format as hardware-rooted robot identity (PAD-064)
+  and physical capability scope (PAD-066), so a passport composes with, and can be
+  cross-checked against, those credentials rather than standing alone.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 No on-the-spot, offline trust check for a physical robot
+
+A person who encounters a robot in a warehouse, a hospital corridor, or a public
+space has no reliable way to check, on the spot, whether it is legitimate, who is
+responsible for it, what it is permitted to do, and whether it is currently
+certified and active. Connectivity may be absent exactly where the check is needed.
+
+### 2.2 URL-bearing codes centralize trust and fail offline
+
+A QR code that encodes a URL requires a network fetch and a trusted server to
+return an answer. That fails with no connectivity and concentrates trust in a
+single endpoint that can be down, spoofed, or retired.
+
+### 2.3 Physical plates and labels are forgeable
+
+A printed serial plate or sticker carries no cryptographic proof of issuer or
+content and is trivially copied onto an impostor unit.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_passport(...)` issues a `RobotPassport` Verifiable Credential whose subject
+carries the robot DID, make, model, owner, `authorizedActions`, `status`
+(active/suspended/decommissioned), and optional certification, signed
+eddsa-jcs-2022 by the robot or an authority. `encode_passport(...)` serializes it:
+
+```
+vouch-passport:u<base64url( JCS(passport credential) )>
+```
+
+The full signed credential travels inside the code. An offline reader runs
+`decode_passport(uri)` then `verify_passport(...)`, which checks the Data Integrity
+proof and validity window using only the issuer's public key (resolved or cached
+out of band). No network call is made at scan time. Rendering the URI to a QR image
+or writing it to an NFC tag is left to any standard QR/NFC library. Because the
+credential uses the shared JCS plus eddsa-jcs-2022 primitives, the same passport
+verifies across the language SDKs.
+
+---
+
+## 4. Prior Art Differentiation
+
+Encoding a signed Verifiable Credential into a QR code for offline verification is
+established prior art (for example, digital health certificates). This disclosure
+does **not** claim that general mechanism. What is differentiated here is the
+embodied-agent application and semantics:
+
+- **Robot-specific subject.** The passport asserts the robot's owner, its
+  authorized **physical** actions, certification, and live operational standing,
+  the properties a bystander needs to judge a machine acting in the physical world,
+  rather than a person's attributes.
+- **`vouch-passport:` self-contained URI scheme** carrying the canonical credential
+  bytes for QR or NFC, designed for a robot tag.
+- **Composition with hardware-rooted identity and physical capability scope.** The
+  passport is one credential in a system where the same robot's hardware-bound
+  identity (PAD-064) and physical limits (PAD-066) are independently verifiable, so
+  a scan can be cross-checked against them.
+- **URL-bearing QR/NFC robot labels.** Require connectivity and a trusted server;
+  the present method is self-contained and offline.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_passport`, `encode_passport`,
+`decode_passport`, and `verify_passport`, plus the `vouch-passport:` URI scheme and
+a `status` of active, suspended, or decommissioned. This ships the open verifier
+and the encoding; rendering the URI to a QR image or writing an NFC tag is the
+caller's concern.
+
+---
+
+## 6. Claims Summary
+
+1. A method for a robot passport expressed as a signed credential whose full bytes
+   are encoded into a scannable URI, so the robot's owner, authorized physical
+   actions, certification, and standing are verifiable offline without a network
+   round-trip.
+2. The method of claim 1 wherein verification at scan time requires only the
+   issuer's public key, resolved or cached out of band, and no server lookup.
+3. The method of claim 1 wherein the subject carries a live standing field
+   (active, suspended, or decommissioned) within the offline-verifiable credential.
+4. The method of claim 1 wherein the passport is built on the same credential
+   format as the robot's hardware-rooted identity and physical capability scope, so
+   the passport composes with and can be cross-checked against them.
+5. The method of claim 1 wherein the credential uses canonicalization and signature
+   primitives shared across language SDKs, so the same passport verifies
+   cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem and the robotics community.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -71,6 +71,22 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-059](./PAD-059-vouch-amnesia-attestation-bridge.md) | Method for Cryptographically Anchoring Deterministic Pre-Push Policy Decisions of an AI Coding Assistant Workspace to W3C Verifiable Credentials with Optional Hybrid Post-Quantum Signatures | 2026-05-14 | Published |
 | [PAD-060](./PAD-060-single-use-audited-override-of-egress-block.md) | Method for One-Time Time-Bounded Override of a Deterministic Egress-Time Policy Block, with Cryptographically Auditable Override Event and Structural Prevention of Repeated Re-Use | 2026-05-14 | Published |
 | [PAD-061](./PAD-061-per-region-human-ai-code-attribution.md) | Per-Region Authorship Attribution for Mixed Human and AI Source Code via Edit-Channel Capture and Independently-Keyed Signatures | 2026-06-10 | Published |
+| [PAD-064](./PAD-064-hardware-rooted-robot-identity.md) | Hardware-Rooted Verifiable Robot Identity and Lifecycle Credential | 2026-06-14 | Published |
+| [PAD-065](./PAD-065-model-config-provenance-attestation.md) | Re-Signable Model-and-Config Provenance Attestation for Embodied Agents | 2026-06-14 | Published |
+| [PAD-066](./PAD-066-physical-capability-scope-attenuation.md) | Physical Capability Scope as Cryptographically Enforceable Attenuation | 2026-06-14 | Published |
+| [PAD-067](./PAD-067-robot-to-robot-bounded-trust-handshake.md) | Robot-to-Robot Bounded-Trust Handshake Across Trust Domains | 2026-06-14 | Published |
+| [PAD-068](./PAD-068-kill-switch-credential.md) | Verifiable Kill-Switch Credential with Attested-Authority Enforcement | 2026-06-14 | Published |
+| [PAD-069](./PAD-069-confidential-tamper-evident-robot-blackbox.md) | Confidential, Tamper-Evident Robot Black-Box with Separable Confidentiality and Integrity | 2026-06-15 | Published |
+| [PAD-070](./PAD-070-scannable-offline-robot-passport.md) | Self-Contained, Offline-Verifiable Robot Passport for Physical-World Scanning | 2026-06-15 | Published |
+
+
+## June 15, 2026: Robotics and Embodied-Agent Primitives (PAD-064 through PAD-070)
+
+Seven disclosures covering the open robotics primitives in the `vouch.robotics`
+package: hardware-rooted identity, model and config provenance, physical capability
+scope, robot-to-robot handshake, kill-switch credential, confidential black box, and
+the scannable offline passport. Each is built on the same eddsa-jcs-2022 credentials
+as the rest of Vouch and verifies with every language SDK.
 
 
 ## June 10, 2026: Per-Region Human and AI Code Attribution (PAD-061)

--- a/docs/robotics.md
+++ b/docs/robotics.md
@@ -1,0 +1,125 @@
+# Vouch Robotics Primitives
+
+Open, vendor-neutral formats and reference implementations for accountable robots
+and embodied agents. All are eddsa-jcs-2022 credentials or hash-linked formats
+built on the existing Vouch primitives, so they verify with the cross-language
+SDKs. These are formats plus references; hosted storage and fleet-scale services
+are out of scope.
+
+## 5.1 Hardware-rooted robot identity (`vouch.robotics.identity`)
+
+A `RobotIdentityCredential` binds a robot's software identity key to a hardware
+root of trust (a TPM or a secure element). The hardware root signs a binding over
+the robot DID and key, embedded as `hardwareRoot.attestation`; a verifier checks
+both the credential proof and the hardware attestation.
+
+```python
+from vouch.robotics import SoftwareRootOfTrust, mint_robot_identity, verify_robot_identity
+
+root = SoftwareRootOfTrust(kind="TPM")          # reference; a TPM/secure-element backend subclasses HardwareRootOfTrust
+cred = mint_robot_identity(robot_signer, root, make="Acme", model="AR-7", serial="SN-123")
+ok, subject = verify_robot_identity(cred, robot_public_key)
+```
+
+`HardwareRootOfTrust` is the interface a TPM- or secure-element-backed
+implementation satisfies (it signs with a hardware-resident attestation key).
+`SoftwareRootOfTrust` is the development reference and is NOT a hardware root.
+`lifecycle` records the make/commission/transfer/decommission history.
+
+## 5.2 Model and config provenance (`vouch.robotics.provenance`)
+
+A `ModelProvenanceAttestation` records the VLA model name, weights hash, safety
+policy, and config hash running on a robot. It is re-signable on an OTA update,
+referencing the attestation it `supersedes`, forming a tamper-evident chain.
+
+```python
+from vouch.robotics import build_provenance_attestation, verify_provenance_attestation
+
+att = build_provenance_attestation(builder_signer, robot_did=robot,
+        model_name="OpenVLA-7B", weights_hash="u...", safety_policy="u...",
+        config=runtime_config, version="2.1.0", supersedes=prev_id)
+ok, subject = verify_provenance_attestation(att, builder_public_key, config=runtime_config)
+```
+
+`configHash` is the multibase SHA-256 of the JCS-canonical config, reproducible
+in any language.
+
+## 5.3 Physical capability scope (`vouch.robotics.capability`)
+
+Extends the capability/attenuation model to the physical world: max force, max
+speed, a slower speed cap near humans, allowed zones, and shift windows, carried
+in a `PhysicalCapabilityScope` credential and enforceable before actuation.
+
+```python
+from vouch.robotics import build_physical_scope_credential, check_physical_action, PhysicalAction, attenuates
+
+cred = build_physical_scope_credential(operator_signer, subject_did=robot,
+        max_force_n=100, max_speed_mps=2.0, max_speed_near_humans_mps=0.5,
+        allowed_zones=["zone-A"], shift_windows=[{"start": "08:00", "end": "18:00"}])
+scope = cred["credentialSubject"]["physicalScope"]
+decision = check_physical_action(scope, PhysicalAction(force_n=50, speed_mps=1.5,
+        near_humans=True, zone="zone-A", time_hm="10:00"))
+# A delegated scope must attenuate (never broaden):
+assert attenuates(parent_scope, child_scope)
+```
+
+## 5.4 Robot-to-robot trust handshake (`vouch.robotics.handshake`)
+
+Two robots in different trust domains authenticate and establish a bounded-trust
+session before cooperating, via three signed messages (HELLO, ACCEPT, CONFIRM).
+The responder checks the initiator's domain against its `TrustPolicy` and
+intersects the proposed scope with what it offers, so the session scope is never
+broader than what either side grants.
+
+```python
+from vouch.robotics import build_hello, build_accept, verify_accept, build_confirm, verify_confirm, TrustPolicy
+
+hello = build_hello(robot_a_signer, proposed_scope=["lift", "carry"])
+accept = build_accept(robot_b_signer, hello=hello, hello_public_key=a_pub,
+                      policy=TrustPolicy(trusted_domains={"robot-a.example.com"}),
+                      offered_scope=["carry", "weld"])
+ok, session = verify_accept(accept, b_pub, expected_nonce=hello["nonce"])   # session.scope == ["carry"]
+confirm = build_confirm(robot_a_signer, session=session)
+verify_confirm(confirm, a_pub, session_id=session.session_id, expected_nonce=session.nonce)
+```
+
+## 5.5 Black box and kill switch (`vouch.robotics.blackbox`)
+
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
+recorder: payloads are confidential, the chain is tamper-evident without the key,
+and the head can be signed to anchor the log. The kill-switch credential is a
+verifiable emergency-stop record; with an authority allowlist, only an attested
+authority can trigger it.
+
+```python
+from vouch.robotics import BlackBoxLog, open_entry, verify_blackbox_chain
+from vouch.robotics import build_killswitch_credential, verify_killswitch_credential
+
+log = BlackBoxLog(key=os.urandom(32))
+log.append("FAULT", {"code": "E12"})
+ok, _ = verify_blackbox_chain(log.entries())        # verifiable without the key
+payload = open_entry(log.entries()[0], key)          # only the key opens the payload
+
+stop = build_killswitch_credential(authority_signer, target=robot_did, reason="human in path")
+ok, subject = verify_killswitch_credential(stop, authority_pub, trusted_authorities={authority_did})
+```
+
+## 5.6 Scannable robot passport (`vouch.robotics.passport`)
+
+A compact, signed passport that anyone can scan (QR or NFC) to check a robot's
+owner, authorized actions, certification, and standing, offline. The QR/NFC
+payload is a `vouch-passport:` URI carrying the multibase JCS bytes of the
+credential, so the reader verifies the signature without a network call.
+
+```python
+from vouch.robotics import build_passport, encode_passport, verify_passport
+
+passport = build_passport(robot_signer, robot_did=robot, make="Acme", model="AR-7",
+                          owner=owner_did, authorized_actions=["carry", "scan"],
+                          certification="CE-2026-001", status="active")
+uri = encode_passport(passport)                      # put this in a QR or NFC tag
+ok, summary = verify_passport(uri, robot_public_key) # offline check of owner/actions/standing
+```
+
+Interop vector: `test-vectors/robotics/vector.json` pins the hardware-root binding
+and the config hash. See `examples/robotics_demo.py`.

--- a/examples/robotics_demo.py
+++ b/examples/robotics_demo.py
@@ -1,0 +1,69 @@
+"""
+Robotics primitives demo (Phase 5.1-5.3).
+
+Run it:  python examples/robotics_demo.py
+"""
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    PhysicalAction,
+    SoftwareRootOfTrust,
+    build_physical_scope_credential,
+    build_provenance_attestation,
+    check_physical_action,
+    mint_robot_identity,
+    verify_provenance_attestation,
+    verify_robot_identity,
+)
+
+
+def main() -> None:
+    kp = generate_identity(domain="robot.example.com")
+    robot = Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+    # 5.1 hardware-rooted identity
+    root = SoftwareRootOfTrust(kind="TPM")  # reference; real deployment uses a TPM
+    identity = mint_robot_identity(
+        robot, root, make="Acme Robotics", model="AR-7", serial="SN-000123"
+    )
+    ok, subject = verify_robot_identity(identity, kp.public_key_jwk)
+    print(
+        f"identity verifies: {ok}  {subject['make']} {subject['model']} (root={subject['hardwareRoot']['kind']})"
+    )
+
+    # 5.2 model + config provenance
+    config = {"temperature": 0.0, "max_torque": 12.5}
+    prov = build_provenance_attestation(
+        robot,
+        robot_did=kp.did,
+        model_name="OpenVLA-7B",
+        weights_hash="uWEIGHTSHASH",
+        safety_policy="uPOLICYHASH",
+        config=config,
+        version="2.1.0",
+    )
+    ok, psub = verify_provenance_attestation(prov, kp.public_key_jwk, config=config)
+    print(
+        f"provenance verifies: {ok}  model={psub['vla']['modelName']} configHash={psub['vla']['configHash'][:12]}..."
+    )
+
+    # 5.3 physical capability scope
+    cred = build_physical_scope_credential(
+        robot,
+        subject_did=kp.did,
+        max_force_n=100,
+        max_speed_mps=2.0,
+        max_speed_near_humans_mps=0.5,
+        allowed_zones=["zone-A"],
+    )
+    scope = cred["credentialSubject"]["physicalScope"]
+    safe = check_physical_action(
+        scope, PhysicalAction(force_n=50, speed_mps=0.4, near_humans=True, zone="zone-A")
+    )
+    unsafe = check_physical_action(scope, PhysicalAction(speed_mps=1.5, near_humans=True))
+    print(f"slow near a human: ok={safe.ok}")
+    print(f"fast near a human: ok={unsafe.ok}  reasons={unsafe.reasons}")
+
+
+if __name__ == "__main__":
+    main()

--- a/gemini-gem/knowledge/robotics.md
+++ b/gemini-gem/knowledge/robotics.md
@@ -1,34 +1,91 @@
-# Robots and embodied agents
+# Robotics Reference: What Vouch Can Do for Robots
 
-A robot is an agent with a body. Identity, accountability, and continuous trust
-matter more, not less, when an agent can cause physical harm or move money in
-the real world. Vouch covers the open identity layer for robots; richer
-robot-lifecycle tooling builds on top of it.
+Vouch covers robots and embodied agents, not just software agents. The robotics
+primitives are open, vendor-neutral, and built on the same eddsa-jcs-2022
+Verifiable Credentials as the rest of Vouch, so they verify with every language
+SDK (Python, Rust, TypeScript, Go, Swift, Kotlin). They live in the
+`vouch.robotics` package. Everything below is built, tested, and shipped.
 
-## The same primitives apply
+These are formats plus reference implementations. Hosted black-box storage and
+fleet-scale kill-switch infrastructure are intentionally left to the deployer.
 
-- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
-  profile in `docs/specs/`).
-- Delegation: a delegation chain records who authorized the robot, on whose
-  behalf, and within what limits, all verifiable.
-- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
-  behaving now," so a robot has to keep proving itself.
-- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
-  check the status.
+## The six capabilities
 
-## The robot-specific open piece: hardware root of trust
+### 1. Hardware-rooted identity (`vouch.robotics.identity`)
+A robot's software identity key is bound to a hardware root of trust (a TPM or a
+secure element). The hardware root signs a binding over the robot's DID and key,
+embedded in a RobotIdentityCredential that also carries make, model, serial, and
+a lifecycle history. Verification checks both the credential proof and the
+hardware attestation, so the identity cannot be cloned to other hardware. This is
+the open alternative to closed or state-run robot-ID schemes.
+Key functions: `mint_robot_identity`, `verify_robot_identity`,
+`HardwareRootOfTrust` (the interface a TPM/secure-element backend satisfies),
+`SoftwareRootOfTrust` (development reference), `lifecycle_event`.
 
-A software agent's key can live in a file. A robot should do better. The
-hardware-root-of-trust profile binds the robot's DID to its secure element (a
-TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
-the signing key and signs the robot's heartbeats, so identity is anchored to the
-physical device, not a config that can be copied. The open `did:vouch:agent`
-profile defines the agent identity scheme; the embodied profile extends it for
-hardware attestation.
+### 2. Model and config provenance (`vouch.robotics.provenance`)
+A signed ModelProvenanceAttestation records the model name, weights hash, safety
+policy, and configuration hash running on a robot. It is re-signable on every
+over-the-air update, with a `supersedes` link, so the chain answers "what model
+and policy were running at any past time." The config hash is reproducible by any
+verifier.
+Key functions: `build_provenance_attestation`, `verify_provenance_attestation`,
+`config_hash`.
 
-## Open vs built on top
+### 3. Physical capability scope (`vouch.robotics.capability`)
+Extends capability attenuation to the physical world: max force, max speed, a
+lower max speed near humans, allowed zones, and shift windows, carried in a
+PhysicalCapabilityScope credential and checked before each actuation. A delegated
+scope must narrow (never broaden) its parent on every physical dimension.
+Key functions: `build_physical_scope_credential`, `check_physical_action`,
+`attenuates`, `PhysicalAction`.
 
-The identity, delegation, continuous-trust, and hardware-attestation profiles
-are open Vouch. Operated robot-lifecycle products (lifecycle identity
-management, model-and-config provenance, fleet trust at scale, and similar)
-build on this open layer and are out of scope for the protocol itself.
+### 4. Robot-to-robot trust handshake (`vouch.robotics.handshake`)
+Two robots in different trust domains authenticate and agree a bounded-trust
+cooperation session via three signed messages (HELLO, ACCEPT, CONFIRM). The
+session scope is the intersection of what each robot offers, and the responder
+checks the initiator's domain against its trust policy.
+Key functions: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, `TrustPolicy`, `BoundedSession`.
+
+### 5. Black box and kill switch (`vouch.robotics.blackbox`)
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
+recorder: payloads are confidential, the chain is tamper-evident without the key,
+and only the key opens the payloads. The kill-switch credential is a verifiable
+emergency stop that proves who issued it and, with an authority allowlist,
+enforces that only an attested authority can trigger it.
+Key functions: `BlackBoxLog`, `open_entry`, `verify_blackbox_chain`,
+`build_killswitch_credential`, `verify_killswitch_credential`.
+
+### 6. Scannable robot passport (`vouch.robotics.passport`)
+A compact, signed passport in a `vouch-passport:` URI for a QR or NFC tag, so
+anyone can check a robot's owner, authorized actions, certification, and standing
+offline, with no network call.
+Key functions: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`.
+
+## Quick answers
+
+- "Can a robot prove which hardware it is?" Yes, via the hardware-rooted identity
+  credential (capability 1).
+- "Can I prove what model and safety policy a robot is running, even after an OTA
+  update?" Yes, via the re-signable provenance attestation (capability 2).
+- "Can I enforce that a robot slows down near people, or stays in its zone?" Yes,
+  via the physical capability scope, checked before actuation (capability 3).
+- "Can two robots from different fleets cooperate safely?" Yes, via the
+  bounded-trust handshake (capability 4).
+- "Can I prove who hit the emergency stop, and stop anyone else from doing it?"
+  Yes, via the kill-switch credential with an attested-authority allowlist
+  (capability 5).
+- "Can a robot have a flight recorder that is private but tamper-evident?" Yes,
+  via the encrypted black box (capability 5).
+- "Can someone scan a robot to check it is legitimate?" Yes, via the scannable
+  passport (capability 6).
+
+## Status
+
+All six are implemented with tests and a runnable demo
+(`examples/robotics_demo.py`), documented in `docs/robotics.md`, with an interop
+vector pinning the hardware-root binding and config hash. Defensive disclosures
+PAD-064 (identity), PAD-065 (provenance), PAD-066 (physical scope), PAD-067
+(handshake), PAD-068 (kill switch), PAD-069 (black box), and PAD-070 (passport)
+cover the novel methods.

--- a/openai-gpt/knowledge/robotics.md
+++ b/openai-gpt/knowledge/robotics.md
@@ -1,34 +1,91 @@
-# Robots and embodied agents
+# Robotics Reference: What Vouch Can Do for Robots
 
-A robot is an agent with a body. Identity, accountability, and continuous trust
-matter more, not less, when an agent can cause physical harm or move money in
-the real world. Vouch covers the open identity layer for robots; richer
-robot-lifecycle tooling builds on top of it.
+Vouch covers robots and embodied agents, not just software agents. The robotics
+primitives are open, vendor-neutral, and built on the same eddsa-jcs-2022
+Verifiable Credentials as the rest of Vouch, so they verify with every language
+SDK (Python, Rust, TypeScript, Go, Swift, Kotlin). They live in the
+`vouch.robotics` package. Everything below is built, tested, and shipped.
 
-## The same primitives apply
+These are formats plus reference implementations. Hosted black-box storage and
+fleet-scale kill-switch infrastructure are intentionally left to the deployer.
 
-- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
-  profile in `docs/specs/`).
-- Delegation: a delegation chain records who authorized the robot, on whose
-  behalf, and within what limits, all verifiable.
-- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
-  behaving now," so a robot has to keep proving itself.
-- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
-  check the status.
+## The six capabilities
 
-## The robot-specific open piece: hardware root of trust
+### 1. Hardware-rooted identity (`vouch.robotics.identity`)
+A robot's software identity key is bound to a hardware root of trust (a TPM or a
+secure element). The hardware root signs a binding over the robot's DID and key,
+embedded in a RobotIdentityCredential that also carries make, model, serial, and
+a lifecycle history. Verification checks both the credential proof and the
+hardware attestation, so the identity cannot be cloned to other hardware. This is
+the open alternative to closed or state-run robot-ID schemes.
+Key functions: `mint_robot_identity`, `verify_robot_identity`,
+`HardwareRootOfTrust` (the interface a TPM/secure-element backend satisfies),
+`SoftwareRootOfTrust` (development reference), `lifecycle_event`.
 
-A software agent's key can live in a file. A robot should do better. The
-hardware-root-of-trust profile binds the robot's DID to its secure element (a
-TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
-the signing key and signs the robot's heartbeats, so identity is anchored to the
-physical device, not a config that can be copied. The open `did:vouch:agent`
-profile defines the agent identity scheme; the embodied profile extends it for
-hardware attestation.
+### 2. Model and config provenance (`vouch.robotics.provenance`)
+A signed ModelProvenanceAttestation records the model name, weights hash, safety
+policy, and configuration hash running on a robot. It is re-signable on every
+over-the-air update, with a `supersedes` link, so the chain answers "what model
+and policy were running at any past time." The config hash is reproducible by any
+verifier.
+Key functions: `build_provenance_attestation`, `verify_provenance_attestation`,
+`config_hash`.
 
-## Open vs built on top
+### 3. Physical capability scope (`vouch.robotics.capability`)
+Extends capability attenuation to the physical world: max force, max speed, a
+lower max speed near humans, allowed zones, and shift windows, carried in a
+PhysicalCapabilityScope credential and checked before each actuation. A delegated
+scope must narrow (never broaden) its parent on every physical dimension.
+Key functions: `build_physical_scope_credential`, `check_physical_action`,
+`attenuates`, `PhysicalAction`.
 
-The identity, delegation, continuous-trust, and hardware-attestation profiles
-are open Vouch. Operated robot-lifecycle products (lifecycle identity
-management, model-and-config provenance, fleet trust at scale, and similar)
-build on this open layer and are out of scope for the protocol itself.
+### 4. Robot-to-robot trust handshake (`vouch.robotics.handshake`)
+Two robots in different trust domains authenticate and agree a bounded-trust
+cooperation session via three signed messages (HELLO, ACCEPT, CONFIRM). The
+session scope is the intersection of what each robot offers, and the responder
+checks the initiator's domain against its trust policy.
+Key functions: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, `TrustPolicy`, `BoundedSession`.
+
+### 5. Black box and kill switch (`vouch.robotics.blackbox`)
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
+recorder: payloads are confidential, the chain is tamper-evident without the key,
+and only the key opens the payloads. The kill-switch credential is a verifiable
+emergency stop that proves who issued it and, with an authority allowlist,
+enforces that only an attested authority can trigger it.
+Key functions: `BlackBoxLog`, `open_entry`, `verify_blackbox_chain`,
+`build_killswitch_credential`, `verify_killswitch_credential`.
+
+### 6. Scannable robot passport (`vouch.robotics.passport`)
+A compact, signed passport in a `vouch-passport:` URI for a QR or NFC tag, so
+anyone can check a robot's owner, authorized actions, certification, and standing
+offline, with no network call.
+Key functions: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`.
+
+## Quick answers
+
+- "Can a robot prove which hardware it is?" Yes, via the hardware-rooted identity
+  credential (capability 1).
+- "Can I prove what model and safety policy a robot is running, even after an OTA
+  update?" Yes, via the re-signable provenance attestation (capability 2).
+- "Can I enforce that a robot slows down near people, or stays in its zone?" Yes,
+  via the physical capability scope, checked before actuation (capability 3).
+- "Can two robots from different fleets cooperate safely?" Yes, via the
+  bounded-trust handshake (capability 4).
+- "Can I prove who hit the emergency stop, and stop anyone else from doing it?"
+  Yes, via the kill-switch credential with an attested-authority allowlist
+  (capability 5).
+- "Can a robot have a flight recorder that is private but tamper-evident?" Yes,
+  via the encrypted black box (capability 5).
+- "Can someone scan a robot to check it is legitimate?" Yes, via the scannable
+  passport (capability 6).
+
+## Status
+
+All six are implemented with tests and a runnable demo
+(`examples/robotics_demo.py`), documented in `docs/robotics.md`, with an interop
+vector pinning the hardware-root binding and config hash. Defensive disclosures
+PAD-064 (identity), PAD-065 (provenance), PAD-066 (physical scope), PAD-067
+(handshake), PAD-068 (kill switch), PAD-069 (black box), and PAD-070 (passport)
+cover the novel methods.

--- a/test-vectors/robotics/generate.py
+++ b/test-vectors/robotics/generate.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""
+Generate the robotics interop vector (Phase 5.1-5.3).
+
+Deterministic (fixed seeds, fixed validFrom). Pins the new byte-level
+computations so other languages reproduce them: the hardware-root binding inside
+a RobotIdentityCredential, and the config hash inside a ModelProvenanceAttestation.
+
+Run:  python test-vectors/robotics/generate.py
+"""
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from vouch import Signer
+from vouch.robotics import (
+    SoftwareRootOfTrust,
+    config_hash,
+    mint_robot_identity,
+)
+
+ROBOT_SEED = bytes(range(32))
+HW_SEED = bytes([7] * 32)
+ROBOT_DID = "did:web:robot.example.com"
+VALID_FROM = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def b64u(b: bytes) -> str:
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def main():
+    sk = Ed25519PrivateKey.from_private_bytes(ROBOT_SEED)
+    pub = sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    priv_jwk = json.dumps({"kty": "OKP", "crv": "Ed25519", "d": b64u(ROBOT_SEED), "x": b64u(pub)})
+    public_jwk = {"kty": "OKP", "crv": "Ed25519", "x": b64u(pub)}
+
+    signer = Signer(private_key=priv_jwk, did=ROBOT_DID)
+    root = SoftwareRootOfTrust(seed=HW_SEED, kind="TPM")
+    identity = mint_robot_identity(
+        signer, root, make="Acme Robotics", model="AR-7", serial="SN-000123",
+        owner="did:web:owner.example.com", valid_from=VALID_FROM,
+        lifecycle=[{"event": "manufactured", "timestamp": "2026-01-01T00:00:00Z"}],
+    )
+
+    config = {"temperature": 0.0, "max_torque": 12.5, "guardrails": ["no_humans_zone"]}
+
+    doc = {
+        "description": (
+            "Robotics interop vector (Phase 5.1-5.3). Pins the hardware-root "
+            "binding inside a RobotIdentityCredential and the config hash used by "
+            "ModelProvenanceAttestation. Both compose the shared JCS + SHA-256 + "
+            "multibase primitives."
+        ),
+        "version": "1.0",
+        "robot_public_key_jwk": public_jwk,
+        "robot_identity_credential": identity,
+        "config": config,
+        "expected_config_hash": config_hash(config),
+    }
+    path = os.path.join(os.path.dirname(__file__), "vector.json")
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(doc, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(f"wrote {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test-vectors/robotics/vector.json
+++ b/test-vectors/robotics/vector.json
@@ -1,0 +1,55 @@
+{
+  "description": "Robotics interop vector (Phase 5.1-5.3). Pins the hardware-root binding inside a RobotIdentityCredential and the config hash used by ModelProvenanceAttestation. Both compose the shared JCS + SHA-256 + multibase primitives.",
+  "version": "1.0",
+  "robot_public_key_jwk": {
+    "kty": "OKP",
+    "crv": "Ed25519",
+    "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"
+  },
+  "robot_identity_credential": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://vouch-protocol.com/contexts/v1"
+    ],
+    "type": [
+      "VerifiableCredential",
+      "RobotIdentityCredential"
+    ],
+    "issuer": "did:web:robot.example.com",
+    "validFrom": "2026-01-01T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:web:robot.example.com",
+      "make": "Acme Robotics",
+      "model": "AR-7",
+      "serial": "SN-000123",
+      "hardwareRoot": {
+        "kind": "TPM",
+        "publicKeyMultibase": "z6MkvDqGT54cXesYGvABpF1UapVNwjCqRcafi4Px6Thv5T3Z",
+        "attestation": "uCb669zDVKNUssuYMSMauxIWC7DQKCPFBU6K0o_XCEuInfJTDoC_tZuG0Ea4AGkQhk7TwNKMQmA7w4myFbbDLDg"
+      },
+      "lifecycle": [
+        {
+          "event": "manufactured",
+          "timestamp": "2026-01-01T00:00:00Z"
+        }
+      ],
+      "owner": "did:web:owner.example.com"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2022",
+      "created": "2026-06-14T04:14:58Z",
+      "verificationMethod": "did:web:robot.example.com#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "zwrtDDka5WiQYyVRFX159554tDvSdeZ25qqinVzQ9PkByYfa5r1Q3fmN6bqYtY8hVGQ6RqmLmXQDKS2S8MBTfShg"
+    }
+  },
+  "config": {
+    "temperature": 0.0,
+    "max_torque": 12.5,
+    "guardrails": [
+      "no_humans_zone"
+    ]
+  },
+  "expected_config_hash": "uMh9_H2Lk51-m9SpBhiEa1oqIwwwA7yT27e2QFS0YKUs"
+}

--- a/tests/test_robot_handshake_blackbox_passport.py
+++ b/tests/test_robot_handshake_blackbox_passport.py
@@ -1,0 +1,186 @@
+"""
+Tests for robot-to-robot handshake (5.4), black box + kill switch (5.5),
+and the scannable passport (5.6).
+"""
+
+import os
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    BlackBoxLog,
+    TrustPolicy,
+    build_accept,
+    build_confirm,
+    build_hello,
+    build_killswitch_credential,
+    build_passport,
+    decode_passport,
+    encode_passport,
+    open_entry,
+    verify_accept,
+    verify_blackbox_chain,
+    verify_confirm,
+    verify_killswitch_credential,
+    verify_passport,
+)
+from vouch.robotics.handshake import HandshakeError
+
+
+def _robot(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestHandshake:
+    def test_full_handshake_bounds_scope(self):
+        a_kp, a = _robot("robot-a.example.com")
+        b_kp, b = _robot("robot-b.example.com")
+        policy_b = TrustPolicy(trusted_domains={"robot-a.example.com"})
+
+        hello = build_hello(a, proposed_scope=["lift", "carry", "scan"])
+        accept = build_accept(
+            b,
+            hello=hello,
+            hello_public_key=a_kp.public_key_jwk,
+            policy=policy_b,
+            offered_scope=["carry", "scan", "weld"],
+        )
+        ok, session = verify_accept(accept, b_kp.public_key_jwk, expected_nonce=hello["nonce"])
+        assert ok is True
+        # Bounded scope is the intersection.
+        assert session.scope == ["carry", "scan"]
+
+        confirm = build_confirm(a, session=session)
+        assert (
+            verify_confirm(
+                confirm,
+                a_kp.public_key_jwk,
+                session_id=session.session_id,
+                expected_nonce=session.nonce,
+            )
+            is True
+        )
+
+    def test_untrusted_domain_refused(self):
+        a_kp, a = _robot("stranger.example.com")
+        _, b = _robot("robot-b.example.com")
+        policy_b = TrustPolicy(trusted_domains={"robot-a.example.com"})
+        hello = build_hello(a, proposed_scope=["lift"])
+        with pytest.raises(HandshakeError):
+            build_accept(
+                b,
+                hello=hello,
+                hello_public_key=a_kp.public_key_jwk,
+                policy=policy_b,
+                offered_scope=["lift"],
+            )
+
+    def test_nonce_must_echo(self):
+        a_kp, a = _robot("robot-a.example.com")
+        b_kp, b = _robot("robot-b.example.com")
+        hello = build_hello(a, proposed_scope=["lift"])
+        accept = build_accept(
+            b,
+            hello=hello,
+            hello_public_key=a_kp.public_key_jwk,
+            policy=TrustPolicy(accept_unknown=True),
+            offered_scope=["lift"],
+        )
+        ok, _ = verify_accept(accept, b_kp.public_key_jwk, expected_nonce="wrong-nonce")
+        assert ok is False
+
+
+class TestBlackBox:
+    def test_append_encrypt_decrypt_and_chain(self):
+        key = os.urandom(32)
+        log = BlackBoxLog(key=key)
+        log.append("MOTION", {"joint": 3, "torque": 4.2})
+        log.append("FAULT", {"code": "E12"})
+        entries = log.entries()
+
+        ok, _ = verify_blackbox_chain(entries)
+        assert ok is True
+        # Payloads are encrypted; only the key opens them.
+        assert "torque" not in entries[0]["ciphertext"]
+        assert open_entry(entries[0], key)["torque"] == 4.2
+
+    def test_wrong_key_fails_to_open(self):
+        log = BlackBoxLog(key=os.urandom(32))
+        log.append("MOTION", {"x": 1})
+        from vouch.robotics.blackbox import BlackBoxError
+
+        with pytest.raises(BlackBoxError):
+            open_entry(log.entries()[0], os.urandom(32))
+
+    def test_tampering_ciphertext_breaks_chain(self):
+        log = BlackBoxLog(key=os.urandom(32))
+        log.append("A", {"x": 1})
+        log.append("B", {"x": 2})
+        entries = log.entries()
+        entries[0]["ciphertext"] = entries[0]["ciphertext"][:-4] + "AAAA"
+        ok, _ = verify_blackbox_chain(entries)
+        assert ok is False
+
+
+class TestKillSwitch:
+    def test_build_and_verify_with_authority_allowlist(self):
+        kp, authority = _robot("safety-authority.example.com")
+        cred = build_killswitch_credential(
+            authority,
+            target="did:web:robot.example.com",
+            reason="human in path",
+        )
+        assert "KillSwitchCredential" in cred["type"]
+        ok, subject = verify_killswitch_credential(
+            cred, kp.public_key_jwk, trusted_authorities={authority.get_did()}
+        )
+        assert ok is True
+        assert subject["command"] == "emergency_stop"
+
+    def test_untrusted_authority_refused(self):
+        kp, attacker = _robot("attacker.example.com")
+        cred = build_killswitch_credential(attacker, target="did:web:robot", reason="x")
+        ok, _ = verify_killswitch_credential(
+            cred, kp.public_key_jwk, trusted_authorities={"did:web:real-authority"}
+        )
+        assert ok is False
+
+
+class TestPassport:
+    def test_encode_decode_verify(self):
+        kp, robot = _robot("robot.example.com")
+        passport = build_passport(
+            robot,
+            robot_did=robot.get_did(),
+            make="Acme",
+            model="AR-7",
+            owner="did:web:owner.example.com",
+            authorized_actions=["carry", "scan"],
+            certification="CE-2026-001",
+            status="active",
+        )
+        uri = encode_passport(passport)
+        assert uri.startswith("vouch-passport:u")
+        assert decode_passport(uri)["credentialSubject"]["model"] == "AR-7"
+
+        ok, summary = verify_passport(uri, kp.public_key_jwk)
+        assert ok is True
+        assert summary["owner"] == "did:web:owner.example.com"
+        assert summary["status"] == "active"
+        assert summary["authorizedActions"] == ["carry", "scan"]
+
+    def test_tampered_passport_fails(self):
+        kp, robot = _robot("robot.example.com")
+        passport = build_passport(
+            robot,
+            robot_did=robot.get_did(),
+            make="Acme",
+            model="AR-7",
+            owner="o",
+            authorized_actions=["carry"],
+        )
+        passport["credentialSubject"]["authorizedActions"] = ["carry", "weld", "drive"]
+        ok, _ = verify_passport(passport, kp.public_key_jwk)
+        assert ok is False

--- a/tests/test_robot_identity.py
+++ b/tests/test_robot_identity.py
@@ -1,0 +1,78 @@
+"""
+Tests for hardware-rooted robot identity (Phase 5.1).
+"""
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    SoftwareRootOfTrust,
+    lifecycle_event,
+    mint_robot_identity,
+    verify_robot_identity,
+)
+
+
+@pytest.fixture
+def robot():
+    kp = generate_identity(domain="robot-fleet.example.com")
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def _mint(robot, root=None):
+    kp, signer = robot
+    root = root or SoftwareRootOfTrust(seed=bytes(range(32)), kind="TPM")
+    return mint_robot_identity(
+        signer,
+        root,
+        make="Acme Robotics",
+        model="AR-7",
+        serial="SN-000123",
+        owner="did:web:owner.example.com",
+        lifecycle=[lifecycle_event("manufactured"), lifecycle_event("commissioned")],
+    )
+
+
+class TestRobotIdentity:
+    def test_mint_and_verify(self, robot):
+        kp, _ = robot
+        cred = _mint(robot)
+        assert "RobotIdentityCredential" in cred["type"]
+        ok, subject = verify_robot_identity(cred, kp.public_key_jwk)
+        assert ok is True
+        assert subject["make"] == "Acme Robotics"
+        assert subject["serial"] == "SN-000123"
+        assert subject["hardwareRoot"]["kind"] == "TPM"
+        assert len(subject["lifecycle"]) == 2
+
+    def test_tampered_serial_fails_credential_proof(self, robot):
+        kp, _ = robot
+        cred = _mint(robot)
+        cred["credentialSubject"]["serial"] = "SN-999999"
+        ok, _ = verify_robot_identity(cred, kp.public_key_jwk)
+        assert ok is False  # the credential proof no longer matches
+
+    def test_forged_hardware_root_fails(self, robot):
+        kp, _ = robot
+        cred = _mint(robot)
+        # Swap in a different hardware root key (attacker cannot re-sign the binding).
+        attacker_root = SoftwareRootOfTrust(seed=bytes([7] * 32))
+        cred["credentialSubject"]["hardwareRoot"]["publicKeyMultibase"] = (
+            attacker_root.public_key_multibase()
+        )
+        # Re-sign the credential proof so only the hardware attestation is wrong.
+        from vouch import Signer
+        from vouch.robotics._signing import attach_proof
+
+        signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+        cred.pop("proof", None)
+        cred = attach_proof(cred, signer)
+        ok, _ = verify_robot_identity(cred, kp.public_key_jwk)
+        assert ok is False  # hardware attestation does not verify against the swapped key
+
+    def test_binding_ties_key_to_hardware(self, robot):
+        # A credential minted for one robot key does not verify under another key.
+        cred = _mint(robot)
+        other = generate_identity(domain="other.example.com")
+        ok, _ = verify_robot_identity(cred, other.public_key_jwk)
+        assert ok is False

--- a/tests/test_robot_provenance_capability.py
+++ b/tests/test_robot_provenance_capability.py
@@ -1,0 +1,159 @@
+"""
+Tests for model/config provenance (5.2) and physical capability scope (5.3).
+"""
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    PhysicalAction,
+    attenuates,
+    build_physical_scope_credential,
+    build_provenance_attestation,
+    check_physical_action,
+    config_hash,
+    verify_provenance_attestation,
+)
+
+ROBOT = "did:web:robot.example.com"
+
+
+@pytest.fixture
+def builder():
+    kp = generate_identity(domain="builder.example.com")
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestProvenance:
+    def test_build_and_verify_with_config(self, builder):
+        kp, s = builder
+        config = {"temperature": 0.0, "max_torque": 12.5, "guardrails": ["no_humans_zone"]}
+        att = build_provenance_attestation(
+            s,
+            robot_did=ROBOT,
+            model_name="OpenVLA-7B",
+            weights_hash="uWEIGHTS",
+            safety_policy="uPOLICY",
+            config=config,
+            version="2.1.0",
+        )
+        assert "ModelProvenanceAttestation" in att["type"]
+        ok, subject = verify_provenance_attestation(att, kp.public_key_jwk, config=config)
+        assert ok is True
+        assert subject["vla"]["modelName"] == "OpenVLA-7B"
+        assert subject["vla"]["configHash"] == config_hash(config)
+
+    def test_config_mismatch_fails(self, builder):
+        kp, s = builder
+        att = build_provenance_attestation(
+            s,
+            robot_did=ROBOT,
+            model_name="m",
+            weights_hash="uW",
+            safety_policy="uP",
+            config={"a": 1},
+        )
+        ok, _ = verify_provenance_attestation(att, kp.public_key_jwk, config={"a": 2})
+        assert ok is False
+
+    def test_ota_chain_supersedes(self, builder):
+        kp, s = builder
+        v1 = build_provenance_attestation(
+            s, robot_did=ROBOT, model_name="m", weights_hash="uW1", safety_policy="uP"
+        )
+        v2 = build_provenance_attestation(
+            s,
+            robot_did=ROBOT,
+            model_name="m",
+            weights_hash="uW2",
+            safety_policy="uP",
+            supersedes=v1["id"] if "id" in v1 else "urn:prev",
+        )
+        ok, subject = verify_provenance_attestation(v2, kp.public_key_jwk)
+        assert ok is True
+        assert "supersedes" in subject
+
+
+class TestPhysicalScope:
+    SCOPE = {
+        "maxForceN": 100.0,
+        "maxSpeedMps": 2.0,
+        "maxSpeedNearHumansMps": 0.5,
+        "allowedZones": ["zone-A", "zone-B"],
+        "shiftWindows": [{"start": "08:00", "end": "18:00"}],
+    }
+
+    def test_within_scope(self):
+        a = PhysicalAction(force_n=50, speed_mps=1.5, zone="zone-A", time_hm="10:00")
+        assert check_physical_action(self.SCOPE, a).ok is True
+
+    def test_force_exceeded(self):
+        r = check_physical_action(self.SCOPE, PhysicalAction(force_n=150))
+        assert r.ok is False
+        assert any("force_exceeded" in x for x in r.reasons)
+
+    def test_near_humans_lower_speed_cap(self):
+        # 1.5 m/s is fine normally but not near humans (cap 0.5).
+        assert check_physical_action(self.SCOPE, PhysicalAction(speed_mps=1.5)).ok is True
+        r = check_physical_action(self.SCOPE, PhysicalAction(speed_mps=1.5, near_humans=True))
+        assert r.ok is False
+        assert any("near_humans" in x for x in r.reasons)
+
+    def test_zone_and_shift(self):
+        assert check_physical_action(self.SCOPE, PhysicalAction(zone="zone-C")).ok is False
+        assert check_physical_action(self.SCOPE, PhysicalAction(time_hm="22:00")).ok is False
+
+    def test_credential_round_trip(self, builder):
+        kp, s = builder
+        cred = build_physical_scope_credential(
+            s,
+            subject_did=ROBOT,
+            max_force_n=100,
+            max_speed_mps=2.0,
+            max_speed_near_humans_mps=0.5,
+            allowed_zones=["zone-A"],
+        )
+        assert "PhysicalCapabilityScope" in cred["type"]
+        scope = cred["credentialSubject"]["physicalScope"]
+        assert check_physical_action(scope, PhysicalAction(force_n=50, zone="zone-A")).ok is True
+
+    def test_attenuation(self):
+        parent = {"maxForceN": 100, "maxSpeedMps": 2.0, "allowedZones": ["A", "B"]}
+        good_child = {"maxForceN": 50, "maxSpeedMps": 1.0, "allowedZones": ["A"]}
+        assert attenuates(parent, good_child) is True
+        # Broader force is not a valid attenuation.
+        assert (
+            attenuates(parent, {"maxForceN": 200, "maxSpeedMps": 1.0, "allowedZones": ["A"]})
+            is False
+        )
+        # Adding a zone the parent did not allow is broader.
+        assert (
+            attenuates(parent, {"maxForceN": 50, "maxSpeedMps": 1.0, "allowedZones": ["A", "C"]})
+            is False
+        )
+
+
+class TestVector:
+    def _vector(self):
+        import json
+        import os
+
+        path = os.path.join(
+            os.path.dirname(__file__), "..", "test-vectors", "robotics", "vector.json"
+        )
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+
+    def test_identity_credential_verifies(self):
+        from vouch.robotics import verify_robot_identity
+
+        v = self._vector()
+        ok, subject = verify_robot_identity(
+            v["robot_identity_credential"], v["robot_public_key_jwk"]
+        )
+        assert ok is True
+        assert subject["hardwareRoot"]["kind"] == "TPM"
+
+    def test_config_hash_reproduces(self):
+        v = self._vector()
+        assert config_hash(v["config"]) == v["expected_config_hash"]

--- a/vouch/robotics/__init__.py
+++ b/vouch/robotics/__init__.py
@@ -1,0 +1,91 @@
+"""
+Vouch robotics primitives.
+
+Open, vendor-neutral formats and reference implementations for accountable
+robots and embodied agents:
+
+  - identity: hardware-rooted robot identity + lifecycle credential profile.
+  - provenance: model-and-config provenance attestation, re-signable on OTA.
+  - capability: physical capability scope (force, speed, zones, shifts).
+  - handshake: robot-to-robot bounded-trust handshake across domains.
+  - blackbox: encrypted append-only flight recorder + kill-switch credential.
+  - passport: scannable (QR/NFC) robot passport and verifier.
+"""
+
+from .capability import (
+    PhysicalAction,
+    attenuates,
+    build_physical_scope_credential,
+    check_physical_action,
+)
+from .identity import (
+    HardwareRootOfTrust,
+    SoftwareRootOfTrust,
+    lifecycle_event,
+    mint_robot_identity,
+    verify_robot_identity,
+)
+from .provenance import (
+    build_provenance_attestation,
+    config_hash,
+    verify_provenance_attestation,
+)
+from .handshake import (
+    BoundedSession,
+    TrustPolicy,
+    build_accept,
+    build_confirm,
+    build_hello,
+    verify_accept,
+    verify_confirm,
+)
+from .blackbox import (
+    BlackBoxLog,
+    build_killswitch_credential,
+    open_entry,
+    verify_blackbox_chain,
+    verify_killswitch_credential,
+)
+from .passport import (
+    build_passport,
+    decode_passport,
+    encode_passport,
+    verify_passport,
+)
+
+__all__ = [
+    # identity
+    "HardwareRootOfTrust",
+    "SoftwareRootOfTrust",
+    "mint_robot_identity",
+    "verify_robot_identity",
+    "lifecycle_event",
+    # provenance
+    "build_provenance_attestation",
+    "verify_provenance_attestation",
+    "config_hash",
+    # capability
+    "PhysicalAction",
+    "build_physical_scope_credential",
+    "check_physical_action",
+    "attenuates",
+    # handshake
+    "TrustPolicy",
+    "BoundedSession",
+    "build_hello",
+    "build_accept",
+    "verify_accept",
+    "build_confirm",
+    "verify_confirm",
+    # blackbox + kill switch
+    "BlackBoxLog",
+    "open_entry",
+    "verify_blackbox_chain",
+    "build_killswitch_credential",
+    "verify_killswitch_credential",
+    # passport
+    "build_passport",
+    "encode_passport",
+    "decode_passport",
+    "verify_passport",
+]

--- a/vouch/robotics/_signing.py
+++ b/vouch/robotics/_signing.py
@@ -1,0 +1,29 @@
+"""
+Shared signing helper for robotics credentials.
+
+Robotics credentials are custom credential types assembled by hand (a robot
+identity, a kill switch, a passport), so they are signed with the low-level
+`data_integrity.build_proof` primitive, the same path the rest of the SDK uses
+for non-intent credentials, rather than the intent-based `Signer.sign_credential`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from .. import data_integrity
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise ValueError("signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    """Attach an eddsa-jcs-2022 Data Integrity proof to a pre-built credential."""
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential

--- a/vouch/robotics/blackbox.py
+++ b/vouch/robotics/blackbox.py
@@ -1,0 +1,228 @@
+"""
+Robot black-box log and kill-switch credential (Phase 5.5).
+
+The black box is an append-only, signed, encrypted event log: the robot flight
+recorder. Each entry's payload is encrypted with AES-256-GCM and hash-linked to
+the previous entry, so the log is confidential yet tamper-evident, and the chain
+head can be signed to anchor the whole log. Only a holder of the black-box key
+can read the payloads; anyone can verify the chain.
+
+The kill-switch credential is a verifiable record of an emergency stop: it proves
+who issued the stop, what it targets, and (when an authority allowlist is
+supplied) that only an attested authority could have triggered it.
+
+This ships the formats and reference libraries. Hosted black-box storage and
+fleet-scale kill-switch infrastructure are out of scope.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from vouch.jcs import canonicalize
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+KILLSWITCH_TYPE = "KillSwitchCredential"
+BLACKBOX_VERSION = "1.0"
+GENESIS_PREV_HASH = "u" + base64.urlsafe_b64encode(b"\x00" * 32).rstrip(b"=").decode("ascii")
+EMERGENCY_STOP = "emergency_stop"
+
+
+class BlackBoxError(Exception):
+    """Raised on black-box log or kill-switch errors."""
+
+
+def _mb64(b: bytes) -> str:
+    return "u" + base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _unmb64(s: str) -> bytes:
+    if not s.startswith("u"):
+        raise BlackBoxError("expected multibase 'u' prefix")
+    payload = s[1:]
+    return base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+
+
+def _entry_hash(body: Dict[str, Any]) -> str:
+    clean = {k: v for k, v in body.items() if k != "entryHash"}
+    return _mb64(hashlib.sha256(canonicalize(clean)).digest())
+
+
+@dataclass
+class BlackBoxLog:
+    """Append-only, encrypted, hash-linked event log. `key` is 32 bytes (AES-256)."""
+
+    key: bytes
+    genesis_prev_hash: str = GENESIS_PREV_HASH
+    _entries: List[Dict[str, Any]] = field(default_factory=list, init=False)
+    _head: str = field(default="", init=False)
+
+    def __post_init__(self) -> None:
+        if len(self.key) != 32:
+            raise BlackBoxError("key must be 32 bytes (AES-256)")
+        self._head = self.genesis_prev_hash
+
+    def append(
+        self,
+        event: str,
+        payload: Dict[str, Any],
+        *,
+        timestamp: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        nonce = os.urandom(12)
+        plaintext = canonicalize(payload)
+        ciphertext = AESGCM(self.key).encrypt(nonce, plaintext, None)
+        body = {
+            "version": BLACKBOX_VERSION,
+            "seq": len(self._entries),
+            "timestamp": timestamp or _iso(datetime.now(timezone.utc)),
+            "event": event,
+            "ciphertext": _mb64(nonce + ciphertext),
+            "prevHash": self._head,
+        }
+        body["entryHash"] = _entry_hash(body)
+        self._entries.append(body)
+        self._head = body["entryHash"]
+        return body
+
+    def head(self) -> str:
+        return self._head
+
+    def entries(self) -> List[Dict[str, Any]]:
+        return [dict(e) for e in self._entries]
+
+    def open_entry(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Decrypt one entry's payload with this log's key."""
+        return open_entry(entry, self.key)
+
+
+def open_entry(entry: Dict[str, Any], key: bytes) -> Dict[str, Any]:
+    """Decrypt a black-box entry payload. Returns the original payload dict."""
+    import json
+
+    blob = _unmb64(entry["ciphertext"])
+    nonce, ciphertext = blob[:12], blob[12:]
+    try:
+        plaintext = AESGCM(key).decrypt(nonce, ciphertext, None)
+    except Exception as exc:  # noqa: BLE001 - decryption failure (wrong key/tampered)
+        raise BlackBoxError(f"decryption failed: {exc}") from exc
+    return json.loads(plaintext.decode("utf-8"))
+
+
+def verify_blackbox_chain(
+    entries: List[Dict[str, Any]],
+    genesis_prev_hash: str = GENESIS_PREV_HASH,
+) -> "tuple[bool, Optional[str]]":
+    """Verify the hash chain over (encrypted) entries. Tamper-evident without the key."""
+    prev = genesis_prev_hash
+    for i, entry in enumerate(entries):
+        if entry.get("seq") != i:
+            return False, f"entry {i} seq mismatch"
+        if entry.get("prevHash") != prev:
+            return False, f"entry {i} prevHash does not link"
+        if entry.get("entryHash") != _entry_hash(entry):
+            return False, f"entry {i} entryHash mismatch (tampered)"
+        prev = entry["entryHash"]
+    return True, None
+
+
+# ---------------------------------------------------------------------------
+# Kill-switch credential
+# ---------------------------------------------------------------------------
+
+
+def build_killswitch_credential(
+    authority_signer: Any,
+    *,
+    target: str,
+    reason: str,
+    command: str = EMERGENCY_STOP,
+    scope: Optional[List[str]] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed KillSwitchCredential proving who issued an emergency stop.
+
+    Args:
+      target: The robot DID, fleet id, or zone the stop applies to.
+      command: The action (default emergency_stop).
+    """
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": target,
+        "command": command,
+        "reason": reason,
+        "issuedBy": authority_signer.get_did(),
+    }
+    if scope is not None:
+        subject["scope"] = list(scope)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", KILLSWITCH_TYPE],
+        "issuer": authority_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, authority_signer)
+
+
+def verify_killswitch_credential(
+    credential: Dict[str, Any],
+    public_key: Any,
+    *,
+    trusted_authorities: Optional[Set[str]] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a KillSwitchCredential. When `trusted_authorities` is supplied, the
+    issuer DID MUST be in it, so only an attested authority can trigger the stop.
+    """
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if KILLSWITCH_TYPE not in type_field:
+        return False, None
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    issuer = credential.get("issuer")
+    if trusted_authorities is not None and issuer not in trusted_authorities:
+        return False, None
+    return True, credential.get("credentialSubject") or {}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "KILLSWITCH_TYPE",
+    "EMERGENCY_STOP",
+    "GENESIS_PREV_HASH",
+    "BlackBoxError",
+    "BlackBoxLog",
+    "open_entry",
+    "verify_blackbox_chain",
+    "build_killswitch_credential",
+    "verify_killswitch_credential",
+]

--- a/vouch/robotics/capability.py
+++ b/vouch/robotics/capability.py
@@ -1,0 +1,170 @@
+"""
+Physical capability scope schema for robots (Phase 5.3).
+
+Extends the capability/attenuation model to the physical world: the maximum
+force and speed a robot may exert, a slower speed cap near humans, the zones it
+may operate in, and the shift windows during which it may act. A physical scope
+is carried in a signed credential, so the bound is cryptographically enforceable:
+a controller checks a proposed physical action against the granted scope before
+actuating, and a delegated scope must attenuate (narrow, never broaden) its
+parent.
+
+Physical scope schema (credentialSubject.physicalScope):
+
+  {
+    "maxForceN": <number, newtons>,
+    "maxSpeedMps": <number, m/s>,
+    "maxSpeedNearHumansMps": <number, m/s>,
+    "allowedZones": [<zone id string>, ...],
+    "shiftWindows": [{"start": "HH:MM", "end": "HH:MM"}, ...]
+  }
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+PHYSICAL_SCOPE_TYPE = "PhysicalCapabilityScope"
+
+
+class PhysicalScopeError(Exception):
+    """Raised on malformed physical-scope input."""
+
+
+@dataclass
+class PhysicalAction:
+    """A proposed physical action to check against a scope."""
+
+    force_n: Optional[float] = None
+    speed_mps: Optional[float] = None
+    near_humans: bool = False
+    zone: Optional[str] = None
+    time_hm: Optional[str] = None  # "HH:MM" local
+
+
+@dataclass
+class CheckResult:
+    ok: bool
+    reasons: List[str] = field(default_factory=list)
+
+
+def build_physical_scope_credential(
+    signer: Any,
+    *,
+    subject_did: str,
+    max_force_n: Optional[float] = None,
+    max_speed_mps: Optional[float] = None,
+    max_speed_near_humans_mps: Optional[float] = None,
+    allowed_zones: Optional[List[str]] = None,
+    shift_windows: Optional[List[Dict[str, str]]] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build a signed PhysicalCapabilityScope credential."""
+    scope: Dict[str, Any] = {}
+    if max_force_n is not None:
+        scope["maxForceN"] = max_force_n
+    if max_speed_mps is not None:
+        scope["maxSpeedMps"] = max_speed_mps
+    if max_speed_near_humans_mps is not None:
+        scope["maxSpeedNearHumansMps"] = max_speed_near_humans_mps
+    if allowed_zones is not None:
+        scope["allowedZones"] = list(allowed_zones)
+    if shift_windows is not None:
+        scope["shiftWindows"] = list(shift_windows)
+
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", PHYSICAL_SCOPE_TYPE],
+        "issuer": signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": {"id": subject_did, "physicalScope": scope},
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, signer)
+
+
+def _in_window(hm: str, window: Dict[str, str]) -> bool:
+    return window.get("start", "00:00") <= hm <= window.get("end", "23:59")
+
+
+def check_physical_action(scope: Dict[str, Any], action: PhysicalAction) -> CheckResult:
+    """Check a proposed physical action against a physical scope object."""
+    reasons: List[str] = []
+
+    if action.force_n is not None and "maxForceN" in scope:
+        if action.force_n > scope["maxForceN"]:
+            reasons.append(f"force_exceeded: {action.force_n}N > {scope['maxForceN']}N")
+
+    if action.speed_mps is not None:
+        cap = scope.get("maxSpeedMps")
+        if action.near_humans and "maxSpeedNearHumansMps" in scope:
+            cap = scope["maxSpeedNearHumansMps"]
+        if cap is not None and action.speed_mps > cap:
+            label = "near_humans " if action.near_humans else ""
+            reasons.append(f"{label}speed_exceeded: {action.speed_mps} m/s > {cap} m/s")
+
+    if action.zone is not None and "allowedZones" in scope:
+        if action.zone not in scope["allowedZones"]:
+            reasons.append(f"zone_not_allowed: {action.zone}")
+
+    if action.time_hm is not None and "shiftWindows" in scope:
+        windows = scope["shiftWindows"]
+        if windows and not any(_in_window(action.time_hm, w) for w in windows):
+            reasons.append(f"outside_shift_window: {action.time_hm}")
+
+    return CheckResult(ok=not reasons, reasons=reasons)
+
+
+def attenuates(parent: Dict[str, Any], child: Dict[str, Any]) -> bool:
+    """
+    True if `child` is a valid attenuation of `parent`: never broader on any
+    physical dimension. Numeric caps may only shrink; allowed zones may only be a
+    subset; shift windows must each fit inside some parent window.
+    """
+    for key in ("maxForceN", "maxSpeedMps", "maxSpeedNearHumansMps"):
+        if key in parent:
+            if key not in child:
+                return False  # child must keep (and may lower) a cap the parent set
+            if child[key] > parent[key]:
+                return False
+        # child adding a cap the parent did not set only narrows; allowed.
+
+    if "allowedZones" in parent:
+        p_zones = set(parent["allowedZones"])
+        c_zones = set(child.get("allowedZones", []))
+        if not c_zones or not c_zones.issubset(p_zones):
+            return False
+
+    if "shiftWindows" in parent:
+        p_windows = parent["shiftWindows"]
+        for cw in child.get("shiftWindows", []):
+            if not any(
+                pw.get("start", "00:00") <= cw.get("start", "00:00")
+                and cw.get("end", "23:59") <= pw.get("end", "23:59")
+                for pw in p_windows
+            ):
+                return False
+    return True
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "PHYSICAL_SCOPE_TYPE",
+    "PhysicalScopeError",
+    "PhysicalAction",
+    "CheckResult",
+    "build_physical_scope_credential",
+    "check_physical_action",
+    "attenuates",
+]

--- a/vouch/robotics/handshake.py
+++ b/vouch/robotics/handshake.py
@@ -1,0 +1,215 @@
+"""
+Robot-to-robot trust handshake protocol (Phase 5.4).
+
+Two robots in different trust domains authenticate each other and establish a
+bounded-trust session before cooperating. The protocol is three signed messages:
+
+  1. HELLO    (initiator A -> responder B): A's DID, a fresh nonce, and the
+     scope A proposes to operate under.
+  2. ACCEPT   (B -> A): B verifies A's identity and that A's domain is allowed by
+     B's trust policy, intersects the proposed scope with what B offers, and
+     signs an acceptance binding the nonce and the bounded scope.
+  3. CONFIRM  (A -> B): A verifies B's identity and acceptance (and that the
+     nonce echoes), and signs a confirmation. Both now hold the same
+     BoundedSession.
+
+Each message is an eddsa-jcs-2022 signed object, so authentication reuses the
+existing verifier. "Bounded trust" means the session scope is the intersection
+of what each side is willing to grant, never the union.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Set
+from ._signing import attach_proof
+
+HELLO = "handshake_hello"
+ACCEPT = "handshake_accept"
+CONFIRM = "handshake_confirm"
+
+
+class HandshakeError(Exception):
+    """Raised on handshake protocol failures."""
+
+
+@dataclass
+class TrustPolicy:
+    """
+    Cross-domain trust policy. A peer is trusted when its did:web domain is in
+    `trusted_domains`, or when `accept_unknown` is set (open cooperation).
+    """
+
+    trusted_domains: Set[str] = field(default_factory=set)
+    accept_unknown: bool = False
+
+    def is_trusted(self, did: str) -> bool:
+        if self.accept_unknown:
+            return True
+        return _did_web_domain(did) in self.trusted_domains
+
+
+@dataclass
+class BoundedSession:
+    session_id: str
+    initiator: str
+    responder: str
+    scope: List[str]
+    nonce: str
+    valid_until: Optional[str] = None
+
+
+def _did_web_domain(did: str) -> Optional[str]:
+    if did.startswith("did:web:"):
+        return did[len("did:web:") :].split(":")[0]
+    return None
+
+
+def _sign(signer: Any, obj: Dict[str, Any]) -> Dict[str, Any]:
+    return attach_proof(obj, signer)
+
+
+def _verify(obj: Dict[str, Any], public_key: Any) -> bool:
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False
+    try:
+        return bool(data_integrity.verify_proof(obj, resolved))
+    except ValueError:
+        return False
+
+
+def build_hello(
+    signer: Any,
+    *,
+    proposed_scope: List[str],
+    nonce: Optional[str] = None,
+    peer_did: Optional[str] = None,
+) -> Dict[str, Any]:
+    """A: open the handshake with a proposed scope and a fresh nonce."""
+    hello = {
+        "type": HELLO,
+        "from": signer.get_did(),
+        "to": peer_did,
+        "nonce": nonce or uuid.uuid4().hex,
+        "proposedScope": list(proposed_scope),
+        "issuedAt": _iso(datetime.now(timezone.utc)),
+    }
+    return _sign(signer, hello)
+
+
+def build_accept(
+    signer: Any,
+    *,
+    hello: Dict[str, Any],
+    hello_public_key: Any,
+    policy: TrustPolicy,
+    offered_scope: List[str],
+    valid_seconds: int = 300,
+    session_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    B: verify A's HELLO and identity domain, intersect the scope, and sign an
+    acceptance. Raises HandshakeError if A is untrusted or the HELLO is invalid.
+    """
+    if hello.get("type") != HELLO:
+        raise HandshakeError("not a HELLO message")
+    if not _verify(hello, hello_public_key):
+        raise HandshakeError("HELLO signature invalid")
+    initiator = hello.get("from")
+    if not policy.is_trusted(initiator):
+        raise HandshakeError(f"peer {initiator} is not in this trust domain's policy")
+
+    bounded = sorted(set(hello.get("proposedScope", [])) & set(offered_scope))
+    sid = session_id or f"urn:uuid:{uuid.uuid4()}"
+    valid_until = _iso(datetime.now(timezone.utc) + timedelta(seconds=valid_seconds))
+    accept = {
+        "type": ACCEPT,
+        "from": signer.get_did(),
+        "to": initiator,
+        "sessionId": sid,
+        "nonce": hello.get("nonce"),
+        "boundedScope": bounded,
+        "validUntil": valid_until,
+    }
+    return _sign(signer, accept)
+
+
+def verify_accept(
+    accept: Dict[str, Any],
+    accept_public_key: Any,
+    *,
+    expected_nonce: str,
+    policy: Optional[TrustPolicy] = None,
+) -> "tuple[bool, Optional[BoundedSession]]":
+    """A: verify B's ACCEPT, that the nonce echoes, and (optionally) that B is trusted."""
+    if accept.get("type") != ACCEPT:
+        return False, None
+    if not _verify(accept, accept_public_key):
+        return False, None
+    if accept.get("nonce") != expected_nonce:
+        return False, None
+    responder = accept.get("from")
+    if policy is not None and not policy.is_trusted(responder):
+        return False, None
+    session = BoundedSession(
+        session_id=accept.get("sessionId"),
+        initiator=accept.get("to"),
+        responder=responder,
+        scope=list(accept.get("boundedScope", [])),
+        nonce=accept.get("nonce"),
+        valid_until=accept.get("validUntil"),
+    )
+    return True, session
+
+
+def build_confirm(signer: Any, *, session: BoundedSession) -> Dict[str, Any]:
+    """A: confirm the bounded session to B."""
+    confirm = {
+        "type": CONFIRM,
+        "from": signer.get_did(),
+        "to": session.responder,
+        "sessionId": session.session_id,
+        "nonce": session.nonce,
+        "acceptedScope": list(session.scope),
+    }
+    return _sign(signer, confirm)
+
+
+def verify_confirm(
+    confirm: Dict[str, Any],
+    confirm_public_key: Any,
+    *,
+    session_id: str,
+    expected_nonce: str,
+) -> bool:
+    """B: verify A's CONFIRM closes the agreed session."""
+    if confirm.get("type") != CONFIRM:
+        return False
+    if not _verify(confirm, confirm_public_key):
+        return False
+    return confirm.get("sessionId") == session_id and confirm.get("nonce") == expected_nonce
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "HELLO",
+    "ACCEPT",
+    "CONFIRM",
+    "HandshakeError",
+    "TrustPolicy",
+    "BoundedSession",
+    "build_hello",
+    "build_accept",
+    "verify_accept",
+    "build_confirm",
+    "verify_confirm",
+]

--- a/vouch/robotics/identity.py
+++ b/vouch/robotics/identity.py
@@ -1,0 +1,258 @@
+"""
+Hardware-rooted robot identity and lifecycle credential profile (Phase 5.1).
+
+A documented profile for a robot's verifiable identity, bound to a hardware root
+of trust (a TPM or a secure element), plus a reference implementation. It is the
+open, vendor-neutral alternative to closed or state-run robot-ID schemes.
+
+A RobotIdentityCredential is an eddsa-jcs-2022 VC whose subject carries the
+robot's make, model, and serial, a lifecycle history, and a `hardwareRoot` block.
+The hardware root signs a binding over (robot DID, robot key), so the robot's
+software identity key is provably bound to a specific piece of hardware. A
+verifier checks both the credential proof (the robot key) and the hardware
+attestation (the root key).
+
+The hardware root is pluggable. `SoftwareRootOfTrust` is the reference; a real
+deployment substitutes a TPM- or secure-element-backed implementation that signs
+with a hardware-resident attestation key. The interface is the contract such a
+backend satisfies.
+"""
+
+from __future__ import annotations
+
+import base64
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from vouch import multikey
+from vouch.jcs import canonicalize
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+ROBOT_IDENTITY_TYPE = "RobotIdentityCredential"
+
+
+class RoboticsError(Exception):
+    """Raised on malformed robot-identity input."""
+
+
+# ---------------------------------------------------------------------------
+# Hardware root of trust
+# ---------------------------------------------------------------------------
+
+
+class HardwareRootOfTrust(ABC):
+    """
+    A hardware-resident key that attests the robot's software identity key.
+
+    A TPM backend signs with an Attestation Key (AK) derived from the
+    Endorsement Key; a secure-element backend signs with a device key fused at
+    manufacture. Both satisfy this interface.
+    """
+
+    @abstractmethod
+    def public_key_raw(self) -> bytes:
+        """The 32-byte Ed25519 public key of the hardware root."""
+
+    @abstractmethod
+    def sign(self, data: bytes) -> bytes:
+        """Sign `data` with the hardware-resident key."""
+
+    @property
+    def kind(self) -> str:
+        return "Software"
+
+    def public_key_multibase(self) -> str:
+        return multikey.encode_ed25519_public(self.public_key_raw())
+
+
+class SoftwareRootOfTrust(HardwareRootOfTrust):
+    """
+    Reference root of trust backed by a local Ed25519 key. Stands in for a TPM
+    or secure element in development and tests. NOT a hardware root: a real
+    deployment MUST use a hardware-backed implementation.
+    """
+
+    def __init__(self, seed: Optional[bytes] = None, kind: str = "Software") -> None:
+        self._sk = (
+            Ed25519PrivateKey.from_private_bytes(seed) if seed else Ed25519PrivateKey.generate()
+        )
+        self._kind = kind
+
+    def public_key_raw(self) -> bytes:
+        return self._sk.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+
+    def sign(self, data: bytes) -> bytes:
+        return self._sk.sign(data)
+
+    @property
+    def kind(self) -> str:
+        return self._kind
+
+
+# ---------------------------------------------------------------------------
+# Binding and minting
+# ---------------------------------------------------------------------------
+
+
+def _binding_bytes(robot_did: str, robot_key_multibase: str) -> bytes:
+    """Canonical bytes the hardware root signs to bind the identity key."""
+    return canonicalize({"key": robot_key_multibase, "robotDid": robot_did})
+
+
+def _mb64(b: bytes) -> str:
+    return "u" + base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _unmb64(s: str) -> bytes:
+    if not s.startswith("u"):
+        raise RoboticsError("expected multibase 'u' prefix")
+    payload = s[1:]
+    return base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+
+
+def mint_robot_identity(
+    robot_signer: Any,
+    root: HardwareRootOfTrust,
+    *,
+    make: str,
+    model: str,
+    serial: str,
+    owner: Optional[str] = None,
+    lifecycle: Optional[List[Dict[str, Any]]] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Mint a hardware-attested RobotIdentityCredential. The robot self-issues the
+    credential with its Vouch key (`robot_signer`); the hardware root signs a
+    binding over the robot DID and key, embedded as `hardwareRoot.attestation`.
+    """
+    robot_did = robot_signer.get_did()
+    robot_key_mb = robot_signer.get_public_key_multikey()
+    attestation = root.sign(_binding_bytes(robot_did, robot_key_mb))
+
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "make": make,
+        "model": model,
+        "serial": serial,
+        "hardwareRoot": {
+            "kind": root.kind,
+            "publicKeyMultibase": root.public_key_multibase(),
+            "attestation": _mb64(attestation),
+        },
+        "lifecycle": lifecycle
+        or [
+            {"event": "commissioned", "timestamp": _iso(issued)},
+        ],
+    }
+    if owner is not None:
+        subject["owner"] = owner
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", ROBOT_IDENTITY_TYPE],
+        "issuer": robot_did,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, robot_signer)
+
+
+def verify_robot_identity(
+    credential: Dict[str, Any],
+    robot_public_key: Any,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a RobotIdentityCredential: the credential proof (robot key) AND the
+    hardware-root attestation binding the robot key to the hardware. Returns
+    (ok, credentialSubject).
+    """
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if ROBOT_IDENTITY_TYPE not in type_field:
+        return False, None
+
+    resolved = (
+        _coerce_ed25519_public_key(robot_public_key) if robot_public_key is not None else None
+    )
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = credential.get("credentialSubject") or {}
+    hw = subject.get("hardwareRoot") or {}
+    hw_mb = hw.get("publicKeyMultibase")
+    attestation = hw.get("attestation")
+    if not hw_mb or not attestation:
+        return False, None
+
+    try:
+        alg, hw_raw = multikey.decode(hw_mb)
+        if alg != "Ed25519":
+            return False, None
+        hw_pub = Ed25519PublicKey.from_public_bytes(hw_raw)
+        robot_raw = resolved.public_bytes(Encoding.Raw, PublicFormat.Raw)
+        robot_key_mb = multikey.encode_ed25519_public(robot_raw)
+        binding = _binding_bytes(subject.get("id", ""), robot_key_mb)
+        hw_pub.verify(_unmb64(attestation), binding)
+    except (InvalidSignature, RoboticsError, ValueError):
+        return False, None
+
+    return True, subject
+
+
+def lifecycle_event(
+    event: str,
+    *,
+    actor: Optional[str] = None,
+    details: Optional[Dict[str, Any]] = None,
+    timestamp: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build a lifecycle history entry (manufactured, commissioned, transferred, decommissioned, ...)."""
+    entry: Dict[str, Any] = {
+        "event": event,
+        "timestamp": _iso(timestamp or datetime.now(timezone.utc)),
+    }
+    if actor is not None:
+        entry["actor"] = actor
+    if details is not None:
+        entry["details"] = details
+    return entry
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "ROBOT_IDENTITY_TYPE",
+    "RoboticsError",
+    "HardwareRootOfTrust",
+    "SoftwareRootOfTrust",
+    "mint_robot_identity",
+    "verify_robot_identity",
+    "lifecycle_event",
+]

--- a/vouch/robotics/passport.py
+++ b/vouch/robotics/passport.py
@@ -1,0 +1,174 @@
+"""
+Scannable robot passport (Phase 5.6).
+
+A compact, signed passport that anyone can scan (QR or NFC) to check a robot's
+owner, authorized actions, certification, and current standing, offline. The
+passport is a small eddsa-jcs-2022 credential; the QR/NFC payload is a
+`vouch-passport:` URI carrying the multibase JCS bytes of that credential, so an
+offline reader can verify the signature without a network round-trip.
+
+This ships the open verifier and the encoding. Rendering the URI to an actual QR
+image or writing an NFC tag is the caller's concern (any QR/NFC library).
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from vouch.jcs import canonicalize
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+ROBOT_PASSPORT_TYPE = "RobotPassport"
+PASSPORT_URI_SCHEME = "vouch-passport:"
+
+STATUS_ACTIVE = "active"
+STATUS_SUSPENDED = "suspended"
+STATUS_DECOMMISSIONED = "decommissioned"
+
+
+class PassportError(Exception):
+    """Raised on malformed passport input."""
+
+
+def build_passport(
+    signer: Any,
+    *,
+    robot_did: str,
+    make: str,
+    model: str,
+    owner: str,
+    authorized_actions: List[str],
+    certification: Optional[str] = None,
+    status: str = STATUS_ACTIVE,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Build a signed RobotPassport credential (issued by the robot or an authority)."""
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "make": make,
+        "model": model,
+        "owner": owner,
+        "authorizedActions": list(authorized_actions),
+        "status": status,
+    }
+    if certification is not None:
+        subject["certification"] = certification
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", ROBOT_PASSPORT_TYPE],
+        "issuer": signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, signer)
+
+
+def encode_passport(passport: Dict[str, Any]) -> str:
+    """Encode a passport into a compact vouch-passport: URI for a QR or NFC tag."""
+    blob = base64.urlsafe_b64encode(canonicalize(passport)).rstrip(b"=").decode("ascii")
+    return PASSPORT_URI_SCHEME + "u" + blob
+
+
+def decode_passport(uri: str) -> Dict[str, Any]:
+    """Decode a vouch-passport: URI back into the passport credential."""
+    import json
+
+    if not uri.startswith(PASSPORT_URI_SCHEME):
+        raise PassportError(f"not a {PASSPORT_URI_SCHEME} URI")
+    body = uri[len(PASSPORT_URI_SCHEME) :]
+    if not body.startswith("u"):
+        raise PassportError("expected multibase 'u' payload")
+    payload = body[1:]
+    raw = base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+    return json.loads(raw.decode("utf-8"))
+
+
+def verify_passport(
+    passport: Any,
+    public_key: Any,
+    *,
+    now: Optional[datetime] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a passport (a credential dict or a vouch-passport: URI). Returns
+    (ok, summary) where summary is the human-facing fields. A suspended or
+    decommissioned status still verifies but is surfaced in the summary so a
+    scanner can refuse cooperation.
+    """
+    if isinstance(passport, str):
+        try:
+            passport = decode_passport(passport)
+        except PassportError:
+            return False, None
+
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = passport.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if ROBOT_PASSPORT_TYPE not in type_field:
+        return False, None
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(passport, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    # Temporal check (a scanner should reject an expired passport).
+    now = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    vu = _parse_iso(passport.get("validUntil", "")) if passport.get("validUntil") else None
+    if vu is not None and now > vu:
+        return False, None
+
+    subject = passport.get("credentialSubject") or {}
+    summary = {
+        "robot": subject.get("id"),
+        "make": subject.get("make"),
+        "model": subject.get("model"),
+        "owner": subject.get("owner"),
+        "authorizedActions": subject.get("authorizedActions", []),
+        "certification": subject.get("certification"),
+        "status": subject.get("status"),
+    }
+    return True, summary
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        if value.endswith("Z"):
+            return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        return datetime.fromisoformat(value).astimezone(timezone.utc)
+    except ValueError:
+        return None
+
+
+__all__ = [
+    "ROBOT_PASSPORT_TYPE",
+    "PASSPORT_URI_SCHEME",
+    "STATUS_ACTIVE",
+    "STATUS_SUSPENDED",
+    "STATUS_DECOMMISSIONED",
+    "PassportError",
+    "build_passport",
+    "encode_passport",
+    "decode_passport",
+    "verify_passport",
+]

--- a/vouch/robotics/provenance.py
+++ b/vouch/robotics/provenance.py
@@ -1,0 +1,130 @@
+"""
+Model-and-config provenance attestation for robots (Phase 5.2).
+
+A signed, verifiable record of the Vision-Language-Action (VLA) model, weights
+hash, safety policy, and configuration running on a robot. It is re-signable on
+an over-the-air (OTA) update: the new attestation references the one it
+supersedes, forming a tamper-evident chain of what software the robot ran and
+when.
+
+A ModelProvenanceAttestation is an eddsa-jcs-2022 VC. `weightsHash` is the
+multibase SHA-256 of the model weights (supplied by the caller, since the robot
+or builder computes it over the artifact); `configHash` is computed here over the
+JCS-canonical config so any verifier reproduces it.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from vouch.jcs import canonicalize
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+MODEL_PROVENANCE_TYPE = "ModelProvenanceAttestation"
+
+
+def config_hash(config: Dict[str, Any]) -> str:
+    """Multibase SHA-256 of the JCS-canonical config object."""
+    digest = hashlib.sha256(canonicalize(config)).digest()
+    return "u" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+def build_provenance_attestation(
+    signer: Any,
+    *,
+    robot_did: str,
+    model_name: str,
+    weights_hash: str,
+    safety_policy: str,
+    config: Optional[Dict[str, Any]] = None,
+    version: Optional[str] = None,
+    supersedes: Optional[str] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed ModelProvenanceAttestation for the software on a robot.
+
+    Args:
+      weights_hash: Multibase SHA-256 of the model weights artifact.
+      safety_policy: An identifier or multibase hash of the active safety policy.
+      config: The runtime config; its JCS SHA-256 is recorded as configHash.
+      supersedes: The id (or hash) of the attestation this OTA update replaces.
+    """
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    vla: Dict[str, Any] = {
+        "modelName": model_name,
+        "weightsHash": weights_hash,
+        "safetyPolicy": safety_policy,
+    }
+    if version is not None:
+        vla["version"] = version
+    if config is not None:
+        vla["configHash"] = config_hash(config)
+
+    subject: Dict[str, Any] = {"id": robot_did, "vla": vla}
+    if supersedes is not None:
+        subject["supersedes"] = supersedes
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", MODEL_PROVENANCE_TYPE],
+        "issuer": signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, signer)
+
+
+def verify_provenance_attestation(
+    attestation: Dict[str, Any],
+    public_key: Any,
+    *,
+    config: Optional[Dict[str, Any]] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a ModelProvenanceAttestation. When `config` is supplied, also check
+    that its hash matches the recorded configHash. Returns (ok, subject).
+    """
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = attestation.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if MODEL_PROVENANCE_TYPE not in type_field:
+        return False, None
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(attestation, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = attestation.get("credentialSubject") or {}
+    if config is not None:
+        recorded = (subject.get("vla") or {}).get("configHash")
+        if recorded != config_hash(config):
+            return False, None
+    return True, subject
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "MODEL_PROVENANCE_TYPE",
+    "config_hash",
+    "build_provenance_attestation",
+    "verify_provenance_attestation",
+]

--- a/website-agent/backend/knowledge/robotics.md
+++ b/website-agent/backend/knowledge/robotics.md
@@ -1,34 +1,91 @@
-# Robots and embodied agents
+# Robotics Reference: What Vouch Can Do for Robots
 
-A robot is an agent with a body. Identity, accountability, and continuous trust
-matter more, not less, when an agent can cause physical harm or move money in
-the real world. Vouch covers the open identity layer for robots; richer
-robot-lifecycle tooling builds on top of it.
+Vouch covers robots and embodied agents, not just software agents. The robotics
+primitives are open, vendor-neutral, and built on the same eddsa-jcs-2022
+Verifiable Credentials as the rest of Vouch, so they verify with every language
+SDK (Python, Rust, TypeScript, Go, Swift, Kotlin). They live in the
+`vouch.robotics` package. Everything below is built, tested, and shipped.
 
-## The same primitives apply
+These are formats plus reference implementations. Hosted black-box storage and
+fleet-scale kill-switch infrastructure are intentionally left to the deployer.
 
-- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
-  profile in `docs/specs/`).
-- Delegation: a delegation chain records who authorized the robot, on whose
-  behalf, and within what limits, all verifiable.
-- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
-  behaving now," so a robot has to keep proving itself.
-- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
-  check the status.
+## The six capabilities
 
-## The robot-specific open piece: hardware root of trust
+### 1. Hardware-rooted identity (`vouch.robotics.identity`)
+A robot's software identity key is bound to a hardware root of trust (a TPM or a
+secure element). The hardware root signs a binding over the robot's DID and key,
+embedded in a RobotIdentityCredential that also carries make, model, serial, and
+a lifecycle history. Verification checks both the credential proof and the
+hardware attestation, so the identity cannot be cloned to other hardware. This is
+the open alternative to closed or state-run robot-ID schemes.
+Key functions: `mint_robot_identity`, `verify_robot_identity`,
+`HardwareRootOfTrust` (the interface a TPM/secure-element backend satisfies),
+`SoftwareRootOfTrust` (development reference), `lifecycle_event`.
 
-A software agent's key can live in a file. A robot should do better. The
-hardware-root-of-trust profile binds the robot's DID to its secure element (a
-TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
-the signing key and signs the robot's heartbeats, so identity is anchored to the
-physical device, not a config that can be copied. The open `did:vouch:agent`
-profile defines the agent identity scheme; the embodied profile extends it for
-hardware attestation.
+### 2. Model and config provenance (`vouch.robotics.provenance`)
+A signed ModelProvenanceAttestation records the model name, weights hash, safety
+policy, and configuration hash running on a robot. It is re-signable on every
+over-the-air update, with a `supersedes` link, so the chain answers "what model
+and policy were running at any past time." The config hash is reproducible by any
+verifier.
+Key functions: `build_provenance_attestation`, `verify_provenance_attestation`,
+`config_hash`.
 
-## Open vs built on top
+### 3. Physical capability scope (`vouch.robotics.capability`)
+Extends capability attenuation to the physical world: max force, max speed, a
+lower max speed near humans, allowed zones, and shift windows, carried in a
+PhysicalCapabilityScope credential and checked before each actuation. A delegated
+scope must narrow (never broaden) its parent on every physical dimension.
+Key functions: `build_physical_scope_credential`, `check_physical_action`,
+`attenuates`, `PhysicalAction`.
 
-The identity, delegation, continuous-trust, and hardware-attestation profiles
-are open Vouch. Operated robot-lifecycle products (lifecycle identity
-management, model-and-config provenance, fleet trust at scale, and similar)
-build on this open layer and are out of scope for the protocol itself.
+### 4. Robot-to-robot trust handshake (`vouch.robotics.handshake`)
+Two robots in different trust domains authenticate and agree a bounded-trust
+cooperation session via three signed messages (HELLO, ACCEPT, CONFIRM). The
+session scope is the intersection of what each robot offers, and the responder
+checks the initiator's domain against its trust policy.
+Key functions: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, `TrustPolicy`, `BoundedSession`.
+
+### 5. Black box and kill switch (`vouch.robotics.blackbox`)
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
+recorder: payloads are confidential, the chain is tamper-evident without the key,
+and only the key opens the payloads. The kill-switch credential is a verifiable
+emergency stop that proves who issued it and, with an authority allowlist,
+enforces that only an attested authority can trigger it.
+Key functions: `BlackBoxLog`, `open_entry`, `verify_blackbox_chain`,
+`build_killswitch_credential`, `verify_killswitch_credential`.
+
+### 6. Scannable robot passport (`vouch.robotics.passport`)
+A compact, signed passport in a `vouch-passport:` URI for a QR or NFC tag, so
+anyone can check a robot's owner, authorized actions, certification, and standing
+offline, with no network call.
+Key functions: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`.
+
+## Quick answers
+
+- "Can a robot prove which hardware it is?" Yes, via the hardware-rooted identity
+  credential (capability 1).
+- "Can I prove what model and safety policy a robot is running, even after an OTA
+  update?" Yes, via the re-signable provenance attestation (capability 2).
+- "Can I enforce that a robot slows down near people, or stays in its zone?" Yes,
+  via the physical capability scope, checked before actuation (capability 3).
+- "Can two robots from different fleets cooperate safely?" Yes, via the
+  bounded-trust handshake (capability 4).
+- "Can I prove who hit the emergency stop, and stop anyone else from doing it?"
+  Yes, via the kill-switch credential with an attested-authority allowlist
+  (capability 5).
+- "Can a robot have a flight recorder that is private but tamper-evident?" Yes,
+  via the encrypted black box (capability 5).
+- "Can someone scan a robot to check it is legitimate?" Yes, via the scannable
+  passport (capability 6).
+
+## Status
+
+All six are implemented with tests and a runnable demo
+(`examples/robotics_demo.py`), documented in `docs/robotics.md`, with an interop
+vector pinning the hardware-root binding and config hash. Defensive disclosures
+PAD-064 (identity), PAD-065 (provenance), PAD-066 (physical scope), PAD-067
+(handshake), PAD-068 (kill switch), PAD-069 (black box), and PAD-070 (passport)
+cover the novel methods.

--- a/website/src/app/robotics/page.tsx
+++ b/website/src/app/robotics/page.tsx
@@ -1,0 +1,137 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata: Metadata = {
+    title: 'Robotics - Vouch Protocol',
+    description:
+        'Open, vendor-neutral trust and accountability for robots and embodied agents: hardware-rooted identity, model and config provenance, cryptographically enforced physical limits, a robot-to-robot handshake, an encrypted black box, a verifiable kill switch, and a scannable passport.',
+};
+
+const CAPABILITIES = [
+    {
+        num: 'i.',
+        title: 'Hardware-rooted identity',
+        body: 'A robot gets an identity bound to a TPM or secure element. The make, model, serial, and lifecycle history are signed, and the binding cannot be cloned to other hardware. The open alternative to closed or state-run robot-ID schemes.',
+        module: 'vouch.robotics.identity',
+    },
+    {
+        num: 'ii.',
+        title: 'Model & config provenance',
+        body: 'A signed record of the model, weights hash, safety policy, and config a robot is running. It is re-signed on every over-the-air update, so you can always prove what software was running, even after the fact.',
+        module: 'vouch.robotics.provenance',
+    },
+    {
+        num: 'iii.',
+        title: 'Physical capability scope',
+        body: 'Max force, a slower speed near people, allowed zones, and shift windows, carried in a signed credential and checked before the actuator moves. A delegated scope can only narrow, never widen, its parent.',
+        module: 'vouch.robotics.capability',
+    },
+    {
+        num: 'iv.',
+        title: 'Robot-to-robot handshake',
+        body: 'Two robots from different trust domains authenticate and agree a cooperation session before acting together. The session scope is the intersection of what each robot offers, gated by a domain trust policy.',
+        module: 'vouch.robotics.handshake',
+    },
+    {
+        num: 'v.',
+        title: 'Black box & kill switch',
+        body: 'An encrypted, tamper-evident flight recorder: the chain proves nothing was changed, and only the key opens the payloads. Plus a verifiable emergency stop that proves who issued it, and that only an attested authority can trigger it.',
+        module: 'vouch.robotics.blackbox',
+    },
+    {
+        num: 'vi.',
+        title: 'Scannable passport',
+        body: 'A compact passport in a QR or NFC tag, so anyone can check a robot\'s owner, authorized actions, certification, and standing offline, with no network call.',
+        module: 'vouch.robotics.passport',
+    },
+];
+
+export default function RoboticsPage() {
+    return (
+        <>
+            {/* Hero */}
+            <section className="border-b border-rule">
+                <div className="container-wide py-16 md:py-24">
+                    <div className="eyebrow mb-5">Robotics</div>
+                    <h1 className="font-serif font-semibold text-ink leading-[1.08] tracking-tight mb-6 max-w-[860px] text-[clamp(2.2rem,4.6vw,3.4rem)]">
+                        Identity and accountability for robots, not just software agents.
+                    </h1>
+                    <p className="text-ink-soft text-[1.15rem] leading-snug max-w-prose mb-4">
+                        As robots and embodied agents act in the physical world, they raise the same
+                        questions a software agent does, and a few new ones. Who is this robot? What
+                        software is it running? What is it allowed to do, and how fast near a person? Who
+                        can stop it? Vouch answers all of these with open, vendor-neutral credentials.
+                    </p>
+                    <p className="text-ink-soft text-[1rem] leading-relaxed max-w-prose">
+                        Every piece below is built on the same Verifiable Credentials as the rest of
+                        Vouch, so it verifies with the Python, Rust, TypeScript, and Go SDKs. These are
+                        open formats and reference implementations; hosted black-box storage and
+                        fleet-scale infrastructure are left to whoever deploys them.
+                    </p>
+                </div>
+            </section>
+
+            {/* Capabilities */}
+            <section className="border-b border-rule">
+                <div className="container-wide py-16">
+                    <div className="section-heading mb-8">
+                        <span className="num">§ I</span>
+                        <h2>What Vouch handles in robotics</h2>
+                    </div>
+                    <div className="grid md:grid-cols-2 gap-10">
+                        {CAPABILITIES.map((cap) => (
+                            <div key={cap.title} className="border-t-2 border-ink pt-5">
+                                <div className="eyebrow-faint mb-2">{cap.num}</div>
+                                <h3 className="font-serif font-semibold text-[1.3rem] tracking-tight mb-3">
+                                    {cap.title}
+                                </h3>
+                                <p className="text-ink-soft leading-relaxed mb-4">{cap.body}</p>
+                                <span className="font-mono text-burgundy text-[0.72rem] tracking-wider">
+                                    {cap.module}
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+            </section>
+
+            {/* Standards + links */}
+            <section className="border-b border-rule">
+                <div className="container-wide py-16">
+                    <div className="section-heading mb-6">
+                        <span className="num">§ II</span>
+                        <h2>Open, and headed for the standards bodies</h2>
+                    </div>
+                    <p className="text-ink-soft leading-relaxed max-w-prose mb-6">
+                        The robot identity, provenance, and passport are Verifiable Credential profiles,
+                        a natural fit to incubate alongside the existing W3C Credentials work. The
+                        physical-safety and emergency-stop pieces are positioned for IEEE and ISO/TC 299
+                        (Robotics). The methods are published as open defensive disclosures so they stay
+                        free for everyone to implement.
+                    </p>
+                    <div className="flex flex-wrap gap-3">
+                        <a
+                            href="https://github.com/vouch-protocol/vouch/blob/main/docs/robotics.md"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-primary"
+                        >
+                            Robotics documentation
+                        </a>
+                        <a
+                            href="https://github.com/vouch-protocol/vouch/tree/main/vouch/robotics"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-secondary"
+                        >
+                            Source on GitHub
+                        </a>
+                        <Link href="/tools/" className="btn-secondary">
+                            All tools
+                        </Link>
+                    </div>
+                </div>
+            </section>
+        </>
+    );
+}

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -7,6 +7,7 @@ import ThemeToggle from './ThemeToggle';
 
 const LINKS = [
     { href: '/tools/', label: 'Tools' },
+    { href: '/robotics/', label: 'Robotics' },
     { href: '/onboard/', label: 'Onboard' },
     { href: '/blog/', label: 'Blog' },
     { href: '/help/', label: 'Guides' },


### PR DESCRIPTION
Adds the robotics layer for accountable robots and embodied agents, signed the same way as the rest of the SDK.

## What's included
The `vouch.robotics` package, six modules:
- **identity**: hardware-rooted robot identity bound to a TPM or secure element, the open alternative to closed or state-run robot-ID schemes
- **provenance**: re-signable model and config provenance attestation (model, weights hash, safety policy), re-signed on every OTA update
- **capability**: physical capability scope (max force, slower speed near humans, allowed zones, shift windows), enforced before actuation, and monotonically narrowing on delegation
- **handshake**: robot-to-robot bounded-trust session across trust domains
- **blackbox**: encrypted, tamper-evident flight recorder (integrity verifiable without the key), plus the verifiable kill-switch credential
- **passport**: a scannable QR/NFC passport for offline checks of a robot's owner, authorized actions, and standing

Plus 25 tests, a runnable demo (`examples/robotics_demo.py`), a cross-language interop vector, the `/robotics` page and nav link, the robotics knowledge base for the assistant, and seven defensive disclosures (PAD-064 through PAD-070).

## Signing
Robotics credentials are custom credential types assembled by hand, so they sign through `data_integrity.build_proof` via a small shared `vouch/robotics/_signing.py` helper, the same pattern Phase 1 and Phase 4 use. No change to `Signer`.

## Verification
- 25 robotics tests pass against current `main`
- Website builds clean; `/robotics` renders
- No changes outside the robotics surface
