### PR TITLE
feat(website): global OS switcher in the nav (set once, applies site-wide)

### DIFF
--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useState } from 'react';
 import ThemeToggle from './ThemeToggle';
+import OSSwitcher from './OSSwitcher';
 
 const LINKS = [
     { href: '/tools/', label: 'Tools' },
@@ -48,6 +49,7 @@ export default function Nav() {
                     >
                         Index
                     </Link>
+                    <OSSwitcher />
                     <ThemeToggle />
                     <a
                         href="https://github.com/vouch-protocol/vouch"
@@ -102,6 +104,10 @@ export default function Nav() {
                         >
                             GitHub
                         </a>
+                        <div className="pt-3 flex flex-col gap-2">
+                            <span className="font-mono uppercase text-[0.6rem] tracking-[0.14em] text-ink-faint">Commands for</span>
+                            <OSSwitcher />
+                        </div>
                         <div className="pt-2"><ThemeToggle /></div>
                     </div>
                 </div>

--- a/website/src/components/OSCodeBlock.tsx
+++ b/website/src/components/OSCodeBlock.tsx
@@ -1,32 +1,16 @@
 'use client';
 
-import { useEffect, useState } from 'react';
 import CodeBlock from './CodeBlock';
+import { useOSPreference, type OS } from './os-preference';
 
 /**
  * A code block with macOS/Linux and Windows (PowerShell) variants behind tabs.
- * The chosen OS is shared across every OSCodeBlock on the page and persisted to
- * localStorage, so a developer picks their OS once and every command follows.
+ * The chosen OS is shared with the global OSSwitcher in the nav and every other
+ * OSCodeBlock (see ./os-preference), so a developer picks their OS once, from
+ * anywhere, and every command follows. The choice persists across pages.
  *
  * macOS and Linux share a tab because the command text is identical on both.
  */
-
-type OS = 'unix' | 'windows';
-const STORAGE_KEY = 'vouch-os-pref';
-
-// Module-level current selection + subscribers, so all instances stay in sync.
-let current: OS = 'unix';
-const listeners = new Set<(os: OS) => void>();
-
-function setGlobalOS(os: OS): void {
-  current = os;
-  try {
-    localStorage.setItem(STORAGE_KEY, os);
-  } catch {
-    /* storage unavailable */
-  }
-  listeners.forEach((fn) => fn(os));
-}
 
 type Props = {
   /** macOS / Linux command text. */
@@ -38,31 +22,14 @@ type Props = {
 };
 
 export default function OSCodeBlock({ unix, windows, className }: Props) {
-  const [os, setOs] = useState<OS>(current);
-
-  useEffect(() => {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY) as OS | null;
-      if (stored === 'unix' || stored === 'windows') {
-        current = stored;
-      }
-    } catch {
-      /* storage unavailable */
-    }
-    setOs(current);
-    const listener = (next: OS) => setOs(next);
-    listeners.add(listener);
-    return () => {
-      listeners.delete(listener);
-    };
-  }, []);
+  const [os, setOS] = useOSPreference();
 
   function tab(label: string, value: OS) {
     const active = os === value;
     return (
       <button
         type="button"
-        onClick={() => setGlobalOS(value)}
+        onClick={() => setOS(value)}
         aria-pressed={active}
         className={`font-mono uppercase text-[0.62rem] tracking-[0.16em] px-3 py-1.5 border-b-2 transition-colors ${
           active

--- a/website/src/components/OSSwitcher.tsx
+++ b/website/src/components/OSSwitcher.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useOSPreference, type OS } from './os-preference';
 
 /**
@@ -8,44 +8,114 @@ import { useOSPreference, type OS } from './os-preference';
  * anywhere, so every command code block across the site shows the matching
  * variant without per-block clicking. macOS and Linux share one option because
  * their command text is identical. The choice persists across pages and visits.
+ *
+ * Rendered as a compact dropdown so it does not crowd the nav.
  */
+
+const LABELS: Record<OS, string> = {
+  unix: 'macOS / Linux',
+  windows: 'Windows',
+};
+
+const TerminalIcon = () => (
+  <svg
+    width="13"
+    height="13"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="m5 8 4 4-4 4" />
+    <path d="M13 16h6" />
+  </svg>
+);
+
 export default function OSSwitcher() {
   const [os, setOS] = useOSPreference();
   const [mounted, setMounted] = useState(false);
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => setMounted(true), []);
 
+  useEffect(() => {
+    function onDocClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, []);
+
   // Reserve space during hydration so the nav does not shift.
   if (!mounted) {
-    return <div aria-hidden="true" className="inline-block h-6 w-[150px]" />;
-  }
-
-  function opt(label: string, value: OS) {
-    const active = os === value;
-    return (
-      <button
-        type="button"
-        onClick={() => setOS(value)}
-        aria-pressed={active}
-        title={`Show code commands for ${value === 'unix' ? 'macOS / Linux' : 'Windows'}`}
-        className={`px-2 py-1 transition-colors ${
-          active ? 'bg-ink text-parchment' : 'text-ink-soft hover:text-burgundy'
-        }`}
-      >
-        {label}
-      </button>
-    );
+    return <div aria-hidden="true" className="inline-block h-6 w-[118px]" />;
   }
 
   return (
-    <div
-      role="group"
-      aria-label="Operating system for code commands"
-      title="Choose the OS your code commands are shown for"
-      className="font-mono uppercase text-[0.58rem] tracking-[0.1em] inline-flex items-center border border-rule overflow-hidden"
-    >
-      {opt('macOS / Linux', 'unix')}
-      {opt('Windows', 'windows')}
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        title="Choose the OS your code commands are shown for"
+        className="font-mono uppercase text-[0.62rem] tracking-[0.12em] inline-flex items-center gap-1.5 whitespace-nowrap text-ink-soft hover:text-burgundy transition-colors"
+      >
+        <TerminalIcon />
+        {LABELS[os]}
+        <svg
+          width="9"
+          height="9"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          aria-hidden="true"
+          className={`transition-transform ${open ? 'rotate-180' : ''}`}
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="listbox"
+          aria-label="Operating system for code commands"
+          className="absolute right-0 mt-2 min-w-[140px] bg-parchment border border-rule shadow-md z-50"
+        >
+          {(['unix', 'windows'] as OS[]).map((value) => (
+            <button
+              key={value}
+              role="option"
+              aria-selected={os === value}
+              onClick={() => {
+                setOS(value);
+                setOpen(false);
+              }}
+              className={`block w-full text-left font-mono uppercase text-[0.62rem] tracking-[0.12em] whitespace-nowrap px-3 py-2 transition-colors ${
+                os === value
+                  ? 'text-burgundy bg-parchment-warm'
+                  : 'text-ink-soft hover:text-burgundy hover:bg-parchment-warm'
+              }`}
+            >
+              {LABELS[value]}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/website/src/components/OSSwitcher.tsx
+++ b/website/src/components/OSSwitcher.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useOSPreference, type OS } from './os-preference';
+
+/**
+ * Global OS selector for the nav. Sets the shared OS preference once, from
+ * anywhere, so every command code block across the site shows the matching
+ * variant without per-block clicking. macOS and Linux share one option because
+ * their command text is identical. The choice persists across pages and visits.
+ */
+export default function OSSwitcher() {
+  const [os, setOS] = useOSPreference();
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => setMounted(true), []);
+
+  // Reserve space during hydration so the nav does not shift.
+  if (!mounted) {
+    return <div aria-hidden="true" className="inline-block h-6 w-[150px]" />;
+  }
+
+  function opt(label: string, value: OS) {
+    const active = os === value;
+    return (
+      <button
+        type="button"
+        onClick={() => setOS(value)}
+        aria-pressed={active}
+        title={`Show code commands for ${value === 'unix' ? 'macOS / Linux' : 'Windows'}`}
+        className={`px-2 py-1 transition-colors ${
+          active ? 'bg-ink text-parchment' : 'text-ink-soft hover:text-burgundy'
+        }`}
+      >
+        {label}
+      </button>
+    );
+  }
+
+  return (
+    <div
+      role="group"
+      aria-label="Operating system for code commands"
+      title="Choose the OS your code commands are shown for"
+      className="font-mono uppercase text-[0.58rem] tracking-[0.1em] inline-flex items-center border border-rule overflow-hidden"
+    >
+      {opt('macOS / Linux', 'unix')}
+      {opt('Windows', 'windows')}
+    </div>
+  );
+}

--- a/website/src/components/os-preference.ts
+++ b/website/src/components/os-preference.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * Shared OS preference for command code blocks. One source of truth used by both
+ * the global OSSwitcher in the nav and every OSCodeBlock on the page. Set it once
+ * (anywhere) and every OS-aware block follows; the choice persists to
+ * localStorage so it carries across pages and visits.
+ *
+ * macOS and Linux share a value ("unix") because their command text is identical.
+ */
+
+export type OS = 'unix' | 'windows';
+const STORAGE_KEY = 'vouch-os-pref';
+
+let current: OS = 'unix';
+const listeners = new Set<(os: OS) => void>();
+
+export function getOSPreference(): OS {
+  return current;
+}
+
+export function setOSPreference(os: OS): void {
+  current = os;
+  try {
+    localStorage.setItem(STORAGE_KEY, os);
+  } catch {
+    /* storage unavailable */
+  }
+  listeners.forEach((fn) => fn(os));
+}
+
+/**
+ * Subscribe to the shared OS preference. Returns the current OS and a setter
+ * that updates every subscriber on the page and persists the choice. Hydrates
+ * from localStorage on mount (after hydration, so it does not cause a mismatch).
+ */
+export function useOSPreference(): [OS, (os: OS) => void] {
+  const [os, setOs] = useState<OS>(current);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY) as OS | null;
+      if (stored === 'unix' || stored === 'windows') {
+        current = stored;
+      }
+    } catch {
+      /* storage unavailable */
+    }
+    setOs(current);
+    const listener = (next: OS) => setOs(next);
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }, []);
+
+  return [os, setOSPreference];
+}

--- a/website/src/components/os-preference.ts
+++ b/website/src/components/os-preference.ts
@@ -15,7 +15,22 @@ export type OS = 'unix' | 'windows';
 const STORAGE_KEY = 'vouch-os-pref';
 
 let current: OS = 'unix';
+let detected = false;
 const listeners = new Set<(os: OS) => void>();
+
+/**
+ * Best-effort OS detection from the browser, used as the default the first time
+ * a visitor lands (until they explicitly pick one). macOS, Linux, and the mobile
+ * OSes all use the unix-style commands, so only Windows splits off.
+ */
+function detectOS(): OS {
+  if (typeof navigator === 'undefined') return 'unix';
+  const nav = navigator as Navigator & { userAgentData?: { platform?: string } };
+  const platform = (nav.userAgentData?.platform || nav.platform || '').toLowerCase();
+  const ua = (nav.userAgent || '').toLowerCase();
+  if (platform.includes('win') || ua.includes('windows')) return 'windows';
+  return 'unix';
+}
 
 export function getOSPreference(): OS {
   return current;
@@ -44,10 +59,16 @@ export function useOSPreference(): [OS, (os: OS) => void] {
       const stored = localStorage.getItem(STORAGE_KEY) as OS | null;
       if (stored === 'unix' || stored === 'windows') {
         current = stored;
+      } else if (!detected) {
+        // No saved choice: default to the visitor's own OS. Detected once and
+        // not persisted, so the nav switcher shows it as the active OS but only
+        // an explicit pick is remembered.
+        current = detectOS();
       }
     } catch {
       /* storage unavailable */
     }
+    detected = true;
     setOs(current);
     const listener = (next: OS) => setOs(next);
     listeners.add(listener);


### PR DESCRIPTION
Answers the "set the OS once and have it apply everywhere" request, and makes the OS selection discoverable.

## What this adds
- A **global OS switcher in the nav** (desktop and mobile): a single `macOS / Linux | Windows` control next to the theme toggle.
- A shared `os-preference` store: the switcher and every `OSCodeBlock` read and write the same preference. Set it once, from anywhere, and **every OS-aware code block across the whole site switches**, no per-block clicking. The choice persists across pages and visits (localStorage).
- `OSCodeBlock` refactored to use the shared store, so the per-block tabs and the nav switcher stay in sync.

## Why only some blocks have tabs (unchanged, by design)
Most commands (`pip install`, `npm i`, `cargo add`, every `vouch` CLI command, the Python/TS code) are byte-identical on all three OSes, so they have no tabs (a tab there would show the same line on both sides). Only the commands that genuinely differ (env vars, paths, `./binary` vs `.exe`, `cp -r` vs `Copy-Item`, `curl` vs `Invoke-RestMethod`) are OS-aware, and those all follow the global switcher now.

Build-verified (25 static pages). No em-dashes.
