### PR TITLE
feat(website): reinstate the restructured Support page + consolidate nav

### DIFF
--- a/website/src/app/support/page.tsx
+++ b/website/src/app/support/page.tsx
@@ -4,24 +4,42 @@ import Link from 'next/link';
 export const metadata: Metadata = {
   title: 'Support',
   description:
-    'How to get help with Vouch Protocol: the Vouch Assistant chat for fast answers, the public-credentials mailing list for specification questions, GitHub Issues for bugs, Discord for community discussion, and a private channel for security disclosure.',
+    'How to get help with Vouch Protocol: the Vouch Assistant chat, the FAQ and guides for self-serve answers, GitHub Issues for bugs, Discord for community discussion, and the public-credentials mailing list for specification questions.',
 };
 
-const CHANNELS = [
+type Channel = {
+  eyebrow: string;
+  title: string;
+  body: string;
+  cta: { label: string; href: string };
+  secondary?: { label: string; href: string };
+};
+
+// Start here: the three self-serve surfaces, Assistant first.
+const PRIMARY: Channel[] = [
   {
     eyebrow: 'For quick answers',
     title: 'Vouch Assistant',
-    body: 'A retrieval-grounded assistant that knows the specification, the SDKs, the conformance levels, and the compliance mappings. Every reply is itself signed by a real Vouch credential. Use the web chat for the fastest path, send an email if you prefer text in your inbox, or run one of the AI-tool packages on your own subscription (Claude Skill, OpenAI Custom GPT, Gemini Gem).',
+    body: 'A retrieval-grounded assistant that knows the specification, the SDKs, the conformance levels, and the compliance mappings. Every reply is itself signed by a real Vouch credential. Use the web chat for the fastest path, or send an email if you prefer text in your inbox.',
     cta: { label: 'Open the chat', href: '/ask/' },
     secondary: { label: 'ask@vouch-protocol.com', href: 'mailto:ask@vouch-protocol.com' },
   },
   {
-    eyebrow: 'For specification questions',
-    title: 'open standards body',
-    body: 'The mailing list is the right venue for normative questions about the specification, transition pathways to the VC Working Group, and proposed clarifications.',
-    cta: { label: 'public-credentials@w3.org', href: 'mailto:public-credentials@w3.org' },
-    secondary: { label: 'Archives', href: '' },
+    eyebrow: 'For common questions',
+    title: 'FAQ',
+    body: 'Plain-English answers to the questions we hear most, grouped by audience: developers, robots and embodied agents, businesses, and the simply curious.',
+    cta: { label: 'Read the FAQ', href: '/faq/' },
   },
+  {
+    eyebrow: 'For step-by-step help',
+    title: 'Help & Guides',
+    body: 'Long-form guides for quickstarts, deployment, cross-language verification, robotics, and integrations, each with runnable code.',
+    cta: { label: 'Open the guides', href: '/help/' },
+  },
+];
+
+// The other channels, in order. The standards mailing list comes last.
+const CHANNELS: Channel[] = [
   {
     eyebrow: 'For implementation bugs',
     title: 'GitHub Issues',
@@ -36,20 +54,49 @@ const CHANNELS = [
     cta: { label: 'Join the Discord', href: 'https://discord.gg/mMqx5cG9Y' },
   },
   {
-    eyebrow: 'For security disclosures',
-    title: 'Private security channel',
-    body: 'Do not file public GitHub issues for vulnerabilities. The disclosure process and PGP key are documented in SECURITY.md. The editor will acknowledge within 48 hours and coordinate a disclosure timeline.',
-    cta: { label: 'Read SECURITY.md', href: 'https://github.com/vouch-protocol/vouch/blob/main/SECURITY.md' },
+    eyebrow: 'For specification questions',
+    title: 'Standards mailing list',
+    body: 'The public-credentials list is the venue for normative questions about the specification, transition pathways to the VC Working Group, and proposed clarifications.',
+    cta: { label: 'public-credentials@w3.org', href: 'mailto:public-credentials@w3.org' },
   },
 ];
 
 const QUICK_LINKS = [
-  { label: 'Vouch Assistant', href: '/ask/', body: 'Retrieval-grounded chat over the entire knowledge base. Signs every reply.' },
-  { label: 'FAQ', href: '/faq/', body: 'Plain-English answers to common questions across every audience.' },
-  { label: 'Help & Guides', href: '/help/', body: 'Long-form guides for quickstarts, deployment, and integrations.' },
   { label: 'Specification', href: 'https://github.com/vouch-protocol/vouch/blob/main/docs/specs/specification-executive-summary.md', external: true, body: 'Executive summary of the specification.' },
   { label: 'CHANGELOG', href: 'https://github.com/vouch-protocol/vouch/blob/main/CHANGELOG.md', external: true, body: 'Every version, every shipped feature.' },
+  { label: 'Test vectors', href: 'https://github.com/vouch-protocol/vouch/tree/main/test-vectors', external: true, body: 'Cross-language vectors to check your implementation against.' },
+  { label: 'GitHub repository', href: 'https://github.com/vouch-protocol/vouch', external: true, body: 'Source, SDKs, and reference implementations.' },
 ];
+
+function ChannelCard({ channel }: { channel: Channel }) {
+  return (
+    <div className="border-t-2 border-ink pt-5">
+      <div className="eyebrow mb-2">{channel.eyebrow}</div>
+      <h2 className="font-serif font-semibold text-[1.4rem] tracking-tight mb-3">{channel.title}</h2>
+      <p className="text-ink-soft leading-relaxed mb-5">{channel.body}</p>
+      <div className="flex flex-wrap gap-3">
+        <a
+          href={channel.cta.href}
+          target={channel.cta.href.startsWith('http') ? '_blank' : undefined}
+          rel={channel.cta.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+          className="btn-primary"
+        >
+          {channel.cta.label}
+        </a>
+        {channel.secondary && (
+          <a
+            href={channel.secondary.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="btn-secondary"
+          >
+            {channel.secondary.label}
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
 
 export default function SupportPage() {
   return (
@@ -62,59 +109,64 @@ export default function SupportPage() {
             How to get help.
           </h1>
           <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-prose">
-            Five channels, each with a clear scope. The Vouch Assistant answers most "how does X work"
-            and "give me a sample of Y" questions in seconds; the other four are for normative
-            specification questions, implementation bugs, community-level discussion, and security
-            disclosures.
+            Start with the Assistant, the FAQ, or the guides. They answer most questions in seconds.
+            For everything else there is the issue tracker, Discord, and the specification mailing list.
           </p>
         </div>
       </section>
 
-      {/* Channels */}
+      {/* Start here */}
       <section className="border-b border-rule">
         <div className="container-wide py-16">
-          <div className="grid md:grid-cols-2 gap-10">
-            {CHANNELS.map((channel) => (
-              <div key={channel.title} className="border-t-2 border-ink pt-5">
-                <div className="eyebrow mb-2">{channel.eyebrow}</div>
-                <h2 className="font-serif font-semibold text-[1.4rem] tracking-tight mb-3">
-                  {channel.title}
-                </h2>
-                <p className="text-ink-soft leading-relaxed mb-5">
-                  {channel.body}
-                </p>
-                <div className="flex flex-wrap gap-3">
-                  <a
-                    href={channel.cta.href}
-                    target={channel.cta.href.startsWith('http') ? '_blank' : undefined}
-                    rel={channel.cta.href.startsWith('http') ? 'noopener noreferrer' : undefined}
-                    className="btn-primary"
-                  >
-                    {channel.cta.label}
-                  </a>
-                  {channel.secondary && (
-                    <a
-                      href={channel.secondary.href}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="btn-secondary"
-                    >
-                      {channel.secondary.label}
-                    </a>
-                  )}
-                </div>
-              </div>
+          <div className="section-heading mb-8">
+            <span className="num">§ I</span>
+            <h2>Start here</h2>
+          </div>
+          <div className="grid md:grid-cols-3 gap-10">
+            {PRIMARY.map((channel) => (
+              <ChannelCard key={channel.title} channel={channel} />
             ))}
           </div>
         </div>
       </section>
 
-      {/* AI-tool packages: same answers on the visitor's own AI subscription */}
+      {/* Other channels */}
+      <section className="border-b border-rule">
+        <div className="container-wide py-16">
+          <div className="section-heading mb-8">
+            <span className="num">§ II</span>
+            <h2>Other channels</h2>
+          </div>
+          <div className="grid md:grid-cols-3 gap-10">
+            {CHANNELS.map((channel) => (
+              <ChannelCard key={channel.title} channel={channel} />
+            ))}
+          </div>
+          {/* Security disclosure: a slim callout, not a channel of its own. */}
+          <div className="mt-10 border-l-2 border-burgundy bg-burgundy/[0.03] px-5 py-4">
+            <p className="text-ink-soft text-[0.95rem] leading-relaxed">
+              <strong className="text-ink">Security disclosure.</strong> Please do not file a public GitHub
+              issue for a vulnerability. Follow the coordinated process and PGP key in{' '}
+              <a
+                href="https://github.com/vouch-protocol/vouch/blob/main/SECURITY.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="underline decoration-1 underline-offset-2 hover:text-burgundy"
+              >
+                SECURITY.md
+              </a>
+              . The editor acknowledges within 48 hours and coordinates a disclosure timeline.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* AI-tool packages: same answers inside the visitor's own assistant */}
       <section className="border-b border-rule">
         <div className="container-wide py-16">
           <div className="section-heading mb-6">
-            <span className="num">§ II</span>
-            <h2>Run the assistant on your own AI subscription</h2>
+            <span className="num">§ III</span>
+            <h2>Run it within your own favourite vibe-coding assistant</h2>
           </div>
           <p className="text-ink-soft leading-relaxed max-w-prose mb-6">
             The same canonical Vouch knowledge that powers{' '}
@@ -122,7 +174,7 @@ export default function SupportPage() {
               the web chat
             </Link>{' '}
             is also packaged for three other AI tools, so you can ask Vouch questions inside the
-            interface you already use. These run on{' '}<em>your</em>{' '}plan, not ours.
+            vibe-coding assistant you already use. These run on{' '}<em>your</em>{' '}plan, not ours.
           </p>
           <div className="grid md:grid-cols-3 gap-6 max-w-prose-wide">
             <a
@@ -169,7 +221,7 @@ export default function SupportPage() {
       <section className="border-b border-rule">
         <div className="container-wide py-16">
           <div className="section-heading">
-            <span className="num">§ III</span>
+            <span className="num">§ IV</span>
             <h2>Before opening an issue</h2>
           </div>
           <p className="text-ink-soft leading-relaxed max-w-prose mb-6">
@@ -204,33 +256,22 @@ export default function SupportPage() {
       <section>
         <div className="container-wide py-16">
           <div className="section-heading">
-            <span className="num">§ IV</span>
+            <span className="num">§ V</span>
             <h2>Quick links</h2>
           </div>
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
-            {QUICK_LINKS.map((link) =>
-              link.external ? (
-                <a
-                  key={link.label}
-                  href={link.href}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block border border-rule p-5 hover:border-burgundy transition-colors no-underline"
-                >
-                  <h3 className="font-serif font-semibold text-[1.1rem] mb-2">{link.label}</h3>
-                  <p className="text-ink-soft text-[0.9rem] leading-relaxed">{link.body}</p>
-                </a>
-              ) : (
-                <Link
-                  key={link.label}
-                  href={link.href}
-                  className="block border border-rule p-5 hover:border-burgundy transition-colors no-underline"
-                >
-                  <h3 className="font-serif font-semibold text-[1.1rem] mb-2">{link.label}</h3>
-                  <p className="text-ink-soft text-[0.9rem] leading-relaxed">{link.body}</p>
-                </Link>
-              )
-            )}
+            {QUICK_LINKS.map((link) => (
+              <a
+                key={link.label}
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block border border-rule p-5 hover:border-burgundy transition-colors no-underline"
+              >
+                <h3 className="font-serif font-semibold text-[1.1rem] mb-2">{link.label}</h3>
+                <p className="text-ink-soft text-[0.9rem] leading-relaxed">{link.body}</p>
+              </a>
+            ))}
           </div>
         </div>
       </section>

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -10,8 +10,7 @@ const LINKS = [
     { href: '/robotics/', label: 'Robotics' },
     { href: '/onboard/', label: 'Onboard' },
     { href: '/blog/', label: 'Blog' },
-    { href: '/help/', label: 'Guides' },
-    { href: '/faq/', label: 'FAQ' },
+    { href: '/support/', label: 'Support' },
 ];
 
 export default function Nav() {


### PR DESCRIPTION
Reinstates the Support page you built and edited previously (commit 763a6eb), which was dropped when the robotics revert landed. Not a fresh rewrite, this is your version restored.

## Support page (restored)
The "Start here" layout: Vouch Assistant, FAQ, and Help and Guides as the three primary self-serve channels, then GitHub Issues, Discord, and the standards mailing list under "Other channels", a slim security-disclosure callout, the "run it within your own vibe-coding assistant" section (Claude Skill / OpenAI GPT / Gemini Gem), and a Quick links grid. Build-verified, no em-dashes.

## Nav consolidation
Replaced the separate Guides and FAQ nav items with a single Support link, so the Support page is the hub for help (FAQ and Guides are the first things on it). Tools, Robotics, Onboard, Blog, Index are unchanged.

Note: this is independent of the OS-switcher work in #62; both touch Nav.tsx in different spots, so expect at most a trivial merge.
