### PR TITLE
fix(website): widen the page container to 1400px

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -105,7 +105,7 @@
 
 @layer components {
   .container-wide {
-    @apply max-w-[1100px] mx-auto px-6 md:px-10;
+    @apply max-w-[1400px] mx-auto px-6 md:px-14;
   }
 
   .container-prose {


### PR DESCRIPTION
The homepage and other wide sections were capped at 1100px, leaving large empty margins on bigger screens. This widens the shared container-wide wrapper to 1400px so content fills the page, keeping the existing responsive horizontal padding.

Build-verified.
