### PR TITLE
Add model-and-config provenance to the TypeScript SDK (byte-identical interop)

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -97,6 +97,13 @@ export type {
   HardwareRootOfTrust,
   MintRobotIdentityOptions,
 } from './robotics/identity';
+export {
+  MODEL_PROVENANCE_TYPE,
+  configHash,
+  buildProvenanceAttestation,
+  verifyProvenanceAttestation,
+} from './robotics/provenance';
+export type { BuildProvenanceOptions } from './robotics/provenance';
 
 // BitstringStatusList (VC-BITSTRING-STATUS-LIST, Specification §11.2)
 export {

--- a/packages/sdk-ts/src/robotics/provenance.ts
+++ b/packages/sdk-ts/src/robotics/provenance.ts
@@ -1,0 +1,97 @@
+/**
+ * Model-and-config provenance attestation for robots (Phase 5.2), TypeScript.
+ *
+ * Mirrors `vouch/robotics/provenance.py` with byte-identical output. A
+ * ModelProvenanceAttestation is an eddsa-jcs-2022 VC recording the VLA model
+ * name, weights hash, safety policy, and a configHash computed over the
+ * JCS-canonical config so any verifier reproduces it. Re-signable on an OTA
+ * update via `supersedes`, forming a tamper-evident chain.
+ */
+
+import * as crypto from 'crypto';
+
+import { verifyProof } from '../data-integrity';
+import { canonicalize } from '../jcs';
+import type { Signer } from '../signer';
+import { VC_CONTEXT_V2, VOUCH_CONTEXT_V1 } from '../vc';
+
+export const MODEL_PROVENANCE_TYPE = 'ModelProvenanceAttestation';
+
+function iso(d: Date): string {
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/** Multibase SHA-256 of the JCS-canonical config object. */
+export function configHash(config: Record<string, unknown>): string {
+  const digest = crypto.createHash('sha256').update(canonicalize(config)).digest();
+  return 'u' + digest.toString('base64url');
+}
+
+export interface BuildProvenanceOptions {
+  robotDid: string;
+  modelName: string;
+  weightsHash: string;
+  safetyPolicy: string;
+  config?: Record<string, unknown>;
+  version?: string;
+  supersedes?: string;
+  validSeconds?: number;
+  validFrom?: Date;
+}
+
+/** Build a signed ModelProvenanceAttestation for the software on a robot. */
+export async function buildProvenanceAttestation(
+  signer: Signer,
+  opts: BuildProvenanceOptions
+): Promise<Record<string, unknown>> {
+  const issued = opts.validFrom ?? new Date();
+  const vla: Record<string, unknown> = {
+    modelName: opts.modelName,
+    weightsHash: opts.weightsHash,
+    safetyPolicy: opts.safetyPolicy,
+  };
+  if (opts.version !== undefined) vla.version = opts.version;
+  if (opts.config !== undefined) vla.configHash = configHash(opts.config);
+
+  const subject: Record<string, unknown> = { id: opts.robotDid, vla };
+  if (opts.supersedes !== undefined) subject.supersedes = opts.supersedes;
+
+  const credential: Record<string, unknown> = {
+    '@context': [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+    type: ['VerifiableCredential', MODEL_PROVENANCE_TYPE],
+    issuer: signer.getDid(),
+    validFrom: iso(issued),
+    credentialSubject: subject,
+  };
+  if (opts.validSeconds !== undefined) {
+    credential.validUntil = iso(new Date(issued.getTime() + opts.validSeconds * 1000));
+  }
+  return signer.attachProof(credential);
+}
+
+/**
+ * Verify a ModelProvenanceAttestation. When `config` is supplied, also check
+ * that its hash matches the recorded configHash.
+ */
+export function verifyProvenanceAttestation(
+  attestation: Record<string, unknown>,
+  publicKey: crypto.KeyObject,
+  config?: Record<string, unknown>
+): { ok: boolean; subject?: Record<string, unknown> } {
+  const typeField = attestation.type;
+  const types = Array.isArray(typeField) ? typeField : [typeField];
+  if (!types.includes(MODEL_PROVENANCE_TYPE)) return { ok: false };
+
+  try {
+    if (!verifyProof(attestation, publicKey)) return { ok: false };
+  } catch {
+    return { ok: false };
+  }
+
+  const subject = (attestation.credentialSubject ?? {}) as Record<string, unknown>;
+  if (config !== undefined) {
+    const vla = (subject.vla ?? {}) as Record<string, unknown>;
+    if (vla.configHash !== configHash(config)) return { ok: false };
+  }
+  return { ok: true, subject };
+}

--- a/packages/sdk-ts/tests/robotics-provenance.test.ts
+++ b/packages/sdk-ts/tests/robotics-provenance.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Model-and-config provenance tests (TypeScript). Mirrors the Python
+ * tests/test_robot_provenance_capability.py provenance cases.
+ *
+ * The first test is the cross-language interop proof: TypeScript reproduces the
+ * exact config hash the Python module pins in the shared interop vector.
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import {
+  Signer,
+  generateIdentity,
+  configHash,
+  buildProvenanceAttestation,
+  verifyProvenanceAttestation,
+  MODEL_PROVENANCE_TYPE,
+} from '../src';
+
+const VECTOR = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, '../../../test-vectors/robotics/vector.json'),
+    'utf8'
+  )
+);
+
+function publicKeyFromJwk(jwk: unknown): crypto.KeyObject {
+  return crypto.createPublicKey({ key: jwk as crypto.JsonWebKey, format: 'jwk' });
+}
+
+describe('model provenance', () => {
+  it('reproduces the Python config hash (byte-identical)', () => {
+    expect(configHash(VECTOR.config)).toBe(VECTOR.expected_config_hash);
+  });
+
+  it('builds and verifies a provenance attestation, including the config hash', async () => {
+    const keys = await generateIdentity('robot.example.com');
+    const signer = new Signer({
+      privateKey: keys.privateKeyJwk,
+      did: 'did:web:robot.example.com',
+    });
+    const att = await buildProvenanceAttestation(signer, {
+      robotDid: 'did:web:robot.example.com',
+      modelName: 'vla-7b',
+      weightsHash: 'uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      safetyPolicy: 'policy-1',
+      config: VECTOR.config,
+      version: '1.0',
+    });
+    expect(att.type as string[]).toContain(MODEL_PROVENANCE_TYPE);
+
+    const robotPub = publicKeyFromJwk(JSON.parse(keys.publicKeyJwk));
+    expect(verifyProvenanceAttestation(att, robotPub, VECTOR.config).ok).toBe(true);
+    // A different config no longer matches the recorded configHash.
+    expect(verifyProvenanceAttestation(att, robotPub, { temperature: 1.0 }).ok).toBe(false);
+  });
+
+  it('re-signs on OTA update via supersedes', async () => {
+    const keys = await generateIdentity('robot.example.com');
+    const signer = new Signer({
+      privateKey: keys.privateKeyJwk,
+      did: 'did:web:robot.example.com',
+    });
+    const v1 = await buildProvenanceAttestation(signer, {
+      robotDid: 'did:web:robot.example.com',
+      modelName: 'vla-7b',
+      weightsHash: 'uAAAA',
+      safetyPolicy: 'policy-1',
+    });
+    const v2 = await buildProvenanceAttestation(signer, {
+      robotDid: 'did:web:robot.example.com',
+      modelName: 'vla-7b',
+      weightsHash: 'uBBBB',
+      safetyPolicy: 'policy-2',
+      supersedes: 'urn:prev',
+    });
+    const robotPub = publicKeyFromJwk(JSON.parse(keys.publicKeyJwk));
+    expect(verifyProvenanceAttestation(v1, robotPub).ok).toBe(true);
+    expect(verifyProvenanceAttestation(v2, robotPub).ok).toBe(true);
+    expect((v2.credentialSubject as Record<string, unknown>).supersedes).toBe('urn:prev');
+  });
+});


### PR DESCRIPTION
Ports the model-and-config provenance capability to the TypeScript SDK, byte-identical with the Python `vouch.robotics.provenance` module.

- `configHash`, `buildProvenanceAttestation`, `verifyProvenanceAttestation` in `src/robotics/provenance.ts`, mirroring `provenance.py`.
- A `ModelProvenanceAttestation` records the VLA model name, weights hash, safety policy, and a `configHash` over the JCS-canonical config; re-signable on OTA via `supersedes`.

**Verification:** the test reproduces the exact `expected_config_hash` from the shared interop vector (`uMh9_H2Lk51-m9SpBhiEa1oqIwwwA7yT27e2QFS0YKUs`) in TypeScript, proving byte-identical hashing across languages. Build/verify round-trip, config-mismatch rejection, and the supersedes chain are also covered. 6/6 robotics tests pass (3 provenance + 3 identity), bundle builds, typecheck clean for these files.

Second of the robotics SDK ports (after identity, #65). Capability, handshake, black box, and passport follow.
