### PR TITLE
Marketplace on-ramp: vouch grade self-check + embeddable trust badge

### DIFF
--- a/tests/test_grade.py
+++ b/tests/test_grade.py
@@ -1,0 +1,66 @@
+"""Tests for the single-agent self-check grader."""
+
+from vouch import grade as g
+
+
+def _signals(**overrides):
+    s = g.empty_signals()
+    s.update(overrides)
+    return s
+
+
+def test_full_identity_is_grade_a():
+    report = g.grade_signals(_signals(has_did=True, has_verification_method=True), domain="a.com")
+    assert report.grade == "A"
+    assert report.score == 100
+
+
+def test_did_without_key_is_grade_c():
+    # Resolvable DID (60) but no usable verification method.
+    report = g.grade_signals(_signals(has_did=True, has_verification_method=False))
+    assert report.score == 60
+    assert report.grade == "C"
+
+
+def test_nothing_is_grade_f():
+    report = g.grade_signals(_signals())
+    assert report.score == 0
+    assert report.grade == "F"
+
+
+def test_fixes_target_missing_pieces():
+    report = g.grade_signals(_signals())
+    blob = " ".join(report.fixes).lower()
+    assert "did:web" in blob
+    assert "verificationmethod" in blob
+    assert "ml-dsa" in blob
+
+
+def test_grade_a_still_suggests_pq_and_revocation():
+    # Even an A agent gets pointers for the extra signals it lacks.
+    report = g.grade_signals(_signals(has_did=True, has_verification_method=True))
+    blob = " ".join(report.fixes).lower()
+    assert "ml-dsa" in blob  # post-quantum suggestion
+    assert "revocation" in blob
+
+
+def test_badge_svg_reflects_grade():
+    report = g.grade_signals(_signals(has_did=True, has_verification_method=True), domain="a.com")
+    svg = g.badge_svg(report)
+    assert svg.startswith("<svg")
+    assert "A (100)" in svg
+    assert g.GRADE_COLORS["A"] in svg
+
+
+def test_badge_svg_f_is_red():
+    report = g.grade_signals(_signals())
+    svg = g.badge_svg(report)
+    assert g.GRADE_COLORS["F"] in svg
+
+
+def test_report_to_dict_round_trips():
+    report = g.grade_signals(_signals(has_did=True, has_verification_method=True), domain="a.com")
+    d = report.to_dict()
+    assert d["grade"] == "A"
+    assert d["domain"] == "a.com"
+    assert d["breakdown"]["resolvable_did"] == 60

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -1244,6 +1244,36 @@ def cmd_trifecta(args) -> int:
     return 1 if result.lethal else 0
 
 
+def cmd_grade(args) -> int:
+    """Grade one agent's trust posture and optionally emit an embeddable badge."""
+    import json as _json
+    from vouch import grade as grading
+
+    report = grading.grade_domain(args.domain, timeout=args.timeout)
+
+    if args.badge:
+        Path(args.badge).write_text(grading.badge_svg(report), encoding="utf-8")
+
+    if args.json:
+        print(_json.dumps(report.to_dict(), indent=2))
+        return 0
+
+    print(f"Agent Trust grade for {report.domain}: {report.grade}  ({report.score}/100)")
+    if report.signals.get("did"):
+        print(f"  identity   : {report.signals['did']}")
+    if report.signals.get("method"):
+        print(f"  key        : {report.signals['method']}")
+    print(f"  post-quantum: {'yes' if report.signals.get('pq_ready') else 'no'}")
+    print(f"  revocation  : {'yes' if report.signals.get('has_revocation') else 'no'}")
+    if report.fixes:
+        print("\nTo raise your grade:")
+        for i, fix in enumerate(report.fixes, 1):
+            print(f"  {i}. {fix}")
+    if args.badge:
+        print(f"\nBadge written to {args.badge}")
+    return 0
+
+
 def cmd_scan(args) -> int:
     """Scan a path for Vouch-shaped private key material.
 
@@ -1402,6 +1432,15 @@ def main() -> int:
     )
     p_trifecta.add_argument("--json", action="store_true", help="Output the result as JSON")
 
+    p_grade = subparsers.add_parser(
+        "grade",
+        help="Grade one agent's trust posture (the Agent Trust Index self-check)",
+    )
+    p_grade.add_argument("domain", help="Domain to grade, e.g. agent.example.com")
+    p_grade.add_argument("--json", action="store_true", help="Output the report as JSON")
+    p_grade.add_argument("--badge", metavar="FILE", help="Write an embeddable SVG badge to FILE")
+    p_grade.add_argument("--timeout", type=int, default=5, help="Network timeout in seconds")
+
     p_onboard = subparsers.add_parser(
         "onboard",
         help="Guided six-step wizard to adopt Vouch (identity, allow-list, verifier, heartbeat)",
@@ -1474,6 +1513,8 @@ def main() -> int:
         from . import attribution_cli
 
         return attribution_cli.dispatch(args, p_attr.print_help)
+    elif args.command == "grade":
+        return cmd_grade(args)
     elif args.command == "onboard":
         from . import onboard as onboard_mod
 

--- a/vouch/grade.py
+++ b/vouch/grade.py
@@ -1,0 +1,221 @@
+"""
+Self-check grader for a single agent's trust posture.
+
+The Agent Trust Index scores the whole agent population. This is the on-ramp: a
+free, local check of one agent, the same scoring the Index uses, with a letter
+grade, the exact reasons, numbered fixes, and an embeddable badge. Run it on your
+own agent before anyone else grades it for you.
+
+Scoring mirrors the Index: 60 points for a resolvable DID, 40 for a usable
+verification method. Post-quantum readiness, a revocation or service endpoint,
+and agent-card identity are reported as extra signals but do not change the
+score, exactly as the public Index measures it.
+
+Open and hosting-free: grade from the command line, get an SVG badge to embed.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+GRADE_COLORS = {
+    "A": "#22c55e",
+    "B": "#84cc16",
+    "C": "#eab308",
+    "D": "#f97316",
+    "F": "#ef4444",
+}
+
+
+def empty_signals() -> Dict[str, Any]:
+    return {
+        "has_did": False,
+        "has_verification_method": False,
+        "did": None,
+        "method": None,
+        "pq_ready": False,
+        "has_revocation": False,
+        "has_card_identity": False,
+    }
+
+
+def score_signals(signals: Dict[str, Any]) -> Dict[str, Any]:
+    """Turn signals into a 0-100 score and a letter grade. Mirrors the Index."""
+    breakdown = {
+        "resolvable_did": 60 if signals.get("has_did") else 0,
+        "valid_verification_method": 40 if signals.get("has_verification_method") else 0,
+    }
+    points = sum(breakdown.values())
+    if points >= 90:
+        grade = "A"
+    elif points >= 75:
+        grade = "B"
+    elif points >= 60:
+        grade = "C"
+    elif points >= 40:
+        grade = "D"
+    else:
+        grade = "F"
+    return {"score": points, "grade": grade, "breakdown": breakdown}
+
+
+def fix_its(signals: Dict[str, Any]) -> List[str]:
+    """Numbered, actionable remediation for whatever is missing."""
+    fixes: List[str] = []
+    if not signals.get("has_did"):
+        fixes.append(
+            "Publish a did:web. Run `vouch init --domain yourdomain.com` and serve the "
+            "DID document at https://yourdomain.com/.well-known/did.json."
+        )
+    if not signals.get("has_verification_method"):
+        fixes.append(
+            "Add a verificationMethod with your public key to the DID document, so others "
+            "can verify what you sign."
+        )
+    if not signals.get("pq_ready"):
+        fixes.append(
+            "Add a post-quantum key (ML-DSA-44) alongside your Ed25519 key and sign with "
+            "`sign_credential_hybrid`, so credentials survive a future quantum break."
+        )
+    if not signals.get("has_revocation"):
+        fixes.append(
+            "Publish a service or revocation endpoint in your DID document, so a "
+            "compromised key can be revoked and discovered."
+        )
+    if not signals.get("has_card_identity"):
+        fixes.append(
+            "Reference your DID in your agent card (/.well-known/agent.json), so a "
+            "counterparty can tie the card to a verifiable identity."
+        )
+    return fixes
+
+
+@dataclass
+class GradeReport:
+    domain: Optional[str]
+    score: int
+    grade: str
+    signals: Dict[str, Any]
+    breakdown: Dict[str, int]
+    fixes: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "domain": self.domain,
+            "score": self.score,
+            "grade": self.grade,
+            "signals": self.signals,
+            "breakdown": self.breakdown,
+            "fixes": self.fixes,
+        }
+
+
+def grade_signals(signals: Dict[str, Any], domain: Optional[str] = None) -> GradeReport:
+    """Score a set of signals and attach fixes (no network)."""
+    scored = score_signals(signals)
+    return GradeReport(
+        domain=domain,
+        score=scored["score"],
+        grade=scored["grade"],
+        signals=signals,
+        breakdown=scored["breakdown"],
+        fixes=fix_its(signals),
+    )
+
+
+def resolve_signals(domain: str, timeout: int = 5) -> Dict[str, Any]:
+    """
+    Resolve one domain and gather trust signals (network). Mirrors the Index's
+    per-domain resolution: did:web identity, key type, post-quantum readiness,
+    a service/revocation endpoint, and agent-card identity.
+    """
+    from vouch.did_web import resolve_did_web_sync
+    from vouch.multikey import algorithm_of
+
+    sig = empty_signals()
+    try:
+        doc = resolve_did_web_sync(f"did:web:{domain}", timeout=timeout)
+        sig["has_did"] = True
+        sig["did"] = f"did:web:{domain}"
+        jwk = None
+        multibase = None
+        try:
+            jwk = doc.get_public_key_jwk()
+        except Exception:
+            jwk = None
+        try:
+            multibase = doc.get_public_key_multibase()
+        except Exception:
+            multibase = None
+        if jwk:
+            sig["has_verification_method"] = True
+            sig["method"] = f"did:web, {jwk.get('crv') or jwk.get('kty') or 'key'} (JWK)"
+        elif multibase:
+            sig["has_verification_method"] = True
+            try:
+                alg = algorithm_of(multibase)
+            except Exception:
+                alg = "key"
+            sig["method"] = f"did:web, {alg} (Multikey)"
+    except Exception:
+        return sig
+
+    raw = _get_json(f"https://{domain}/.well-known/did.json", timeout)
+    if isinstance(raw, dict):
+        services = raw.get("service")
+        if isinstance(services, list) and services:
+            sig["has_revocation"] = True
+        blob = json.dumps(raw).lower()
+        if "ml-dsa" in blob or "mldsa" in blob or "dilithium" in blob:
+            sig["pq_ready"] = True
+
+    card = _get_json(f"https://{domain}/.well-known/agent.json", timeout) or _get_json(
+        f"https://{domain}/.well-known/agent-card.json", timeout
+    )
+    if isinstance(card, dict):
+        blob = json.dumps(card).lower()
+        if "did:" in blob or "signature" in blob:
+            sig["has_card_identity"] = True
+
+    return sig
+
+
+def _get_json(url: str, timeout: int = 5) -> Optional[Any]:
+    try:
+        import httpx
+
+        resp = httpx.get(url, timeout=timeout, follow_redirects=True)
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        return None
+    return None
+
+
+def grade_domain(domain: str, timeout: int = 5) -> GradeReport:
+    """Resolve a domain live and grade it."""
+    return grade_signals(resolve_signals(domain, timeout=timeout), domain=domain)
+
+
+def badge_svg(report: GradeReport, label: str = "agent trust") -> str:
+    """A shields-style SVG badge showing the grade. Embed it in a README or page."""
+    grade = report.grade
+    color = GRADE_COLORS.get(grade, "#9ca3af")
+    value = f"{grade} ({report.score})"
+    # Rough width estimates so the two halves fit their text.
+    label_w = 7 * len(label) + 16
+    value_w = 7 * len(value) + 16
+    total = label_w + value_w
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{total}" height="20" '
+        f'role="img" aria-label="{label}: {value}">'
+        f'<rect width="{total}" height="20" rx="3" fill="#555"/>'
+        f'<rect x="{label_w}" width="{value_w}" height="20" rx="3" fill="{color}"/>'
+        f'<rect x="{label_w}" width="4" height="20" fill="{color}"/>'
+        f'<g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">'
+        f'<text x="{label_w / 2:.0f}" y="14" text-anchor="middle">{label}</text>'
+        f'<text x="{label_w + value_w / 2:.0f}" y="14" text-anchor="middle">{value}</text>'
+        f"</g></svg>"
+    )

--- a/website/src/app/agent-trust-index/page.tsx
+++ b/website/src/app/agent-trust-index/page.tsx
@@ -138,6 +138,36 @@ export default function AgentTrustIndexPage() {
                     <AtiLeaderboard agents={ATI_AGENTS} />
                 </div>
 
+                <div className="border border-burgundy bg-parchment-warm p-8 md:p-10 max-w-3xl mb-16">
+                    <p className="eyebrow text-burgundy mb-2">Check your own agent</p>
+                    <h2 className="font-serif font-semibold text-[1.5rem] tracking-tight mb-3">
+                        Grade your agent before anyone else does
+                    </h2>
+                    <p className="text-ink-soft leading-relaxed max-w-prose mb-5">
+                        Run the same check the Index runs, on your own agent. You get a letter grade, the
+                        exact reasons, and numbered fixes to raise it. Add the badge to your README or
+                        agent page so a counterparty can see your trust grade at a glance.
+                    </p>
+                    <div className="max-w-md mb-4">
+                        <CodeBlock code={"vouch grade yourdomain.com\nvouch grade yourdomain.com --badge trust-badge.svg"} className="text-[0.85rem]" />
+                    </div>
+                    <p className="text-ink-soft text-[0.9rem] leading-relaxed max-w-prose">
+                        Claiming and verified listings are coming. If you want your agent listed when
+                        they open, say so in the discussion and we will follow up.
+                    </p>
+                    <div className="flex flex-wrap gap-3 mt-5">
+                        <Link href="/onboard/" className="btn-primary">Raise your grade</Link>
+                        <a
+                            href="https://github.com/vouch-protocol/vouch/discussions"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="btn-secondary"
+                        >
+                            Register interest
+                        </a>
+                    </div>
+                </div>
+
                 <div className="border border-rule bg-parchment-warm p-8 max-w-prose">
                     <p className="eyebrow text-burgundy mb-2">How the score works</p>
                     <h2 className="font-serif font-semibold text-[1.4rem] tracking-tight mb-3">Open methodology</h2>


### PR DESCRIPTION
## Marketplace on-ramp: self-check grader and trust badge

The open funnel for the Agent Trust Index. The Index measures the whole agent
population; this lets any single agent check and improve itself, the first step
of the marketplace. The claim-and-verify listings, scores API, and the
marketplace itself are the commercial layer and are intentionally not here.

### What this adds
- **`vouch grade <domain>`** (`vouch/grade.py`): grades one agent with the exact
  Index scoring (60 points for a resolvable did:web, 40 for a usable
  verification method), and reports the letter grade, the reasons, the extra
  signals (post-quantum, revocation, agent-card identity), and numbered fixes to
  raise the grade.
- **Embeddable trust badge**: `vouch grade yourdomain.com --badge trust-badge.svg`
  writes a shields-style SVG (grade and score, colored A green to F red) to drop
  in a README or agent page.
- **Self-check section on the Agent Trust Index page**: a "grade your agent"
  call to action with the command, the badge, and a register-interest link.

### Verification
- 8 new tests (`tests/test_grade.py`), full suite green.
- Live-checked: feedoracle.io grades A (100), matching the Index; example.com
  grades F (0).
- Website type-check (tsc) clean.
- No em-dashes; brand guard satisfied.
