### PR TITLE
Add physical capability scope to the TypeScript SDK (byte-identical interop)

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -104,6 +104,18 @@ export {
   verifyProvenanceAttestation,
 } from './robotics/provenance';
 export type { BuildProvenanceOptions } from './robotics/provenance';
+export {
+  PHYSICAL_SCOPE_TYPE,
+  buildPhysicalScopeCredential,
+  checkPhysicalAction,
+  attenuates,
+} from './robotics/capability';
+export type {
+  PhysicalAction,
+  CheckResult,
+  ShiftWindow,
+  BuildPhysicalScopeOptions,
+} from './robotics/capability';
 
 // BitstringStatusList (VC-BITSTRING-STATUS-LIST, Specification §11.2)
 export {

--- a/packages/sdk-ts/src/robotics/capability.ts
+++ b/packages/sdk-ts/src/robotics/capability.ts
@@ -1,0 +1,155 @@
+/**
+ * Physical capability scope for robots (Phase 5.3), TypeScript.
+ *
+ * Mirrors `vouch/robotics/capability.py`. Extends capability attenuation to the
+ * physical world: max force and speed, a slower speed cap near humans, allowed
+ * zones, and shift windows, carried in a signed credential so the bound is
+ * cryptographically enforceable. A controller checks a proposed action against
+ * the granted scope before actuating, and a delegated scope must attenuate
+ * (narrow, never broaden) its parent.
+ */
+
+import type { Signer } from '../signer';
+import { VC_CONTEXT_V2, VOUCH_CONTEXT_V1 } from '../vc';
+
+export const PHYSICAL_SCOPE_TYPE = 'PhysicalCapabilityScope';
+
+export interface PhysicalAction {
+  forceN?: number;
+  speedMps?: number;
+  nearHumans?: boolean;
+  zone?: string;
+  timeHm?: string; // "HH:MM" local
+}
+
+export interface CheckResult {
+  ok: boolean;
+  reasons: string[];
+}
+
+export interface ShiftWindow {
+  start: string;
+  end: string;
+}
+
+function iso(d: Date): string {
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+export interface BuildPhysicalScopeOptions {
+  subjectDid: string;
+  maxForceN?: number;
+  maxSpeedMps?: number;
+  maxSpeedNearHumansMps?: number;
+  allowedZones?: string[];
+  shiftWindows?: ShiftWindow[];
+  validSeconds?: number;
+  validFrom?: Date;
+}
+
+/** Build a signed PhysicalCapabilityScope credential. */
+export async function buildPhysicalScopeCredential(
+  signer: Signer,
+  opts: BuildPhysicalScopeOptions
+): Promise<Record<string, unknown>> {
+  const scope: Record<string, unknown> = {};
+  if (opts.maxForceN !== undefined) scope.maxForceN = opts.maxForceN;
+  if (opts.maxSpeedMps !== undefined) scope.maxSpeedMps = opts.maxSpeedMps;
+  if (opts.maxSpeedNearHumansMps !== undefined) {
+    scope.maxSpeedNearHumansMps = opts.maxSpeedNearHumansMps;
+  }
+  if (opts.allowedZones !== undefined) scope.allowedZones = [...opts.allowedZones];
+  if (opts.shiftWindows !== undefined) scope.shiftWindows = opts.shiftWindows.map((w) => ({ ...w }));
+
+  const issued = opts.validFrom ?? new Date();
+  const credential: Record<string, unknown> = {
+    '@context': [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+    type: ['VerifiableCredential', PHYSICAL_SCOPE_TYPE],
+    issuer: signer.getDid(),
+    validFrom: iso(issued),
+    credentialSubject: { id: opts.subjectDid, physicalScope: scope },
+  };
+  if (opts.validSeconds !== undefined) {
+    credential.validUntil = iso(new Date(issued.getTime() + opts.validSeconds * 1000));
+  }
+  return signer.attachProof(credential);
+}
+
+function inWindow(hm: string, w: { start?: string; end?: string }): boolean {
+  return (w.start ?? '00:00') <= hm && hm <= (w.end ?? '23:59');
+}
+
+/** Check a proposed physical action against a physical scope object. */
+export function checkPhysicalAction(
+  scope: Record<string, any>,
+  action: PhysicalAction
+): CheckResult {
+  const reasons: string[] = [];
+
+  if (action.forceN !== undefined && 'maxForceN' in scope) {
+    if (action.forceN > scope.maxForceN) {
+      reasons.push(`force_exceeded: ${action.forceN}N > ${scope.maxForceN}N`);
+    }
+  }
+
+  if (action.speedMps !== undefined) {
+    let cap = scope.maxSpeedMps;
+    if (action.nearHumans && 'maxSpeedNearHumansMps' in scope) {
+      cap = scope.maxSpeedNearHumansMps;
+    }
+    if (cap !== undefined && action.speedMps > cap) {
+      const label = action.nearHumans ? 'near_humans ' : '';
+      reasons.push(`${label}speed_exceeded: ${action.speedMps} m/s > ${cap} m/s`);
+    }
+  }
+
+  if (action.zone !== undefined && 'allowedZones' in scope) {
+    if (!scope.allowedZones.includes(action.zone)) {
+      reasons.push(`zone_not_allowed: ${action.zone}`);
+    }
+  }
+
+  if (action.timeHm !== undefined && 'shiftWindows' in scope) {
+    const windows = scope.shiftWindows as ShiftWindow[];
+    if (windows.length && !windows.some((w) => inWindow(action.timeHm as string, w))) {
+      reasons.push(`outside_shift_window: ${action.timeHm}`);
+    }
+  }
+
+  return { ok: reasons.length === 0, reasons };
+}
+
+/**
+ * True if `child` is a valid attenuation of `parent`: never broader on any
+ * physical dimension. Numeric caps may only shrink; allowed zones may only be a
+ * subset; shift windows must each fit inside some parent window.
+ */
+export function attenuates(
+  parent: Record<string, any>,
+  child: Record<string, any>
+): boolean {
+  for (const key of ['maxForceN', 'maxSpeedMps', 'maxSpeedNearHumansMps']) {
+    if (key in parent) {
+      if (!(key in child)) return false;
+      if (child[key] > parent[key]) return false;
+    }
+  }
+
+  if ('allowedZones' in parent) {
+    const pZones = new Set<string>(parent.allowedZones);
+    const cZones: string[] = child.allowedZones ?? [];
+    if (cZones.length === 0 || !cZones.every((z) => pZones.has(z))) return false;
+  }
+
+  if ('shiftWindows' in parent) {
+    const pWindows = parent.shiftWindows as ShiftWindow[];
+    for (const cw of (child.shiftWindows ?? []) as ShiftWindow[]) {
+      const fits = pWindows.some(
+        (pw) => (pw.start ?? '00:00') <= (cw.start ?? '00:00') && (cw.end ?? '23:59') <= (pw.end ?? '23:59')
+      );
+      if (!fits) return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/sdk-ts/tests/robotics-capability.test.ts
+++ b/packages/sdk-ts/tests/robotics-capability.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Physical capability scope tests (TypeScript). Mirrors the Python
+ * tests/test_robot_provenance_capability.py and tests/test_attenuation_vectors.py
+ * capability cases: enforce force/speed/zone/shift limits before actuation, and
+ * require a delegated scope to narrow (never broaden) its parent.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Signer,
+  generateIdentity,
+  verifyProof,
+  buildPhysicalScopeCredential,
+  checkPhysicalAction,
+  attenuates,
+  PHYSICAL_SCOPE_TYPE,
+} from '../src';
+
+function pub(jwk: string): crypto.KeyObject {
+  return crypto.createPublicKey({ key: JSON.parse(jwk) as crypto.JsonWebKey, format: 'jwk' });
+}
+
+const SCOPE = {
+  maxForceN: 50,
+  maxSpeedMps: 2,
+  maxSpeedNearHumansMps: 0.5,
+  allowedZones: ['zone-a'],
+  shiftWindows: [{ start: '08:00', end: '18:00' }],
+};
+
+describe('physical capability scope', () => {
+  it('builds and verifies a scope credential', async () => {
+    const keys = await generateIdentity('robot.example.com');
+    const signer = new Signer({ privateKey: keys.privateKeyJwk, did: 'did:web:robot.example.com' });
+    const cred = await buildPhysicalScopeCredential(signer, {
+      subjectDid: 'did:web:robot.example.com',
+      ...SCOPE,
+    });
+    expect(cred.type as string[]).toContain(PHYSICAL_SCOPE_TYPE);
+    expect(verifyProof(cred, pub(keys.publicKeyJwk))).toBe(true);
+  });
+
+  it('checks actions against the scope, including the slower cap near humans', () => {
+    expect(checkPhysicalAction(SCOPE, { forceN: 40, speedMps: 1.5, zone: 'zone-a', timeHm: '10:00' }).ok).toBe(true);
+    expect(checkPhysicalAction(SCOPE, { forceN: 60 }).ok).toBe(false); // force over cap
+    expect(checkPhysicalAction(SCOPE, { speedMps: 1.0, nearHumans: true }).ok).toBe(false); // 1.0 > 0.5 near humans
+    expect(checkPhysicalAction(SCOPE, { speedMps: 1.0, nearHumans: false }).ok).toBe(true); // 1.0 <= 2 normal
+    expect(checkPhysicalAction(SCOPE, { zone: 'zone-b' }).ok).toBe(false); // zone not allowed
+    expect(checkPhysicalAction(SCOPE, { timeHm: '20:00' }).ok).toBe(false); // outside shift window
+  });
+
+  it('enforces attenuation: narrow never broaden', () => {
+    const parent = {
+      maxForceN: 50,
+      maxSpeedMps: 2,
+      allowedZones: ['zone-a', 'zone-b'],
+      shiftWindows: [{ start: '08:00', end: '18:00' }],
+    };
+    // Strictly narrower child.
+    expect(
+      attenuates(parent, {
+        maxForceN: 30,
+        maxSpeedMps: 1,
+        allowedZones: ['zone-a'],
+        shiftWindows: [{ start: '09:00', end: '17:00' }],
+      })
+    ).toBe(true);
+    expect(attenuates(parent, { maxForceN: 80, maxSpeedMps: 1 })).toBe(false); // broader force
+    expect(attenuates(parent, { maxForceN: 30 })).toBe(false); // drops a parent cap
+    expect(attenuates(parent, { maxForceN: 30, maxSpeedMps: 1, allowedZones: ['zone-c'] })).toBe(false); // zone not a subset
+    expect(
+      attenuates(parent, {
+        maxForceN: 30,
+        maxSpeedMps: 1,
+        allowedZones: ['zone-a'],
+        shiftWindows: [{ start: '07:00', end: '19:00' }],
+      })
+    ).toBe(false); // shift window wider than parent
+  });
+});


### PR DESCRIPTION
Ports the physical capability scope to the TypeScript SDK, byte-identical with the Python `vouch.robotics.capability` module.

- `buildPhysicalScopeCredential`, `checkPhysicalAction`, `attenuates` in `src/robotics/capability.ts`, mirroring `capability.py`.
- A `PhysicalCapabilityScope` credential carries max force, max speed, a slower speed cap near humans, allowed zones, and shift windows. A controller checks a proposed action against it before actuating, and a delegated scope must narrow (never broaden) its parent on every dimension.

**Verification:** build/verify round-trip of the signed scope credential, the action checks (force, speed, the slower near-humans cap, zones, shift windows), and the attenuation rules (numeric caps shrink, zones subset, shift windows fit). 9/9 robotics tests pass (capability + provenance + identity), bundle builds, typecheck clean for these files.

Third of the robotics SDK ports (after identity #65 and provenance #72). Handshake, black box, and passport follow.
