### PR TITLE
Add robot-to-robot handshake to the TypeScript SDK (byte-identical interop)

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -116,6 +116,23 @@ export type {
   ShiftWindow,
   BuildPhysicalScopeOptions,
 } from './robotics/capability';
+export {
+  HELLO,
+  ACCEPT,
+  CONFIRM,
+  HandshakeError,
+  TrustPolicy,
+  buildHello,
+  buildAccept,
+  verifyAccept,
+  buildConfirm,
+  verifyConfirm,
+} from './robotics/handshake';
+export type {
+  BoundedSession,
+  BuildHelloOptions,
+  BuildAcceptOptions,
+} from './robotics/handshake';
 
 // BitstringStatusList (VC-BITSTRING-STATUS-LIST, Specification §11.2)
 export {

--- a/packages/sdk-ts/src/robotics/handshake.ts
+++ b/packages/sdk-ts/src/robotics/handshake.ts
@@ -1,0 +1,183 @@
+/**
+ * Robot-to-robot trust handshake (Phase 5.4), TypeScript.
+ *
+ * Mirrors `vouch/robotics/handshake.py`. Two robots in different trust domains
+ * authenticate and establish a bounded-trust session via three signed messages
+ * (HELLO, ACCEPT, CONFIRM). The session scope is the intersection of what each
+ * side offers, never the union, and the responder checks the initiator's domain
+ * against its trust policy. Each message is an eddsa-jcs-2022 signed object, so
+ * authentication reuses the shared verifier and is interoperable with Python.
+ */
+
+import * as crypto from 'crypto';
+
+import { verifyProof } from '../data-integrity';
+import type { Signer } from '../signer';
+
+export const HELLO = 'handshake_hello';
+export const ACCEPT = 'handshake_accept';
+export const CONFIRM = 'handshake_confirm';
+
+export class HandshakeError extends Error {}
+
+/** A peer is trusted when its did:web domain is allowed, or when open. */
+export class TrustPolicy {
+  trustedDomains: Set<string>;
+  acceptUnknown: boolean;
+
+  constructor(opts: { trustedDomains?: Iterable<string>; acceptUnknown?: boolean } = {}) {
+    this.trustedDomains = new Set(opts.trustedDomains ?? []);
+    this.acceptUnknown = opts.acceptUnknown ?? false;
+  }
+
+  isTrusted(did: string | null | undefined): boolean {
+    if (this.acceptUnknown) return true;
+    const d = didWebDomain(did ?? '');
+    return d !== undefined && this.trustedDomains.has(d);
+  }
+}
+
+export interface BoundedSession {
+  sessionId: string;
+  initiator: string;
+  responder: string;
+  scope: string[];
+  nonce: string;
+  validUntil?: string;
+}
+
+function didWebDomain(did: string): string | undefined {
+  if (did.startsWith('did:web:')) return did.slice('did:web:'.length).split(':')[0];
+  return undefined;
+}
+
+function iso(d: Date): string {
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function verify(obj: Record<string, unknown>, publicKey: crypto.KeyObject): boolean {
+  try {
+    return verifyProof(obj, publicKey);
+  } catch {
+    return false;
+  }
+}
+
+export interface BuildHelloOptions {
+  proposedScope: string[];
+  nonce?: string;
+  peerDid?: string;
+}
+
+/** A: open the handshake with a proposed scope and a fresh nonce. */
+export async function buildHello(
+  signer: Signer,
+  opts: BuildHelloOptions
+): Promise<Record<string, unknown>> {
+  const hello = {
+    type: HELLO,
+    from: signer.getDid(),
+    to: opts.peerDid ?? null,
+    nonce: opts.nonce ?? crypto.randomBytes(16).toString('hex'),
+    proposedScope: [...opts.proposedScope],
+    issuedAt: iso(new Date()),
+  };
+  return signer.attachProof(hello);
+}
+
+export interface BuildAcceptOptions {
+  hello: Record<string, any>;
+  helloPublicKey: crypto.KeyObject;
+  policy: TrustPolicy;
+  offeredScope: string[];
+  validSeconds?: number;
+  sessionId?: string;
+}
+
+/**
+ * B: verify A's HELLO and identity domain, intersect the scope, and sign an
+ * acceptance. Throws HandshakeError if A is untrusted or the HELLO is invalid.
+ */
+export async function buildAccept(
+  signer: Signer,
+  opts: BuildAcceptOptions
+): Promise<Record<string, unknown>> {
+  const { hello, helloPublicKey, policy, offeredScope } = opts;
+  if (hello.type !== HELLO) throw new HandshakeError('not a HELLO message');
+  if (!verify(hello, helloPublicKey)) throw new HandshakeError('HELLO signature invalid');
+  const initiator = hello.from as string;
+  if (!policy.isTrusted(initiator)) {
+    throw new HandshakeError(`peer ${initiator} is not in this trust domain's policy`);
+  }
+
+  const offered = new Set<string>(offeredScope);
+  const bounded = [...new Set((hello.proposedScope ?? []) as string[])]
+    .filter((s) => offered.has(s))
+    .sort();
+  const sid = opts.sessionId ?? `urn:uuid:${crypto.randomUUID()}`;
+  const validUntil = iso(new Date(Date.now() + (opts.validSeconds ?? 300) * 1000));
+
+  const accept = {
+    type: ACCEPT,
+    from: signer.getDid(),
+    to: initiator,
+    sessionId: sid,
+    nonce: hello.nonce,
+    boundedScope: bounded,
+    validUntil,
+  };
+  return signer.attachProof(accept);
+}
+
+/** A: verify B's ACCEPT, that the nonce echoes, and optionally that B is trusted. */
+export function verifyAccept(
+  accept: Record<string, any>,
+  acceptPublicKey: crypto.KeyObject,
+  opts: { expectedNonce: string; policy?: TrustPolicy }
+): { ok: boolean; session?: BoundedSession } {
+  if (accept.type !== ACCEPT) return { ok: false };
+  if (!verify(accept, acceptPublicKey)) return { ok: false };
+  if (accept.nonce !== opts.expectedNonce) return { ok: false };
+  const responder = accept.from as string;
+  if (opts.policy && !opts.policy.isTrusted(responder)) return { ok: false };
+
+  return {
+    ok: true,
+    session: {
+      sessionId: accept.sessionId,
+      initiator: accept.to,
+      responder,
+      scope: [...(accept.boundedScope ?? [])],
+      nonce: accept.nonce,
+      validUntil: accept.validUntil,
+    },
+  };
+}
+
+/** A: confirm the bounded session to B. */
+export async function buildConfirm(
+  signer: Signer,
+  opts: { session: BoundedSession }
+): Promise<Record<string, unknown>> {
+  const { session } = opts;
+  const confirm = {
+    type: CONFIRM,
+    from: signer.getDid(),
+    to: session.responder,
+    sessionId: session.sessionId,
+    nonce: session.nonce,
+    acceptedScope: [...session.scope],
+  };
+  return signer.attachProof(confirm);
+}
+
+/** B: verify A's CONFIRM closes the agreed session. */
+export function verifyConfirm(
+  confirm: Record<string, any>,
+  confirmPublicKey: crypto.KeyObject,
+  opts: { sessionId: string; expectedNonce: string }
+): boolean {
+  if (confirm.type !== CONFIRM) return false;
+  if (!verify(confirm, confirmPublicKey)) return false;
+  return confirm.sessionId === opts.sessionId && confirm.nonce === opts.expectedNonce;
+}

--- a/packages/sdk-ts/tests/robotics-handshake.test.ts
+++ b/packages/sdk-ts/tests/robotics-handshake.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Robot-to-robot handshake tests (TypeScript). Mirrors the Python
+ * tests/test_robot_handshake_blackbox_passport.py handshake cases: a full
+ * HELLO/ACCEPT/CONFIRM exchange with scope intersection, plus trust-policy and
+ * nonce-mismatch rejection.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Signer,
+  generateIdentity,
+  TrustPolicy,
+  buildHello,
+  buildAccept,
+  verifyAccept,
+  buildConfirm,
+  verifyConfirm,
+} from '../src';
+
+async function robot(domain: string) {
+  const keys = await generateIdentity(domain);
+  const signer = new Signer({ privateKey: keys.privateKeyJwk, did: `did:web:${domain}` });
+  const pub = crypto.createPublicKey({ key: JSON.parse(keys.publicKeyJwk) as crypto.JsonWebKey, format: 'jwk' });
+  return { signer, pub, did: `did:web:${domain}` };
+}
+
+describe('robot-to-robot handshake', () => {
+  it('completes a bounded-trust handshake with scope intersection', async () => {
+    const a = await robot('a.example.com');
+    const b = await robot('b.example.com');
+    const policyB = new TrustPolicy({ trustedDomains: ['a.example.com'] });
+
+    const hello = await buildHello(a.signer, {
+      proposedScope: ['lift', 'move', 'weld'],
+      peerDid: b.did,
+    });
+    const accept = await buildAccept(b.signer, {
+      hello,
+      helloPublicKey: a.pub,
+      policy: policyB,
+      offeredScope: ['move', 'weld', 'paint'],
+    });
+
+    const { ok, session } = verifyAccept(accept, b.pub, { expectedNonce: hello.nonce as string });
+    expect(ok).toBe(true);
+    expect(session!.scope).toEqual(['move', 'weld']); // intersection, sorted
+
+    const confirm = await buildConfirm(a.signer, { session: session! });
+    expect(
+      verifyConfirm(confirm, a.pub, { sessionId: session!.sessionId, expectedNonce: hello.nonce as string })
+    ).toBe(true);
+  });
+
+  it('rejects an initiator outside the trust policy', async () => {
+    const a = await robot('evil.example.com');
+    const b = await robot('b.example.com');
+    const policyB = new TrustPolicy({ trustedDomains: ['good.example.com'] });
+    const hello = await buildHello(a.signer, { proposedScope: ['move'] });
+    await expect(
+      buildAccept(b.signer, { hello, helloPublicKey: a.pub, policy: policyB, offeredScope: ['move'] })
+    ).rejects.toThrow();
+  });
+
+  it('rejects a nonce mismatch on accept', async () => {
+    const a = await robot('a.example.com');
+    const b = await robot('b.example.com');
+    const policyB = new TrustPolicy({ acceptUnknown: true });
+    const hello = await buildHello(a.signer, { proposedScope: ['move'] });
+    const accept = await buildAccept(b.signer, {
+      hello,
+      helloPublicKey: a.pub,
+      policy: policyB,
+      offeredScope: ['move'],
+    });
+    expect(verifyAccept(accept, b.pub, { expectedNonce: 'wrong-nonce' }).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Ports the robot-to-robot trust handshake to the TypeScript SDK, byte-identical with the Python `vouch.robotics.handshake` module.

- `TrustPolicy`, `buildHello`, `buildAccept`, `verifyAccept`, `buildConfirm`, `verifyConfirm`, and `BoundedSession` in `src/robotics/handshake.ts`, mirroring `handshake.py`.
- Two robots in different trust domains authenticate via three signed messages (HELLO, ACCEPT, CONFIRM). The session scope is the intersection of what each side offers (never the union), and the responder checks the initiator's did:web domain against its trust policy.

**Verification:** a full HELLO/ACCEPT/CONFIRM exchange between two TS robots with correct scope intersection, plus trust-policy rejection of an untrusted initiator and nonce-mismatch rejection. Each message is an eddsa-jcs-2022 signed object, so it cross-verifies with Python via the shared proof path. 12/12 robotics tests pass, bundle builds, typecheck clean for these files.

Fourth of the robotics SDK ports (after identity #65, provenance #72, capability #74). Black box and passport remain.
