### PR TITLE
Add robot black box and kill switch to the TypeScript SDK (byte-identical interop)

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -133,6 +133,19 @@ export type {
   BuildHelloOptions,
   BuildAcceptOptions,
 } from './robotics/handshake';
+export {
+  KILLSWITCH_TYPE,
+  BLACKBOX_VERSION,
+  EMERGENCY_STOP,
+  GENESIS_PREV_HASH,
+  BlackBoxError,
+  BlackBoxLog,
+  openEntry,
+  verifyBlackboxChain,
+  buildKillswitchCredential,
+  verifyKillswitchCredential,
+} from './robotics/blackbox';
+export type { BuildKillswitchOptions } from './robotics/blackbox';
 
 // BitstringStatusList (VC-BITSTRING-STATUS-LIST, Specification §11.2)
 export {

--- a/packages/sdk-ts/src/robotics/blackbox.ts
+++ b/packages/sdk-ts/src/robotics/blackbox.ts
@@ -1,0 +1,195 @@
+/**
+ * Robot black-box log and kill-switch credential (Phase 5.5), TypeScript.
+ *
+ * Mirrors `vouch/robotics/blackbox.py`. The black box is an append-only,
+ * AES-256-GCM-encrypted, hash-linked event log: payloads are confidential, the
+ * chain is tamper-evident without the key, and only the key opens the payloads.
+ * The encrypted blob is `nonce(12) || ciphertext || tag(16)`, the same layout
+ * Python's AESGCM produces, so a Python-written entry decrypts here and vice
+ * versa, and the JCS hash chain verifies across languages.
+ *
+ * The kill-switch credential is a verifiable emergency stop proving who issued
+ * it and, with an authority allowlist, that only an attested authority can
+ * trigger it.
+ */
+
+import * as crypto from 'crypto';
+
+import { verifyProof } from '../data-integrity';
+import { canonicalize } from '../jcs';
+import type { Signer } from '../signer';
+import { VC_CONTEXT_V2, VOUCH_CONTEXT_V1 } from '../vc';
+
+export const KILLSWITCH_TYPE = 'KillSwitchCredential';
+export const BLACKBOX_VERSION = '1.0';
+export const EMERGENCY_STOP = 'emergency_stop';
+export const GENESIS_PREV_HASH = 'u' + Buffer.alloc(32).toString('base64url');
+
+export class BlackBoxError extends Error {}
+
+function mb64(b: Uint8Array): string {
+  return 'u' + Buffer.from(b).toString('base64url');
+}
+
+function unmb64(s: string): Buffer {
+  if (!s.startsWith('u')) throw new BlackBoxError("expected multibase 'u' prefix");
+  return Buffer.from(s.slice(1), 'base64url');
+}
+
+function iso(d: Date): string {
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+function entryHash(body: Record<string, unknown>): string {
+  const clean: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(body)) if (k !== 'entryHash') clean[k] = v;
+  return mb64(crypto.createHash('sha256').update(canonicalize(clean)).digest());
+}
+
+/** Append-only, encrypted, hash-linked event log. `key` is 32 bytes (AES-256). */
+export class BlackBoxLog {
+  readonly genesisPrevHash: string;
+  private key: Buffer;
+  private _entries: Array<Record<string, unknown>> = [];
+  private _head: string;
+
+  constructor(key: Uint8Array, genesisPrevHash: string = GENESIS_PREV_HASH) {
+    if (key.length !== 32) throw new BlackBoxError('key must be 32 bytes (AES-256)');
+    this.key = Buffer.from(key);
+    this.genesisPrevHash = genesisPrevHash;
+    this._head = genesisPrevHash;
+  }
+
+  append(
+    event: string,
+    payload: Record<string, unknown>,
+    opts: { timestamp?: string } = {}
+  ): Record<string, unknown> {
+    const nonce = crypto.randomBytes(12);
+    const plaintext = Buffer.from(canonicalize(payload));
+    const cipher = crypto.createCipheriv('aes-256-gcm', this.key, nonce);
+    const ct = Buffer.concat([cipher.update(plaintext), cipher.final()]);
+    const tag = cipher.getAuthTag();
+
+    const body: Record<string, unknown> = {
+      version: BLACKBOX_VERSION,
+      seq: this._entries.length,
+      timestamp: opts.timestamp ?? iso(new Date()),
+      event,
+      ciphertext: mb64(Buffer.concat([nonce, ct, tag])),
+      prevHash: this._head,
+    };
+    body.entryHash = entryHash(body);
+    this._entries.push(body);
+    this._head = body.entryHash as string;
+    return body;
+  }
+
+  head(): string {
+    return this._head;
+  }
+
+  entries(): Array<Record<string, unknown>> {
+    return this._entries.map((e) => ({ ...e }));
+  }
+
+  openEntry(entry: Record<string, unknown>): Record<string, unknown> {
+    return openEntry(entry, this.key);
+  }
+}
+
+/** Decrypt a black-box entry payload. Returns the original payload object. */
+export function openEntry(entry: Record<string, any>, key: Uint8Array): Record<string, unknown> {
+  const blob = unmb64(entry.ciphertext);
+  const nonce = blob.subarray(0, 12);
+  const ct = blob.subarray(12, blob.length - 16);
+  const tag = blob.subarray(blob.length - 16);
+  try {
+    const decipher = crypto.createDecipheriv('aes-256-gcm', Buffer.from(key), nonce);
+    decipher.setAuthTag(tag);
+    const pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+    return JSON.parse(pt.toString('utf8'));
+  } catch (e) {
+    throw new BlackBoxError(`decryption failed: ${(e as Error).message}`);
+  }
+}
+
+/** Verify the hash chain over (encrypted) entries. Tamper-evident without the key. */
+export function verifyBlackboxChain(
+  entries: Array<Record<string, any>>,
+  genesisPrevHash: string = GENESIS_PREV_HASH
+): { ok: boolean; reason?: string } {
+  let prev = genesisPrevHash;
+  for (let i = 0; i < entries.length; i++) {
+    const entry = entries[i];
+    if (entry.seq !== i) return { ok: false, reason: `entry ${i} seq mismatch` };
+    if (entry.prevHash !== prev) return { ok: false, reason: `entry ${i} prevHash does not link` };
+    if (entry.entryHash !== entryHash(entry)) {
+      return { ok: false, reason: `entry ${i} entryHash mismatch (tampered)` };
+    }
+    prev = entry.entryHash;
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// Kill-switch credential
+// ---------------------------------------------------------------------------
+
+export interface BuildKillswitchOptions {
+  target: string;
+  reason: string;
+  command?: string;
+  scope?: string[];
+  validSeconds?: number;
+  validFrom?: Date;
+}
+
+/** Build a signed KillSwitchCredential proving who issued an emergency stop. */
+export async function buildKillswitchCredential(
+  authoritySigner: Signer,
+  opts: BuildKillswitchOptions
+): Promise<Record<string, unknown>> {
+  const issued = opts.validFrom ?? new Date();
+  const subject: Record<string, unknown> = {
+    id: opts.target,
+    command: opts.command ?? EMERGENCY_STOP,
+    reason: opts.reason,
+    issuedBy: authoritySigner.getDid(),
+  };
+  if (opts.scope !== undefined) subject.scope = [...opts.scope];
+
+  const credential: Record<string, unknown> = {
+    '@context': [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+    type: ['VerifiableCredential', KILLSWITCH_TYPE],
+    issuer: authoritySigner.getDid(),
+    validFrom: iso(issued),
+    credentialSubject: subject,
+  };
+  if (opts.validSeconds !== undefined) {
+    credential.validUntil = iso(new Date(issued.getTime() + opts.validSeconds * 1000));
+  }
+  return authoritySigner.attachProof(credential);
+}
+
+/**
+ * Verify a KillSwitchCredential. When `trustedAuthorities` is supplied, the
+ * issuer DID MUST be in it, so only an attested authority can trigger the stop.
+ */
+export function verifyKillswitchCredential(
+  credential: Record<string, any>,
+  publicKey: crypto.KeyObject,
+  opts: { trustedAuthorities?: Set<string> } = {}
+): { ok: boolean; subject?: Record<string, unknown> } {
+  const types = Array.isArray(credential.type) ? credential.type : [credential.type];
+  if (!types.includes(KILLSWITCH_TYPE)) return { ok: false };
+  try {
+    if (!verifyProof(credential, publicKey)) return { ok: false };
+  } catch {
+    return { ok: false };
+  }
+  if (opts.trustedAuthorities && !opts.trustedAuthorities.has(credential.issuer)) {
+    return { ok: false };
+  }
+  return { ok: true, subject: credential.credentialSubject ?? {} };
+}

--- a/packages/sdk-ts/tests/robotics-blackbox.test.ts
+++ b/packages/sdk-ts/tests/robotics-blackbox.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Robot black-box + kill-switch tests (TypeScript). Mirrors the Python
+ * tests/test_robot_handshake_blackbox_passport.py black-box cases: encrypted,
+ * hash-linked entries that verify and decrypt, tamper detection without the key,
+ * and a kill-switch credential with an attested-authority allowlist.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Signer,
+  generateIdentity,
+  BlackBoxLog,
+  BlackBoxError,
+  openEntry,
+  verifyBlackboxChain,
+  buildKillswitchCredential,
+  verifyKillswitchCredential,
+} from '../src';
+
+describe('robot black box', () => {
+  it('logs encrypted, hash-linked entries that verify and decrypt', () => {
+    const key = crypto.randomBytes(32);
+    const log = new BlackBoxLog(key);
+    const e1 = log.append('boot', { ok: true });
+    const e2 = log.append('move', { x: 1, y: 2 });
+
+    expect(verifyBlackboxChain(log.entries()).ok).toBe(true);
+    expect(openEntry(e1, key)).toEqual({ ok: true });
+    expect(log.openEntry(e2)).toEqual({ x: 1, y: 2 });
+  });
+
+  it('detects tampering without the key', () => {
+    const key = crypto.randomBytes(32);
+    const log = new BlackBoxLog(key);
+    log.append('a', { v: 1 });
+    log.append('b', { v: 2 });
+    const entries = log.entries();
+    entries[1].event = 'tampered';
+    expect(verifyBlackboxChain(entries).ok).toBe(false);
+  });
+
+  it('refuses to open with the wrong key', () => {
+    const log = new BlackBoxLog(crypto.randomBytes(32));
+    const e = log.append('x', { secret: 1 });
+    expect(() => openEntry(e, crypto.randomBytes(32))).toThrow(BlackBoxError);
+  });
+
+  it('rejects a non-32-byte key', () => {
+    expect(() => new BlackBoxLog(crypto.randomBytes(16))).toThrow(BlackBoxError);
+  });
+
+  it('issues and verifies a kill-switch credential with an authority allowlist', async () => {
+    const keys = await generateIdentity('authority.example.com');
+    const signer = new Signer({ privateKey: keys.privateKeyJwk, did: 'did:web:authority.example.com' });
+    const pub = crypto.createPublicKey({ key: JSON.parse(keys.publicKeyJwk) as crypto.JsonWebKey, format: 'jwk' });
+
+    const cred = await buildKillswitchCredential(signer, {
+      target: 'did:web:robot.example.com',
+      reason: 'fault detected',
+    });
+    expect(verifyKillswitchCredential(cred, pub).ok).toBe(true);
+    expect(
+      verifyKillswitchCredential(cred, pub, {
+        trustedAuthorities: new Set(['did:web:authority.example.com']),
+      }).ok
+    ).toBe(true);
+    // An issuer outside the allowlist cannot trigger the stop.
+    expect(
+      verifyKillswitchCredential(cred, pub, {
+        trustedAuthorities: new Set(['did:web:other.example.com']),
+      }).ok
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
Ports the robot black box and kill-switch credential to the TypeScript SDK, byte-identical with the Python `vouch.robotics.blackbox` module.

- `BlackBoxLog`, `openEntry`, `verifyBlackboxChain`, `buildKillswitchCredential`, `verifyKillswitchCredential` in `src/robotics/blackbox.ts`, mirroring `blackbox.py`.
- The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight recorder. The encrypted blob is `nonce(12) ‖ ciphertext ‖ tag(16)`, the same layout Python's AESGCM produces, so an entry written by either language decrypts in the other, and the JCS hash chain verifies across languages. Integrity is checkable without the key; only the key opens the payloads.
- The kill-switch credential is a verifiable emergency stop that proves who issued it and, with an authority allowlist, enforces that only an attested authority can trigger it.

**Verification:** encrypted hash-linked entries that verify and decrypt, tamper detection without the key, wrong-key refusal, 32-byte-key enforcement, and kill-switch issue/verify with the authority allowlist. 17/17 robotics tests pass, bundle builds, typecheck clean for these files.

Fifth of the robotics SDK ports. Only the scannable passport remains.
