### PR TITLE
Add scannable robot passport to the TypeScript SDK (completes robotics in TS)

### DIFF
--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -146,6 +146,19 @@ export {
   verifyKillswitchCredential,
 } from './robotics/blackbox';
 export type { BuildKillswitchOptions } from './robotics/blackbox';
+export {
+  ROBOT_PASSPORT_TYPE,
+  PASSPORT_URI_SCHEME,
+  STATUS_ACTIVE,
+  STATUS_SUSPENDED,
+  STATUS_DECOMMISSIONED,
+  PassportError,
+  buildPassport,
+  encodePassport,
+  decodePassport,
+  verifyPassport,
+} from './robotics/passport';
+export type { BuildPassportOptions, PassportSummary } from './robotics/passport';
 
 // BitstringStatusList (VC-BITSTRING-STATUS-LIST, Specification §11.2)
 export {

--- a/packages/sdk-ts/src/robotics/passport.ts
+++ b/packages/sdk-ts/src/robotics/passport.ts
@@ -1,0 +1,146 @@
+/**
+ * Scannable robot passport (Phase 5.6), TypeScript.
+ *
+ * Mirrors `vouch/robotics/passport.py`. A compact, signed RobotPassport that
+ * anyone can scan (QR or NFC) to check a robot's owner, authorized actions,
+ * certification, and current standing, offline. The QR/NFC payload is a
+ * `vouch-passport:` URI carrying the multibase JCS bytes of the credential, so
+ * an offline reader verifies the signature with no network round-trip. The URI
+ * encoding is deterministic, so a passport encoded by either language decodes
+ * and verifies in the other.
+ */
+
+import * as crypto from 'crypto';
+
+import { verifyProof } from '../data-integrity';
+import { canonicalize } from '../jcs';
+import type { Signer } from '../signer';
+import { VC_CONTEXT_V2, VOUCH_CONTEXT_V1 } from '../vc';
+
+export const ROBOT_PASSPORT_TYPE = 'RobotPassport';
+export const PASSPORT_URI_SCHEME = 'vouch-passport:';
+export const STATUS_ACTIVE = 'active';
+export const STATUS_SUSPENDED = 'suspended';
+export const STATUS_DECOMMISSIONED = 'decommissioned';
+
+export class PassportError extends Error {}
+
+function iso(d: Date): string {
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+export interface BuildPassportOptions {
+  robotDid: string;
+  make: string;
+  model: string;
+  owner: string;
+  authorizedActions: string[];
+  certification?: string;
+  status?: string;
+  validSeconds?: number;
+  validFrom?: Date;
+}
+
+/** Build a signed RobotPassport credential (issued by the robot or an authority). */
+export async function buildPassport(
+  signer: Signer,
+  opts: BuildPassportOptions
+): Promise<Record<string, unknown>> {
+  const issued = opts.validFrom ?? new Date();
+  const subject: Record<string, unknown> = {
+    id: opts.robotDid,
+    make: opts.make,
+    model: opts.model,
+    owner: opts.owner,
+    authorizedActions: [...opts.authorizedActions],
+    status: opts.status ?? STATUS_ACTIVE,
+  };
+  if (opts.certification !== undefined) subject.certification = opts.certification;
+
+  const credential: Record<string, unknown> = {
+    '@context': [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+    type: ['VerifiableCredential', ROBOT_PASSPORT_TYPE],
+    issuer: signer.getDid(),
+    validFrom: iso(issued),
+    credentialSubject: subject,
+  };
+  if (opts.validSeconds !== undefined) {
+    credential.validUntil = iso(new Date(issued.getTime() + opts.validSeconds * 1000));
+  }
+  return signer.attachProof(credential);
+}
+
+/** Encode a passport into a compact vouch-passport: URI for a QR or NFC tag. */
+export function encodePassport(passport: Record<string, unknown>): string {
+  const blob = Buffer.from(canonicalize(passport)).toString('base64url');
+  return PASSPORT_URI_SCHEME + 'u' + blob;
+}
+
+/** Decode a vouch-passport: URI back into the passport credential. */
+export function decodePassport(uri: string): Record<string, unknown> {
+  if (!uri.startsWith(PASSPORT_URI_SCHEME)) throw new PassportError(`not a ${PASSPORT_URI_SCHEME} URI`);
+  const body = uri.slice(PASSPORT_URI_SCHEME.length);
+  if (!body.startsWith('u')) throw new PassportError("expected multibase 'u' payload");
+  const raw = Buffer.from(body.slice(1), 'base64url');
+  return JSON.parse(raw.toString('utf8'));
+}
+
+export interface PassportSummary {
+  robot?: string;
+  make?: string;
+  model?: string;
+  owner?: string;
+  authorizedActions: string[];
+  certification?: string;
+  status?: string;
+}
+
+/**
+ * Verify a passport (a credential object or a vouch-passport: URI). A suspended
+ * or decommissioned status still verifies but is surfaced in the summary so a
+ * scanner can refuse cooperation. An expired passport fails.
+ */
+export function verifyPassport(
+  passport: Record<string, any> | string,
+  publicKey: crypto.KeyObject,
+  opts: { now?: Date } = {}
+): { ok: boolean; summary?: PassportSummary } {
+  let p: Record<string, any>;
+  if (typeof passport === 'string') {
+    try {
+      p = decodePassport(passport);
+    } catch {
+      return { ok: false };
+    }
+  } else {
+    p = passport;
+  }
+
+  const types = Array.isArray(p.type) ? p.type : [p.type];
+  if (!types.includes(ROBOT_PASSPORT_TYPE)) return { ok: false };
+  try {
+    if (!verifyProof(p, publicKey)) return { ok: false };
+  } catch {
+    return { ok: false };
+  }
+
+  const now = opts.now ?? new Date();
+  if (p.validUntil) {
+    const vu = new Date(p.validUntil);
+    if (!Number.isNaN(vu.getTime()) && now > vu) return { ok: false };
+  }
+
+  const s = (p.credentialSubject ?? {}) as Record<string, any>;
+  return {
+    ok: true,
+    summary: {
+      robot: s.id,
+      make: s.make,
+      model: s.model,
+      owner: s.owner,
+      authorizedActions: s.authorizedActions ?? [],
+      certification: s.certification,
+      status: s.status,
+    },
+  };
+}

--- a/packages/sdk-ts/tests/robotics-passport.test.ts
+++ b/packages/sdk-ts/tests/robotics-passport.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Scannable robot passport tests (TypeScript). Mirrors the Python
+ * tests/test_robot_handshake_blackbox_passport.py passport cases: build, encode
+ * to a vouch-passport: URI, decode and verify offline, surface live standing,
+ * and reject an expired passport.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Signer,
+  generateIdentity,
+  buildPassport,
+  encodePassport,
+  decodePassport,
+  verifyPassport,
+  PASSPORT_URI_SCHEME,
+  STATUS_SUSPENDED,
+} from '../src';
+
+async function authority(domain = 'owner.example.com') {
+  const keys = await generateIdentity(domain);
+  const signer = new Signer({ privateKey: keys.privateKeyJwk, did: `did:web:${domain}` });
+  const pub = crypto.createPublicKey({ key: JSON.parse(keys.publicKeyJwk) as crypto.JsonWebKey, format: 'jwk' });
+  return { signer, pub };
+}
+
+describe('scannable robot passport', () => {
+  it('encodes to a vouch-passport URI and decodes back unchanged', async () => {
+    const { signer } = await authority();
+    const passport = await buildPassport(signer, {
+      robotDid: 'did:web:robot.example.com',
+      make: 'Acme',
+      model: 'AR-7',
+      owner: 'did:web:owner.example.com',
+      authorizedActions: ['lift', 'move'],
+      certification: 'CE-2026',
+    });
+    const uri = encodePassport(passport);
+    expect(uri.startsWith(PASSPORT_URI_SCHEME + 'u')).toBe(true);
+    expect(decodePassport(uri)).toEqual(passport);
+  });
+
+  it('verifies a passport offline from its URI and surfaces standing', async () => {
+    const { signer, pub } = await authority();
+    const passport = await buildPassport(signer, {
+      robotDid: 'did:web:robot.example.com',
+      make: 'Acme',
+      model: 'AR-7',
+      owner: 'did:web:owner.example.com',
+      authorizedActions: ['lift'],
+      status: STATUS_SUSPENDED,
+    });
+    const uri = encodePassport(passport);
+
+    const fromCred = verifyPassport(passport, pub);
+    const fromUri = verifyPassport(uri, pub);
+    expect(fromCred.ok).toBe(true);
+    expect(fromUri.ok).toBe(true);
+    // A suspended passport still verifies, but the scanner sees the status.
+    expect(fromUri.summary!.status).toBe(STATUS_SUSPENDED);
+    expect(fromUri.summary!.owner).toBe('did:web:owner.example.com');
+  });
+
+  it('rejects an expired passport and a non-passport URI', async () => {
+    const { signer, pub } = await authority();
+    const passport = await buildPassport(signer, {
+      robotDid: 'did:web:robot.example.com',
+      make: 'Acme',
+      model: 'AR-7',
+      owner: 'did:web:owner.example.com',
+      authorizedActions: ['lift'],
+      validSeconds: 60,
+    });
+    // A scan far in the future sees it expired.
+    expect(verifyPassport(passport, pub, { now: new Date('2099-01-01T00:00:00Z') }).ok).toBe(false);
+    expect(verifyPassport('not-a-passport-uri', pub).ok).toBe(false);
+  });
+});


### PR DESCRIPTION
Ports the scannable robot passport to the TypeScript SDK, byte-identical with the Python `vouch.robotics.passport` module. This completes the robotics layer in the TS SDK (all six capabilities).

- `buildPassport`, `encodePassport`, `decodePassport`, `verifyPassport` in `src/robotics/passport.ts`, mirroring `passport.py`.
- A compact signed RobotPassport encoded into a `vouch-passport:` URI carrying the multibase JCS bytes of the credential, so anyone can scan a QR or NFC tag and verify a robot's owner, authorized actions, certification, and live standing fully offline. The URI encoding is deterministic, so a passport encoded by either language decodes and verifies in the other.

**Verification:** encode/decode round-trip, offline verification from both the credential object and the URI, the live standing surfaced (suspended), expired-passport rejection, and bad-URI rejection. 20/20 robotics tests pass, bundle builds, typecheck clean for these files.

Sixth and last of the robotics SDK ports (after identity #65, provenance #72, capability #74, handshake #75, black box #76). The full `vouch.robotics` surface now exists in the TypeScript SDK with byte-identical cross-language interop.
