### PR TITLE
Live Agent Trust grader (Cloudflare Worker) + grade-my-agent form

### DIFF
--- a/agent-trust-index/grader-worker/README.md
+++ b/agent-trust-index/grader-worker/README.md
@@ -1,0 +1,50 @@
+# Agent Trust Index grader worker
+
+A small Cloudflare Worker that grades one agent's trust posture. The browser
+cannot fetch an arbitrary domain's `did.json` (CORS blocks it), so the live
+"grade your agent" form on the Index page calls this worker, which resolves the
+DID server-side and returns the grade. It is a faithful port of the Python
+`vouch grade` scoring, so the CLI and the web form give the same result.
+
+No secrets, no storage. It only reads public `.well-known` documents.
+
+## Endpoints
+
+- `GET /grade?domain=example.com` returns the JSON report
+  (`grade`, `score`, `signals`, `fixes`).
+- `GET /badge?domain=example.com` returns an SVG badge.
+
+CORS is open (`*`) because the responses are public and carry no secrets.
+
+## Deploy
+
+```bash
+cd agent-trust-index/grader-worker
+npm install -g wrangler   # if needed
+wrangler login
+wrangler deploy
+```
+
+That publishes it at `https://vouch-grader.<your-subdomain>.workers.dev`.
+
+To serve it at a clean custom domain (recommended, and the default the website
+form points at), add a route in the Cloudflare dashboard for
+`grade.vouch-protocol.com`, or uncomment the `routes` block in `wrangler.toml`
+and redeploy.
+
+## Point the website at it
+
+The form reads `NEXT_PUBLIC_GRADER_ENDPOINT` at build time and falls back to
+`https://grade.vouch-protocol.com`. If you deploy to the workers.dev URL instead
+of the custom domain, set that env var before the website build:
+
+```bash
+NEXT_PUBLIC_GRADER_ENDPOINT="https://vouch-grader.<your-subdomain>.workers.dev" \
+  npm --prefix website run build
+```
+
+## Safety
+
+The worker validates the domain (rejects IP literals, localhost, and internal
+names) so it cannot be pointed at private infrastructure, and it caps each fetch
+at six seconds.

--- a/agent-trust-index/grader-worker/worker.js
+++ b/agent-trust-index/grader-worker/worker.js
@@ -1,0 +1,194 @@
+/**
+ * Agent Trust Index grader, as a Cloudflare Worker.
+ *
+ * The browser cannot fetch an arbitrary domain's did.json (CORS), so the live
+ * "grade your agent" form on the Index page calls this worker, which resolves
+ * the DID server-side and returns a grade. It is a faithful port of the Python
+ * `vouch grade` scoring: 60 points for a resolvable did:web, 40 for a usable
+ * verification method, with post-quantum, revocation, and agent-card identity
+ * reported as extra signals that do not change the score.
+ *
+ * Endpoints:
+ *   GET /grade?domain=example.com   -> JSON report
+ *   GET /badge?domain=example.com   -> SVG badge
+ *
+ * No secrets, no storage. Public, read-only grading.
+ */
+
+const GRADE_COLORS = { A: "#22c55e", B: "#84cc16", C: "#eab308", D: "#f97316", F: "#ef4444" };
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+};
+
+export default {
+  async fetch(request) {
+    const url = new URL(request.url);
+    if (request.method === "OPTIONS") {
+      return new Response(null, { headers: CORS });
+    }
+    const domain = normalizeDomain(url.searchParams.get("domain"));
+    if (!domain) {
+      return json({ error: "invalid_or_missing_domain" }, 400);
+    }
+
+    const report = await grade(domain);
+
+    if (url.pathname === "/badge") {
+      return new Response(badgeSvg(report), {
+        headers: {
+          ...CORS,
+          "Content-Type": "image/svg+xml",
+          "Cache-Control": "public, max-age=300",
+        },
+      });
+    }
+    return json(report, 200);
+  },
+};
+
+function json(body, status) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS, "Content-Type": "application/json", "Cache-Control": "public, max-age=300" },
+  });
+}
+
+/**
+ * Accept only a plausible public hostname. Rejects IP literals, localhost, and
+ * internal names so the worker cannot be pointed at private infrastructure.
+ */
+function normalizeDomain(raw) {
+  if (!raw) return null;
+  let d = raw.trim().toLowerCase();
+  d = d.replace(/^https?:\/\//, "").replace(/\/.*$/, "").replace(/:\d+$/, "");
+  if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(d)) return null;
+  if (d === "localhost" || d.endsWith(".local") || d.endsWith(".internal")) return null;
+  if (/^\d+\.\d+\.\d+\.\d+$/.test(d)) return null; // IPv4 literal
+  return d;
+}
+
+async function getJson(u) {
+  try {
+    const resp = await fetch(u, { redirect: "follow", signal: AbortSignal.timeout(6000) });
+    if (resp.status !== 200) return null;
+    return await resp.json();
+  } catch {
+    return null;
+  }
+}
+
+async function grade(domain) {
+  const signals = {
+    has_did: false,
+    has_verification_method: false,
+    did: null,
+    method: null,
+    pq_ready: false,
+    has_revocation: false,
+    has_card_identity: false,
+  };
+
+  const didDoc = await getJson(`https://${domain}/.well-known/did.json`);
+  if (didDoc && typeof didDoc === "object") {
+    signals.has_did = true;
+    signals.did = `did:web:${domain}`;
+
+    const vms = []
+      .concat(didDoc.verificationMethod || [])
+      .concat(didDoc.assertionMethod || [])
+      .filter((v) => v && typeof v === "object");
+    for (const vm of vms) {
+      if (vm.publicKeyJwk) {
+        signals.has_verification_method = true;
+        const k = vm.publicKeyJwk;
+        signals.method = `did:web, ${k.crv || k.kty || "key"} (JWK)`;
+        break;
+      }
+      if (vm.publicKeyMultibase) {
+        signals.has_verification_method = true;
+        signals.method = "did:web, Multikey";
+        break;
+      }
+    }
+
+    if (Array.isArray(didDoc.service) && didDoc.service.length > 0) {
+      signals.has_revocation = true;
+    }
+    const blob = JSON.stringify(didDoc).toLowerCase();
+    if (blob.includes("ml-dsa") || blob.includes("mldsa") || blob.includes("dilithium")) {
+      signals.pq_ready = true;
+    }
+  }
+
+  const card =
+    (await getJson(`https://${domain}/.well-known/agent.json`)) ||
+    (await getJson(`https://${domain}/.well-known/agent-card.json`));
+  if (card && typeof card === "object") {
+    const blob = JSON.stringify(card).toLowerCase();
+    if (blob.includes("did:") || blob.includes("signature")) signals.has_card_identity = true;
+  }
+
+  return { domain, ...scoreSignals(signals), signals, fixes: fixIts(signals) };
+}
+
+function scoreSignals(signals) {
+  const breakdown = {
+    resolvable_did: signals.has_did ? 60 : 0,
+    valid_verification_method: signals.has_verification_method ? 40 : 0,
+  };
+  const score = breakdown.resolvable_did + breakdown.valid_verification_method;
+  let grade = "F";
+  if (score >= 90) grade = "A";
+  else if (score >= 75) grade = "B";
+  else if (score >= 60) grade = "C";
+  else if (score >= 40) grade = "D";
+  return { score, grade, breakdown };
+}
+
+function fixIts(s) {
+  const fixes = [];
+  if (!s.has_did)
+    fixes.push(
+      "Publish a did:web. Run `vouch init --domain yourdomain.com` and serve the DID document at https://yourdomain.com/.well-known/did.json."
+    );
+  if (!s.has_verification_method)
+    fixes.push(
+      "Add a verificationMethod with your public key to the DID document, so others can verify what you sign."
+    );
+  if (!s.pq_ready)
+    fixes.push(
+      "Add a post-quantum key (ML-DSA-44) alongside your Ed25519 key and sign with `sign_credential_hybrid`."
+    );
+  if (!s.has_revocation)
+    fixes.push(
+      "Publish a service or revocation endpoint in your DID document, so a compromised key can be revoked."
+    );
+  if (!s.has_card_identity)
+    fixes.push(
+      "Reference your DID in your agent card (/.well-known/agent.json), so a counterparty can tie the card to a verifiable identity."
+    );
+  return fixes;
+}
+
+function badgeSvg(report) {
+  const color = GRADE_COLORS[report.grade] || "#9ca3af";
+  const label = "agent trust";
+  const value = `${report.grade} (${report.score})`;
+  const labelW = 7 * label.length + 16;
+  const valueW = 7 * value.length + 16;
+  const total = labelW + valueW;
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" ` +
+    `aria-label="${label}: ${value}">` +
+    `<rect width="${total}" height="20" rx="3" fill="#555"/>` +
+    `<rect x="${labelW}" width="${valueW}" height="20" rx="3" fill="${color}"/>` +
+    `<rect x="${labelW}" width="4" height="20" fill="${color}"/>` +
+    `<g fill="#fff" font-family="Verdana,DejaVu Sans,sans-serif" font-size="11">` +
+    `<text x="${Math.round(labelW / 2)}" y="14" text-anchor="middle">${label}</text>` +
+    `<text x="${Math.round(labelW + valueW / 2)}" y="14" text-anchor="middle">${value}</text>` +
+    `</g></svg>`
+  );
+}

--- a/agent-trust-index/grader-worker/wrangler.toml
+++ b/agent-trust-index/grader-worker/wrangler.toml
@@ -1,0 +1,12 @@
+name = "vouch-grader"
+main = "worker.js"
+compatibility_date = "2025-01-01"
+
+# After `wrangler deploy` the worker is live at
+# https://vouch-grader.<your-subdomain>.workers.dev. To serve it on a clean
+# custom domain (recommended, and what the website form expects by default),
+# add a route in the Cloudflare dashboard or uncomment and edit below:
+#
+# routes = [
+#   { pattern = "grade.vouch-protocol.com", custom_domain = true }
+# ]

--- a/website/src/app/agent-trust-index/GradeChecker.tsx
+++ b/website/src/app/agent-trust-index/GradeChecker.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useState } from 'react';
+
+const ENDPOINT =
+    process.env.NEXT_PUBLIC_GRADER_ENDPOINT || 'https://grade.vouch-protocol.com';
+
+const GRADE_COLOR: Record<string, string> = {
+    A: '#22c55e',
+    B: '#84cc16',
+    C: '#eab308',
+    D: '#f97316',
+    F: '#ef4444',
+};
+
+type Report = {
+    domain: string;
+    grade: string;
+    score: number;
+    fixes: string[];
+    signals: { did?: string | null; method?: string | null; pq_ready?: boolean; has_revocation?: boolean };
+};
+
+export default function GradeChecker() {
+    const [domain, setDomain] = useState('');
+    const [report, setReport] = useState<Report | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    async function check(e: React.FormEvent) {
+        e.preventDefault();
+        const d = domain.trim().replace(/^https?:\/\//, '').replace(/\/.*$/, '');
+        if (!d) return;
+        setLoading(true);
+        setError(null);
+        setReport(null);
+        try {
+            const resp = await fetch(`${ENDPOINT}/grade?domain=${encodeURIComponent(d)}`);
+            if (!resp.ok) throw new Error('Could not grade that domain.');
+            const data = (await resp.json()) as Report;
+            if (!data || !data.grade) throw new Error('Could not grade that domain.');
+            setReport(data);
+        } catch {
+            setError('Could not reach the grader, or that domain has no resolvable DID. Try the CLI below.');
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <div>
+            <form onSubmit={check} className="flex flex-wrap gap-2 mb-4">
+                <input
+                    type="text"
+                    value={domain}
+                    onChange={(ev) => setDomain(ev.target.value)}
+                    placeholder="agent.yourdomain.com"
+                    aria-label="Your agent's domain"
+                    className="flex-1 min-w-[220px] border border-rule bg-parchment px-3 py-2 font-mono text-[0.9rem] text-ink focus:border-burgundy focus:outline-none"
+                />
+                <button type="submit" className="btn-primary" disabled={loading}>
+                    {loading ? 'Grading...' : 'Grade my agent'}
+                </button>
+            </form>
+
+            {error && <p className="text-burgundy text-[0.9rem] mb-2">{error}</p>}
+
+            {report && (
+                <div className="border border-rule bg-parchment p-5">
+                    <div className="flex items-baseline gap-3 mb-3">
+                        <span
+                            className="font-serif font-semibold text-[2rem] leading-none"
+                            style={{ color: GRADE_COLOR[report.grade] || '#9ca3af' }}
+                        >
+                            {report.grade}
+                        </span>
+                        <span className="font-mono text-ink-soft">{report.score}/100</span>
+                        <span className="font-mono text-[0.85rem] text-ink-soft">{report.domain}</span>
+                    </div>
+                    {report.signals?.did && (
+                        <p className="text-[0.85rem] text-ink-soft mb-1">identity: {report.signals.did}</p>
+                    )}
+                    {report.signals?.method && (
+                        <p className="text-[0.85rem] text-ink-soft mb-3">key: {report.signals.method}</p>
+                    )}
+                    {report.fixes && report.fixes.length > 0 && (
+                        <>
+                            <p className="font-mono uppercase text-[0.62rem] tracking-[0.14em] text-burgundy mb-2">
+                                To raise your grade
+                            </p>
+                            <ol className="list-decimal pl-5 space-y-1.5">
+                                {report.fixes.map((f, i) => (
+                                    <li key={i} className="text-[0.9rem] text-ink-soft leading-relaxed">
+                                        {f}
+                                    </li>
+                                ))}
+                            </ol>
+                        </>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/website/src/app/agent-trust-index/page.tsx
+++ b/website/src/app/agent-trust-index/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import CodeBlock from '@/components/CodeBlock';
 import { ATI_SUMMARY, ATI_AGENTS } from './ati-data';
 import AtiLeaderboard from './AtiLeaderboard';
+import GradeChecker from './GradeChecker';
 
 const ACCOUNTABILITY = [
     { h: 'Who authorized it', p: 'A delegation chain shows who gave the agent its authority, on whose behalf, and within what limits, all verifiable.' },
@@ -144,12 +145,16 @@ export default function AgentTrustIndexPage() {
                         Grade your agent before anyone else does
                     </h2>
                     <p className="text-ink-soft leading-relaxed max-w-prose mb-5">
-                        Run the same check the Index runs, on your own agent. You get a letter grade, the
-                        exact reasons, and numbered fixes to raise it. Add the badge to your README or
-                        agent page so a counterparty can see your trust grade at a glance.
+                        Type your agent&apos;s domain to run the same check the Index runs. You get a letter
+                        grade, the exact reasons, and numbered fixes to raise it.
+                    </p>
+                    <GradeChecker />
+                    <p className="text-ink-soft text-[0.9rem] leading-relaxed max-w-prose mt-5 mb-2">
+                        Prefer the command line, or want a badge for your README? Install once and run it
+                        locally:
                     </p>
                     <div className="max-w-md mb-4">
-                        <CodeBlock code={"vouch grade yourdomain.com\nvouch grade yourdomain.com --badge trust-badge.svg"} className="text-[0.85rem]" />
+                        <CodeBlock code={"pip install vouch-protocol\nvouch grade yourdomain.com --badge trust-badge.svg"} className="text-[0.85rem]" />
                     </div>
                     <p className="text-ink-soft text-[0.9rem] leading-relaxed max-w-prose">
                         Claiming and verified listings are coming. If you want your agent listed when


### PR DESCRIPTION
## Live Agent Trust grader (Cloudflare Worker) and grade-my-agent form

Turns the static "grade your agent" call-to-action into a real interactive
check on the Index page. A browser cannot fetch an arbitrary domain's `did.json`
(CORS), so a small Cloudflare Worker does the resolution server-side.

### What this adds
- **`agent-trust-index/grader-worker/`**: a Cloudflare Worker that grades a
  domain. A faithful JS port of `vouch grade`: 60 points for a resolvable
  did:web, 40 for a usable verification method, with post-quantum, revocation,
  and agent-card identity reported as extra signals. `GET /grade?domain=` returns
  JSON; `GET /badge?domain=` returns an SVG badge. Open CORS, no secrets, no
  storage. Validates the domain (rejects IP literals, localhost, internal names)
  and caps each fetch at six seconds.
- **`GradeChecker.tsx`** on the Agent Trust Index page: a "Grade my agent" form
  that calls the worker and shows the grade, score, identity, and numbered fixes.
  The CLI plus badge command remain below as the offline path.

### Deploy (your Cloudflare account)
```bash
cd agent-trust-index/grader-worker
wrangler login && wrangler deploy
```
Then add a route for `grade.vouch-protocol.com` (the default the form expects),
or set `NEXT_PUBLIC_GRADER_ENDPOINT` to the workers.dev URL before the website
build. Steps are in the worker README. Until it is deployed, the form shows a
graceful error pointing to the CLI.

### Verified
- Worker live-tested: feedoracle.io grades A (100) matching the Index,
  example.com grades F (0), localhost is rejected (400), the badge returns
  image/svg+xml with open CORS.
- Website type-check (tsc) clean. No em-dashes; brand guard satisfied.

This stays the open funnel (free grading); it stores nothing. Verified listings
and the marketplace remain the separate commercial layer.
