### PR TITLE
chore: enable grade.vouch-protocol.com custom domain for the grader worker

### DIFF
--- a/agent-trust-index/grader-worker/wrangler.toml
+++ b/agent-trust-index/grader-worker/wrangler.toml
@@ -2,11 +2,8 @@ name = "vouch-grader"
 main = "worker.js"
 compatibility_date = "2025-01-01"
 
-# After `wrangler deploy` the worker is live at
-# https://vouch-grader.<your-subdomain>.workers.dev. To serve it on a clean
-# custom domain (recommended, and what the website form expects by default),
-# add a route in the Cloudflare dashboard or uncomment and edit below:
-#
-# routes = [
-#   { pattern = "grade.vouch-protocol.com", custom_domain = true }
-# ]
+# Served on the custom domain the website form points at by default
+# (grade.vouch-protocol.com). The workers.dev URL stays available too.
+routes = [
+  { pattern = "grade.vouch-protocol.com", custom_domain = true }
+]


### PR DESCRIPTION
Uncomments the custom-domain route in the grader worker config to match what is now deployed. The worker is live at grade.vouch-protocol.com (and vouch-grader.vouch-protocol.workers.dev), so the website grade-my-agent form works against its default endpoint. Keeping the route in the committed config means a future redeploy preserves the custom domain. Config-only, no code.