### PR TITLE
fix(website): repoint the broken Specification link

### DIFF
--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -93,7 +93,7 @@ It is not affiliated with or endorsed by any employer.`,
       },
       {
         q: 'Where can I read the formal specification?',
-        a: `Most people never need to. The FAQ and [Guides](/help/) cover everything you'll use day to day. But if you want the formal version, an executive summary is available [here](https://github.com/vouch-protocol/vouch/blob/main/docs/specs/specification-executive-summary.md).`,
+        a: `Most people never need to. The FAQ and [Guides](/help/) cover everything you'll use day to day. But if you want the formal version, an executive summary is available [here](https://github.com/vouch-protocol/vouch/blob/main/docs/specs/cg-report-executive-summary.md).`,
       },
     ],
   },

--- a/website/src/app/support/page.tsx
+++ b/website/src/app/support/page.tsx
@@ -62,7 +62,7 @@ const CHANNELS: Channel[] = [
 ];
 
 const QUICK_LINKS = [
-  { label: 'Specification', href: 'https://github.com/vouch-protocol/vouch/blob/main/docs/specs/specification-executive-summary.md', external: true, body: 'Executive summary of the specification.' },
+  { label: 'Specification', href: 'https://github.com/vouch-protocol/vouch/blob/main/docs/specs/cg-report-executive-summary.md', external: true, body: 'Executive summary of the specification.' },
   { label: 'CHANGELOG', href: 'https://github.com/vouch-protocol/vouch/blob/main/CHANGELOG.md', external: true, body: 'Every version, every shipped feature.' },
   { label: 'Test vectors', href: 'https://github.com/vouch-protocol/vouch/tree/main/test-vectors', external: true, body: 'Cross-language vectors to check your implementation against.' },
   { label: 'GitHub repository', href: 'https://github.com/vouch-protocol/vouch', external: true, body: 'Source, SDKs, and reference implementations.' },

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -16,7 +16,7 @@ const FOOTER_GROUPS = [
     title: 'Resources',
     links: [
       { label: 'GitHub', href: 'https://github.com/vouch-protocol/vouch', external: true },
-      { label: 'Specification', href: 'https://github.com/vouch-protocol/vouch/blob/main/docs/specs/specification-executive-summary.md', external: true },
+      { label: 'Specification', href: 'https://github.com/vouch-protocol/vouch/blob/main/docs/specs/cg-report-executive-summary.md', external: true },
       { label: 'Prior Art Disclosures', href: '/disclosures/' },
       { label: 'Conformance Levels', href: '/conformance/' },
       { label: 'Regulatory Mapping', href: '/compliance/' },


### PR DESCRIPTION
The Specification link returned a 404. It pointed to docs/specs/specification-executive-summary.md, which does not exist. Repointed to the real file, docs/specs/cg-report-executive-summary.md ("Vouch Protocol: Executive Summary"), in the three places it appears: the Support page, the footer, and one FAQ answer.
