### PR TITLE
Add hardware-rooted robot identity to the Go sidecar (byte-identical interop)

### DIFF
--- a/go-sidecar/robotics/identity.go
+++ b/go-sidecar/robotics/identity.go
@@ -1,0 +1,227 @@
+// Package robotics ports the Vouch robotics primitives to Go, byte-identical
+// with the Python vouch.robotics package and the TypeScript SDK. This file
+// covers hardware-rooted robot identity (Phase 5.1): a RobotIdentityCredential
+// is an eddsa-jcs-2022 VC whose subject carries make, model, serial, a lifecycle
+// history, and a hardwareRoot block. The hardware root signs a binding over
+// (robot DID, robot key), so the software identity key is provably bound to a
+// specific piece of hardware. Verification checks both the credential proof and
+// the hardware attestation.
+package robotics
+
+import (
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"time"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+const (
+	vcContextV2       = "https://www.w3.org/ns/credentials/v2"
+	vouchContextV1    = "https://vouch-protocol.com/contexts/v1"
+	RobotIdentityType = "RobotIdentityCredential"
+)
+
+// HardwareRootOfTrust is a hardware-resident key that attests the robot's
+// software identity key. A TPM or secure-element backend satisfies it.
+type HardwareRootOfTrust interface {
+	Kind() string
+	PublicKeyRaw() []byte
+	Sign(data []byte) []byte
+	PublicKeyMultibase() (string, error)
+}
+
+// SoftwareRootOfTrust is the reference root backed by a local Ed25519 key. It
+// stands in for a TPM or secure element in development and tests. NOT a hardware
+// root: a real deployment MUST use a hardware-backed implementation.
+type SoftwareRootOfTrust struct {
+	priv ed25519.PrivateKey
+	kind string
+}
+
+// NewSoftwareRoot builds a SoftwareRootOfTrust. A nil seed generates a fresh
+// key; a non-nil seed must be 32 bytes. An empty kind defaults to "Software".
+func NewSoftwareRoot(seed []byte, kind string) (*SoftwareRootOfTrust, error) {
+	if kind == "" {
+		kind = "Software"
+	}
+	var priv ed25519.PrivateKey
+	if seed != nil {
+		if len(seed) != ed25519.SeedSize {
+			return nil, errors.New("robotics: Ed25519 seed must be 32 bytes")
+		}
+		priv = ed25519.NewKeyFromSeed(seed)
+	} else {
+		_, p, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			return nil, err
+		}
+		priv = p
+	}
+	return &SoftwareRootOfTrust{priv: priv, kind: kind}, nil
+}
+
+func (r *SoftwareRootOfTrust) Kind() string            { return r.kind }
+func (r *SoftwareRootOfTrust) PublicKeyRaw() []byte    { return r.priv.Public().(ed25519.PublicKey) }
+func (r *SoftwareRootOfTrust) Sign(data []byte) []byte { return ed25519.Sign(r.priv, data) }
+func (r *SoftwareRootOfTrust) PublicKeyMultibase() (string, error) {
+	return signer.EncodeEd25519Public(r.PublicKeyRaw())
+}
+
+func mb64(b []byte) string {
+	return "u" + base64.RawURLEncoding.EncodeToString(b)
+}
+
+func unmb64(s string) ([]byte, error) {
+	if len(s) == 0 || s[0] != 'u' {
+		return nil, errors.New("robotics: expected multibase 'u' prefix")
+	}
+	return base64.RawURLEncoding.DecodeString(s[1:])
+}
+
+// bindingBytes returns the canonical bytes the hardware root signs to bind the
+// identity key.
+func bindingBytes(robotDID, robotKeyMultibase string) ([]byte, error) {
+	return signer.Canonicalize(map[string]any{"key": robotKeyMultibase, "robotDid": robotDID})
+}
+
+func iso(t time.Time) string {
+	return t.UTC().Format("2006-01-02T15:04:05Z")
+}
+
+// MintOptions configures MintRobotIdentity.
+type MintOptions struct {
+	Make         string
+	Model        string
+	Serial       string
+	Owner        string           // optional; "" omits the field
+	Lifecycle    []map[string]any // optional; nil uses a default "commissioned" entry
+	ValidSeconds int              // 0 omits validUntil
+	ValidFrom    time.Time        // zero uses now
+}
+
+// MintRobotIdentity mints a hardware-attested RobotIdentityCredential. The robot
+// self-issues with its Vouch key (robotSigner); the hardware root signs a
+// binding over the robot DID and key, embedded as hardwareRoot.attestation.
+func MintRobotIdentity(robotSigner *signer.Signer, root HardwareRootOfTrust, opts MintOptions) (map[string]any, error) {
+	robotDID := robotSigner.DID()
+	robotKeyMB, err := robotSigner.PublicKeyMultikey()
+	if err != nil {
+		return nil, err
+	}
+	binding, err := bindingBytes(robotDID, robotKeyMB)
+	if err != nil {
+		return nil, err
+	}
+	attestation := root.Sign(binding)
+	rootMB, err := root.PublicKeyMultibase()
+	if err != nil {
+		return nil, err
+	}
+
+	issued := opts.ValidFrom
+	if issued.IsZero() {
+		issued = time.Now().UTC()
+	}
+
+	lifecycle := opts.Lifecycle
+	if lifecycle == nil {
+		lifecycle = []map[string]any{{"event": "commissioned", "timestamp": iso(issued)}}
+	}
+	lifecycleAny := make([]any, len(lifecycle))
+	for i, e := range lifecycle {
+		lifecycleAny[i] = e
+	}
+
+	subject := map[string]any{
+		"id":     robotDID,
+		"make":   opts.Make,
+		"model":  opts.Model,
+		"serial": opts.Serial,
+		"hardwareRoot": map[string]any{
+			"kind":               root.Kind(),
+			"publicKeyMultibase": rootMB,
+			"attestation":        mb64(attestation),
+		},
+		"lifecycle": lifecycleAny,
+	}
+	if opts.Owner != "" {
+		subject["owner"] = opts.Owner
+	}
+
+	cred := map[string]any{
+		"@context":          []any{vcContextV2, vouchContextV1},
+		"type":              []any{"VerifiableCredential", RobotIdentityType},
+		"issuer":            robotDID,
+		"validFrom":         iso(issued),
+		"credentialSubject": subject,
+	}
+	if opts.ValidSeconds > 0 {
+		cred["validUntil"] = iso(issued.Add(time.Duration(opts.ValidSeconds) * time.Second))
+	}
+	return robotSigner.AttachProof(cred)
+}
+
+// VerifyRobotIdentity verifies a RobotIdentityCredential: the credential proof
+// (robot key) AND the hardware-root attestation binding the robot key to the
+// hardware. Returns (ok, credentialSubject).
+func VerifyRobotIdentity(cred map[string]any, robotPub ed25519.PublicKey) (bool, map[string]any) {
+	if !hasType(cred["type"], RobotIdentityType) {
+		return false, nil
+	}
+	ok, err := signer.VerifyDataIntegrityProof(cred, robotPub)
+	if err != nil || !ok {
+		return false, nil
+	}
+
+	subject, _ := cred["credentialSubject"].(map[string]any)
+	hw, _ := subject["hardwareRoot"].(map[string]any)
+	hwMB, _ := hw["publicKeyMultibase"].(string)
+	att, _ := hw["attestation"].(string)
+	if hwMB == "" || att == "" {
+		return false, nil
+	}
+
+	alg, hwRaw, err := signer.MultikeyDecode(hwMB)
+	if err != nil || alg != "Ed25519" || len(hwRaw) != ed25519.PublicKeySize {
+		return false, nil
+	}
+	attBytes, err := unmb64(att)
+	if err != nil {
+		return false, nil
+	}
+	robotKeyMB, err := signer.EncodeEd25519Public(robotPub)
+	if err != nil {
+		return false, nil
+	}
+	id, _ := subject["id"].(string)
+	binding, err := bindingBytes(id, robotKeyMB)
+	if err != nil {
+		return false, nil
+	}
+	if !ed25519.Verify(ed25519.PublicKey(hwRaw), binding, attBytes) {
+		return false, nil
+	}
+	return true, subject
+}
+
+func hasType(field any, want string) bool {
+	switch v := field.(type) {
+	case string:
+		return v == want
+	case []any:
+		for _, t := range v {
+			if s, ok := t.(string); ok && s == want {
+				return true
+			}
+		}
+	case []string:
+		for _, s := range v {
+			if s == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/go-sidecar/robotics/identity_test.go
+++ b/go-sidecar/robotics/identity_test.go
@@ -1,0 +1,116 @@
+package robotics
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+func loadVector(t *testing.T) map[string]any {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "test-vectors", "robotics", "vector.json"))
+	if err != nil {
+		t.Fatalf("read vector: %v", err)
+	}
+	var v map[string]any
+	if err := json.Unmarshal(data, &v); err != nil {
+		t.Fatalf("parse vector: %v", err)
+	}
+	return v
+}
+
+func ed25519FromJWK(t *testing.T, jwk map[string]any) ed25519.PublicKey {
+	t.Helper()
+	x, _ := jwk["x"].(string)
+	raw, err := base64.RawURLEncoding.DecodeString(x)
+	if err != nil {
+		t.Fatalf("decode jwk x: %v", err)
+	}
+	return ed25519.PublicKey(raw)
+}
+
+func newRobot(t *testing.T, did string) *signer.Signer {
+	t.Helper()
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatal(err)
+	}
+	s, err := signer.New(signer.Config{DID: did, Ed25519Seed: seed})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s
+}
+
+func filled(b byte) []byte {
+	s := make([]byte, 32)
+	for i := range s {
+		s[i] = b
+	}
+	return s
+}
+
+// TestVerifyInteropVector is the cross-language interop proof: Go verifies the
+// RobotIdentityCredential minted by the Python module and pinned in the shared
+// interop vector.
+func TestVerifyInteropVector(t *testing.T) {
+	v := loadVector(t)
+	pub := ed25519FromJWK(t, v["robot_public_key_jwk"].(map[string]any))
+	cred := v["robot_identity_credential"].(map[string]any)
+	ok, subject := VerifyRobotIdentity(cred, pub)
+	if !ok {
+		t.Fatal("expected the Python-minted interop vector to verify in Go")
+	}
+	if subject["make"] != "Acme Robotics" {
+		t.Fatalf("unexpected make: %v", subject["make"])
+	}
+}
+
+func TestMintVerifyRoundTrip(t *testing.T) {
+	s := newRobot(t, "did:web:robot.example.com")
+	root, err := NewSoftwareRoot(filled(7), "TPM")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cred, err := MintRobotIdentity(s, root, MintOptions{
+		Make: "Acme", Model: "AR-7", Serial: "SN-1", Owner: "did:web:owner.example.com",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, _ := VerifyRobotIdentity(cred, s.PublicKeyEd25519())
+	if !ok {
+		t.Fatal("round-trip verify failed")
+	}
+}
+
+func TestForgedHardwareRootFails(t *testing.T) {
+	s := newRobot(t, "did:web:robot.example.com")
+	root, _ := NewSoftwareRoot(filled(7), "TPM")
+	cred, err := MintRobotIdentity(s, root, MintOptions{Make: "A", Model: "B", Serial: "C"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Point the hardware-root key at an attacker's; the attestation, signed by
+	// the real root over the binding, no longer verifies.
+	attacker, _ := NewSoftwareRoot(filled(9), "TPM")
+	amb, _ := attacker.PublicKeyMultibase()
+	hw := cred["credentialSubject"].(map[string]any)["hardwareRoot"].(map[string]any)
+	hw["publicKeyMultibase"] = amb
+	// Re-sign the credential proof so only the hardware attestation is wrong.
+	delete(cred, "proof")
+	resigned, err := s.AttachProof(cred)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := VerifyRobotIdentity(resigned, s.PublicKeyEd25519()); ok {
+		t.Fatal("expected a forged hardware root to fail verification")
+	}
+}

--- a/go-sidecar/signer/credential.go
+++ b/go-sidecar/signer/credential.go
@@ -74,13 +74,13 @@ func (s *Signer) SignCredential(opts SignCredentialOptions) (map[string]any, err
 	}
 
 	cred, err := BuildVouchCredential(BuildVouchCredentialOptions{
-		IssuerDID:    s.did,
-		Intent:      opts.Intent,
-		ValidSeconds:   validSeconds,
-		ReputationScore: opts.ReputationScore,
-		DelegationChain: chain,
-		CredentialID:   opts.CredentialID,
-		ValidFrom:    opts.ValidFrom,
+		IssuerDID:        s.did,
+		Intent:           opts.Intent,
+		ValidSeconds:     validSeconds,
+		ReputationScore:  opts.ReputationScore,
+		DelegationChain:  chain,
+		CredentialID:     opts.CredentialID,
+		ValidFrom:        opts.ValidFrom,
 		CredentialStatus: opts.CredentialStatus,
 	})
 	if err != nil {
@@ -88,7 +88,7 @@ func (s *Signer) SignCredential(opts SignCredentialOptions) (map[string]any, err
 	}
 
 	proof, err := BuildDataIntegrityProof(cred, BuildProofOptions{
-		PrivateKey:     s.ed25519Private,
+		PrivateKey:         s.ed25519Private,
 		VerificationMethod: s.VerificationMethodID(),
 	})
 	if err != nil {
@@ -148,6 +148,23 @@ func (s *Signer) DID() string {
 	return s.did
 }
 
+// AttachProof attaches an eddsa-jcs-2022 Data Integrity proof to a pre-built
+// credential map, for custom credential types (for example robotics
+// credentials) the caller assembles directly rather than from an intent.
+// Mirrors the signing step of SignCredential; returns the credential with its
+// "proof" set.
+func (s *Signer) AttachProof(credential map[string]any) (map[string]any, error) {
+	proof, err := BuildDataIntegrityProof(credential, BuildProofOptions{
+		PrivateKey:         s.ed25519Private,
+		VerificationMethod: s.VerificationMethodID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("attach proof: %w", err)
+	}
+	credential["proof"] = proofToMap(proof)
+	return credential, nil
+}
+
 // SignCredentialHybrid issues a Vouch Credential under the hybrid
 // post-quantum profile (Specification §13.2). The credential carries a
 // hybrid-eddsa-mldsa44-jcs-2026 Data Integrity proof containing both an
@@ -173,13 +190,13 @@ func (s *Signer) SignCredentialHybrid(opts SignCredentialOptions) (map[string]an
 	}
 
 	cred, err := BuildVouchCredential(BuildVouchCredentialOptions{
-		IssuerDID:    s.did,
-		Intent:      opts.Intent,
-		ValidSeconds:   validSeconds,
-		ReputationScore: opts.ReputationScore,
-		DelegationChain: chain,
-		CredentialID:   opts.CredentialID,
-		ValidFrom:    opts.ValidFrom,
+		IssuerDID:        s.did,
+		Intent:           opts.Intent,
+		ValidSeconds:     validSeconds,
+		ReputationScore:  opts.ReputationScore,
+		DelegationChain:  chain,
+		CredentialID:     opts.CredentialID,
+		ValidFrom:        opts.ValidFrom,
 		CredentialStatus: opts.CredentialStatus,
 	})
 	if err != nil {
@@ -187,8 +204,8 @@ func (s *Signer) SignCredentialHybrid(opts SignCredentialOptions) (map[string]an
 	}
 
 	proof, err := BuildHybridDataIntegrityProof(cred, BuildHybridProofOptions{
-		Ed25519PrivateKey: s.ed25519Private,
-		MLDSA44PrivateKey: s.mldsa44Private,
+		Ed25519PrivateKey:  s.ed25519Private,
+		MLDSA44PrivateKey:  s.mldsa44Private,
 		VerificationMethod: s.VerificationMethodID(),
 	})
 	if err != nil {
@@ -252,11 +269,11 @@ func (s *Signer) extendDelegationChain(
 	parentValidUntil, _ := parentCredential["validUntil"].(string)
 
 	newLink := map[string]any{
-		"issuer":      parentIssuer,
-		"subject":     s.did,
-		"intent":      currentIntent,
-		"validFrom":    parentValidFrom,
-		"validUntil":    parentValidUntil,
+		"issuer":           parentIssuer,
+		"subject":          s.did,
+		"intent":           currentIntent,
+		"validFrom":        parentValidFrom,
+		"validUntil":       parentValidUntil,
 		"parentProofValue": parentProofValue,
 	}
 


### PR DESCRIPTION
Starts the robotics port in the Go sidecar with hardware-rooted robot identity, byte-identical with the Python `vouch.robotics` package and the TypeScript SDK.

- New `robotics` package (`go-sidecar/robotics/identity.go`): `HardwareRootOfTrust`, `SoftwareRootOfTrust`, `MintRobotIdentity`, `VerifyRobotIdentity`, mirroring `identity.py`.
- A small `Signer.AttachProof` (in `signer/credential.go`) for signing custom credential types, the Go analog of the Python/TS house pattern (it reuses `BuildDataIntegrityProof`). No change to existing signing paths.

**Verification:** the test verifies the *Python-minted* RobotIdentityCredential pinned in the shared interop vector (`test-vectors/robotics/vector.json`) from Go, proving the Go JCS + Ed25519 path reproduces and checks the same canonical bytes. Round-trip mint/verify and forged-hardware-root rejection are also covered. `go test ./robotics/` and `./signer/` pass, `gofmt` and `go vet` clean.

First of the Go robotics ports (the TypeScript SDK already has all six: identity #65, provenance #72, capability #74, handshake #75, black box #76, passport #77). Provenance, capability, handshake, black box, and passport follow for Go.
