### PR TITLE
Add model-and-config provenance to the Go sidecar (byte-identical interop)

### DIFF
--- a/go-sidecar/robotics/provenance.go
+++ b/go-sidecar/robotics/provenance.go
@@ -1,0 +1,114 @@
+// Model-and-config provenance attestation for robots (Phase 5.2), Go.
+//
+// Mirrors vouch/robotics/provenance.py and the TypeScript SDK with byte-identical
+// output. A ModelProvenanceAttestation is an eddsa-jcs-2022 VC recording the VLA
+// model name, weights hash, safety policy, and a configHash computed over the
+// JCS-canonical config so any verifier reproduces it. It is re-signable on an OTA
+// update via supersedes, forming a tamper-evident chain.
+package robotics
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"time"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+// ModelProvenanceType is the credential type for a provenance attestation.
+const ModelProvenanceType = "ModelProvenanceAttestation"
+
+// ConfigHash returns the multibase SHA-256 of the JCS-canonical config object.
+// Python, TypeScript, and Go all canonicalize identically, so the digest is the
+// same byte string in every language.
+func ConfigHash(config map[string]any) (string, error) {
+	canon, err := signer.Canonicalize(config)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(canon)
+	return mb64(sum[:]), nil
+}
+
+// BuildProvenanceOptions configures BuildProvenanceAttestation. RobotDID names
+// the robot the attestation is about; the issuer is the signer (the robot itself
+// or an authority attesting on its behalf).
+type BuildProvenanceOptions struct {
+	RobotDID     string
+	ModelName    string
+	WeightsHash  string
+	SafetyPolicy string
+	Config       map[string]any // optional; nil omits configHash
+	Version      string         // optional; "" omits the field
+	Supersedes   string         // optional; "" omits the field (prior attestation id)
+	ValidSeconds int            // 0 omits validUntil
+	ValidFrom    time.Time      // zero uses now
+}
+
+// BuildProvenanceAttestation builds a signed ModelProvenanceAttestation for the
+// software running on a robot.
+func BuildProvenanceAttestation(s *signer.Signer, opts BuildProvenanceOptions) (map[string]any, error) {
+	issued := opts.ValidFrom
+	if issued.IsZero() {
+		issued = time.Now().UTC()
+	}
+
+	vla := map[string]any{
+		"modelName":    opts.ModelName,
+		"weightsHash":  opts.WeightsHash,
+		"safetyPolicy": opts.SafetyPolicy,
+	}
+	if opts.Version != "" {
+		vla["version"] = opts.Version
+	}
+	if opts.Config != nil {
+		ch, err := ConfigHash(opts.Config)
+		if err != nil {
+			return nil, err
+		}
+		vla["configHash"] = ch
+	}
+
+	subject := map[string]any{"id": opts.RobotDID, "vla": vla}
+	if opts.Supersedes != "" {
+		subject["supersedes"] = opts.Supersedes
+	}
+
+	cred := map[string]any{
+		"@context":          []any{vcContextV2, vouchContextV1},
+		"type":              []any{"VerifiableCredential", ModelProvenanceType},
+		"issuer":            s.DID(),
+		"validFrom":         iso(issued),
+		"credentialSubject": subject,
+	}
+	if opts.ValidSeconds > 0 {
+		cred["validUntil"] = iso(issued.Add(time.Duration(opts.ValidSeconds) * time.Second))
+	}
+	return s.AttachProof(cred)
+}
+
+// VerifyProvenanceAttestation verifies a ModelProvenanceAttestation proof. When
+// config is non-nil, it also checks that the recorded configHash reproduces from
+// that config. Returns (ok, credentialSubject).
+func VerifyProvenanceAttestation(att map[string]any, pub ed25519.PublicKey, config map[string]any) (bool, map[string]any) {
+	if !hasType(att["type"], ModelProvenanceType) {
+		return false, nil
+	}
+	ok, err := signer.VerifyDataIntegrityProof(att, pub)
+	if err != nil || !ok {
+		return false, nil
+	}
+
+	subject, _ := att["credentialSubject"].(map[string]any)
+	if config != nil {
+		vla, _ := subject["vla"].(map[string]any)
+		want, err := ConfigHash(config)
+		if err != nil {
+			return false, nil
+		}
+		if got, _ := vla["configHash"].(string); got != want {
+			return false, nil
+		}
+	}
+	return true, subject
+}

--- a/go-sidecar/robotics/provenance_test.go
+++ b/go-sidecar/robotics/provenance_test.go
@@ -1,0 +1,84 @@
+package robotics
+
+import "testing"
+
+// vectorConfigHash is the configHash the Python module pinned in the shared
+// interop vector for the config {temperature, max_torque, guardrails}.
+const vectorConfigHash = "uMh9_H2Lk51-m9SpBhiEa1oqIwwwA7yT27e2QFS0YKUs"
+
+// TestConfigHashInteropVector is the cross-language interop proof for Phase 5.2:
+// Go must reproduce the exact configHash that Python pinned in the shared vector
+// from the same config object. This exercises JCS canonicalization of floats
+// (0.0, 12.5) and arrays across languages.
+func TestConfigHashInteropVector(t *testing.T) {
+	v := loadVector(t)
+	config := v["config"].(map[string]any)
+	got, err := ConfigHash(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want, _ := v["expected_config_hash"].(string); got != want {
+		t.Fatalf("config hash mismatch: got %s want %s", got, want)
+	}
+	if got != vectorConfigHash {
+		t.Fatalf("config hash %s does not match the pinned constant", got)
+	}
+}
+
+func TestProvenanceRoundTrip(t *testing.T) {
+	s := newRobot(t, "did:web:robot.example.com")
+	config := loadVector(t)["config"].(map[string]any)
+	att, err := BuildProvenanceAttestation(s, BuildProvenanceOptions{
+		RobotDID:     "did:web:robot.example.com",
+		ModelName:    "openvla-7b",
+		WeightsHash:  "uABCDEF",
+		SafetyPolicy: "did:web:authority.example.com#policy-v3",
+		Config:       config,
+		Version:      "2026.06",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, subject := VerifyProvenanceAttestation(att, s.PublicKeyEd25519(), config)
+	if !ok {
+		t.Fatal("round-trip verify failed")
+	}
+	vla := subject["vla"].(map[string]any)
+	if vla["configHash"] != vectorConfigHash {
+		t.Fatalf("embedded configHash mismatch: %v", vla["configHash"])
+	}
+}
+
+// TestProvenanceConfigTamperFails: a verifier presented a different config than
+// the one that was signed must reject, even though the proof itself is valid.
+func TestProvenanceConfigTamperFails(t *testing.T) {
+	s := newRobot(t, "did:web:robot.example.com")
+	config := loadVector(t)["config"].(map[string]any)
+	att, err := BuildProvenanceAttestation(s, BuildProvenanceOptions{
+		RobotDID: "did:web:robot.example.com", ModelName: "openvla-7b",
+		WeightsHash: "uABCDEF", SafetyPolicy: "policy", Config: config,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tampered := map[string]any{"temperature": 1.0, "max_torque": 99.0}
+	if ok, _ := VerifyProvenanceAttestation(att, s.PublicKeyEd25519(), tampered); ok {
+		t.Fatal("expected verification to fail when config does not match configHash")
+	}
+}
+
+// TestProvenanceWrongTypeFails: a credential that is not a ModelProvenanceAttestation
+// must be rejected by the type guard.
+func TestProvenanceWrongTypeFails(t *testing.T) {
+	s := newRobot(t, "did:web:robot.example.com")
+	att, err := BuildProvenanceAttestation(s, BuildProvenanceOptions{
+		RobotDID: "did:web:robot.example.com", ModelName: "m", WeightsHash: "w", SafetyPolicy: "p",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	att["type"] = []any{"VerifiableCredential"}
+	if ok, _ := VerifyProvenanceAttestation(att, s.PublicKeyEd25519(), nil); ok {
+		t.Fatal("expected a non-provenance type to fail")
+	}
+}


### PR DESCRIPTION
Ports the robotics model/config provenance primitive (Phase 5.2) to the Go sidecar, continuing the cross-language port after the Go identity work in #82.

What this adds in :

-  — multibase SHA-256 of the JCS-canonical config object, byte-identical with Python and TypeScript.
-  — signs a  VC recording the VLA model name, weights hash, safety policy, and an embedded , with optional  and  (the OTA-update chain).
-  — verifies the proof and, when a config is supplied, checks it reproduces the recorded .

Tests ():

-  — the cross-language proof: Go reproduces the exact  Python pinned in  (), exercising JCS canonicalization of floats and arrays.
- Round-trip, config-tamper-rejection, and wrong-type-rejection.

, , and  are clean; all robotics tests pass.