### PR TITLE
feat(accountability): commit-before-outcome verdict credentials

### DIFF
--- a/docs/disclosures/PAD-071-outcome-evidence-commit-before-outcome-credential.md
+++ b/docs/disclosures/PAD-071-outcome-evidence-commit-before-outcome-credential.md
@@ -1,0 +1,190 @@
+# PAD-071: Commit-Before-Outcome Verdict Credential with Neutral-Settler Outcome Attestation
+
+**Identifier:** PAD-071  
+**Title:** Method for an Outcome-Evidence Credential in Which a Verdict, Prediction, or Recommendation Is Cryptographically Committed and Signed Before Its Outcome Is Known, and a Separately-Signed Settlement Attestation Binds the Observed Outcome Back to That Prior Commitment, So an Agent's Track Record Cannot Be Backdated, Cherry-Picked, or Unilaterally Edited  
+**Publication Date:** June 17, 2026  
+**Prior Art Effective Date:** June 17, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Agent Accountability / Reputation / Verifiable Credentials / Commit-Reveal  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-016 (Heartbeat), PAD-030 (ZK Reputation Portability), PAD-036 (Aggregated Reputation Scoring via Verifiable State Receipts), PAD-031 (Canary Identities)  
+
+---
+
+## 1. Abstract
+
+A method for recording an autonomous agent's track record as tamper-evident
+cryptographic evidence rather than as a mutable score. An issuer commits a
+verdict, prediction, or recommendation as a signed Verifiable Credential whose
+subject carries a salted SHA-256 digest of the canonical claim, fixed **before**
+the outcome is known. After the outcome is observable, a separately-signed
+settlement attestation reveals the claim and salt, lets any verifier recompute
+the committed digest, and binds the observed outcome to that prior commitment. A
+verifier rejects any settlement whose timestamp precedes the commitment, so a
+winning verdict cannot be minted with hindsight.
+
+Key innovations:
+
+- **Commit-before-outcome binding.** The verdict is fixed by a signed digest at
+  commit time. The signed `created` time and the digest together make backdating
+  detectable: a claim revealed at settlement must recompute to a digest that was
+  already signed earlier, so no party can substitute a different verdict after
+  seeing the result.
+- **Private commitment with later reveal.** A salt over the JCS-canonical claim
+  lets the issuer publish only the digest, so the verdict cannot be read or
+  front-run before settlement, yet is provably unalterable. The salt and claim
+  are disclosed at settlement and checked against the published digest.
+- **Neutral settler distinct from the committer.** The settlement attestation is
+  signed by whoever observes the outcome, who may differ from the committer. It
+  binds to the committed digest, not to trust in the committer, so the party
+  whose record is at stake is not the party who certifies the result.
+- **Anti-cherry-pick by construction.** Because each verdict is an independently
+  signed, externally referenceable artifact committed before its result, a
+  selectively-omitted loss is a visible gap against a settlement record rather
+  than a silent absence in a self-reported score.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Authenticity is not soundness
+
+A protocol that proves an action authentically came from agent X, under valid
+authority, with a non-revoked key, still says nothing about whether X is usually
+right. A correctly-signed credential can carry a wrong prediction. Identity and
+provenance answer "who did this," not "does this agent have a proven record of
+being correct."
+
+### 2.2 A score the agent can move is not evidence
+
+A reputation value maintained by the party that benefits from it, or by an
+engine that party operates, can be set, reset, or selectively updated. Whoever
+controls the write path controls the number. A record that can be edited by its
+own subject is an assertion, not evidence.
+
+### 2.3 Self-reported track records permit hindsight and omission
+
+Without a commitment fixed before the outcome, a track record can be assembled
+after results are known: a verdict can be backdated to look prescient, and a
+losing verdict can simply be left out. Aggregating such reports, however
+rigorously, inherits the bias of the inputs.
+
+---
+
+## 3. Solution (The Invention)
+
+`commit_outcome(...)` issues an `OutcomeCommitmentCredential`: an
+`eddsa-jcs-2022` Verifiable Credential whose subject carries a `claimType`, a
+vendor-neutral `settlement` descriptor (`method`, `locator`, `resolutionCriteria`,
+optional `resolveBy`), and a `commitment` block holding `algorithm`
+(`sha-256-jcs`), the multibase `digest`, and a `salted` flag. In private mode the
+cleartext claim is withheld and only the digest is published; the function
+returns the salt and claim as a secret the committer keeps for settlement.
+
+`attest_outcome(...)` issues an `OutcomeAttestationCredential`, signed by the
+settler. Its subject reveals the claim and salt, reproduces the committed digest
+and commitment timestamp, and records the observed `outcome` with an optional
+`matchesCommitment` verdict. Before signing, the function recomputes the digest
+from the revealed claim and salt and refuses to issue if it does not match the
+commitment, so a settler cannot attach a reveal that disagrees with what was
+committed.
+
+`verify_attestation(...)` checks the settler's Data Integrity proof, recomputes
+the digest from the revealed claim and salt, and confirms it equals the cited
+commitment digest. When the original commitment is supplied, it further confirms
+the two digests agree, the subject is the same, and the settlement timestamp does
+not precede the commitment; when the committer's key is supplied, the
+commitment's own proof is verified too. `accountability_pointer(...)` builds a
+small `AccountabilityRecord` object that any other credential can embed in its
+subject to reference such a record, so an identity credential can point at an
+agent's settled track record.
+
+Because both credentials use the shared JCS and `eddsa-jcs-2022` primitives, the
+same commitment and attestation verify across the language SDKs, and the outcome
+evidence can feed, but is independent of, any scoring engine.
+
+---
+
+## 4. Prior Art Differentiation
+
+Commit-reveal hashing, prediction markets, and encoding reputation as Verifiable
+Credentials are each established prior art. This disclosure does **not** claim
+those general mechanisms. What is differentiated here is their composition into a
+verdict-accountability primitive for autonomous agents:
+
+- **Commit-before-outcome applied to a verdict's correctness.** A salted digest
+  fixes the claim before its result, and verification rejects a settlement that
+  predates the commitment. The protected property is the soundness of a
+  prediction or recommendation over time, not liveness. This differs from
+  commit-reveal used for canary liveness or heartbeat freshness (PAD-016,
+  PAD-031), where the revealed value proves presence rather than a pre-committed
+  judgment whose correctness is later settled.
+- **Evidence versus aggregated or portable scores.** PAD-036 aggregates
+  verifiable state receipts into a reputation value; PAD-030 carries a reputation
+  attestation between contexts in zero knowledge. Both operate on reputation
+  values already assigned. The present method produces the upstream, per-verdict,
+  commit-before-outcome evidence that such systems would consume, and is what
+  prevents the inputs themselves from being backdated or cherry-picked.
+- **Neutral settler binding rather than self-report.** The outcome attestation is
+  signed by the observer of the result and binds to the committed digest, so the
+  subject of the record is structurally separated from the certifier of the
+  result. A self-maintained score has no such separation.
+- **Private verdict with provable fixity.** The salted commitment lets a verdict
+  stay confidential until settlement while remaining unalterable, so it can be
+  published before the outcome without being front-run. A plain signed claim
+  discloses its content at commit time.
+- **Transport-neutral settlement descriptor.** The record of ground truth is
+  named by `method` and `locator` and is deliberately not bound to any one
+  chain, feed, notary, or payment rail, so the primitive composes with the open
+  protocol rather than a specific external service.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation ships in the Python SDK as `vouch.accountability`,
+exposing `commit_outcome`, `verify_commitment`, `attest_outcome`,
+`verify_attestation`, `commitment_digest`, and `accountability_pointer`, with the
+`OutcomeCommitmentCredential` and `OutcomeAttestationCredential` types and the
+`sha-256-jcs` commitment algorithm. The commitment digest is SHA-256 over the
+RFC 8785 JCS canonical form of the claim with an optional appended salt, the same
+canonicalization the rest of the SDK uses, so the digest is reproducible across
+languages. Signing uses the shared `eddsa-jcs-2022` Data Integrity path; the
+choice of public ledger or notary for the settlement record is left to the
+caller.
+
+---
+
+## 6. Claims Summary
+
+1. A method for recording an agent's track record in which a verdict, prediction,
+   or recommendation is committed as a signed credential carrying a digest of the
+   canonical claim fixed before the outcome is known, and a separately-signed
+   attestation later binds the observed outcome to that commitment.
+2. The method of claim 1 wherein the commitment carries a salted digest and
+   withholds the cleartext claim, and the claim and salt are revealed at
+   settlement and checked against the committed digest, so the verdict is
+   confidential before settlement yet provably unalterable.
+3. The method of claim 1 wherein verification rejects any settlement whose
+   timestamp precedes the commitment, so a verdict cannot be minted with
+   hindsight.
+4. The method of claim 1 wherein the settlement attestation is signed by a party
+   distinct from the committer and binds to the committed digest rather than to
+   trust in the committer.
+5. The method of claim 1 wherein the settlement record of ground truth is named
+   by a transport-neutral descriptor of method and locator, so the primitive is
+   not bound to any single ledger, feed, notary, or payment rail.
+6. The method of claim 1 wherein the commitment and attestation are
+   Verifiable Credentials using canonicalization and signature primitives shared
+   across language SDKs, so the same evidence verifies cross-language and can be
+   referenced from another credential by a pointer object.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -78,6 +78,20 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-068](./PAD-068-kill-switch-credential.md) | Verifiable Kill-Switch Credential with Attested-Authority Enforcement | 2026-06-14 | Published |
 | [PAD-069](./PAD-069-confidential-tamper-evident-robot-blackbox.md) | Confidential, Tamper-Evident Robot Black-Box with Separable Confidentiality and Integrity | 2026-06-15 | Published |
 | [PAD-070](./PAD-070-scannable-offline-robot-passport.md) | Self-Contained, Offline-Verifiable Robot Passport for Physical-World Scanning | 2026-06-15 | Published |
+| [PAD-071](./PAD-071-outcome-evidence-commit-before-outcome-credential.md) | Commit-Before-Outcome Verdict Credential with Neutral-Settler Outcome Attestation | 2026-06-17 | Published |
+
+
+## June 17, 2026: Commit-Before-Outcome Verdict Evidence (PAD-071)
+
+One disclosure covering the `vouch.accountability` outcome-evidence primitive: a
+verdict, prediction, or recommendation committed and signed before its outcome is
+known, settled later by a separately-signed attestation that binds the observed
+outcome to the prior commitment. A salted commitment keeps the verdict private
+until settlement, and verification rejects any settlement timestamped before the
+commitment, so an agent's track record cannot be backdated, cherry-picked, or
+unilaterally edited. It is the per-verdict evidence layer beneath aggregated and
+portable reputation (PAD-036, PAD-030), built on the same eddsa-jcs-2022
+credentials as the rest of Vouch.
 
 
 ## June 15, 2026: Robotics and Embodied-Agent Primitives (PAD-064 through PAD-070)

--- a/examples/accountability_demo.py
+++ b/examples/accountability_demo.py
@@ -1,0 +1,110 @@
+"""
+Outcome-evidence credentials: commit a verdict before the outcome, settle it later.
+
+Vouch proves *who* acted. This demo shows the complementary layer: proving an
+agent's verdict was fixed *before* its outcome was known, so its track record
+cannot be backdated or cherry-picked.
+
+Run:
+    python examples/accountability_demo.py
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from vouch import Signer, generate_identity
+from vouch.accountability import (
+    accountability_pointer,
+    attest_outcome,
+    commit_outcome,
+    verify_attestation,
+    verify_commitment,
+)
+
+
+def main() -> None:
+    # Two independent parties: the agent making the call, and a neutral settler.
+    agent_kp = generate_identity(domain="agent.example.com")
+    agent = Signer(private_key=agent_kp.private_key_jwk, did=agent_kp.did)
+
+    settler_kp = generate_identity(domain="settler.example.com")
+    settler = Signer(private_key=settler_kp.private_key_jwk, did=settler_kp.did)
+
+    committed_at = datetime.now(timezone.utc)
+
+    # 1) The agent commits a verdict BEFORE the outcome is known. Private mode
+    #    publishes only a salted digest, so the verdict cannot be read or
+    #    front-run, yet is provably unalterable.
+    claim = {"asset": "XYZ", "direction": "up", "horizon": "2026-07-01"}
+    settlement = {
+        "method": "market-settlement",
+        "locator": "https://example.com/markets/42",
+        "resolutionCriteria": "settled price at expiry versus strike",
+        "resolveBy": "2026-07-01T00:00:00Z",
+    }
+    commitment, secret = commit_outcome(
+        agent,
+        claim=claim,
+        settlement=settlement,
+        claim_type="prediction",
+        private=True,
+        valid_from=committed_at,
+    )
+
+    ok, _ = verify_commitment(commitment, agent_kp.public_key_jwk)
+    print("commitment id:        ", commitment["id"])
+    print("verdict published?    ", "claim" in commitment["credentialSubject"])  # False
+    print("digest:               ", commitment["credentialSubject"]["commitment"]["digest"])
+    print("commitment verifies:  ", ok)
+
+    # 2) After the outcome is observable, the neutral settler reveals the claim
+    #    and salt, binds the observed outcome to the prior commitment, and signs.
+    outcome = {
+        "result": "up",
+        "evidence": "https://example.com/markets/42/settle",
+        "observedAt": "2026-07-01T00:05:00Z",
+    }
+    attestation = attest_outcome(
+        settler,
+        commitment=commitment,
+        outcome=outcome,
+        secret=secret,
+        matches=True,
+        valid_from=committed_at + timedelta(days=14),
+    )
+
+    # 3) Anyone verifies: the settler's signature, that the revealed claim
+    #    recomputes to the committed digest, and that settlement did not predate
+    #    the commitment.
+    ok, subject = verify_attestation(
+        attestation,
+        settler_kp.public_key_jwk,
+        commitment=commitment,
+        committer_public_key=agent_kp.public_key_jwk,
+    )
+    print("\nrevealed verdict:     ", subject["reveal"]["claim"])
+    print("outcome correct?      ", subject["outcome"]["matchesCommitment"])
+    print("settled by:           ", attestation["issuer"])
+    print("attestation verifies: ", ok)
+
+    # A backdated settlement (timestamped before the commitment) is rejected.
+    backdated = attest_outcome(
+        settler,
+        commitment=commitment,
+        outcome=outcome,
+        secret=secret,
+        valid_from=committed_at - timedelta(days=1),
+    )
+    ok_bad, _ = verify_attestation(backdated, settler_kp.public_key_jwk, commitment=commitment)
+    print("backdated settlement: ", "rejected" if not ok_bad else "ACCEPTED (bug)")
+
+    # An identity credential can point at the settled record.
+    pointer = accountability_pointer(
+        ledger="https://example.com/markets/42",
+        record=attestation["id"],
+        subject=agent_kp.did,
+    )
+    print("\naccountability pointer:", pointer)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_accountability.py
+++ b/tests/test_accountability.py
@@ -1,0 +1,233 @@
+"""Tests for outcome-evidence credentials (commit-before-outcome + settlement)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.accountability import (
+    OUTCOME_ATTESTATION_TYPE,
+    OUTCOME_COMMITMENT_TYPE,
+    AccountabilityError,
+    accountability_pointer,
+    attest_outcome,
+    commit_outcome,
+    commitment_digest,
+    verify_attestation,
+    verify_commitment,
+)
+
+
+def _identity(domain: str = "agent.example.com"):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+SETTLEMENT = {
+    "method": "market-settlement",
+    "locator": "https://example.com/markets/42",
+    "resolutionCriteria": "settled price at expiry vs strike",
+    "resolveBy": "2026-07-01T00:00:00Z",
+}
+
+CLAIM = {"asset": "XYZ", "direction": "up", "horizon": "2026-07-01"}
+OUTCOME = {"result": "up", "evidence": "https://example.com/markets/42/settle"}
+
+
+class TestCommitment:
+    def test_public_commit_and_verify(self):
+        kp, signer = _identity()
+        cred, secret = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT)
+
+        assert OUTCOME_COMMITMENT_TYPE in cred["type"]
+        assert cred["issuer"] == kp.did
+        subject = cred["credentialSubject"]
+        assert subject["id"] == kp.did  # self-commitment by default
+        assert subject["claim"] == CLAIM  # public claim disclosed
+        assert subject["commitment"]["salted"] is False
+        assert secret["claim"] == CLAIM
+
+        ok, returned = verify_commitment(cred, kp.public_key_jwk)
+        assert ok is True
+        assert returned["commitment"]["digest"] == subject["commitment"]["digest"]
+
+    def test_public_commitment_digest_matches_claim(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT)
+        from vouch.accountability import _mb64  # internal helper, tested for parity
+
+        assert cred["credentialSubject"]["commitment"]["digest"] == _mb64(
+            commitment_digest(CLAIM, None)
+        )
+
+    def test_private_commit_hides_claim(self):
+        kp, signer = _identity()
+        cred, secret = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+
+        subject = cred["credentialSubject"]
+        assert "claim" not in subject  # withheld until settlement
+        assert subject["commitment"]["salted"] is True
+        assert secret["salt"] is not None
+        assert secret["claim"] == CLAIM
+
+        ok, _ = verify_commitment(cred, kp.public_key_jwk)
+        assert ok is True
+
+    def test_wrong_key_fails(self):
+        _, signer = _identity()
+        other, _ = _identity("other.example.com")
+        cred, _ = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT)
+        ok, _ = verify_commitment(cred, other.public_key_jwk)
+        assert ok is False
+
+    def test_tampered_digest_fails_proof(self):
+        kp, signer = _identity()
+        cred, _ = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT)
+        cred["credentialSubject"]["commitment"]["digest"] = "uAAAA"
+        ok, _ = verify_commitment(cred, kp.public_key_jwk)
+        assert ok is False
+
+    def test_settlement_fields_required(self):
+        _, signer = _identity()
+        with pytest.raises(AccountabilityError):
+            commit_outcome(
+                signer, claim=CLAIM, settlement={"method": "oracle"}
+            )  # missing resolutionCriteria
+
+    def test_claim_must_be_object(self):
+        _, signer = _identity()
+        with pytest.raises(AccountabilityError):
+            commit_outcome(signer, claim="up", settlement=SETTLEMENT)
+
+
+class TestAttestation:
+    def test_full_private_chain(self):
+        kp, signer = _identity()
+        cred, secret = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        att = attest_outcome(signer, commitment=cred, outcome=OUTCOME, secret=secret, matches=True)
+
+        assert OUTCOME_ATTESTATION_TYPE in att["type"]
+        subj = att["credentialSubject"]
+        assert subj["reveal"]["claim"] == CLAIM
+        assert subj["outcome"]["matchesCommitment"] is True
+        assert subj["commitment"]["digest"] == cred["credentialSubject"]["commitment"]["digest"]
+
+        ok, _ = verify_attestation(
+            att, kp.public_key_jwk, commitment=cred, committer_public_key=kp.public_key_jwk
+        )
+        assert ok is True
+
+    def test_neutral_third_party_settler(self):
+        committer_kp, committer = _identity("committer.example.com")
+        settler_kp, settler = _identity("settler.example.com")
+
+        cred, secret = commit_outcome(committer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        att = attest_outcome(settler, commitment=cred, outcome=OUTCOME, secret=secret, matches=True)
+
+        assert att["issuer"] == settler_kp.did
+        assert att["credentialSubject"]["id"] == committer_kp.did  # subject is still the committer
+        ok, _ = verify_attestation(
+            att,
+            settler_kp.public_key_jwk,
+            commitment=cred,
+            committer_public_key=committer_kp.public_key_jwk,
+        )
+        assert ok is True
+
+    def test_reveal_mismatch_rejected_at_signing(self):
+        _, signer = _identity()
+        cred, secret = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        with pytest.raises(AccountabilityError):
+            attest_outcome(
+                signer,
+                commitment=cred,
+                outcome=OUTCOME,
+                claim={"asset": "XYZ", "direction": "down", "horizon": "2026-07-01"},
+                salt=None,
+            )
+
+    def test_salt_required_for_salted_commitment(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        with pytest.raises(AccountabilityError):
+            attest_outcome(signer, commitment=cred, outcome=OUTCOME, claim=CLAIM)
+
+    def test_backdated_settlement_rejected(self):
+        kp, signer = _identity()
+        committed_at = datetime(2026, 6, 17, 0, 0, 0, tzinfo=timezone.utc)
+        cred, secret = commit_outcome(
+            signer, claim=CLAIM, settlement=SETTLEMENT, private=True, valid_from=committed_at
+        )
+        # Settlement timestamped BEFORE the commitment must be rejected.
+        att = attest_outcome(
+            signer,
+            commitment=cred,
+            outcome=OUTCOME,
+            secret=secret,
+            valid_from=committed_at - timedelta(days=1),
+        )
+        ok, _ = verify_attestation(att, kp.public_key_jwk, commitment=cred)
+        assert ok is False
+
+    def test_forward_settlement_accepted(self):
+        kp, signer = _identity()
+        committed_at = datetime(2026, 6, 17, 0, 0, 0, tzinfo=timezone.utc)
+        cred, secret = commit_outcome(
+            signer, claim=CLAIM, settlement=SETTLEMENT, private=True, valid_from=committed_at
+        )
+        att = attest_outcome(
+            signer,
+            commitment=cred,
+            outcome=OUTCOME,
+            secret=secret,
+            valid_from=committed_at + timedelta(days=7),
+        )
+        ok, _ = verify_attestation(att, kp.public_key_jwk, commitment=cred)
+        assert ok is True
+
+    def test_tampered_reveal_fails_verification(self):
+        kp, signer = _identity()
+        cred, secret = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        att = attest_outcome(signer, commitment=cred, outcome=OUTCOME, secret=secret)
+        # Swap the revealed claim after signing: digest no longer reproduces, and
+        # the settler proof breaks too.
+        att["credentialSubject"]["reveal"]["claim"] = {"asset": "XYZ", "direction": "down"}
+        ok, _ = verify_attestation(att, kp.public_key_jwk)
+        assert ok is False
+
+    def test_digest_mismatch_between_commitment_and_attestation(self):
+        kp, signer = _identity()
+        cred_a, secret_a = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        other_claim = {"asset": "ABC", "direction": "up", "horizon": "2026-07-01"}
+        cred_b, _ = commit_outcome(signer, claim=other_claim, settlement=SETTLEMENT, private=True)
+        att = attest_outcome(signer, commitment=cred_a, outcome=OUTCOME, secret=secret_a)
+        # Attestation settles commitment A but is checked against commitment B.
+        ok, _ = verify_attestation(att, kp.public_key_jwk, commitment=cred_b)
+        assert ok is False
+
+
+class TestAccountabilityPointer:
+    def test_pointer_shape(self):
+        ptr = accountability_pointer(
+            ledger="https://example.com/ledger",
+            record="anchor-1",
+            subject="did:web:agent.example.com",
+            digest="uABC",
+        )
+        assert ptr["type"] == "AccountabilityRecord"
+        assert ptr["ledger"] == "https://example.com/ledger"
+        assert ptr["record"] == "anchor-1"
+        assert ptr["subject"] == "did:web:agent.example.com"
+        assert ptr["digest"] == "uABC"
+
+    def test_pointer_requires_ledger(self):
+        with pytest.raises(AccountabilityError):
+            accountability_pointer(ledger="")
+
+
+class TestDigest:
+    def test_reproducible_and_salt_sensitive(self):
+        d1 = commitment_digest(CLAIM, None)
+        d2 = commitment_digest(CLAIM, None)
+        assert d1 == d2
+        assert commitment_digest(CLAIM, b"\x00" * 32) != d1

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -176,6 +176,21 @@ def __getattr__(name):
         from . import reputation
 
         return getattr(reputation, name)
+    # Outcome-evidence credentials (commit-before-outcome verdicts + settlement)
+    elif name in (
+        "AccountabilityError",
+        "commit_outcome",
+        "verify_commitment",
+        "attest_outcome",
+        "verify_attestation",
+        "accountability_pointer",
+        "commitment_digest",
+        "OUTCOME_COMMITMENT_TYPE",
+        "OUTCOME_ATTESTATION_TYPE",
+    ):
+        from . import accountability
+
+        return getattr(accountability, name)
     # Cloud KMS
     elif name in ("CloudKMSProvider", "AWSKMSProvider", "GCPKMSProvider", "AzureKeyVaultProvider"):
         from . import kms
@@ -247,6 +262,16 @@ __all__ = [
     "RedisReputationStore",
     "KafkaReputationStore",
     "KafkaReputationConsumer",
+    # Outcome-evidence credentials
+    "AccountabilityError",
+    "commit_outcome",
+    "verify_commitment",
+    "attest_outcome",
+    "verify_attestation",
+    "accountability_pointer",
+    "commitment_digest",
+    "OUTCOME_COMMITMENT_TYPE",
+    "OUTCOME_ATTESTATION_TYPE",
     # Cloud KMS
     "CloudKMSProvider",
     "AWSKMSProvider",

--- a/vouch/accountability.py
+++ b/vouch/accountability.py
@@ -1,0 +1,467 @@
+"""
+Outcome-evidence credentials: commit-before-outcome verdicts and settlement.
+
+Vouch answers "is this authentically agent X, acting under this authority?" It
+does not, on its own, answer "does agent X have a verifiable record of being
+right?" The existing reputation engine (`vouch.reputation`) keeps a score, but
+that score is asserted by whoever runs the engine and can be moved at will. A
+record that an agent can edit is not evidence.
+
+This module adds the missing primitive: a verdict, prediction, or recommendation
+that an issuer **commits and signs before the outcome is known**, plus a separate
+**settlement attestation** that binds the observed outcome back to that
+commitment. Two properties make the record non-gameable:
+
+  - Commit-before-outcome. The commitment carries a salted SHA-256 digest over
+    the JCS-canonical claim. The claim may stay private until settlement (so it
+    cannot be front-run), yet the digest fixes it. No one can backdate a winning
+    verdict after seeing the result, because the signed `created` time and the
+    digest are fixed at commit time.
+  - Neutral settler. The settlement attestation reproduces the revealed claim and
+    salt so any verifier recomputes the digest and confirms it matches what was
+    committed. The settler may be a third party, distinct from the committer; the
+    attestation binds to the committed digest, not to trust in the committer.
+
+Both are ordinary `eddsa-jcs-2022` Verifiable Credentials, so they compose with
+the rest of the protocol and verify across the language SDKs. The transport for
+the public record (a chain, a notary, a feed, a URL) is left open: the settlement
+descriptor names a method and a locator and is deliberately vendor-neutral.
+
+An `accountability_pointer(...)` helper builds a small `AccountabilityRecord`
+object that any other credential can embed in its subject to reference such a
+record, so an identity credential can point at an agent's settled track record.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Tuple
+
+from . import data_integrity
+from .jcs import canonicalize
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+
+OUTCOME_COMMITMENT_TYPE = "OutcomeCommitmentCredential"
+OUTCOME_ATTESTATION_TYPE = "OutcomeAttestationCredential"
+ACCOUNTABILITY_RECORD_TYPE = "AccountabilityRecord"
+
+COMMITMENT_ALGORITHM = "sha-256-jcs"
+
+
+class AccountabilityError(Exception):
+    """Raised on malformed outcome-evidence input."""
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(s: str) -> datetime:
+    try:
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError) as exc:
+        raise AccountabilityError(f"malformed timestamp: {s!r}") from exc
+
+
+def _mb64(b: bytes) -> str:
+    return "u" + base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _unmb64(s: str) -> bytes:
+    if not isinstance(s, str) or not s.startswith("u"):
+        raise AccountabilityError("expected multibase 'u' prefix")
+    payload = s[1:]
+    return base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise AccountabilityError("signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    """Attach an eddsa-jcs-2022 Data Integrity proof to a pre-built credential."""
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+def commitment_digest(claim: Dict[str, Any], salt: Optional[bytes] = None) -> bytes:
+    """
+    The binding digest for a claim: SHA-256 over the JCS-canonical claim, with an
+    optional salt appended. The same canonicalization the rest of the SDK uses, so
+    the digest is reproducible across languages.
+    """
+    if not isinstance(claim, dict):
+        raise AccountabilityError("claim must be a JSON object")
+    return hashlib.sha256(canonicalize(claim) + (salt or b"")).digest()
+
+
+def _type_list(credential: Dict[str, Any]) -> list:
+    t = credential.get("type") or []
+    return [t] if isinstance(t, str) else list(t)
+
+
+# ---------------------------------------------------------------------------
+# Commitment: a verdict signed before the outcome is known
+# ---------------------------------------------------------------------------
+
+
+def commit_outcome(
+    signer: Any,
+    *,
+    claim: Dict[str, Any],
+    settlement: Dict[str, Any],
+    subject: Optional[str] = None,
+    claim_type: str = "prediction",
+    private: bool = False,
+    salt: Optional[bytes] = None,
+    valid_from: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Issue an OutcomeCommitmentCredential: a claim committed and signed before its
+    outcome is known.
+
+    The credential subject carries a `commitment` block (algorithm + salted
+    SHA-256 digest of the claim) and a vendor-neutral `settlement` descriptor that
+    says how the truth will be determined and where it will be recorded. When
+    `private` is set, the cleartext claim is withheld and only the digest is
+    published, so the verdict cannot be read or front-run before settlement; the
+    returned secret carries the salt and claim needed to settle later.
+
+    Args:
+        signer: A Vouch ``Signer`` (the committer).
+        claim: The verdict, prediction, or recommendation as a JSON object.
+        settlement: Descriptor of how the outcome is resolved. Must include
+            ``method`` and ``resolutionCriteria``; ``locator`` and ``resolveBy``
+            are recommended.
+        subject: DID whose claim is being judged. Defaults to the committer's DID
+            (a self-commitment).
+        claim_type: Free-form label for the claim (``prediction``, ``verdict``,
+            ``recommendation``, ...).
+        private: If True, withhold the cleartext claim and publish only the digest.
+        salt: Optional explicit salt. A random 32-byte salt is generated when the
+            commitment is private and no salt is supplied.
+        valid_from: Commitment time (defaults to now, UTC).
+        credential_id: Optional credential id (defaults to a ``urn:uuid``).
+
+    Returns:
+        ``(credential, secret)`` where ``secret`` is ``{"claim": ..., "salt": ...}``
+        and must be retained to settle the commitment later (mandatory when
+        private; the salt is multibase-encoded or None).
+    """
+    if not isinstance(claim, dict):
+        raise AccountabilityError("claim must be a JSON object")
+    if not isinstance(settlement, dict):
+        raise AccountabilityError("settlement must be a JSON object")
+    for required in ("method", "resolutionCriteria"):
+        if not settlement.get(required):
+            raise AccountabilityError(f"settlement.{required} is required")
+
+    if salt is None and private:
+        salt = secrets.token_bytes(32)
+    digest = commitment_digest(claim, salt)
+
+    issuer = signer.get_did()
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    subject_block: Dict[str, Any] = {
+        "id": subject or issuer,
+        "claimType": claim_type,
+        "commitment": {
+            "algorithm": COMMITMENT_ALGORITHM,
+            "digest": _mb64(digest),
+            "salted": salt is not None,
+        },
+        "settlement": dict(settlement),
+    }
+    if not private:
+        subject_block["claim"] = claim
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", OUTCOME_COMMITMENT_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": issuer,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject_block,
+    }
+    _attach_proof(credential, signer)
+
+    secret = {"claim": claim, "salt": _mb64(salt) if salt is not None else None}
+    return credential, secret
+
+
+def verify_commitment(
+    credential: Dict[str, Any],
+    public_key: Any,
+) -> "Tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify an OutcomeCommitmentCredential's Data Integrity proof and structure.
+
+    When the commitment is public (the cleartext claim is present and unsalted),
+    the published digest is recomputed and checked against the claim. Returns
+    ``(ok, credentialSubject)``.
+    """
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if OUTCOME_COMMITMENT_TYPE not in _type_list(credential):
+        return False, None
+
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = credential.get("credentialSubject") or {}
+    commitment = subject.get("commitment") or {}
+    if not commitment.get("digest"):
+        return False, None
+
+    claim = subject.get("claim")
+    if claim is not None and not commitment.get("salted"):
+        try:
+            recomputed = _mb64(commitment_digest(claim, None))
+        except AccountabilityError:
+            return False, None
+        if recomputed != commitment.get("digest"):
+            return False, None
+
+    return True, subject
+
+
+# ---------------------------------------------------------------------------
+# Attestation: bind the observed outcome back to the commitment
+# ---------------------------------------------------------------------------
+
+
+def attest_outcome(
+    signer: Any,
+    *,
+    commitment: Dict[str, Any],
+    outcome: Dict[str, Any],
+    secret: Optional[Dict[str, Any]] = None,
+    claim: Optional[Dict[str, Any]] = None,
+    salt: Optional[bytes] = None,
+    matches: Optional[bool] = None,
+    valid_from: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Issue an OutcomeAttestationCredential settling a prior commitment.
+
+    The attestation reveals the claim and salt (so any verifier recomputes the
+    committed digest), records the observed `outcome`, and is signed by the settler
+    (who may differ from the committer). The revealed claim is checked against the
+    committed digest before signing, so a settler cannot attach a reveal that does
+    not match the commitment.
+
+    Args:
+        signer: A Vouch ``Signer`` (the settler).
+        commitment: The OutcomeCommitmentCredential being settled.
+        outcome: The observed result as a JSON object (e.g.
+            ``{"result": ..., "evidence": ..., "observedAt": ...}``).
+        secret: The ``{"claim", "salt"}`` returned by :func:`commit_outcome`.
+            Required when the commitment was private.
+        claim: The revealed claim, if not supplied via ``secret`` or already
+            public in the commitment.
+        salt: The raw salt bytes, if not supplied via ``secret``.
+        matches: Optional explicit verdict on whether the claim proved correct;
+            recorded as ``outcome.matchesCommitment``.
+        valid_from: Settlement time (defaults to now, UTC).
+        credential_id: Optional credential id (defaults to a ``urn:uuid``).
+
+    Returns:
+        The signed OutcomeAttestationCredential.
+    """
+    if not isinstance(outcome, dict):
+        raise AccountabilityError("outcome must be a JSON object")
+
+    csubject = commitment.get("credentialSubject") or {}
+    ccommit = csubject.get("commitment") or {}
+    committed_digest = ccommit.get("digest")
+    if not committed_digest:
+        raise AccountabilityError("commitment carries no digest")
+
+    revealed_claim = claim
+    if revealed_claim is None and secret is not None:
+        revealed_claim = secret.get("claim")
+    if revealed_claim is None:
+        revealed_claim = csubject.get("claim")
+    if revealed_claim is None:
+        raise AccountabilityError("the revealed claim is required to settle a commitment")
+
+    revealed_salt = salt
+    if revealed_salt is None and secret is not None and secret.get("salt"):
+        revealed_salt = _unmb64(secret["salt"])
+    if revealed_salt is None and ccommit.get("salted"):
+        raise AccountabilityError("the salt is required to settle a salted commitment")
+
+    if _mb64(commitment_digest(revealed_claim, revealed_salt)) != committed_digest:
+        raise AccountabilityError("revealed claim does not match the commitment digest")
+
+    settled = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    reveal: Dict[str, Any] = {"claim": revealed_claim}
+    if revealed_salt is not None:
+        reveal["salt"] = _mb64(revealed_salt)
+
+    outcome_block = dict(outcome)
+    if matches is not None:
+        outcome_block["matchesCommitment"] = matches
+
+    subject_block: Dict[str, Any] = {
+        "id": csubject.get("id", commitment.get("issuer")),
+        "commitment": {
+            "credentialId": commitment.get("id"),
+            "issuer": commitment.get("issuer"),
+            "digest": committed_digest,
+            "committedAt": commitment.get("validFrom"),
+        },
+        "reveal": reveal,
+        "outcome": outcome_block,
+    }
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", OUTCOME_ATTESTATION_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": signer.get_did(),
+        "validFrom": _iso(settled),
+        "credentialSubject": subject_block,
+    }
+    return _attach_proof(credential, signer)
+
+
+def verify_attestation(
+    attestation: Dict[str, Any],
+    public_key: Any,
+    *,
+    commitment: Optional[Dict[str, Any]] = None,
+    committer_public_key: Any = None,
+) -> "Tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify an OutcomeAttestationCredential.
+
+    Always checks the settler's Data Integrity proof and that the revealed claim
+    (with salt) recomputes to the digest the attestation cites. When the original
+    `commitment` is supplied, additionally checks that the two digests agree, that
+    the subject is the same, and that settlement did not precede the commitment;
+    when `committer_public_key` is supplied, the commitment's own proof is verified
+    too. Returns ``(ok, credentialSubject)``.
+    """
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if OUTCOME_ATTESTATION_TYPE not in _type_list(attestation):
+        return False, None
+
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(attestation, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = attestation.get("credentialSubject") or {}
+    reveal = subject.get("reveal") or {}
+    cited = subject.get("commitment") or {}
+    cited_digest = cited.get("digest")
+    claim = reveal.get("claim")
+    if claim is None or not cited_digest:
+        return False, None
+
+    try:
+        salt = _unmb64(reveal["salt"]) if reveal.get("salt") else None
+        if _mb64(commitment_digest(claim, salt)) != cited_digest:
+            return False, None
+    except AccountabilityError:
+        return False, None
+
+    if commitment is not None:
+        if committer_public_key is not None:
+            ok, _ = verify_commitment(commitment, committer_public_key)
+            if not ok:
+                return False, None
+        csubject = commitment.get("credentialSubject") or {}
+        ccommit = csubject.get("commitment") or {}
+        if ccommit.get("digest") != cited_digest:
+            return False, None
+        if csubject.get("id") != subject.get("id"):
+            return False, None
+        try:
+            if _parse_iso(attestation.get("validFrom")) < _parse_iso(commitment.get("validFrom")):
+                return False, None
+        except AccountabilityError:
+            return False, None
+
+    return True, subject
+
+
+# ---------------------------------------------------------------------------
+# Accountability pointer: reference a track record from another credential
+# ---------------------------------------------------------------------------
+
+
+def accountability_pointer(
+    *,
+    ledger: str,
+    record: Optional[str] = None,
+    subject: Optional[str] = None,
+    digest: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Build a vendor-neutral ``AccountabilityRecord`` pointer that another credential
+    can embed in its subject to reference an agent's settled track record.
+
+    Args:
+        ledger: Where the record lives (transport-agnostic locator).
+        record: Optional anchor or id of the specific record within the ledger.
+        subject: Optional DID the record is about.
+        digest: Optional commitment digest the pointer references.
+    """
+    if not ledger:
+        raise AccountabilityError("ledger is required")
+    pointer: Dict[str, Any] = {"type": ACCOUNTABILITY_RECORD_TYPE, "ledger": ledger}
+    if record is not None:
+        pointer["record"] = record
+    if subject is not None:
+        pointer["subject"] = subject
+    if digest is not None:
+        pointer["digest"] = digest
+    return pointer
+
+
+__all__ = [
+    "OUTCOME_COMMITMENT_TYPE",
+    "OUTCOME_ATTESTATION_TYPE",
+    "ACCOUNTABILITY_RECORD_TYPE",
+    "COMMITMENT_ALGORITHM",
+    "AccountabilityError",
+    "commitment_digest",
+    "commit_outcome",
+    "verify_commitment",
+    "attest_outcome",
+    "verify_attestation",
+    "accountability_pointer",
+]


### PR DESCRIPTION
## What

Adds `vouch.accountability`, a vendor-neutral outcome-evidence credential type:

- **`OutcomeCommitmentCredential`** is a verdict, prediction, or recommendation committed and signed *before* its outcome is known. The subject carries a salted SHA-256 digest of the JCS-canonical claim, so the claim can stay private until settlement yet is provably fixed at commit time.
- **`OutcomeAttestationCredential`** is signed by a settler (who may differ from the committer). It reveals the claim and salt, lets anyone recompute the committed digest, and binds the observed outcome back to the commitment.
- Verification rejects any settlement timestamped before its commitment, so a winning verdict cannot be minted with hindsight.
- `accountability_pointer(...)` builds a small `AccountabilityRecord` object another credential can embed to reference a settled track record.

Both are ordinary `eddsa-jcs-2022` Verifiable Credentials, so they compose with the rest of the protocol and verify across the language SDKs. The transport for the public record (chain, notary, feed, URL) is left open in a `settlement` descriptor.

## Why

Vouch proves *who* acted and under what authority. It did not, on its own, give per-verdict evidence that an agent's calls were fixed before their outcomes. The existing `vouch.reputation` engine keeps a score, but that score is asserted by whoever runs the engine and can be moved at will. This adds the upstream, tamper-evident evidence layer that such scoring should consume: a record the subject cannot backdate, cherry-pick, or unilaterally edit.

This came out of discussion #53. It is the neutral primitive, with no domain logic, oracle, or payment rail baked in, so an external service can build its own judging layer on top of a standard credential rather than a bespoke endpoint.

## Tests

`tests/test_accountability.py` (18 cases): public and private commitment, full settlement chain, neutral third-party settler, reveal and digest mismatch rejection, backdated-settlement rejection, tamper detection, and the pointer helper. Full suite: 633 passing (3 pre-existing failures in `test_git_workflow.py` are unrelated; they shell out to a `python` binary absent in this environment).

Runnable demo: `python examples/accountability_demo.py`.

Defensive disclosure: PAD-071.
