### PR TITLE
Robotics hero: drop the not-just construct

### DIFF
--- a/website/src/app/robotics/page.tsx
+++ b/website/src/app/robotics/page.tsx
@@ -54,7 +54,7 @@ export default function RoboticsPage() {
                 <div className="container-wide py-16 md:py-24">
                     <div className="eyebrow mb-5">Robotics</div>
                     <h1 className="font-serif font-semibold text-ink leading-[1.08] tracking-tight mb-6 max-w-[860px] text-[clamp(2.2rem,4.6vw,3.4rem)]">
-                        Identity and accountability for robots, not just software agents.
+                        Identity and accountability for robots and embodied agents.
                     </h1>
                     <p className="text-ink-soft text-[1.15rem] leading-snug max-w-prose mb-4">
                         As robots and embodied agents act in the physical world, they raise the same


### PR DESCRIPTION
Rewrites the robotics hero line to a plain positive statement.

Before: `Identity and accountability for robots, not just software agents.`
After: `Identity and accountability for robots and embodied agents.`

Text-only change to the robotics page hero; no code or behaviour change.
