### PR TITLE
feat(website): add Conformance to the nav More dropdown after Index

### DIFF
--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -18,6 +18,7 @@ const LINKS = [
 const MORE = [
     { href: '/blog/', label: 'Blog' },
     { href: '/agent-trust-index/', label: 'Index' },
+    { href: '/conformance/', label: 'Conformance' },
 ];
 
 const navLinkClass = (active: boolean) =>


### PR DESCRIPTION
Adds a Conformance link to the top navbar More dropdown, positioned right after Index. It points to the existing /conformance/ page (previously only linked from the footer). One-line change to the MORE array in Nav.tsx.