### PR TITLE
Add robot-to-robot trust handshake to the Go sidecar (byte-identical interop)

### DIFF
--- a/go-sidecar/robotics/handshake.go
+++ b/go-sidecar/robotics/handshake.go
@@ -1,0 +1,269 @@
+// Robot-to-robot trust handshake (Phase 5.4), Go.
+//
+// Mirrors vouch/robotics/handshake.py and the TypeScript SDK. Two robots in
+// different trust domains authenticate and establish a bounded-trust session via
+// three signed messages (HELLO, ACCEPT, CONFIRM). The session scope is the
+// intersection of what each side offers, never the union, and the responder
+// checks the initiator's domain against its trust policy. Each message is an
+// eddsa-jcs-2022 signed object, so authentication reuses the shared signer and
+// verifier and is interoperable with Python and TypeScript.
+package robotics
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+// Handshake message types.
+const (
+	HELLO   = "handshake_hello"
+	ACCEPT  = "handshake_accept"
+	CONFIRM = "handshake_confirm"
+)
+
+// HandshakeError is returned when a handshake step fails (untrusted peer, bad
+// signature, malformed message).
+type HandshakeError struct{ Msg string }
+
+func (e *HandshakeError) Error() string { return e.Msg }
+
+func handshakeErr(format string, a ...any) error {
+	return &HandshakeError{Msg: fmt.Sprintf(format, a...)}
+}
+
+// TrustPolicy decides whether a peer DID is trusted. A peer is trusted when its
+// did:web domain is in TrustedDomains, or when AcceptUnknown is set.
+type TrustPolicy struct {
+	TrustedDomains map[string]bool
+	AcceptUnknown  bool
+}
+
+// NewTrustPolicy builds a TrustPolicy from a list of allowed did:web domains.
+func NewTrustPolicy(domains []string, acceptUnknown bool) *TrustPolicy {
+	set := make(map[string]bool, len(domains))
+	for _, d := range domains {
+		set[d] = true
+	}
+	return &TrustPolicy{TrustedDomains: set, AcceptUnknown: acceptUnknown}
+}
+
+// IsTrusted reports whether the given DID is trusted under this policy.
+func (p *TrustPolicy) IsTrusted(did string) bool {
+	if p.AcceptUnknown {
+		return true
+	}
+	d, ok := didWebDomain(did)
+	return ok && p.TrustedDomains[d]
+}
+
+// BoundedSession is the agreed cooperation session after a successful handshake.
+type BoundedSession struct {
+	SessionID  string
+	Initiator  string
+	Responder  string
+	Scope      []string
+	Nonce      string
+	ValidUntil string
+}
+
+func didWebDomain(did string) (string, bool) {
+	const prefix = "did:web:"
+	if !strings.HasPrefix(did, prefix) {
+		return "", false
+	}
+	rest := did[len(prefix):]
+	if i := strings.IndexByte(rest, ':'); i >= 0 {
+		rest = rest[:i]
+	}
+	if rest == "" {
+		return "", false
+	}
+	return rest, true
+}
+
+func strsToAny(ss []string) []any {
+	out := make([]any, len(ss))
+	for i, s := range ss {
+		out[i] = s
+	}
+	return out
+}
+
+func uuidV4() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	b[6] = (b[6] & 0x0f) | 0x40 // version 4
+	b[8] = (b[8] & 0x3f) | 0x80 // variant 10
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16]), nil
+}
+
+// BuildHelloOptions configures BuildHello.
+type BuildHelloOptions struct {
+	ProposedScope []string
+	Nonce         string // "" generates a fresh 16-byte hex nonce
+	PeerDID       string // "" leaves "to" as null
+}
+
+// BuildHello opens the handshake (initiator A) with a proposed scope and a fresh
+// nonce.
+func BuildHello(s *signer.Signer, opts BuildHelloOptions) (map[string]any, error) {
+	nonce := opts.Nonce
+	if nonce == "" {
+		b := make([]byte, 16)
+		if _, err := rand.Read(b); err != nil {
+			return nil, err
+		}
+		nonce = hex.EncodeToString(b)
+	}
+	var to any // nil marshals to JSON null, matching the TypeScript default
+	if opts.PeerDID != "" {
+		to = opts.PeerDID
+	}
+	hello := map[string]any{
+		"type":          HELLO,
+		"from":          s.DID(),
+		"to":            to,
+		"nonce":         nonce,
+		"proposedScope": strsToAny(opts.ProposedScope),
+		"issuedAt":      iso(time.Now().UTC()),
+	}
+	return s.AttachProof(hello)
+}
+
+// BuildAcceptOptions configures BuildAccept.
+type BuildAcceptOptions struct {
+	Hello          map[string]any
+	HelloPublicKey ed25519.PublicKey
+	Policy         *TrustPolicy
+	OfferedScope   []string
+	ValidSeconds   int    // 0 defaults to 300
+	SessionID      string // "" generates a urn:uuid
+}
+
+// BuildAccept verifies A's HELLO and identity domain, intersects the scope, and
+// signs an acceptance (responder B). Returns a HandshakeError if A is untrusted
+// or the HELLO is invalid.
+func BuildAccept(s *signer.Signer, opts BuildAcceptOptions) (map[string]any, error) {
+	if t, _ := opts.Hello["type"].(string); t != HELLO {
+		return nil, handshakeErr("not a HELLO message")
+	}
+	if ok, err := signer.VerifyDataIntegrityProof(opts.Hello, opts.HelloPublicKey); err != nil || !ok {
+		return nil, handshakeErr("HELLO signature invalid")
+	}
+	initiator, _ := opts.Hello["from"].(string)
+	if opts.Policy == nil || !opts.Policy.IsTrusted(initiator) {
+		return nil, handshakeErr("peer %s is not in this trust domain's policy", initiator)
+	}
+
+	offered := make(map[string]bool, len(opts.OfferedScope))
+	for _, x := range opts.OfferedScope {
+		offered[x] = true
+	}
+	seen := map[string]bool{}
+	var bounded []string
+	for _, sc := range toStrSlice(opts.Hello["proposedScope"]) {
+		if offered[sc] && !seen[sc] {
+			seen[sc] = true
+			bounded = append(bounded, sc)
+		}
+	}
+	sort.Strings(bounded)
+
+	sid := opts.SessionID
+	if sid == "" {
+		u, err := uuidV4()
+		if err != nil {
+			return nil, err
+		}
+		sid = "urn:uuid:" + u
+	}
+	validSeconds := opts.ValidSeconds
+	if validSeconds == 0 {
+		validSeconds = 300
+	}
+	validUntil := iso(time.Now().UTC().Add(time.Duration(validSeconds) * time.Second))
+
+	accept := map[string]any{
+		"type":         ACCEPT,
+		"from":         s.DID(),
+		"to":           initiator,
+		"sessionId":    sid,
+		"nonce":        opts.Hello["nonce"],
+		"boundedScope": strsToAny(bounded),
+		"validUntil":   validUntil,
+	}
+	return s.AttachProof(accept)
+}
+
+// VerifyAcceptOptions configures VerifyAccept.
+type VerifyAcceptOptions struct {
+	ExpectedNonce string
+	Policy        *TrustPolicy // optional; when set, the responder must be trusted
+}
+
+// VerifyAccept verifies B's ACCEPT (initiator A): the signature, that the nonce
+// echoes A's HELLO, and optionally that B is trusted. Returns (ok, session).
+func VerifyAccept(accept map[string]any, acceptPublicKey ed25519.PublicKey, opts VerifyAcceptOptions) (bool, *BoundedSession) {
+	if t, _ := accept["type"].(string); t != ACCEPT {
+		return false, nil
+	}
+	if ok, err := signer.VerifyDataIntegrityProof(accept, acceptPublicKey); err != nil || !ok {
+		return false, nil
+	}
+	if n, _ := accept["nonce"].(string); n != opts.ExpectedNonce {
+		return false, nil
+	}
+	responder, _ := accept["from"].(string)
+	if opts.Policy != nil && !opts.Policy.IsTrusted(responder) {
+		return false, nil
+	}
+
+	initiator, _ := accept["to"].(string)
+	sid, _ := accept["sessionId"].(string)
+	nonce, _ := accept["nonce"].(string)
+	validUntil, _ := accept["validUntil"].(string)
+	return true, &BoundedSession{
+		SessionID:  sid,
+		Initiator:  initiator,
+		Responder:  responder,
+		Scope:      toStrSlice(accept["boundedScope"]),
+		Nonce:      nonce,
+		ValidUntil: validUntil,
+	}
+}
+
+// BuildConfirm signs A's confirmation of the bounded session to B.
+func BuildConfirm(s *signer.Signer, session BoundedSession) (map[string]any, error) {
+	confirm := map[string]any{
+		"type":          CONFIRM,
+		"from":          s.DID(),
+		"to":            session.Responder,
+		"sessionId":     session.SessionID,
+		"nonce":         session.Nonce,
+		"acceptedScope": strsToAny(session.Scope),
+	}
+	return s.AttachProof(confirm)
+}
+
+// VerifyConfirm verifies A's CONFIRM closes the agreed session (responder B):
+// the signature, and that the session id and nonce match what B accepted.
+func VerifyConfirm(confirm map[string]any, confirmPublicKey ed25519.PublicKey, sessionID, expectedNonce string) bool {
+	if t, _ := confirm["type"].(string); t != CONFIRM {
+		return false
+	}
+	if ok, err := signer.VerifyDataIntegrityProof(confirm, confirmPublicKey); err != nil || !ok {
+		return false
+	}
+	sid, _ := confirm["sessionId"].(string)
+	nonce, _ := confirm["nonce"].(string)
+	return sid == sessionID && nonce == expectedNonce
+}

--- a/go-sidecar/robotics/handshake_test.go
+++ b/go-sidecar/robotics/handshake_test.go
@@ -1,0 +1,193 @@
+package robotics
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+const (
+	didA = "did:web:robot-a.example.com"
+	didB = "did:web:robot-b.example.com"
+)
+
+// TestHandshakeFullFlow runs HELLO -> ACCEPT -> CONFIRM end to end and checks the
+// session scope is the intersection of the two offers.
+func TestHandshakeFullFlow(t *testing.T) {
+	a := newRobot(t, didA)
+	b := newRobot(t, didB)
+	policyB := NewTrustPolicy([]string{"robot-a.example.com"}, false)
+
+	hello, err := BuildHello(a, BuildHelloOptions{ProposedScope: []string{"lift", "carry", "scan"}, PeerDID: didB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce, _ := hello["nonce"].(string)
+	if nonce == "" {
+		t.Fatal("hello has no nonce")
+	}
+
+	accept, err := BuildAccept(b, BuildAcceptOptions{
+		Hello: hello, HelloPublicKey: a.PublicKeyEd25519(), Policy: policyB,
+		OfferedScope: []string{"carry", "scan", "weld"},
+	})
+	if err != nil {
+		t.Fatalf("accept failed: %v", err)
+	}
+
+	ok, session := VerifyAccept(accept, b.PublicKeyEd25519(), VerifyAcceptOptions{ExpectedNonce: nonce})
+	if !ok {
+		t.Fatal("A failed to verify B's ACCEPT")
+	}
+	// Intersection of {lift,carry,scan} and {carry,scan,weld}, sorted.
+	want := []string{"carry", "scan"}
+	if len(session.Scope) != len(want) || session.Scope[0] != want[0] || session.Scope[1] != want[1] {
+		t.Fatalf("bounded scope = %v, want %v", session.Scope, want)
+	}
+	if session.Initiator != didA || session.Responder != didB {
+		t.Fatalf("session parties wrong: %s / %s", session.Initiator, session.Responder)
+	}
+
+	confirm, err := BuildConfirm(a, *session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !VerifyConfirm(confirm, a.PublicKeyEd25519(), session.SessionID, nonce) {
+		t.Fatal("B failed to verify A's CONFIRM")
+	}
+}
+
+func TestUntrustedPeerRejected(t *testing.T) {
+	a := newRobot(t, didA)
+	b := newRobot(t, didB)
+	policyB := NewTrustPolicy([]string{"someone-else.example.com"}, false)
+
+	hello, err := BuildHello(a, BuildHelloOptions{ProposedScope: []string{"lift"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := BuildAccept(b, BuildAcceptOptions{
+		Hello: hello, HelloPublicKey: a.PublicKeyEd25519(), Policy: policyB, OfferedScope: []string{"lift"},
+	}); err == nil {
+		t.Fatal("expected an untrusted initiator to be rejected")
+	} else if _, isHS := err.(*HandshakeError); !isHS {
+		t.Fatalf("expected HandshakeError, got %T", err)
+	}
+}
+
+func TestAcceptUnknownPolicy(t *testing.T) {
+	a := newRobot(t, didA)
+	b := newRobot(t, didB)
+	open := NewTrustPolicy(nil, true)
+
+	hello, _ := BuildHello(a, BuildHelloOptions{ProposedScope: []string{"lift"}})
+	if _, err := BuildAccept(b, BuildAcceptOptions{
+		Hello: hello, HelloPublicKey: a.PublicKeyEd25519(), Policy: open, OfferedScope: []string{"lift"},
+	}); err != nil {
+		t.Fatalf("an open policy should accept any peer: %v", err)
+	}
+}
+
+func TestTamperedHelloRejected(t *testing.T) {
+	a := newRobot(t, didA)
+	b := newRobot(t, didB)
+	policyB := NewTrustPolicy([]string{"robot-a.example.com"}, false)
+
+	hello, _ := BuildHello(a, BuildHelloOptions{ProposedScope: []string{"lift"}})
+	// Broaden the scope after signing; the signature no longer covers it.
+	hello["proposedScope"] = []any{"lift", "weld", "drive"}
+	if _, err := BuildAccept(b, BuildAcceptOptions{
+		Hello: hello, HelloPublicKey: a.PublicKeyEd25519(), Policy: policyB, OfferedScope: []string{"lift", "weld"},
+	}); err == nil {
+		t.Fatal("expected a tampered HELLO to fail signature verification")
+	}
+}
+
+func TestVerifyAcceptNonceMismatch(t *testing.T) {
+	a := newRobot(t, didA)
+	b := newRobot(t, didB)
+	policyB := NewTrustPolicy([]string{"robot-a.example.com"}, false)
+
+	hello, _ := BuildHello(a, BuildHelloOptions{ProposedScope: []string{"lift"}})
+	accept, err := BuildAccept(b, BuildAcceptOptions{
+		Hello: hello, HelloPublicKey: a.PublicKeyEd25519(), Policy: policyB, OfferedScope: []string{"lift"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := VerifyAccept(accept, b.PublicKeyEd25519(), VerifyAcceptOptions{ExpectedNonce: "deadbeef"}); ok {
+		t.Fatal("expected a nonce mismatch to fail")
+	}
+}
+
+func TestVerifyConfirmWrongSession(t *testing.T) {
+	a := newRobot(t, didA)
+	session := BoundedSession{SessionID: "urn:uuid:abc", Responder: didB, Nonce: "n1", Scope: []string{"lift"}}
+	confirm, err := BuildConfirm(a, session)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if VerifyConfirm(confirm, a.PublicKeyEd25519(), "urn:uuid:other", "n1") {
+		t.Fatal("expected a wrong session id to fail")
+	}
+	if VerifyConfirm(confirm, a.PublicKeyEd25519(), "urn:uuid:abc", "n2") {
+		t.Fatal("expected a wrong nonce to fail")
+	}
+}
+
+func TestDidWebDomain(t *testing.T) {
+	cases := map[string]string{
+		"did:web:example.com":             "example.com",
+		"did:web:robot.example.com:agent": "robot.example.com",
+		"did:key:z6Mk":                    "",
+	}
+	for in, want := range cases {
+		got, ok := didWebDomain(in)
+		if want == "" {
+			if ok {
+				t.Fatalf("%s: expected no domain, got %s", in, got)
+			}
+			continue
+		}
+		if !ok || got != want {
+			t.Fatalf("%s: got %q (ok=%v), want %q", in, got, ok, want)
+		}
+	}
+}
+
+// TestHandshakeAfterJSONRoundTrip exercises the cross-language path: A's HELLO is
+// serialized and decoded (as it would arrive over the wire from a Python or
+// TypeScript robot) before B accepts it. The scope, decoded as []any, must still
+// intersect correctly and the signature must still verify.
+func TestHandshakeAfterJSONRoundTrip(t *testing.T) {
+	a := newRobot(t, didA)
+	b := newRobot(t, didB)
+	policyB := NewTrustPolicy([]string{"robot-a.example.com"}, false)
+
+	hello, err := BuildHello(a, BuildHelloOptions{ProposedScope: []string{"lift", "carry"}, PeerDID: didB})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blob, err := json.Marshal(hello)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var wire map[string]any
+	if err := json.Unmarshal(blob, &wire); err != nil {
+		t.Fatal(err)
+	}
+
+	accept, err := BuildAccept(b, BuildAcceptOptions{
+		Hello: wire, HelloPublicKey: a.PublicKeyEd25519(), Policy: policyB, OfferedScope: []string{"carry", "weld"},
+	})
+	if err != nil {
+		t.Fatalf("accept of a JSON-decoded HELLO failed: %v", err)
+	}
+	nonce, _ := wire["nonce"].(string)
+	ok, session := VerifyAccept(accept, b.PublicKeyEd25519(), VerifyAcceptOptions{ExpectedNonce: nonce})
+	if !ok {
+		t.Fatal("verify of accept failed")
+	}
+	if len(session.Scope) != 1 || session.Scope[0] != "carry" {
+		t.Fatalf("bounded scope = %v, want [carry]", session.Scope)
+	}
+}


### PR DESCRIPTION
Ports the robot-to-robot trust handshake (Phase 5.4) to the Go sidecar, continuing the cross-language port after identity (#82), provenance (#83), and capability (#84).

What this adds in `go-sidecar/robotics/handshake.go`:

- `BuildHello` / `BuildAccept` / `VerifyAccept` / `BuildConfirm` / `VerifyConfirm` — the three-message HELLO → ACCEPT → CONFIRM exchange, each an `eddsa-jcs-2022` signed object.
- `TrustPolicy` — allow a peer by its `did:web` domain, or accept unknowns explicitly.

Security boundary:

- `BuildAccept` signs an acceptance only if the HELLO signature verifies **and** the initiator's `did:web` domain passes the responder's `TrustPolicy`. An untrusted initiator or a tampered HELLO is rejected.
- The session scope is the **intersection** of the initiator's proposed scope and the responder's offered scope, sorted and de-duplicated — never the union, so neither side can widen the other's grant.
- The initiator's nonce is echoed in the ACCEPT and checked by `VerifyAccept`, binding the acceptance to that HELLO; `VerifyConfirm` checks the session id and nonce.

Cross-language behaviour: messages are read through helpers that accept both Go-native and JSON-decoded shapes (scope as `[]any`, nonce as a string), so a HELLO signed by a Python or TypeScript robot is accepted in Go and vice versa.

Tests (`handshake_test.go`): full HELLO/ACCEPT/CONFIRM flow with scope intersection, untrusted-peer rejection, accept-unknown policy, tampered-HELLO rejection, nonce-mismatch rejection, wrong-session rejection, `did:web` domain parsing, and a JSON-wire-shape round trip.

`go build`, `go vet`, and `gofmt -l` are clean; all robotics and signer tests pass.
