### PR TITLE
Add scannable robot passport to the Go sidecar

### DIFF
--- a/go-sidecar/robotics/passport.go
+++ b/go-sidecar/robotics/passport.go
@@ -1,0 +1,167 @@
+// Scannable robot passport (Phase 5.6), Go.
+//
+// Mirrors vouch/robotics/passport.py and the TypeScript SDK. A compact, signed
+// RobotPassport that anyone can scan (QR or NFC) to check a robot's owner,
+// authorized actions, certification, and current standing, offline. The QR/NFC
+// payload is a vouch-passport: URI carrying the multibase JCS bytes of the
+// credential, so an offline reader verifies the signature with no network call.
+// The URI encoding is deterministic, so a passport encoded by any language
+// decodes and verifies in the others.
+package robotics
+
+import (
+	"crypto/ed25519"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+// Passport constants.
+const (
+	RobotPassportType    = "RobotPassport"
+	PassportURIScheme    = "vouch-passport:"
+	StatusActive         = "active"
+	StatusSuspended      = "suspended"
+	StatusDecommissioned = "decommissioned"
+)
+
+// PassportError is returned for malformed passport URIs.
+type PassportError struct{ Msg string }
+
+func (e *PassportError) Error() string { return e.Msg }
+
+// BuildPassportOptions configures BuildPassport.
+type BuildPassportOptions struct {
+	RobotDID          string
+	Make              string
+	Model             string
+	Owner             string
+	AuthorizedActions []string
+	Certification     string // "" omits the field
+	Status            string // "" defaults to active
+	ValidSeconds      int    // 0 omits validUntil
+	ValidFrom         time.Time
+}
+
+// BuildPassport builds a signed RobotPassport credential (issued by the robot or
+// an authority).
+func BuildPassport(s *signer.Signer, opts BuildPassportOptions) (map[string]any, error) {
+	issued := opts.ValidFrom
+	if issued.IsZero() {
+		issued = time.Now().UTC()
+	}
+	status := opts.Status
+	if status == "" {
+		status = StatusActive
+	}
+	subject := map[string]any{
+		"id":                opts.RobotDID,
+		"make":              opts.Make,
+		"model":             opts.Model,
+		"owner":             opts.Owner,
+		"authorizedActions": strsToAny(opts.AuthorizedActions),
+		"status":            status,
+	}
+	if opts.Certification != "" {
+		subject["certification"] = opts.Certification
+	}
+	cred := map[string]any{
+		"@context":          []any{vcContextV2, vouchContextV1},
+		"type":              []any{"VerifiableCredential", RobotPassportType},
+		"issuer":            s.DID(),
+		"validFrom":         iso(issued),
+		"credentialSubject": subject,
+	}
+	if opts.ValidSeconds > 0 {
+		cred["validUntil"] = iso(issued.Add(time.Duration(opts.ValidSeconds) * time.Second))
+	}
+	return s.AttachProof(cred)
+}
+
+// EncodePassport encodes a passport into a compact vouch-passport: URI for a QR
+// or NFC tag.
+func EncodePassport(passport map[string]any) (string, error) {
+	canon, err := signer.Canonicalize(passport)
+	if err != nil {
+		return "", err
+	}
+	return PassportURIScheme + mb64(canon), nil
+}
+
+// DecodePassport decodes a vouch-passport: URI back into the passport credential.
+func DecodePassport(uri string) (map[string]any, error) {
+	if !strings.HasPrefix(uri, PassportURIScheme) {
+		return nil, &PassportError{"not a " + PassportURIScheme + " URI"}
+	}
+	body := uri[len(PassportURIScheme):]
+	raw, err := unmb64(body)
+	if err != nil {
+		return nil, &PassportError{"expected multibase 'u' payload"}
+	}
+	var p map[string]any
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, &PassportError{"passport decode failed: " + err.Error()}
+	}
+	return p, nil
+}
+
+// PassportSummary is the human-readable result of a successful verification.
+type PassportSummary struct {
+	Robot             string
+	Make              string
+	Model             string
+	Owner             string
+	AuthorizedActions []string
+	Certification     string
+	Status            string
+}
+
+// VerifyPassport verifies a passport credential object. A suspended or
+// decommissioned status still verifies but is surfaced in the summary so a
+// scanner can refuse cooperation; an expired passport fails. A zero now uses the
+// current time.
+func VerifyPassport(passport map[string]any, publicKey ed25519.PublicKey, now time.Time) (bool, *PassportSummary) {
+	if !hasType(passport["type"], RobotPassportType) {
+		return false, nil
+	}
+	if ok, err := signer.VerifyDataIntegrityProof(passport, publicKey); err != nil || !ok {
+		return false, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if vu, _ := passport["validUntil"].(string); vu != "" {
+		if t, err := time.Parse(time.RFC3339, vu); err == nil && now.After(t) {
+			return false, nil
+		}
+	}
+
+	s, _ := passport["credentialSubject"].(map[string]any)
+	robot, _ := s["id"].(string)
+	mk, _ := s["make"].(string)
+	model, _ := s["model"].(string)
+	owner, _ := s["owner"].(string)
+	cert, _ := s["certification"].(string)
+	status, _ := s["status"].(string)
+	return true, &PassportSummary{
+		Robot:             robot,
+		Make:              mk,
+		Model:             model,
+		Owner:             owner,
+		AuthorizedActions: toStrSlice(s["authorizedActions"]),
+		Certification:     cert,
+		Status:            status,
+	}
+}
+
+// VerifyPassportURI decodes a vouch-passport: URI and verifies it. Returns
+// (false, nil) if the URI is malformed.
+func VerifyPassportURI(uri string, publicKey ed25519.PublicKey, now time.Time) (bool, *PassportSummary) {
+	p, err := DecodePassport(uri)
+	if err != nil {
+		return false, nil
+	}
+	return VerifyPassport(p, publicKey, now)
+}

--- a/go-sidecar/robotics/passport_test.go
+++ b/go-sidecar/robotics/passport_test.go
@@ -1,0 +1,134 @@
+package robotics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func buildSamplePassport(t *testing.T) (map[string]any, []byte) {
+	t.Helper()
+	robot := newRobot(t, "did:web:robot.example.com")
+	pass, err := BuildPassport(robot, BuildPassportOptions{
+		RobotDID:          "did:web:robot.example.com",
+		Make:              "Acme Robotics",
+		Model:             "AR-7",
+		Owner:             "did:web:owner.example.com",
+		AuthorizedActions: []string{"lift", "carry"},
+		Certification:     "ISO-10218",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pass, robot.PublicKeyEd25519()
+}
+
+func TestPassportBuildVerify(t *testing.T) {
+	pass, pub := buildSamplePassport(t)
+	ok, summary := VerifyPassport(pass, pub, time.Time{})
+	if !ok {
+		t.Fatal("passport should verify")
+	}
+	if summary.Owner != "did:web:owner.example.com" || summary.Make != "Acme Robotics" {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+	if len(summary.AuthorizedActions) != 2 || summary.AuthorizedActions[0] != "lift" {
+		t.Fatalf("unexpected actions: %v", summary.AuthorizedActions)
+	}
+	if summary.Status != StatusActive {
+		t.Fatalf("default status should be active, got %s", summary.Status)
+	}
+}
+
+// TestPassportEncodeDecodeVerify is the offline-scan path and the cross-language
+// shape check in one: encode to a vouch-passport: URI, decode it (JSON-decoded,
+// so authorizedActions is []any), and verify the decoded form.
+func TestPassportEncodeDecodeVerify(t *testing.T) {
+	pass, pub := buildSamplePassport(t)
+	uri, err := EncodePassport(pass)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(uri, PassportURIScheme+"u") {
+		t.Fatalf("URI missing scheme/multibase prefix: %s", uri[:20])
+	}
+	decoded, err := DecodePassport(uri)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, summary := VerifyPassport(decoded, pub, time.Time{})
+	if !ok {
+		t.Fatal("decoded passport should verify")
+	}
+	if len(summary.AuthorizedActions) != 2 {
+		t.Fatalf("actions lost across decode: %v", summary.AuthorizedActions)
+	}
+	// And the convenience URI verifier agrees.
+	if ok, _ := VerifyPassportURI(uri, pub, time.Time{}); !ok {
+		t.Fatal("VerifyPassportURI should verify a freshly encoded passport")
+	}
+}
+
+func TestPassportExpired(t *testing.T) {
+	robot := newRobot(t, "did:web:robot.example.com")
+	issued := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	pass, err := BuildPassport(robot, BuildPassportOptions{
+		RobotDID: "did:web:robot.example.com", Make: "Acme", Model: "AR-7",
+		Owner: "did:web:owner.example.com", AuthorizedActions: []string{"lift"},
+		ValidSeconds: 60, ValidFrom: issued,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pub := robot.PublicKeyEd25519()
+	// Within the window: valid.
+	if ok, _ := VerifyPassport(pass, pub, issued.Add(30*time.Second)); !ok {
+		t.Fatal("passport should be valid inside its window")
+	}
+	// Past validUntil: expired.
+	if ok, _ := VerifyPassport(pass, pub, issued.Add(120*time.Second)); ok {
+		t.Fatal("expired passport should fail")
+	}
+}
+
+func TestPassportSuspendedStillVerifies(t *testing.T) {
+	robot := newRobot(t, "did:web:robot.example.com")
+	pass, err := BuildPassport(robot, BuildPassportOptions{
+		RobotDID: "did:web:robot.example.com", Make: "Acme", Model: "AR-7",
+		Owner: "did:web:owner.example.com", AuthorizedActions: []string{"lift"},
+		Status: StatusSuspended,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ok, summary := VerifyPassport(pass, robot.PublicKeyEd25519(), time.Time{})
+	if !ok {
+		t.Fatal("a suspended passport still verifies (status surfaced, not rejected)")
+	}
+	if summary.Status != StatusSuspended {
+		t.Fatalf("status should be surfaced as suspended, got %s", summary.Status)
+	}
+}
+
+func TestPassportTamperRejected(t *testing.T) {
+	pass, pub := buildSamplePassport(t)
+	// Change the owner after signing.
+	pass["credentialSubject"].(map[string]any)["owner"] = "did:web:attacker.example.com"
+	if ok, _ := VerifyPassport(pass, pub, time.Time{}); ok {
+		t.Fatal("a tampered passport must fail verification")
+	}
+}
+
+func TestPassportWrongTypeRejected(t *testing.T) {
+	pass, pub := buildSamplePassport(t)
+	pass["type"] = []any{"VerifiableCredential"}
+	if ok, _ := VerifyPassport(pass, pub, time.Time{}); ok {
+		t.Fatal("a non-passport type must be rejected")
+	}
+}
+
+func TestDecodePassportRejectsBadURI(t *testing.T) {
+	if _, err := DecodePassport("https://example.com/not-a-passport"); err == nil {
+		t.Fatal("expected a non-vouch-passport URI to be rejected")
+	}
+}


### PR DESCRIPTION
Adds the scannable robot passport (Phase 5.6) to the Go sidecar, the final capability in the Go robotics port.

- `BuildPassport` / `EncodePassport` / `DecodePassport` / `VerifyPassport` / `VerifyPassportURI`: a signed `RobotPassport` encoded into a deterministic `vouch-passport:` URI for offline QR or NFC verification.

Security boundary: verification is fully offline (caller supplies the issuer key); an expired passport fails; a suspended or decommissioned one still verifies but surfaces its status; tamper and wrong-type are rejected. The cross-language decoded shape is covered by a JSON round-trip test.

With this, the Go sidecar has byte-identical parity with Python and TypeScript across all six robotics primitives. `go build`, `go vet`, `gofmt -l` clean; tests pass.
