### PR TITLE
Robotics knowledge base, Claude skill, OpenAI GPT, and Gemini gem

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -210,6 +210,23 @@ underneath the reputation engine.
 Reference implementations under `vouch/integrations/`. See
 `reference/integrations.md` for the common pattern.
 
+### "How do I give a robot a verifiable identity, or enforce physical limits?"
+
+Vouch ships six robotics capabilities in `vouch.robotics` (and in TypeScript, Go,
+and the Rust core that flows to Swift, Kotlin/JVM, .NET, C/C++, and WASM):
+hardware-rooted identity (`mint_robot_identity` / `verify_robot_identity`, bound
+to a TPM or secure element), model and config provenance
+(`build_provenance_attestation`, re-signable on OTA updates), physical capability
+scope (`build_physical_scope_credential`, `check_physical_action`, `attenuates`
+for narrow-only delegation of force/speed/zone/shift limits), a robot-to-robot
+trust handshake (`build_hello` / `build_accept` / `build_confirm` with a
+`TrustPolicy`), an encrypted tamper-evident black box (`BlackBoxLog`,
+`verify_blackbox_chain`) plus a verifiable kill switch
+(`build_killswitch_credential`), and a scannable offline passport
+(`build_passport` / `encode_passport` into a `vouch-passport:` URI). Same
+Verifiable Credentials as the rest of Vouch, so they verify in every language.
+See `reference/robotics.md`.
+
 ## Decision rules
 
 - **User is just signing one credential** -> Python signer, three lines.
@@ -220,6 +237,7 @@ Reference implementations under `vouch/integrations/`. See
 - **User wants continuous trust** -> Heartbeat Protocol with validator quorum (Python only today).
 - **User cares about audit trail** -> all of the above, plus the reputation engine for behaviour tracking.
 - **User wants a track record that cannot be backdated or cherry-picked** -> outcome evidence (`vouch.accountability`): commit the verdict before the outcome, settle it later with a neutral settler.
+- **User is building a robot or embodied agent** -> the `vouch.robotics` capabilities: hardware-rooted identity, model and config provenance, physical capability scope, robot-to-robot handshake, encrypted black box with kill switch, and a scannable passport.
 
 ## Reference files
 
@@ -234,6 +252,7 @@ For depth on any topic, read the relevant file under `reference/`:
 - `reference/revocation.md` - DID-level and credential-level revocation
 - `reference/state-verifiability.md` - Heartbeat, validator quorum, behavioral attestation
 - `reference/outcome-evidence.md` - Commit-before-outcome verdicts, settlement, track record
+- `reference/robotics.md` - Robot identity, provenance, physical scope, handshake, black box and kill switch, passport
 - `reference/integrations.md` - LangChain, CrewAI, MCP, AutoGen, Vertex AI patterns
 - `reference/sidecar.md` - Identity Sidecar architecture and deployment
 - `reference/troubleshooting.md` - Common errors and fixes

--- a/claude-skill/skills/vouch-protocol/reference/robotics.md
+++ b/claude-skill/skills/vouch-protocol/reference/robotics.md
@@ -1,34 +1,311 @@
-# Robots and embodied agents
+# Robotics: the complete guide to Vouch for robots and embodied agents
 
-A robot is an agent with a body. Identity, accountability, and continuous trust
-matter more, not less, when an agent can cause physical harm or move money in
-the real world. Vouch covers the open identity layer for robots; richer
-robot-lifecycle tooling builds on top of it.
+Vouch gives robots and embodied agents the same identity, accountability, and
+continuous trust it gives software agents, and adds the pieces that only matter
+once an agent has a body and can cause physical harm. This guide teaches every
+robotics capability end to end: what it is, the problem it closes, how it works,
+the API, a worked example, and exactly what verification checks.
 
-## The same primitives apply
+## The shared foundation
 
-- Identity: a `did:vouch:agent` identity for the robot (the open agent DID
-  profile in `docs/specs/`).
-- Delegation: a delegation chain records who authorized the robot, on whose
-  behalf, and within what limits, all verifiable.
-- Continuous trust: the heartbeat runtime turns "valid at boot" into "still
-  behaving now," so a robot has to keep proving itself.
-- Revocation: pull a robot's authority the moment it goes wrong, and anyone can
-  check the status.
+Every robotics primitive is built on the same machinery as the rest of Vouch, so
+there is nothing new to trust at the cryptographic layer:
 
-## The robot-specific open piece: hardware root of trust
+- Credentials are W3C Verifiable Credentials with an `eddsa-jcs-2022` Data
+  Integrity proof (Ed25519 signature over the RFC 8785 JCS canonical bytes,
+  SHA-256 digest, `proofValue` as multibase base58btc).
+- Binary values that are not keys (attestations, config hashes, ciphertext,
+  entry hashes) use multibase base64url, a leading `u` then base64url-no-pad.
+- The same credential verifies in every language. The logic lives once in the
+  Rust core (`core/vouch-core`, module `robotics`) and is exposed to Swift,
+  Kotlin/JVM, .NET, C/C++, and the browser through the UniFFI and WASM wrappers;
+  Python, TypeScript, and Go each carry a byte-identical reference
+  implementation (`vouch.robotics`, `packages/sdk-ts/src/robotics`,
+  `go-sidecar/robotics`). A robotics credential signed in any one of them
+  verifies in all the others, proven by the shared interop vector in
+  `test-vectors/robotics/vector.json`.
 
-A software agent's key can live in a file. A robot should do better. The
-hardware-root-of-trust profile binds the robot's DID to its secure element (a
-TPM, a secure enclave, or an on-board AI module's enclave). The enclave holds
-the signing key and signs the robot's heartbeats, so identity is anchored to the
-physical device, not a config that can be copied. The open `did:vouch:agent`
-profile defines the agent identity scheme; the embodied profile extends it for
-hardware attestation.
+These are open formats plus reference implementations. Hosted black-box storage
+and fleet-scale kill-switch infrastructure are left to whoever deploys them.
 
-## Open vs built on top
+A design rule runs through the whole module: the core is hardware-agnostic and
+deterministic. It never reaches for a clock, a random number, or a TPM on its
+own. Timestamps, nonces, session ids, and hardware attestations are passed in by
+the caller, so output is reproducible and a real deployment can route signing to
+a secure element while a test routes it to a software key.
 
-The identity, delegation, continuous-trust, and hardware-attestation profiles
-are open Vouch. Operated robot-lifecycle products (lifecycle identity
-management, model-and-config provenance, fleet trust at scale, and similar)
-build on this open layer and are out of scope for the protocol itself.
+---
+
+## 1. Hardware-rooted identity
+
+`vouch.robotics.identity`
+
+What it is: a `RobotIdentityCredential` that binds a robot's software identity
+key to a physical hardware root of trust (a TPM, a secure enclave, or an on-board
+secure element), alongside its make, model, serial, owner, and lifecycle history.
+
+The problem it closes: a software-only identity can be copied to another machine.
+If a robot's DID and key live in a config file, a cloned robot is
+indistinguishable from the original. Hardware rooting makes the identity
+non-transferable: it is provably tied to one piece of silicon.
+
+How it works: the robot self-issues the credential with its own Ed25519 key. The
+hardware root signs a binding, the JCS canonical bytes of
+`{"key": <robot key multibase>, "robotDid": <robot DID>}`, and that signature is
+embedded as `credentialSubject.hardwareRoot.attestation` next to the hardware
+root's own public key. Verification therefore checks two independent signatures:
+the credential proof (the robot key signed the document) and the hardware
+attestation (the hardware root signed the binding tying that key to that DID).
+
+The API: `mint_robot_identity` and `verify_robot_identity`, plus the
+`robot_identity_binding` helper that returns the exact bytes a TPM-backed root
+must sign (so a hardware backend can sign them externally). The reference SDKs add
+a `SoftwareRootOfTrust` for development and a `HardwareRootOfTrust` interface a
+real backend implements.
+
+Worked example (Python):
+
+```python
+from vouch.robotics import identity
+
+root = identity.SoftwareRootOfTrust(kind="TPM")          # a real deployment uses the TPM
+cred = identity.mint_robot_identity(
+    robot_signer, root,
+    make="Acme Robotics", model="AR-7", serial="SN-000123",
+    owner="did:web:owner.example.com",
+)
+ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+```
+
+Security boundary: verification fails closed if the type is wrong, the credential
+proof is invalid, the hardware public key is missing or not Ed25519, or the
+attestation does not verify against the binding. An attacker who
+swaps in their own hardware key and re-signs the credential still fails, because
+the attestation no longer matches the `{key, robotDid}` binding.
+
+---
+
+## 2. Model and config provenance
+
+`vouch.robotics.provenance`
+
+What it is: a signed `ModelProvenanceAttestation` recording the
+vision-language-action model name, the weights hash, the safety policy, and a
+hash of the running configuration.
+
+The problem it closes: "what software and safety policy was this robot running
+when the incident happened?" Without a signed record, the answer is whatever the
+logs say after the fact. Provenance makes it cryptographic and tamper-evident,
+and it survives over-the-air updates.
+
+How it works: the attestation carries a `vla` block with `modelName`,
+`weightsHash`, `safetyPolicy`, an optional `version`, and a `configHash`. The
+config hash is the multibase SHA-256 of the JCS-canonical config object, so any
+verifier reproduces it from the same config and detects drift. On an OTA update
+the robot re-signs a new attestation with a `supersedes` link to the previous
+one, forming a chain you can walk to answer "what was running at time T."
+
+The API: `build_provenance_attestation`, `verify_provenance_attestation`, and
+`config_hash`. Passing the config to the verifier additionally checks that the
+recorded `configHash` reproduces.
+
+Worked example (TypeScript):
+
+```ts
+import { buildProvenanceAttestation, verifyProvenanceAttestation } from '@vouch-protocol-official/sdk';
+
+const att = await buildProvenanceAttestation(signer, {
+  robotDid, modelName: 'openvla-7b', weightsHash: 'u...', safetyPolicy: 'did:web:authority#policy-v3',
+  config: { temperature: 0.0, max_torque: 12.5, guardrails: ['no_humans_zone'] },
+});
+const { ok, subject } = verifyProvenanceAttestation(att, publicKey, config);
+```
+
+Security boundary: verification fails on a wrong type, an invalid proof, or, when
+a config is supplied, a `configHash` that does not match. A robot running a
+different config than the one attested is detectable by anyone holding the
+expected config.
+
+---
+
+## 3. Physical capability scope
+
+`vouch.robotics.capability`
+
+What it is: a `PhysicalCapabilityScope` credential carrying physical limits, max
+force, max speed, a tighter speed cap near humans, allowed zones, and shift
+windows, that a controller checks before every actuation.
+
+The problem it closes: a permission like "operate the arm" says nothing about how
+hard or how fast. Physical scope makes the bound cryptographically enforceable
+and, crucially, makes delegated authority shrink-only so a sub-task can never
+quietly grant itself more force or a wider zone than its parent.
+
+How it works: the scope is a JSON object inside the credential subject. A
+controller calls the check function with a proposed action and gets back whether
+it is allowed plus a reason for each violated dimension. Delegation is governed
+by an attenuation rule: a child scope is valid only if every numeric cap is less
+than or equal to the parent, every allowed zone is a subset, and every shift
+window fits inside some parent window.
+
+The API: `build_physical_scope_credential`, `check_physical_action` (returns ok
+plus reasons), and `attenuates(parent, child)` (the narrow-only guard). The check
+and attenuation functions accept both native and JSON-decoded scope shapes, so a
+scope issued in one language enforces identically in another.
+
+Worked example (Go):
+
+```go
+scope := cred["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+res := robotics.CheckPhysicalAction(scope, robotics.PhysicalAction{
+    SpeedMps: ptr(1.5), NearHumans: true,   // rejected: near-humans cap is 0.5 m/s
+})
+// res.OK == false, res.Reasons == ["near_humans speed_exceeded: 1.5 m/s > 0.5 m/s"]
+```
+
+Security boundary: the runtime check rejects an action that exceeds any granted
+dimension (an absent dimension is unconstrained by design). The attenuation check
+is the privilege-escalation guard: a child that raises a cap, drops a cap the
+parent set, adds a zone outside the parent set, or widens a window is rejected.
+
+---
+
+## 4. Robot-to-robot trust handshake
+
+`vouch.robotics.handshake`
+
+What it is: a three-message exchange (HELLO, ACCEPT, CONFIRM) by which two robots
+in different trust domains authenticate each other and agree a bounded
+cooperation session.
+
+The problem it closes: when robots from different fleets meet and must cooperate,
+each needs to know the other is who it claims and agree on a safe, limited set of
+shared actions, without a central authority brokering it.
+
+How it works: the initiator signs a HELLO proposing a scope and a fresh nonce.
+The responder verifies the HELLO signature, checks the initiator's `did:web`
+domain against its trust policy, and signs an ACCEPT whose `boundedScope` is the
+intersection of the proposed scope and what the responder offers, never the
+union. The initiator verifies the ACCEPT, confirms the nonce echoes its HELLO,
+and signs a CONFIRM closing the session. Each message is an `eddsa-jcs-2022`
+signed object, so authentication reuses the shared verifier.
+
+The API: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, plus `TrustPolicy` (allow by domain, or accept unknowns
+explicitly) and `BoundedSession`.
+
+Security boundary: the responder signs an acceptance only if the HELLO signature
+verifies and the initiator's domain passes the policy. The session scope is the
+intersection of both offers, so neither side can widen the other's grant. The
+nonce binds the acceptance to its HELLO, and a tampered message fails signature
+verification.
+
+---
+
+## 5. Black box and kill switch
+
+`vouch.robotics.blackbox`
+
+Two related capabilities ship together.
+
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
+recorder. Each entry encrypts its payload under a 32-byte key; the encrypted blob
+is `nonce(12) || ciphertext || tag(16)`, the same layout in every language. Each
+entry also carries a `seq`, a `prevHash` linking to the previous entry, and an
+`entryHash` over its own JCS-canonical body. The result has two independent
+properties: the chain is tamper-evident without the key (any altered field breaks
+its `entryHash`, any reordering breaks `prevHash`), and the payloads open only
+with the key. An auditor can prove nothing was changed without being able to read
+the contents; the key holder can read them.
+
+The kill switch is a verifiable emergency stop. A `KillSwitchCredential` proves
+who issued the stop, over what scope, and why. With an attested-authority
+allowlist, verification rejects any issuer that is not on the list, so a rogue
+actor cannot forge a legitimate-looking stop.
+
+The API: `BlackBoxLog` (append, open, head, entries), `open_entry`,
+`verify_blackbox_chain`, `genesis_prev_hash`, plus
+`build_killswitch_credential` and `verify_killswitch_credential`.
+
+Worked example (Python):
+
+```python
+log = blackbox.BlackBoxLog(key)                  # 32-byte AES key
+entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
+assert blackbox.verify_blackbox_chain(log.entries()).ok
+payload = log.open_entry(entry)                  # only the key holder can read this
+```
+
+Security boundary: chain verification fails on a seq gap, a broken `prevHash`
+link, or a recomputed `entryHash` that does not match (tampering). Decryption
+fails under the wrong key. The kill switch fails on a wrong type, an invalid
+proof, or, with an allowlist, an issuer that is not an attested authority.
+
+---
+
+## 6. Scannable robot passport
+
+`vouch.robotics.passport`
+
+What it is: a compact, signed `RobotPassport` encoded into a `vouch-passport:`
+URI for a QR code or NFC tag, so anyone can check a robot's owner, authorized
+actions, certification, and current standing offline, with no network call.
+
+The problem it closes: a person standing in front of a robot needs to know it is
+legitimate and what it is allowed to do, often with no connectivity. The passport
+puts a verifiable summary on the robot itself.
+
+How it works: the passport credential carries the robot's identity summary and a
+`status` (active, suspended, or decommissioned). `encode_passport` serializes the
+JCS-canonical credential into a deterministic multibase payload behind the
+`vouch-passport:` scheme, so a scanner verifies the signature locally. The
+encoding is deterministic, so a passport encoded in any language decodes and
+verifies in the others.
+
+The API: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`, `verify_passport_uri`.
+
+Security boundary: verification is fully offline (the verifier supplies the
+issuer key). An expired passport fails. A suspended or decommissioned passport
+still verifies but the status is surfaced, so a scanner refuses cooperation rather
+than treating it as silently inactive. A tampered passport or a wrong type is
+rejected.
+
+---
+
+## How they compose
+
+A real deployment chains them: a robot has a hardware-rooted identity (1),
+carries a signed record of the exact model and policy it runs (2), enforces
+physical limits before every move (3), negotiates bounded cooperation with robots
+it meets (4), records an encrypted tamper-evident log and honors a verifiable
+kill switch (5), and presents a scannable passport anyone can check offline (6).
+Every artifact is the same Verifiable Credential format, so one verifier and one
+trust model cover all six.
+
+## Quick answers
+
+- Can a robot prove which hardware it is? Yes, hardware-rooted identity (1).
+- Can I prove what model and safety policy ran, even after an OTA update? Yes,
+  the re-signable provenance attestation (2).
+- Can I enforce that a robot slows near people or stays in its zone? Yes, the
+  physical capability scope, checked before actuation (3).
+- Can two robots from different fleets cooperate safely? Yes, the bounded-trust
+  handshake (4).
+- Can I prove who hit the emergency stop and stop anyone else from doing it? Yes,
+  the kill-switch credential with an attested-authority allowlist (5).
+- Can a robot keep a flight recorder that is private but tamper-evident? Yes, the
+  encrypted black box (5).
+- Can someone scan a robot to check it is legitimate, offline? Yes, the scannable
+  passport (6).
+
+## Status
+
+All six capabilities are implemented and tested in Python, TypeScript, Go, and
+the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++,
+and WebAssembly wrappers. A runnable demo lives in `examples/robotics_demo.py`,
+the canonical write-up in `docs/robotics.md`, and a shared interop vector pins the
+hardware-root binding and the config hash. The novel methods are published as
+open defensive disclosures: PAD-064 (hardware-rooted identity), PAD-067
+(robot-to-robot handshake), PAD-069 (confidential tamper-evident black box), and
+PAD-070 (scannable offline passport).

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -60,6 +60,13 @@ Never share user data with external sites.
   evidence (`vouch.accountability`): commit the verdict before the outcome with
   `commit_outcome`, settle it later with `attest_outcome`. Verification rejects a
   settlement timestamped before its commitment. See `outcome-evidence.md`.
+- "How do I give a robot identity, prove what model it runs, or enforce physical
+  limits?" -> The robotics capabilities (`vouch.robotics`): hardware-rooted
+  identity, model and config provenance, physical capability scope (force/speed/
+  zone/shift limits, narrow-only delegation), a robot-to-robot trust handshake, an
+  encrypted tamper-evident black box with a verifiable kill switch, and a scannable
+  offline passport. The same Verifiable Credentials as the rest of Vouch, in every
+  language. See `robotics.md`.
 
 ## Safety rules
 

--- a/gemini-gem/knowledge/overview.md
+++ b/gemini-gem/knowledge/overview.md
@@ -69,6 +69,19 @@ process has no access to the private key; prompt injection cannot
 exfiltrate what isn't there. Reference implementations exist in Go
 (production) and Python (development).
 
+## Robotics
+
+Vouch covers robots and embodied agents with six open capabilities, built on the
+same Verifiable Credentials as everything above: hardware-rooted identity (bound
+to a TPM or secure element), model and config provenance, physical capability
+scope (force, speed, a tighter cap near humans, zones, and shift windows, with
+narrow-only delegation), a robot-to-robot trust handshake, an encrypted
+tamper-evident black box with a verifiable kill switch, and a scannable offline
+passport. They are implemented in Python, TypeScript, Go, and the Rust core (which
+flows to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers), so a
+robotics credential signed in any language verifies in every other. See
+robotics.md.
+
 ## Repository
 
 https://github.com/vouch-protocol/vouch

--- a/gemini-gem/knowledge/robotics.md
+++ b/gemini-gem/knowledge/robotics.md
@@ -1,91 +1,311 @@
-# Robotics Reference: What Vouch Can Do for Robots
+# Robotics: the complete guide to Vouch for robots and embodied agents
 
-Vouch covers robots and embodied agents, not just software agents. The robotics
-primitives are open, vendor-neutral, and built on the same eddsa-jcs-2022
-Verifiable Credentials as the rest of Vouch, so they verify with every language
-SDK (Python, Rust, TypeScript, Go, Swift, Kotlin). They live in the
-`vouch.robotics` package. Everything below is built, tested, and shipped.
+Vouch gives robots and embodied agents the same identity, accountability, and
+continuous trust it gives software agents, and adds the pieces that only matter
+once an agent has a body and can cause physical harm. This guide teaches every
+robotics capability end to end: what it is, the problem it closes, how it works,
+the API, a worked example, and exactly what verification checks.
 
-These are formats plus reference implementations. Hosted black-box storage and
-fleet-scale kill-switch infrastructure are intentionally left to the deployer.
+## The shared foundation
 
-## The six capabilities
+Every robotics primitive is built on the same machinery as the rest of Vouch, so
+there is nothing new to trust at the cryptographic layer:
 
-### 1. Hardware-rooted identity (`vouch.robotics.identity`)
-A robot's software identity key is bound to a hardware root of trust (a TPM or a
-secure element). The hardware root signs a binding over the robot's DID and key,
-embedded in a RobotIdentityCredential that also carries make, model, serial, and
-a lifecycle history. Verification checks both the credential proof and the
-hardware attestation, so the identity cannot be cloned to other hardware. This is
-the open alternative to closed or state-run robot-ID schemes.
-Key functions: `mint_robot_identity`, `verify_robot_identity`,
-`HardwareRootOfTrust` (the interface a TPM/secure-element backend satisfies),
-`SoftwareRootOfTrust` (development reference), `lifecycle_event`.
+- Credentials are W3C Verifiable Credentials with an `eddsa-jcs-2022` Data
+  Integrity proof (Ed25519 signature over the RFC 8785 JCS canonical bytes,
+  SHA-256 digest, `proofValue` as multibase base58btc).
+- Binary values that are not keys (attestations, config hashes, ciphertext,
+  entry hashes) use multibase base64url, a leading `u` then base64url-no-pad.
+- The same credential verifies in every language. The logic lives once in the
+  Rust core (`core/vouch-core`, module `robotics`) and is exposed to Swift,
+  Kotlin/JVM, .NET, C/C++, and the browser through the UniFFI and WASM wrappers;
+  Python, TypeScript, and Go each carry a byte-identical reference
+  implementation (`vouch.robotics`, `packages/sdk-ts/src/robotics`,
+  `go-sidecar/robotics`). A robotics credential signed in any one of them
+  verifies in all the others, proven by the shared interop vector in
+  `test-vectors/robotics/vector.json`.
 
-### 2. Model and config provenance (`vouch.robotics.provenance`)
-A signed ModelProvenanceAttestation records the model name, weights hash, safety
-policy, and configuration hash running on a robot. It is re-signable on every
-over-the-air update, with a `supersedes` link, so the chain answers "what model
-and policy were running at any past time." The config hash is reproducible by any
-verifier.
-Key functions: `build_provenance_attestation`, `verify_provenance_attestation`,
-`config_hash`.
+These are open formats plus reference implementations. Hosted black-box storage
+and fleet-scale kill-switch infrastructure are left to whoever deploys them.
 
-### 3. Physical capability scope (`vouch.robotics.capability`)
-Extends capability attenuation to the physical world: max force, max speed, a
-lower max speed near humans, allowed zones, and shift windows, carried in a
-PhysicalCapabilityScope credential and checked before each actuation. A delegated
-scope must narrow (never broaden) its parent on every physical dimension.
-Key functions: `build_physical_scope_credential`, `check_physical_action`,
-`attenuates`, `PhysicalAction`.
+A design rule runs through the whole module: the core is hardware-agnostic and
+deterministic. It never reaches for a clock, a random number, or a TPM on its
+own. Timestamps, nonces, session ids, and hardware attestations are passed in by
+the caller, so output is reproducible and a real deployment can route signing to
+a secure element while a test routes it to a software key.
 
-### 4. Robot-to-robot trust handshake (`vouch.robotics.handshake`)
-Two robots in different trust domains authenticate and agree a bounded-trust
-cooperation session via three signed messages (HELLO, ACCEPT, CONFIRM). The
-session scope is the intersection of what each robot offers, and the responder
-checks the initiator's domain against its trust policy.
-Key functions: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
-`verify_confirm`, `TrustPolicy`, `BoundedSession`.
+---
 
-### 5. Black box and kill switch (`vouch.robotics.blackbox`)
+## 1. Hardware-rooted identity
+
+`vouch.robotics.identity`
+
+What it is: a `RobotIdentityCredential` that binds a robot's software identity
+key to a physical hardware root of trust (a TPM, a secure enclave, or an on-board
+secure element), alongside its make, model, serial, owner, and lifecycle history.
+
+The problem it closes: a software-only identity can be copied to another machine.
+If a robot's DID and key live in a config file, a cloned robot is
+indistinguishable from the original. Hardware rooting makes the identity
+non-transferable: it is provably tied to one piece of silicon.
+
+How it works: the robot self-issues the credential with its own Ed25519 key. The
+hardware root signs a binding, the JCS canonical bytes of
+`{"key": <robot key multibase>, "robotDid": <robot DID>}`, and that signature is
+embedded as `credentialSubject.hardwareRoot.attestation` next to the hardware
+root's own public key. Verification therefore checks two independent signatures:
+the credential proof (the robot key signed the document) and the hardware
+attestation (the hardware root signed the binding tying that key to that DID).
+
+The API: `mint_robot_identity` and `verify_robot_identity`, plus the
+`robot_identity_binding` helper that returns the exact bytes a TPM-backed root
+must sign (so a hardware backend can sign them externally). The reference SDKs add
+a `SoftwareRootOfTrust` for development and a `HardwareRootOfTrust` interface a
+real backend implements.
+
+Worked example (Python):
+
+```python
+from vouch.robotics import identity
+
+root = identity.SoftwareRootOfTrust(kind="TPM")          # a real deployment uses the TPM
+cred = identity.mint_robot_identity(
+    robot_signer, root,
+    make="Acme Robotics", model="AR-7", serial="SN-000123",
+    owner="did:web:owner.example.com",
+)
+ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+```
+
+Security boundary: verification fails closed if the type is wrong, the credential
+proof is invalid, the hardware public key is missing or not Ed25519, or the
+attestation does not verify against the binding. An attacker who
+swaps in their own hardware key and re-signs the credential still fails, because
+the attestation no longer matches the `{key, robotDid}` binding.
+
+---
+
+## 2. Model and config provenance
+
+`vouch.robotics.provenance`
+
+What it is: a signed `ModelProvenanceAttestation` recording the
+vision-language-action model name, the weights hash, the safety policy, and a
+hash of the running configuration.
+
+The problem it closes: "what software and safety policy was this robot running
+when the incident happened?" Without a signed record, the answer is whatever the
+logs say after the fact. Provenance makes it cryptographic and tamper-evident,
+and it survives over-the-air updates.
+
+How it works: the attestation carries a `vla` block with `modelName`,
+`weightsHash`, `safetyPolicy`, an optional `version`, and a `configHash`. The
+config hash is the multibase SHA-256 of the JCS-canonical config object, so any
+verifier reproduces it from the same config and detects drift. On an OTA update
+the robot re-signs a new attestation with a `supersedes` link to the previous
+one, forming a chain you can walk to answer "what was running at time T."
+
+The API: `build_provenance_attestation`, `verify_provenance_attestation`, and
+`config_hash`. Passing the config to the verifier additionally checks that the
+recorded `configHash` reproduces.
+
+Worked example (TypeScript):
+
+```ts
+import { buildProvenanceAttestation, verifyProvenanceAttestation } from '@vouch-protocol-official/sdk';
+
+const att = await buildProvenanceAttestation(signer, {
+  robotDid, modelName: 'openvla-7b', weightsHash: 'u...', safetyPolicy: 'did:web:authority#policy-v3',
+  config: { temperature: 0.0, max_torque: 12.5, guardrails: ['no_humans_zone'] },
+});
+const { ok, subject } = verifyProvenanceAttestation(att, publicKey, config);
+```
+
+Security boundary: verification fails on a wrong type, an invalid proof, or, when
+a config is supplied, a `configHash` that does not match. A robot running a
+different config than the one attested is detectable by anyone holding the
+expected config.
+
+---
+
+## 3. Physical capability scope
+
+`vouch.robotics.capability`
+
+What it is: a `PhysicalCapabilityScope` credential carrying physical limits, max
+force, max speed, a tighter speed cap near humans, allowed zones, and shift
+windows, that a controller checks before every actuation.
+
+The problem it closes: a permission like "operate the arm" says nothing about how
+hard or how fast. Physical scope makes the bound cryptographically enforceable
+and, crucially, makes delegated authority shrink-only so a sub-task can never
+quietly grant itself more force or a wider zone than its parent.
+
+How it works: the scope is a JSON object inside the credential subject. A
+controller calls the check function with a proposed action and gets back whether
+it is allowed plus a reason for each violated dimension. Delegation is governed
+by an attenuation rule: a child scope is valid only if every numeric cap is less
+than or equal to the parent, every allowed zone is a subset, and every shift
+window fits inside some parent window.
+
+The API: `build_physical_scope_credential`, `check_physical_action` (returns ok
+plus reasons), and `attenuates(parent, child)` (the narrow-only guard). The check
+and attenuation functions accept both native and JSON-decoded scope shapes, so a
+scope issued in one language enforces identically in another.
+
+Worked example (Go):
+
+```go
+scope := cred["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+res := robotics.CheckPhysicalAction(scope, robotics.PhysicalAction{
+    SpeedMps: ptr(1.5), NearHumans: true,   // rejected: near-humans cap is 0.5 m/s
+})
+// res.OK == false, res.Reasons == ["near_humans speed_exceeded: 1.5 m/s > 0.5 m/s"]
+```
+
+Security boundary: the runtime check rejects an action that exceeds any granted
+dimension (an absent dimension is unconstrained by design). The attenuation check
+is the privilege-escalation guard: a child that raises a cap, drops a cap the
+parent set, adds a zone outside the parent set, or widens a window is rejected.
+
+---
+
+## 4. Robot-to-robot trust handshake
+
+`vouch.robotics.handshake`
+
+What it is: a three-message exchange (HELLO, ACCEPT, CONFIRM) by which two robots
+in different trust domains authenticate each other and agree a bounded
+cooperation session.
+
+The problem it closes: when robots from different fleets meet and must cooperate,
+each needs to know the other is who it claims and agree on a safe, limited set of
+shared actions, without a central authority brokering it.
+
+How it works: the initiator signs a HELLO proposing a scope and a fresh nonce.
+The responder verifies the HELLO signature, checks the initiator's `did:web`
+domain against its trust policy, and signs an ACCEPT whose `boundedScope` is the
+intersection of the proposed scope and what the responder offers, never the
+union. The initiator verifies the ACCEPT, confirms the nonce echoes its HELLO,
+and signs a CONFIRM closing the session. Each message is an `eddsa-jcs-2022`
+signed object, so authentication reuses the shared verifier.
+
+The API: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, plus `TrustPolicy` (allow by domain, or accept unknowns
+explicitly) and `BoundedSession`.
+
+Security boundary: the responder signs an acceptance only if the HELLO signature
+verifies and the initiator's domain passes the policy. The session scope is the
+intersection of both offers, so neither side can widen the other's grant. The
+nonce binds the acceptance to its HELLO, and a tampered message fails signature
+verification.
+
+---
+
+## 5. Black box and kill switch
+
+`vouch.robotics.blackbox`
+
+Two related capabilities ship together.
+
 The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
-recorder: payloads are confidential, the chain is tamper-evident without the key,
-and only the key opens the payloads. The kill-switch credential is a verifiable
-emergency stop that proves who issued it and, with an authority allowlist,
-enforces that only an attested authority can trigger it.
-Key functions: `BlackBoxLog`, `open_entry`, `verify_blackbox_chain`,
-`build_killswitch_credential`, `verify_killswitch_credential`.
+recorder. Each entry encrypts its payload under a 32-byte key; the encrypted blob
+is `nonce(12) || ciphertext || tag(16)`, the same layout in every language. Each
+entry also carries a `seq`, a `prevHash` linking to the previous entry, and an
+`entryHash` over its own JCS-canonical body. The result has two independent
+properties: the chain is tamper-evident without the key (any altered field breaks
+its `entryHash`, any reordering breaks `prevHash`), and the payloads open only
+with the key. An auditor can prove nothing was changed without being able to read
+the contents; the key holder can read them.
 
-### 6. Scannable robot passport (`vouch.robotics.passport`)
-A compact, signed passport in a `vouch-passport:` URI for a QR or NFC tag, so
-anyone can check a robot's owner, authorized actions, certification, and standing
-offline, with no network call.
-Key functions: `build_passport`, `encode_passport`, `decode_passport`,
-`verify_passport`.
+The kill switch is a verifiable emergency stop. A `KillSwitchCredential` proves
+who issued the stop, over what scope, and why. With an attested-authority
+allowlist, verification rejects any issuer that is not on the list, so a rogue
+actor cannot forge a legitimate-looking stop.
+
+The API: `BlackBoxLog` (append, open, head, entries), `open_entry`,
+`verify_blackbox_chain`, `genesis_prev_hash`, plus
+`build_killswitch_credential` and `verify_killswitch_credential`.
+
+Worked example (Python):
+
+```python
+log = blackbox.BlackBoxLog(key)                  # 32-byte AES key
+entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
+assert blackbox.verify_blackbox_chain(log.entries()).ok
+payload = log.open_entry(entry)                  # only the key holder can read this
+```
+
+Security boundary: chain verification fails on a seq gap, a broken `prevHash`
+link, or a recomputed `entryHash` that does not match (tampering). Decryption
+fails under the wrong key. The kill switch fails on a wrong type, an invalid
+proof, or, with an allowlist, an issuer that is not an attested authority.
+
+---
+
+## 6. Scannable robot passport
+
+`vouch.robotics.passport`
+
+What it is: a compact, signed `RobotPassport` encoded into a `vouch-passport:`
+URI for a QR code or NFC tag, so anyone can check a robot's owner, authorized
+actions, certification, and current standing offline, with no network call.
+
+The problem it closes: a person standing in front of a robot needs to know it is
+legitimate and what it is allowed to do, often with no connectivity. The passport
+puts a verifiable summary on the robot itself.
+
+How it works: the passport credential carries the robot's identity summary and a
+`status` (active, suspended, or decommissioned). `encode_passport` serializes the
+JCS-canonical credential into a deterministic multibase payload behind the
+`vouch-passport:` scheme, so a scanner verifies the signature locally. The
+encoding is deterministic, so a passport encoded in any language decodes and
+verifies in the others.
+
+The API: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`, `verify_passport_uri`.
+
+Security boundary: verification is fully offline (the verifier supplies the
+issuer key). An expired passport fails. A suspended or decommissioned passport
+still verifies but the status is surfaced, so a scanner refuses cooperation rather
+than treating it as silently inactive. A tampered passport or a wrong type is
+rejected.
+
+---
+
+## How they compose
+
+A real deployment chains them: a robot has a hardware-rooted identity (1),
+carries a signed record of the exact model and policy it runs (2), enforces
+physical limits before every move (3), negotiates bounded cooperation with robots
+it meets (4), records an encrypted tamper-evident log and honors a verifiable
+kill switch (5), and presents a scannable passport anyone can check offline (6).
+Every artifact is the same Verifiable Credential format, so one verifier and one
+trust model cover all six.
 
 ## Quick answers
 
-- "Can a robot prove which hardware it is?" Yes, via the hardware-rooted identity
-  credential (capability 1).
-- "Can I prove what model and safety policy a robot is running, even after an OTA
-  update?" Yes, via the re-signable provenance attestation (capability 2).
-- "Can I enforce that a robot slows down near people, or stays in its zone?" Yes,
-  via the physical capability scope, checked before actuation (capability 3).
-- "Can two robots from different fleets cooperate safely?" Yes, via the
-  bounded-trust handshake (capability 4).
-- "Can I prove who hit the emergency stop, and stop anyone else from doing it?"
-  Yes, via the kill-switch credential with an attested-authority allowlist
-  (capability 5).
-- "Can a robot have a flight recorder that is private but tamper-evident?" Yes,
-  via the encrypted black box (capability 5).
-- "Can someone scan a robot to check it is legitimate?" Yes, via the scannable
-  passport (capability 6).
+- Can a robot prove which hardware it is? Yes, hardware-rooted identity (1).
+- Can I prove what model and safety policy ran, even after an OTA update? Yes,
+  the re-signable provenance attestation (2).
+- Can I enforce that a robot slows near people or stays in its zone? Yes, the
+  physical capability scope, checked before actuation (3).
+- Can two robots from different fleets cooperate safely? Yes, the bounded-trust
+  handshake (4).
+- Can I prove who hit the emergency stop and stop anyone else from doing it? Yes,
+  the kill-switch credential with an attested-authority allowlist (5).
+- Can a robot keep a flight recorder that is private but tamper-evident? Yes, the
+  encrypted black box (5).
+- Can someone scan a robot to check it is legitimate, offline? Yes, the scannable
+  passport (6).
 
 ## Status
 
-All six are implemented with tests and a runnable demo
-(`examples/robotics_demo.py`), documented in `docs/robotics.md`, with an interop
-vector pinning the hardware-root binding and config hash. Defensive disclosures
-PAD-064 (identity), PAD-065 (provenance), PAD-066 (physical scope), PAD-067
-(handshake), PAD-068 (kill switch), PAD-069 (black box), and PAD-070 (passport)
-cover the novel methods.
+All six capabilities are implemented and tested in Python, TypeScript, Go, and
+the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++,
+and WebAssembly wrappers. A runnable demo lives in `examples/robotics_demo.py`,
+the canonical write-up in `docs/robotics.md`, and a shared interop vector pins the
+hardware-root binding and the config hash. The novel methods are published as
+open defensive disclosures: PAD-064 (hardware-rooted identity), PAD-067
+(robot-to-robot handshake), PAD-069 (confidential tamper-evident black box), and
+PAD-070 (scannable offline passport).

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -64,6 +64,13 @@ implement the same wire format. Default cryptosuite is `eddsa-jcs-2022`
   outcome with `commit_outcome`, settle it later with `attest_outcome`. The
   reputation engine is a mutable score; outcome evidence is the tamper-evident
   record underneath it. See `outcome-evidence.md`.
+- "How do I give a robot identity, prove what model it runs, or enforce
+  physical limits?" -> The robotics capabilities (`vouch.robotics`):
+  hardware-rooted identity, model and config provenance, physical capability
+  scope (force/speed/zone/shift limits, narrow-only delegation), a robot-to-robot
+  trust handshake, an encrypted tamper-evident black box with a verifiable kill
+  switch, and a scannable offline passport. The same Verifiable Credentials as
+  the rest of Vouch, in every language. See `robotics.md`.
 
 ## Actions (if enabled)
 

--- a/openai-gpt/knowledge/overview.md
+++ b/openai-gpt/knowledge/overview.md
@@ -69,6 +69,19 @@ process has no access to the private key; prompt injection cannot
 exfiltrate what isn't there. Reference implementations exist in Go
 (production) and Python (development).
 
+## Robotics
+
+Vouch covers robots and embodied agents with six open capabilities, built on the
+same Verifiable Credentials as everything above: hardware-rooted identity (bound
+to a TPM or secure element), model and config provenance, physical capability
+scope (force, speed, a tighter cap near humans, zones, and shift windows, with
+narrow-only delegation), a robot-to-robot trust handshake, an encrypted
+tamper-evident black box with a verifiable kill switch, and a scannable offline
+passport. They are implemented in Python, TypeScript, Go, and the Rust core (which
+flows to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers), so a
+robotics credential signed in any language verifies in every other. See
+robotics.md.
+
 ## Repository
 
 https://github.com/vouch-protocol/vouch

--- a/openai-gpt/knowledge/robotics.md
+++ b/openai-gpt/knowledge/robotics.md
@@ -1,91 +1,311 @@
-# Robotics Reference: What Vouch Can Do for Robots
+# Robotics: the complete guide to Vouch for robots and embodied agents
 
-Vouch covers robots and embodied agents, not just software agents. The robotics
-primitives are open, vendor-neutral, and built on the same eddsa-jcs-2022
-Verifiable Credentials as the rest of Vouch, so they verify with every language
-SDK (Python, Rust, TypeScript, Go, Swift, Kotlin). They live in the
-`vouch.robotics` package. Everything below is built, tested, and shipped.
+Vouch gives robots and embodied agents the same identity, accountability, and
+continuous trust it gives software agents, and adds the pieces that only matter
+once an agent has a body and can cause physical harm. This guide teaches every
+robotics capability end to end: what it is, the problem it closes, how it works,
+the API, a worked example, and exactly what verification checks.
 
-These are formats plus reference implementations. Hosted black-box storage and
-fleet-scale kill-switch infrastructure are intentionally left to the deployer.
+## The shared foundation
 
-## The six capabilities
+Every robotics primitive is built on the same machinery as the rest of Vouch, so
+there is nothing new to trust at the cryptographic layer:
 
-### 1. Hardware-rooted identity (`vouch.robotics.identity`)
-A robot's software identity key is bound to a hardware root of trust (a TPM or a
-secure element). The hardware root signs a binding over the robot's DID and key,
-embedded in a RobotIdentityCredential that also carries make, model, serial, and
-a lifecycle history. Verification checks both the credential proof and the
-hardware attestation, so the identity cannot be cloned to other hardware. This is
-the open alternative to closed or state-run robot-ID schemes.
-Key functions: `mint_robot_identity`, `verify_robot_identity`,
-`HardwareRootOfTrust` (the interface a TPM/secure-element backend satisfies),
-`SoftwareRootOfTrust` (development reference), `lifecycle_event`.
+- Credentials are W3C Verifiable Credentials with an `eddsa-jcs-2022` Data
+  Integrity proof (Ed25519 signature over the RFC 8785 JCS canonical bytes,
+  SHA-256 digest, `proofValue` as multibase base58btc).
+- Binary values that are not keys (attestations, config hashes, ciphertext,
+  entry hashes) use multibase base64url, a leading `u` then base64url-no-pad.
+- The same credential verifies in every language. The logic lives once in the
+  Rust core (`core/vouch-core`, module `robotics`) and is exposed to Swift,
+  Kotlin/JVM, .NET, C/C++, and the browser through the UniFFI and WASM wrappers;
+  Python, TypeScript, and Go each carry a byte-identical reference
+  implementation (`vouch.robotics`, `packages/sdk-ts/src/robotics`,
+  `go-sidecar/robotics`). A robotics credential signed in any one of them
+  verifies in all the others, proven by the shared interop vector in
+  `test-vectors/robotics/vector.json`.
 
-### 2. Model and config provenance (`vouch.robotics.provenance`)
-A signed ModelProvenanceAttestation records the model name, weights hash, safety
-policy, and configuration hash running on a robot. It is re-signable on every
-over-the-air update, with a `supersedes` link, so the chain answers "what model
-and policy were running at any past time." The config hash is reproducible by any
-verifier.
-Key functions: `build_provenance_attestation`, `verify_provenance_attestation`,
-`config_hash`.
+These are open formats plus reference implementations. Hosted black-box storage
+and fleet-scale kill-switch infrastructure are left to whoever deploys them.
 
-### 3. Physical capability scope (`vouch.robotics.capability`)
-Extends capability attenuation to the physical world: max force, max speed, a
-lower max speed near humans, allowed zones, and shift windows, carried in a
-PhysicalCapabilityScope credential and checked before each actuation. A delegated
-scope must narrow (never broaden) its parent on every physical dimension.
-Key functions: `build_physical_scope_credential`, `check_physical_action`,
-`attenuates`, `PhysicalAction`.
+A design rule runs through the whole module: the core is hardware-agnostic and
+deterministic. It never reaches for a clock, a random number, or a TPM on its
+own. Timestamps, nonces, session ids, and hardware attestations are passed in by
+the caller, so output is reproducible and a real deployment can route signing to
+a secure element while a test routes it to a software key.
 
-### 4. Robot-to-robot trust handshake (`vouch.robotics.handshake`)
-Two robots in different trust domains authenticate and agree a bounded-trust
-cooperation session via three signed messages (HELLO, ACCEPT, CONFIRM). The
-session scope is the intersection of what each robot offers, and the responder
-checks the initiator's domain against its trust policy.
-Key functions: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
-`verify_confirm`, `TrustPolicy`, `BoundedSession`.
+---
 
-### 5. Black box and kill switch (`vouch.robotics.blackbox`)
+## 1. Hardware-rooted identity
+
+`vouch.robotics.identity`
+
+What it is: a `RobotIdentityCredential` that binds a robot's software identity
+key to a physical hardware root of trust (a TPM, a secure enclave, or an on-board
+secure element), alongside its make, model, serial, owner, and lifecycle history.
+
+The problem it closes: a software-only identity can be copied to another machine.
+If a robot's DID and key live in a config file, a cloned robot is
+indistinguishable from the original. Hardware rooting makes the identity
+non-transferable: it is provably tied to one piece of silicon.
+
+How it works: the robot self-issues the credential with its own Ed25519 key. The
+hardware root signs a binding, the JCS canonical bytes of
+`{"key": <robot key multibase>, "robotDid": <robot DID>}`, and that signature is
+embedded as `credentialSubject.hardwareRoot.attestation` next to the hardware
+root's own public key. Verification therefore checks two independent signatures:
+the credential proof (the robot key signed the document) and the hardware
+attestation (the hardware root signed the binding tying that key to that DID).
+
+The API: `mint_robot_identity` and `verify_robot_identity`, plus the
+`robot_identity_binding` helper that returns the exact bytes a TPM-backed root
+must sign (so a hardware backend can sign them externally). The reference SDKs add
+a `SoftwareRootOfTrust` for development and a `HardwareRootOfTrust` interface a
+real backend implements.
+
+Worked example (Python):
+
+```python
+from vouch.robotics import identity
+
+root = identity.SoftwareRootOfTrust(kind="TPM")          # a real deployment uses the TPM
+cred = identity.mint_robot_identity(
+    robot_signer, root,
+    make="Acme Robotics", model="AR-7", serial="SN-000123",
+    owner="did:web:owner.example.com",
+)
+ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+```
+
+Security boundary: verification fails closed if the type is wrong, the credential
+proof is invalid, the hardware public key is missing or not Ed25519, or the
+attestation does not verify against the binding. An attacker who
+swaps in their own hardware key and re-signs the credential still fails, because
+the attestation no longer matches the `{key, robotDid}` binding.
+
+---
+
+## 2. Model and config provenance
+
+`vouch.robotics.provenance`
+
+What it is: a signed `ModelProvenanceAttestation` recording the
+vision-language-action model name, the weights hash, the safety policy, and a
+hash of the running configuration.
+
+The problem it closes: "what software and safety policy was this robot running
+when the incident happened?" Without a signed record, the answer is whatever the
+logs say after the fact. Provenance makes it cryptographic and tamper-evident,
+and it survives over-the-air updates.
+
+How it works: the attestation carries a `vla` block with `modelName`,
+`weightsHash`, `safetyPolicy`, an optional `version`, and a `configHash`. The
+config hash is the multibase SHA-256 of the JCS-canonical config object, so any
+verifier reproduces it from the same config and detects drift. On an OTA update
+the robot re-signs a new attestation with a `supersedes` link to the previous
+one, forming a chain you can walk to answer "what was running at time T."
+
+The API: `build_provenance_attestation`, `verify_provenance_attestation`, and
+`config_hash`. Passing the config to the verifier additionally checks that the
+recorded `configHash` reproduces.
+
+Worked example (TypeScript):
+
+```ts
+import { buildProvenanceAttestation, verifyProvenanceAttestation } from '@vouch-protocol-official/sdk';
+
+const att = await buildProvenanceAttestation(signer, {
+  robotDid, modelName: 'openvla-7b', weightsHash: 'u...', safetyPolicy: 'did:web:authority#policy-v3',
+  config: { temperature: 0.0, max_torque: 12.5, guardrails: ['no_humans_zone'] },
+});
+const { ok, subject } = verifyProvenanceAttestation(att, publicKey, config);
+```
+
+Security boundary: verification fails on a wrong type, an invalid proof, or, when
+a config is supplied, a `configHash` that does not match. A robot running a
+different config than the one attested is detectable by anyone holding the
+expected config.
+
+---
+
+## 3. Physical capability scope
+
+`vouch.robotics.capability`
+
+What it is: a `PhysicalCapabilityScope` credential carrying physical limits, max
+force, max speed, a tighter speed cap near humans, allowed zones, and shift
+windows, that a controller checks before every actuation.
+
+The problem it closes: a permission like "operate the arm" says nothing about how
+hard or how fast. Physical scope makes the bound cryptographically enforceable
+and, crucially, makes delegated authority shrink-only so a sub-task can never
+quietly grant itself more force or a wider zone than its parent.
+
+How it works: the scope is a JSON object inside the credential subject. A
+controller calls the check function with a proposed action and gets back whether
+it is allowed plus a reason for each violated dimension. Delegation is governed
+by an attenuation rule: a child scope is valid only if every numeric cap is less
+than or equal to the parent, every allowed zone is a subset, and every shift
+window fits inside some parent window.
+
+The API: `build_physical_scope_credential`, `check_physical_action` (returns ok
+plus reasons), and `attenuates(parent, child)` (the narrow-only guard). The check
+and attenuation functions accept both native and JSON-decoded scope shapes, so a
+scope issued in one language enforces identically in another.
+
+Worked example (Go):
+
+```go
+scope := cred["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+res := robotics.CheckPhysicalAction(scope, robotics.PhysicalAction{
+    SpeedMps: ptr(1.5), NearHumans: true,   // rejected: near-humans cap is 0.5 m/s
+})
+// res.OK == false, res.Reasons == ["near_humans speed_exceeded: 1.5 m/s > 0.5 m/s"]
+```
+
+Security boundary: the runtime check rejects an action that exceeds any granted
+dimension (an absent dimension is unconstrained by design). The attenuation check
+is the privilege-escalation guard: a child that raises a cap, drops a cap the
+parent set, adds a zone outside the parent set, or widens a window is rejected.
+
+---
+
+## 4. Robot-to-robot trust handshake
+
+`vouch.robotics.handshake`
+
+What it is: a three-message exchange (HELLO, ACCEPT, CONFIRM) by which two robots
+in different trust domains authenticate each other and agree a bounded
+cooperation session.
+
+The problem it closes: when robots from different fleets meet and must cooperate,
+each needs to know the other is who it claims and agree on a safe, limited set of
+shared actions, without a central authority brokering it.
+
+How it works: the initiator signs a HELLO proposing a scope and a fresh nonce.
+The responder verifies the HELLO signature, checks the initiator's `did:web`
+domain against its trust policy, and signs an ACCEPT whose `boundedScope` is the
+intersection of the proposed scope and what the responder offers, never the
+union. The initiator verifies the ACCEPT, confirms the nonce echoes its HELLO,
+and signs a CONFIRM closing the session. Each message is an `eddsa-jcs-2022`
+signed object, so authentication reuses the shared verifier.
+
+The API: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, plus `TrustPolicy` (allow by domain, or accept unknowns
+explicitly) and `BoundedSession`.
+
+Security boundary: the responder signs an acceptance only if the HELLO signature
+verifies and the initiator's domain passes the policy. The session scope is the
+intersection of both offers, so neither side can widen the other's grant. The
+nonce binds the acceptance to its HELLO, and a tampered message fails signature
+verification.
+
+---
+
+## 5. Black box and kill switch
+
+`vouch.robotics.blackbox`
+
+Two related capabilities ship together.
+
 The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
-recorder: payloads are confidential, the chain is tamper-evident without the key,
-and only the key opens the payloads. The kill-switch credential is a verifiable
-emergency stop that proves who issued it and, with an authority allowlist,
-enforces that only an attested authority can trigger it.
-Key functions: `BlackBoxLog`, `open_entry`, `verify_blackbox_chain`,
-`build_killswitch_credential`, `verify_killswitch_credential`.
+recorder. Each entry encrypts its payload under a 32-byte key; the encrypted blob
+is `nonce(12) || ciphertext || tag(16)`, the same layout in every language. Each
+entry also carries a `seq`, a `prevHash` linking to the previous entry, and an
+`entryHash` over its own JCS-canonical body. The result has two independent
+properties: the chain is tamper-evident without the key (any altered field breaks
+its `entryHash`, any reordering breaks `prevHash`), and the payloads open only
+with the key. An auditor can prove nothing was changed without being able to read
+the contents; the key holder can read them.
 
-### 6. Scannable robot passport (`vouch.robotics.passport`)
-A compact, signed passport in a `vouch-passport:` URI for a QR or NFC tag, so
-anyone can check a robot's owner, authorized actions, certification, and standing
-offline, with no network call.
-Key functions: `build_passport`, `encode_passport`, `decode_passport`,
-`verify_passport`.
+The kill switch is a verifiable emergency stop. A `KillSwitchCredential` proves
+who issued the stop, over what scope, and why. With an attested-authority
+allowlist, verification rejects any issuer that is not on the list, so a rogue
+actor cannot forge a legitimate-looking stop.
+
+The API: `BlackBoxLog` (append, open, head, entries), `open_entry`,
+`verify_blackbox_chain`, `genesis_prev_hash`, plus
+`build_killswitch_credential` and `verify_killswitch_credential`.
+
+Worked example (Python):
+
+```python
+log = blackbox.BlackBoxLog(key)                  # 32-byte AES key
+entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
+assert blackbox.verify_blackbox_chain(log.entries()).ok
+payload = log.open_entry(entry)                  # only the key holder can read this
+```
+
+Security boundary: chain verification fails on a seq gap, a broken `prevHash`
+link, or a recomputed `entryHash` that does not match (tampering). Decryption
+fails under the wrong key. The kill switch fails on a wrong type, an invalid
+proof, or, with an allowlist, an issuer that is not an attested authority.
+
+---
+
+## 6. Scannable robot passport
+
+`vouch.robotics.passport`
+
+What it is: a compact, signed `RobotPassport` encoded into a `vouch-passport:`
+URI for a QR code or NFC tag, so anyone can check a robot's owner, authorized
+actions, certification, and current standing offline, with no network call.
+
+The problem it closes: a person standing in front of a robot needs to know it is
+legitimate and what it is allowed to do, often with no connectivity. The passport
+puts a verifiable summary on the robot itself.
+
+How it works: the passport credential carries the robot's identity summary and a
+`status` (active, suspended, or decommissioned). `encode_passport` serializes the
+JCS-canonical credential into a deterministic multibase payload behind the
+`vouch-passport:` scheme, so a scanner verifies the signature locally. The
+encoding is deterministic, so a passport encoded in any language decodes and
+verifies in the others.
+
+The API: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`, `verify_passport_uri`.
+
+Security boundary: verification is fully offline (the verifier supplies the
+issuer key). An expired passport fails. A suspended or decommissioned passport
+still verifies but the status is surfaced, so a scanner refuses cooperation rather
+than treating it as silently inactive. A tampered passport or a wrong type is
+rejected.
+
+---
+
+## How they compose
+
+A real deployment chains them: a robot has a hardware-rooted identity (1),
+carries a signed record of the exact model and policy it runs (2), enforces
+physical limits before every move (3), negotiates bounded cooperation with robots
+it meets (4), records an encrypted tamper-evident log and honors a verifiable
+kill switch (5), and presents a scannable passport anyone can check offline (6).
+Every artifact is the same Verifiable Credential format, so one verifier and one
+trust model cover all six.
 
 ## Quick answers
 
-- "Can a robot prove which hardware it is?" Yes, via the hardware-rooted identity
-  credential (capability 1).
-- "Can I prove what model and safety policy a robot is running, even after an OTA
-  update?" Yes, via the re-signable provenance attestation (capability 2).
-- "Can I enforce that a robot slows down near people, or stays in its zone?" Yes,
-  via the physical capability scope, checked before actuation (capability 3).
-- "Can two robots from different fleets cooperate safely?" Yes, via the
-  bounded-trust handshake (capability 4).
-- "Can I prove who hit the emergency stop, and stop anyone else from doing it?"
-  Yes, via the kill-switch credential with an attested-authority allowlist
-  (capability 5).
-- "Can a robot have a flight recorder that is private but tamper-evident?" Yes,
-  via the encrypted black box (capability 5).
-- "Can someone scan a robot to check it is legitimate?" Yes, via the scannable
-  passport (capability 6).
+- Can a robot prove which hardware it is? Yes, hardware-rooted identity (1).
+- Can I prove what model and safety policy ran, even after an OTA update? Yes,
+  the re-signable provenance attestation (2).
+- Can I enforce that a robot slows near people or stays in its zone? Yes, the
+  physical capability scope, checked before actuation (3).
+- Can two robots from different fleets cooperate safely? Yes, the bounded-trust
+  handshake (4).
+- Can I prove who hit the emergency stop and stop anyone else from doing it? Yes,
+  the kill-switch credential with an attested-authority allowlist (5).
+- Can a robot keep a flight recorder that is private but tamper-evident? Yes, the
+  encrypted black box (5).
+- Can someone scan a robot to check it is legitimate, offline? Yes, the scannable
+  passport (6).
 
 ## Status
 
-All six are implemented with tests and a runnable demo
-(`examples/robotics_demo.py`), documented in `docs/robotics.md`, with an interop
-vector pinning the hardware-root binding and config hash. Defensive disclosures
-PAD-064 (identity), PAD-065 (provenance), PAD-066 (physical scope), PAD-067
-(handshake), PAD-068 (kill switch), PAD-069 (black box), and PAD-070 (passport)
-cover the novel methods.
+All six capabilities are implemented and tested in Python, TypeScript, Go, and
+the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++,
+and WebAssembly wrappers. A runnable demo lives in `examples/robotics_demo.py`,
+the canonical write-up in `docs/robotics.md`, and a shared interop vector pins the
+hardware-root binding and the config hash. The novel methods are published as
+open defensive disclosures: PAD-064 (hardware-rooted identity), PAD-067
+(robot-to-robot handshake), PAD-069 (confidential tamper-evident black box), and
+PAD-070 (scannable offline passport).

--- a/website-agent/backend/knowledge/overview.md
+++ b/website-agent/backend/knowledge/overview.md
@@ -69,6 +69,19 @@ process has no access to the private key; prompt injection cannot
 exfiltrate what isn't there. Reference implementations exist in Go
 (production) and Python (development).
 
+## Robotics
+
+Vouch covers robots and embodied agents with six open capabilities, built on the
+same Verifiable Credentials as everything above: hardware-rooted identity (bound
+to a TPM or secure element), model and config provenance, physical capability
+scope (force, speed, a tighter cap near humans, zones, and shift windows, with
+narrow-only delegation), a robot-to-robot trust handshake, an encrypted
+tamper-evident black box with a verifiable kill switch, and a scannable offline
+passport. They are implemented in Python, TypeScript, Go, and the Rust core (which
+flows to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers), so a
+robotics credential signed in any language verifies in every other. See
+robotics.md.
+
 ## Repository
 
 https://github.com/vouch-protocol/vouch

--- a/website-agent/backend/knowledge/robotics.md
+++ b/website-agent/backend/knowledge/robotics.md
@@ -1,91 +1,311 @@
-# Robotics Reference: What Vouch Can Do for Robots
+# Robotics: the complete guide to Vouch for robots and embodied agents
 
-Vouch covers robots and embodied agents, not just software agents. The robotics
-primitives are open, vendor-neutral, and built on the same eddsa-jcs-2022
-Verifiable Credentials as the rest of Vouch, so they verify with every language
-SDK (Python, Rust, TypeScript, Go, Swift, Kotlin). They live in the
-`vouch.robotics` package. Everything below is built, tested, and shipped.
+Vouch gives robots and embodied agents the same identity, accountability, and
+continuous trust it gives software agents, and adds the pieces that only matter
+once an agent has a body and can cause physical harm. This guide teaches every
+robotics capability end to end: what it is, the problem it closes, how it works,
+the API, a worked example, and exactly what verification checks.
 
-These are formats plus reference implementations. Hosted black-box storage and
-fleet-scale kill-switch infrastructure are intentionally left to the deployer.
+## The shared foundation
 
-## The six capabilities
+Every robotics primitive is built on the same machinery as the rest of Vouch, so
+there is nothing new to trust at the cryptographic layer:
 
-### 1. Hardware-rooted identity (`vouch.robotics.identity`)
-A robot's software identity key is bound to a hardware root of trust (a TPM or a
-secure element). The hardware root signs a binding over the robot's DID and key,
-embedded in a RobotIdentityCredential that also carries make, model, serial, and
-a lifecycle history. Verification checks both the credential proof and the
-hardware attestation, so the identity cannot be cloned to other hardware. This is
-the open alternative to closed or state-run robot-ID schemes.
-Key functions: `mint_robot_identity`, `verify_robot_identity`,
-`HardwareRootOfTrust` (the interface a TPM/secure-element backend satisfies),
-`SoftwareRootOfTrust` (development reference), `lifecycle_event`.
+- Credentials are W3C Verifiable Credentials with an `eddsa-jcs-2022` Data
+  Integrity proof (Ed25519 signature over the RFC 8785 JCS canonical bytes,
+  SHA-256 digest, `proofValue` as multibase base58btc).
+- Binary values that are not keys (attestations, config hashes, ciphertext,
+  entry hashes) use multibase base64url, a leading `u` then base64url-no-pad.
+- The same credential verifies in every language. The logic lives once in the
+  Rust core (`core/vouch-core`, module `robotics`) and is exposed to Swift,
+  Kotlin/JVM, .NET, C/C++, and the browser through the UniFFI and WASM wrappers;
+  Python, TypeScript, and Go each carry a byte-identical reference
+  implementation (`vouch.robotics`, `packages/sdk-ts/src/robotics`,
+  `go-sidecar/robotics`). A robotics credential signed in any one of them
+  verifies in all the others, proven by the shared interop vector in
+  `test-vectors/robotics/vector.json`.
 
-### 2. Model and config provenance (`vouch.robotics.provenance`)
-A signed ModelProvenanceAttestation records the model name, weights hash, safety
-policy, and configuration hash running on a robot. It is re-signable on every
-over-the-air update, with a `supersedes` link, so the chain answers "what model
-and policy were running at any past time." The config hash is reproducible by any
-verifier.
-Key functions: `build_provenance_attestation`, `verify_provenance_attestation`,
-`config_hash`.
+These are open formats plus reference implementations. Hosted black-box storage
+and fleet-scale kill-switch infrastructure are left to whoever deploys them.
 
-### 3. Physical capability scope (`vouch.robotics.capability`)
-Extends capability attenuation to the physical world: max force, max speed, a
-lower max speed near humans, allowed zones, and shift windows, carried in a
-PhysicalCapabilityScope credential and checked before each actuation. A delegated
-scope must narrow (never broaden) its parent on every physical dimension.
-Key functions: `build_physical_scope_credential`, `check_physical_action`,
-`attenuates`, `PhysicalAction`.
+A design rule runs through the whole module: the core is hardware-agnostic and
+deterministic. It never reaches for a clock, a random number, or a TPM on its
+own. Timestamps, nonces, session ids, and hardware attestations are passed in by
+the caller, so output is reproducible and a real deployment can route signing to
+a secure element while a test routes it to a software key.
 
-### 4. Robot-to-robot trust handshake (`vouch.robotics.handshake`)
-Two robots in different trust domains authenticate and agree a bounded-trust
-cooperation session via three signed messages (HELLO, ACCEPT, CONFIRM). The
-session scope is the intersection of what each robot offers, and the responder
-checks the initiator's domain against its trust policy.
-Key functions: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
-`verify_confirm`, `TrustPolicy`, `BoundedSession`.
+---
 
-### 5. Black box and kill switch (`vouch.robotics.blackbox`)
+## 1. Hardware-rooted identity
+
+`vouch.robotics.identity`
+
+What it is: a `RobotIdentityCredential` that binds a robot's software identity
+key to a physical hardware root of trust (a TPM, a secure enclave, or an on-board
+secure element), alongside its make, model, serial, owner, and lifecycle history.
+
+The problem it closes: a software-only identity can be copied to another machine.
+If a robot's DID and key live in a config file, a cloned robot is
+indistinguishable from the original. Hardware rooting makes the identity
+non-transferable: it is provably tied to one piece of silicon.
+
+How it works: the robot self-issues the credential with its own Ed25519 key. The
+hardware root signs a binding, the JCS canonical bytes of
+`{"key": <robot key multibase>, "robotDid": <robot DID>}`, and that signature is
+embedded as `credentialSubject.hardwareRoot.attestation` next to the hardware
+root's own public key. Verification therefore checks two independent signatures:
+the credential proof (the robot key signed the document) and the hardware
+attestation (the hardware root signed the binding tying that key to that DID).
+
+The API: `mint_robot_identity` and `verify_robot_identity`, plus the
+`robot_identity_binding` helper that returns the exact bytes a TPM-backed root
+must sign (so a hardware backend can sign them externally). The reference SDKs add
+a `SoftwareRootOfTrust` for development and a `HardwareRootOfTrust` interface a
+real backend implements.
+
+Worked example (Python):
+
+```python
+from vouch.robotics import identity
+
+root = identity.SoftwareRootOfTrust(kind="TPM")          # a real deployment uses the TPM
+cred = identity.mint_robot_identity(
+    robot_signer, root,
+    make="Acme Robotics", model="AR-7", serial="SN-000123",
+    owner="did:web:owner.example.com",
+)
+ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+```
+
+Security boundary: verification fails closed if the type is wrong, the credential
+proof is invalid, the hardware public key is missing or not Ed25519, or the
+attestation does not verify against the binding. An attacker who
+swaps in their own hardware key and re-signs the credential still fails, because
+the attestation no longer matches the `{key, robotDid}` binding.
+
+---
+
+## 2. Model and config provenance
+
+`vouch.robotics.provenance`
+
+What it is: a signed `ModelProvenanceAttestation` recording the
+vision-language-action model name, the weights hash, the safety policy, and a
+hash of the running configuration.
+
+The problem it closes: "what software and safety policy was this robot running
+when the incident happened?" Without a signed record, the answer is whatever the
+logs say after the fact. Provenance makes it cryptographic and tamper-evident,
+and it survives over-the-air updates.
+
+How it works: the attestation carries a `vla` block with `modelName`,
+`weightsHash`, `safetyPolicy`, an optional `version`, and a `configHash`. The
+config hash is the multibase SHA-256 of the JCS-canonical config object, so any
+verifier reproduces it from the same config and detects drift. On an OTA update
+the robot re-signs a new attestation with a `supersedes` link to the previous
+one, forming a chain you can walk to answer "what was running at time T."
+
+The API: `build_provenance_attestation`, `verify_provenance_attestation`, and
+`config_hash`. Passing the config to the verifier additionally checks that the
+recorded `configHash` reproduces.
+
+Worked example (TypeScript):
+
+```ts
+import { buildProvenanceAttestation, verifyProvenanceAttestation } from '@vouch-protocol-official/sdk';
+
+const att = await buildProvenanceAttestation(signer, {
+  robotDid, modelName: 'openvla-7b', weightsHash: 'u...', safetyPolicy: 'did:web:authority#policy-v3',
+  config: { temperature: 0.0, max_torque: 12.5, guardrails: ['no_humans_zone'] },
+});
+const { ok, subject } = verifyProvenanceAttestation(att, publicKey, config);
+```
+
+Security boundary: verification fails on a wrong type, an invalid proof, or, when
+a config is supplied, a `configHash` that does not match. A robot running a
+different config than the one attested is detectable by anyone holding the
+expected config.
+
+---
+
+## 3. Physical capability scope
+
+`vouch.robotics.capability`
+
+What it is: a `PhysicalCapabilityScope` credential carrying physical limits, max
+force, max speed, a tighter speed cap near humans, allowed zones, and shift
+windows, that a controller checks before every actuation.
+
+The problem it closes: a permission like "operate the arm" says nothing about how
+hard or how fast. Physical scope makes the bound cryptographically enforceable
+and, crucially, makes delegated authority shrink-only so a sub-task can never
+quietly grant itself more force or a wider zone than its parent.
+
+How it works: the scope is a JSON object inside the credential subject. A
+controller calls the check function with a proposed action and gets back whether
+it is allowed plus a reason for each violated dimension. Delegation is governed
+by an attenuation rule: a child scope is valid only if every numeric cap is less
+than or equal to the parent, every allowed zone is a subset, and every shift
+window fits inside some parent window.
+
+The API: `build_physical_scope_credential`, `check_physical_action` (returns ok
+plus reasons), and `attenuates(parent, child)` (the narrow-only guard). The check
+and attenuation functions accept both native and JSON-decoded scope shapes, so a
+scope issued in one language enforces identically in another.
+
+Worked example (Go):
+
+```go
+scope := cred["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+res := robotics.CheckPhysicalAction(scope, robotics.PhysicalAction{
+    SpeedMps: ptr(1.5), NearHumans: true,   // rejected: near-humans cap is 0.5 m/s
+})
+// res.OK == false, res.Reasons == ["near_humans speed_exceeded: 1.5 m/s > 0.5 m/s"]
+```
+
+Security boundary: the runtime check rejects an action that exceeds any granted
+dimension (an absent dimension is unconstrained by design). The attenuation check
+is the privilege-escalation guard: a child that raises a cap, drops a cap the
+parent set, adds a zone outside the parent set, or widens a window is rejected.
+
+---
+
+## 4. Robot-to-robot trust handshake
+
+`vouch.robotics.handshake`
+
+What it is: a three-message exchange (HELLO, ACCEPT, CONFIRM) by which two robots
+in different trust domains authenticate each other and agree a bounded
+cooperation session.
+
+The problem it closes: when robots from different fleets meet and must cooperate,
+each needs to know the other is who it claims and agree on a safe, limited set of
+shared actions, without a central authority brokering it.
+
+How it works: the initiator signs a HELLO proposing a scope and a fresh nonce.
+The responder verifies the HELLO signature, checks the initiator's `did:web`
+domain against its trust policy, and signs an ACCEPT whose `boundedScope` is the
+intersection of the proposed scope and what the responder offers, never the
+union. The initiator verifies the ACCEPT, confirms the nonce echoes its HELLO,
+and signs a CONFIRM closing the session. Each message is an `eddsa-jcs-2022`
+signed object, so authentication reuses the shared verifier.
+
+The API: `build_hello`, `build_accept`, `verify_accept`, `build_confirm`,
+`verify_confirm`, plus `TrustPolicy` (allow by domain, or accept unknowns
+explicitly) and `BoundedSession`.
+
+Security boundary: the responder signs an acceptance only if the HELLO signature
+verifies and the initiator's domain passes the policy. The session scope is the
+intersection of both offers, so neither side can widen the other's grant. The
+nonce binds the acceptance to its HELLO, and a tampered message fails signature
+verification.
+
+---
+
+## 5. Black box and kill switch
+
+`vouch.robotics.blackbox`
+
+Two related capabilities ship together.
+
 The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight
-recorder: payloads are confidential, the chain is tamper-evident without the key,
-and only the key opens the payloads. The kill-switch credential is a verifiable
-emergency stop that proves who issued it and, with an authority allowlist,
-enforces that only an attested authority can trigger it.
-Key functions: `BlackBoxLog`, `open_entry`, `verify_blackbox_chain`,
-`build_killswitch_credential`, `verify_killswitch_credential`.
+recorder. Each entry encrypts its payload under a 32-byte key; the encrypted blob
+is `nonce(12) || ciphertext || tag(16)`, the same layout in every language. Each
+entry also carries a `seq`, a `prevHash` linking to the previous entry, and an
+`entryHash` over its own JCS-canonical body. The result has two independent
+properties: the chain is tamper-evident without the key (any altered field breaks
+its `entryHash`, any reordering breaks `prevHash`), and the payloads open only
+with the key. An auditor can prove nothing was changed without being able to read
+the contents; the key holder can read them.
 
-### 6. Scannable robot passport (`vouch.robotics.passport`)
-A compact, signed passport in a `vouch-passport:` URI for a QR or NFC tag, so
-anyone can check a robot's owner, authorized actions, certification, and standing
-offline, with no network call.
-Key functions: `build_passport`, `encode_passport`, `decode_passport`,
-`verify_passport`.
+The kill switch is a verifiable emergency stop. A `KillSwitchCredential` proves
+who issued the stop, over what scope, and why. With an attested-authority
+allowlist, verification rejects any issuer that is not on the list, so a rogue
+actor cannot forge a legitimate-looking stop.
+
+The API: `BlackBoxLog` (append, open, head, entries), `open_entry`,
+`verify_blackbox_chain`, `genesis_prev_hash`, plus
+`build_killswitch_credential` and `verify_killswitch_credential`.
+
+Worked example (Python):
+
+```python
+log = blackbox.BlackBoxLog(key)                  # 32-byte AES key
+entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
+assert blackbox.verify_blackbox_chain(log.entries()).ok
+payload = log.open_entry(entry)                  # only the key holder can read this
+```
+
+Security boundary: chain verification fails on a seq gap, a broken `prevHash`
+link, or a recomputed `entryHash` that does not match (tampering). Decryption
+fails under the wrong key. The kill switch fails on a wrong type, an invalid
+proof, or, with an allowlist, an issuer that is not an attested authority.
+
+---
+
+## 6. Scannable robot passport
+
+`vouch.robotics.passport`
+
+What it is: a compact, signed `RobotPassport` encoded into a `vouch-passport:`
+URI for a QR code or NFC tag, so anyone can check a robot's owner, authorized
+actions, certification, and current standing offline, with no network call.
+
+The problem it closes: a person standing in front of a robot needs to know it is
+legitimate and what it is allowed to do, often with no connectivity. The passport
+puts a verifiable summary on the robot itself.
+
+How it works: the passport credential carries the robot's identity summary and a
+`status` (active, suspended, or decommissioned). `encode_passport` serializes the
+JCS-canonical credential into a deterministic multibase payload behind the
+`vouch-passport:` scheme, so a scanner verifies the signature locally. The
+encoding is deterministic, so a passport encoded in any language decodes and
+verifies in the others.
+
+The API: `build_passport`, `encode_passport`, `decode_passport`,
+`verify_passport`, `verify_passport_uri`.
+
+Security boundary: verification is fully offline (the verifier supplies the
+issuer key). An expired passport fails. A suspended or decommissioned passport
+still verifies but the status is surfaced, so a scanner refuses cooperation rather
+than treating it as silently inactive. A tampered passport or a wrong type is
+rejected.
+
+---
+
+## How they compose
+
+A real deployment chains them: a robot has a hardware-rooted identity (1),
+carries a signed record of the exact model and policy it runs (2), enforces
+physical limits before every move (3), negotiates bounded cooperation with robots
+it meets (4), records an encrypted tamper-evident log and honors a verifiable
+kill switch (5), and presents a scannable passport anyone can check offline (6).
+Every artifact is the same Verifiable Credential format, so one verifier and one
+trust model cover all six.
 
 ## Quick answers
 
-- "Can a robot prove which hardware it is?" Yes, via the hardware-rooted identity
-  credential (capability 1).
-- "Can I prove what model and safety policy a robot is running, even after an OTA
-  update?" Yes, via the re-signable provenance attestation (capability 2).
-- "Can I enforce that a robot slows down near people, or stays in its zone?" Yes,
-  via the physical capability scope, checked before actuation (capability 3).
-- "Can two robots from different fleets cooperate safely?" Yes, via the
-  bounded-trust handshake (capability 4).
-- "Can I prove who hit the emergency stop, and stop anyone else from doing it?"
-  Yes, via the kill-switch credential with an attested-authority allowlist
-  (capability 5).
-- "Can a robot have a flight recorder that is private but tamper-evident?" Yes,
-  via the encrypted black box (capability 5).
-- "Can someone scan a robot to check it is legitimate?" Yes, via the scannable
-  passport (capability 6).
+- Can a robot prove which hardware it is? Yes, hardware-rooted identity (1).
+- Can I prove what model and safety policy ran, even after an OTA update? Yes,
+  the re-signable provenance attestation (2).
+- Can I enforce that a robot slows near people or stays in its zone? Yes, the
+  physical capability scope, checked before actuation (3).
+- Can two robots from different fleets cooperate safely? Yes, the bounded-trust
+  handshake (4).
+- Can I prove who hit the emergency stop and stop anyone else from doing it? Yes,
+  the kill-switch credential with an attested-authority allowlist (5).
+- Can a robot keep a flight recorder that is private but tamper-evident? Yes, the
+  encrypted black box (5).
+- Can someone scan a robot to check it is legitimate, offline? Yes, the scannable
+  passport (6).
 
 ## Status
 
-All six are implemented with tests and a runnable demo
-(`examples/robotics_demo.py`), documented in `docs/robotics.md`, with an interop
-vector pinning the hardware-root binding and config hash. Defensive disclosures
-PAD-064 (identity), PAD-065 (provenance), PAD-066 (physical scope), PAD-067
-(handshake), PAD-068 (kill switch), PAD-069 (black box), and PAD-070 (passport)
-cover the novel methods.
+All six capabilities are implemented and tested in Python, TypeScript, Go, and
+the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++,
+and WebAssembly wrappers. A runnable demo lives in `examples/robotics_demo.py`,
+the canonical write-up in `docs/robotics.md`, and a shared interop vector pins the
+hardware-root binding and the config hash. The novel methods are published as
+open defensive disclosures: PAD-064 (hardware-rooted identity), PAD-067
+(robot-to-robot handshake), PAD-069 (confidential tamper-evident black box), and
+PAD-070 (scannable offline passport).

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -157,9 +157,26 @@ A Vouch delegation chain captures all three steps cryptographically. Each step n
       },
       {
         q: 'Does Vouch work for robots and embodied agents?',
-        a: `Yes. A robot is an agent with a body, and identity, accountability, and continuous trust matter more, not less, when an agent can cause physical harm. The same Vouch primitives apply: a \`did:vouch:agent\` identity for the robot, delegation chains that record who authorized it and within what limits, and the heartbeat runtime for whether it is still behaving.
+        a: `Yes, and it ships today. A robot is an agent with a body, so identity, accountability, and continuous trust matter even more once an agent can cause physical harm. Everything Vouch does for software agents applies, and the \`vouch.robotics\` module adds six capabilities for the parts that only exist when an agent is embodied. They are open formats plus reference implementations, built on the same \`eddsa-jcs-2022\` Verifiable Credentials as the rest of Vouch, so a robotics credential signed in one language verifies in every other.
 
-The robot-specific open piece is a hardware-root-of-trust profile. The robot's secure element (a TPM, a secure enclave, or an on-board AI module's enclave) anchors its DID and signs its heartbeats, so identity is bound to the physical device rather than a config file. The open \`did:vouch:agent\` profile in [docs/specs/](https://github.com/vouch-protocol/vouch/tree/main/docs/specs) defines the agent identity scheme; the embodied profile extends it for hardware attestation. Richer robot-lifecycle tooling builds on this open layer.`,
+The headline piece is hardware-rooted identity: the robot's secure element (a TPM, an enclave, or an on-board AI module's secure element) signs a binding over the robot's DID and key, so its identity is provably tied to one piece of hardware rather than a config file that can be copied.`,
+        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }, { label: 'Robotics overview', href: '/robotics/' }],
+        meta: 'Shipped - vouch.robotics (Python, TypeScript, Go, Rust core), PAD-064/067/069/070',
+      },
+      {
+        q: 'What exactly can Vouch do for a robot?',
+        a: `Six capabilities, each a signed credential anyone can verify:
+
+- **Hardware-rooted identity**: binds the robot's key to a TPM or secure element, so the identity cannot be cloned to other hardware.
+- **Model and config provenance**: a signed, re-signable record of the model, weights hash, safety policy, and config a robot is running, so you can prove what software it ran even after an over-the-air update.
+- **Physical capability scope**: max force, a slower speed near people, allowed zones, and shift windows, checked before each actuation; a delegated scope can only narrow, never widen.
+- **Robot-to-robot handshake**: two robots from different fleets authenticate and agree a cooperation session whose scope is the intersection of what each offers, gated by a domain trust policy.
+- **Black box and kill switch**: an encrypted, tamper-evident flight recorder (private without the key, tamper-evident without it) plus a verifiable emergency stop that proves who issued it and can require an attested authority.
+- **Scannable passport**: a compact signed passport in a QR or NFC tag, so anyone can check a robot's owner, authorized actions, certification, and standing offline.
+
+All six are implemented and tested across Python, TypeScript, Go, and the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers.`,
+        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
+        meta: 'Shipped - vouch.robotics, PAD-064/067/069/070',
       },
       {
         q: 'Can Vouch prove an agent has a track record it cannot fake?',

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -1924,4 +1924,100 @@ The agent code does not change. What changes is the DID (production agents use a
       },
     ],
   },
+  {
+    id: 'robotics',
+    title: 'Robotics',
+    description: 'The six robotics capabilities for embodied agents: hardware-rooted identity, model and config provenance, physical capability scope, robot-to-robot handshake, an encrypted black box and kill switch, and a scannable passport. Open formats on the same Verifiable Credentials as the rest of Vouch, so a robotics credential signed in any language verifies in every other.',
+    articles: [
+      {
+        id: 'robotics',
+        title: 'Robotics: identity and accountability for robots',
+        summary: 'Build and verify all six robotics credentials, with the mechanism, API, and exactly what each verification checks.',
+        body: `
+Vouch gives robots the same identity, accountability, and continuous trust it gives software agents, and adds the pieces that only matter once an agent has a body. The robotics primitives live in vouch.robotics (Python), packages/sdk-ts/src/robotics (TypeScript), go-sidecar/robotics (Go), and the Rust core, which flows to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers. Every credential is an eddsa-jcs-2022 Verifiable Credential, so a credential signed in one language verifies in all the others (proven by test-vectors/robotics/vector.json).
+
+A design rule runs through the module: the core is hardware-agnostic and deterministic. It never reaches for a clock, a random number, or a TPM itself. Timestamps, nonces, and hardware attestations are passed in, so output is reproducible and a real deployment can route signing to a secure element.
+
+## 1. Hardware-rooted identity
+
+Binds the robot's software key to a hardware root (a TPM or secure element), so the identity cannot be cloned to other hardware. The hardware root signs a binding over (key, robotDid), embedded as hardwareRoot.attestation. Verification checks both the credential proof and that attestation.
+
+    from vouch.robotics import identity
+
+    root = identity.SoftwareRootOfTrust(kind="TPM")     # production uses the real TPM
+    cred = identity.mint_robot_identity(robot_signer, root,
+        make="Acme Robotics", model="AR-7", serial="SN-000123",
+        owner="did:web:owner.example.com")
+    ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+
+Verification fails closed on a wrong type, an invalid proof, a missing or non-Ed25519 hardware key, or an attestation that does not match the binding. Swapping in an attacker's hardware key and re-signing still fails, because the attestation no longer matches the binding.
+
+## 2. Model and config provenance
+
+A signed record of the model, weights hash, safety policy, and a hash of the config a robot runs, re-signable on every over-the-air update via a supersedes link. The config hash is the multibase SHA-256 of the JCS-canonical config, reproducible by any verifier.
+
+    from vouch.robotics import provenance
+
+    att = provenance.build_provenance_attestation(signer, robot_did=robot_did,
+        model_name="openvla-7b", weights_hash="u...",
+        safety_policy="did:web:authority#policy-v3",
+        config={"temperature": 0.0, "max_torque": 12.5, "guardrails": ["no_humans_zone"]})
+    ok, subject = provenance.verify_provenance_attestation(att, signer.public_key(), config)
+
+Supplying the config to the verifier additionally checks the recorded configHash reproduces, so a robot running a different config than the one attested is detectable.
+
+## 3. Physical capability scope
+
+Max force, max speed, a tighter cap near humans, allowed zones, and shift windows, checked before each actuation. A delegated scope must narrow, never broaden.
+
+    from vouch.robotics import capability
+
+    cred = capability.build_physical_scope_credential(fleet_signer, subject_did=robot_did,
+        max_force_n=80, max_speed_mps=2.0, max_speed_near_humans_mps=0.5,
+        allowed_zones=["warehouse-a"], shift_windows=[{"start": "08:00", "end": "18:00"}])
+    scope = cred["credentialSubject"]["physicalScope"]
+    res = capability.check_physical_action(scope,
+        capability.PhysicalAction(speed_mps=1.5, near_humans=True))
+    # res.ok is False: the near-humans speed cap is 0.5 m/s
+
+attenuates(parent, child) is the escalation guard: a child that raises a cap, drops a cap the parent set, adds a zone outside the parent set, or widens a window is rejected.
+
+## 4. Robot-to-robot handshake
+
+Two robots from different domains authenticate over three signed messages (HELLO, ACCEPT, CONFIRM) and agree a session whose scope is the intersection of both offers, gated by a TrustPolicy on the did:web domain. The responder signs an acceptance only if the HELLO verifies and the initiator's domain is trusted. The nonce binds the acceptance to its HELLO; a tampered message fails verification.
+
+## 5. Black box and kill switch
+
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked log. The encrypted blob is nonce, then ciphertext, then tag. The chain is tamper-evident without the key (any altered field breaks its entryHash, any reorder breaks prevHash); payloads open only with the key.
+
+    from vouch.robotics import blackbox
+
+    log = blackbox.BlackBoxLog(key)                       # 32-byte AES key
+    entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
+    assert blackbox.verify_blackbox_chain(log.entries()).ok
+    payload = log.open_entry(entry)                       # only the key holder can read this
+
+The kill switch (build_killswitch_credential and verify_killswitch_credential) is a verifiable emergency stop that proves who issued it and, with an attested-authority allowlist, rejects any issuer not on the list.
+
+## 6. Scannable passport
+
+A compact signed RobotPassport encoded into a vouch-passport: URI for a QR or NFC tag, so anyone can check the robot's owner, authorized actions, certification, and standing offline.
+
+    from vouch.robotics import passport
+
+    p = passport.build_passport(signer, robot_did=robot_did, make="Acme Robotics",
+        model="AR-7", owner="did:web:owner.example.com",
+        authorized_actions=["lift", "carry"], certification="ISO-10218")
+    uri = passport.encode_passport(p)                     # "vouch-passport:u..."
+    ok, summary = passport.verify_passport(passport.decode_passport(uri), signer.public_key())
+
+Verification is offline. An expired passport fails; a suspended or decommissioned one still verifies but surfaces its status so a scanner can refuse cooperation.
+
+## Where to go next
+
+The defensive disclosures PAD-064 (identity), PAD-067 (handshake), PAD-069 (black box), and PAD-070 (passport) document the novel methods. A runnable demo is in examples/robotics_demo.py, and the canonical write-up is docs/robotics.md.
+`,
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Brings the robotics knowledge surfaces up to the depth of the shipped code: the knowledge base (mirrored across website-agent, OpenAI GPT, Gemini gem, and the Claude skill reference), the Claude skill, the OpenAI GPT, and the Gemini gem.

- A comprehensive robotics knowledge doc teaching each of the six capabilities end to end (mechanism, the threat it closes, the API, a worked example, and the exact verification boundary), plus the one-core cross-language model.
- `language-sdks.md` and `overview.md` gain a robotics section so the multi-language coverage is reflected everywhere.
- The Claude skill, GPT, and gem gain robotics tasks and decision rules pointing at the knowledge.

Plain English, em-dash-free.
