### PR TITLE
Robotics on the website: agents/robotics toggle, per-capability FAQ and help guides

### DIFF
--- a/gemini-gem/knowledge/language-sdks.md
+++ b/gemini-gem/knowledge/language-sdks.md
@@ -43,8 +43,28 @@ All of the local SDKs cover the same surface:
   older composite profile
 - Delegation: build a link and validate a chain's time-bound rule
 - Revocation: check a credential's BitstringStatusList status
+- Robotics: the six embodied-agent capabilities (see the Robotics section below)
 
 Binary values cross the boundary as base64; credentials and proofs cross as JSON.
+
+## Robotics in every language
+
+The robotics primitives (hardware-rooted identity, model and config provenance,
+physical capability scope, robot-to-robot handshake, an encrypted black box with
+a kill switch, and a scannable passport) are implemented once in the Rust core and
+exposed through the same UniFFI and WASM wrappers as the rest of the surface, so
+Swift, Kotlin/JVM, .NET, C/C++, and the browser get them too. Python
+(`vouch.robotics`), TypeScript (`packages/sdk-ts/src/robotics`), and Go
+(`go-sidecar/robotics`) each carry a byte-identical reference implementation.
+
+The FFI surface is JSON-in / JSON-out, with keys passed as bytes and binary fields
+as multibase strings, so every wrapper calls the same shared facade. Function names
+follow each language's convention: for example `mint_robot_identity` /
+`verify_robot_identity` in Python and Go, `mintRobotIdentity` / `verifyRobotIdentity`
+in TypeScript, and `roboticsMintIdentity` / `roboticsVerifyIdentity` over the WASM
+and UniFFI boundary. A robotics credential signed in any language verifies in every
+other, pinned by `test-vectors/robotics/vector.json`. See robotics.md for the
+per-capability API and worked examples.
 
 ## Mobile and native builds
 

--- a/openai-gpt/knowledge/language-sdks.md
+++ b/openai-gpt/knowledge/language-sdks.md
@@ -43,8 +43,28 @@ All of the local SDKs cover the same surface:
   older composite profile
 - Delegation: build a link and validate a chain's time-bound rule
 - Revocation: check a credential's BitstringStatusList status
+- Robotics: the six embodied-agent capabilities (see the Robotics section below)
 
 Binary values cross the boundary as base64; credentials and proofs cross as JSON.
+
+## Robotics in every language
+
+The robotics primitives (hardware-rooted identity, model and config provenance,
+physical capability scope, robot-to-robot handshake, an encrypted black box with
+a kill switch, and a scannable passport) are implemented once in the Rust core and
+exposed through the same UniFFI and WASM wrappers as the rest of the surface, so
+Swift, Kotlin/JVM, .NET, C/C++, and the browser get them too. Python
+(`vouch.robotics`), TypeScript (`packages/sdk-ts/src/robotics`), and Go
+(`go-sidecar/robotics`) each carry a byte-identical reference implementation.
+
+The FFI surface is JSON-in / JSON-out, with keys passed as bytes and binary fields
+as multibase strings, so every wrapper calls the same shared facade. Function names
+follow each language's convention: for example `mint_robot_identity` /
+`verify_robot_identity` in Python and Go, `mintRobotIdentity` / `verifyRobotIdentity`
+in TypeScript, and `roboticsMintIdentity` / `roboticsVerifyIdentity` over the WASM
+and UniFFI boundary. A robotics credential signed in any language verifies in every
+other, pinned by `test-vectors/robotics/vector.json`. See robotics.md for the
+per-capability API and worked examples.
 
 ## Mobile and native builds
 

--- a/website-agent/backend/knowledge/language-sdks.md
+++ b/website-agent/backend/knowledge/language-sdks.md
@@ -43,8 +43,28 @@ All of the local SDKs cover the same surface:
   older composite profile
 - Delegation: build a link and validate a chain's time-bound rule
 - Revocation: check a credential's BitstringStatusList status
+- Robotics: the six embodied-agent capabilities (see the Robotics section below)
 
 Binary values cross the boundary as base64; credentials and proofs cross as JSON.
+
+## Robotics in every language
+
+The robotics primitives (hardware-rooted identity, model and config provenance,
+physical capability scope, robot-to-robot handshake, an encrypted black box with
+a kill switch, and a scannable passport) are implemented once in the Rust core and
+exposed through the same UniFFI and WASM wrappers as the rest of the surface, so
+Swift, Kotlin/JVM, .NET, C/C++, and the browser get them too. Python
+(`vouch.robotics`), TypeScript (`packages/sdk-ts/src/robotics`), and Go
+(`go-sidecar/robotics`) each carry a byte-identical reference implementation.
+
+The FFI surface is JSON-in / JSON-out, with keys passed as bytes and binary fields
+as multibase strings, so every wrapper calls the same shared facade. Function names
+follow each language's convention: for example `mint_robot_identity` /
+`verify_robot_identity` in Python and Go, `mintRobotIdentity` / `verifyRobotIdentity`
+in TypeScript, and `roboticsMintIdentity` / `roboticsVerifyIdentity` over the WASM
+and UniFFI boundary. A robotics credential signed in any language verifies in every
+other, pinned by `test-vectors/robotics/vector.json`. See robotics.md for the
+per-capability API and worked examples.
 
 ## Mobile and native builds
 

--- a/website/src/app/faq/FAQClient.tsx
+++ b/website/src/app/faq/FAQClient.tsx
@@ -135,15 +135,15 @@ export default function FAQClient({ sections }: { sections: FAQSection[] }) {
     return (
         <div>
             {hasRobotics && (
-                <div className="mb-10 flex flex-wrap gap-1.5 border-b border-rule pb-5">
+                <div className="mb-10 flex flex-wrap gap-1 border-b border-rule">
                     {DOMAINS.map((d) => (
                         <button
                             key={d.key}
                             onClick={() => setDomain(d.key)}
-                            className={`px-4 py-2 text-[0.9rem] rounded-md transition-colors ${
+                            className={`px-4 py-2.5 -mb-px text-[0.92rem] border-b-2 transition-colors ${
                                 domain === d.key
-                                    ? 'bg-ink text-parchment font-medium'
-                                    : 'text-ink-soft hover:text-ink'
+                                    ? 'border-burgundy text-ink font-medium'
+                                    : 'border-transparent text-ink-soft hover:text-ink'
                             }`}
                         >
                             {d.label}

--- a/website/src/app/faq/FAQClient.tsx
+++ b/website/src/app/faq/FAQClient.tsx
@@ -97,12 +97,20 @@ function renderAnswer(text: string): React.ReactNode {
 
 export default function FAQClient({ sections }: { sections: FAQSection[] }) {
     const [search, setSearch] = useState('');
+    const [domain, setDomain] = useState<'all' | 'agents' | 'robotics'>('all');
 
     const query = search.toLowerCase().trim();
 
+    const hasRobotics = useMemo(() => sections.some((s) => s.domain === 'robotics'), [sections]);
+
+    const domainSections = useMemo(
+        () => sections.filter((s) => domain === 'all' || (s.domain ?? 'agents') === domain),
+        [sections, domain]
+    );
+
     const filteredSections = useMemo(() => {
-        if (!query) return sections;
-        return sections
+        if (!query) return domainSections;
+        return domainSections
             .map((section) => ({
                 ...section,
                 items: section.items.filter(
@@ -114,17 +122,41 @@ export default function FAQClient({ sections }: { sections: FAQSection[] }) {
                 ),
             }))
             .filter((section) => section.items.length > 0);
-    }, [sections, query]);
+    }, [domainSections, query]);
+
+    const DOMAINS: { key: 'all' | 'agents' | 'robotics'; label: string }[] = [
+        { key: 'all', label: 'All' },
+        { key: 'agents', label: 'AI agents' },
+        { key: 'robotics', label: 'Embodied agents (robotics)' },
+    ];
 
     const totalResults = filteredSections.reduce((sum, s) => sum + s.items.length, 0);
 
     return (
-        <div className="grid lg:grid-cols-[220px_1fr] gap-12 lg:gap-16">
+        <div>
+            {hasRobotics && (
+                <div className="mb-10 flex flex-wrap gap-1.5 border-b border-rule pb-5">
+                    {DOMAINS.map((d) => (
+                        <button
+                            key={d.key}
+                            onClick={() => setDomain(d.key)}
+                            className={`px-4 py-2 text-[0.9rem] rounded-md transition-colors ${
+                                domain === d.key
+                                    ? 'bg-ink text-parchment font-medium'
+                                    : 'text-ink-soft hover:text-ink'
+                            }`}
+                        >
+                            {d.label}
+                        </button>
+                    ))}
+                </div>
+            )}
+            <div className="grid lg:grid-cols-[220px_1fr] gap-12 lg:gap-16">
             {/* Marginalia / table of contents */}
             <aside className="lg:sticky lg:top-8 lg:self-start lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto">
                 <div className="eyebrow mb-3 border-b border-rule pb-2">In this section</div>
                 <nav>
-                    {sections.map((section) => (
+                    {domainSections.map((section) => (
                         <a key={section.id} href={`#${section.id}`} className="marginalia-link">
                             {section.audience}
                         </a>
@@ -216,6 +248,7 @@ export default function FAQClient({ sections }: { sections: FAQSection[] }) {
                     ))
                 )}
             </div>
+        </div>
         </div>
     );
 }

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -81,7 +81,7 @@ Vouch fixes this by turning every agent action into a signed receipt. Identity, 
       },
       {
         q: 'Who is behind Vouch?',
-        a: `Vouch is a personal open-source project from [Ramprasad Gaddam](https://github.com/vouch-protocol), an AI engineering director with 20+ years in regulated industries (healthcare, banking, manufacturing), 20 patents in cryptography and AI, and active membership in The Linux Foundation, C2PA, the Content Authenticity Initiative, DIF, and IEEE.
+        a: `Vouch is a personal open-source project from [Ramprasad Gaddam](https://github.com/vouch-protocol), an AI engineering director with 20+ years in regulated industries (healthcare and manufacturing), 20 patents in cryptography and AI, and active membership in The Linux Foundation, C2PA, the Content Authenticity Initiative, DIF, and IEEE.
 
 It is not affiliated with or endorsed by any employer.`,
       },
@@ -201,6 +201,31 @@ The headline piece is hardware-rooted identity: the robot's secure element (a TP
 All six are implemented and tested across Python, TypeScript, Go, and the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers.`,
         helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
         meta: 'Shipped - vouch.robotics, PAD-064/067/069/070',
+      },
+      {
+        q: 'Which languages can I use the robotics capabilities from?',
+        a: `All of them. The six capabilities are implemented once in the Rust core and exposed through the same UniFFI and WebAssembly wrappers as the rest of Vouch, plus byte-identical reference implementations in Python, TypeScript, and Go.
+
+So you can build and verify robot identity, provenance, physical scope, handshakes, the black box and kill switch, and the passport from Python, TypeScript, Go, Swift, Kotlin/JVM, .NET, C/C++, or the browser, and a robotics credential signed in one verifies in all the others, byte for byte.`,
+        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
+        meta: 'Shipped - vouch.robotics across every SDK',
+      },
+      {
+        q: 'How is a robot’s identity different from a software agent’s?',
+        a: `It adds a hardware root. A software agent has a DID and a signing key; a robot has those plus a binding signed by a TPM or secure element, so its identity is provably tied to one physical device and cannot be cloned to another machine.
+
+Everything else Vouch does for a software agent (delegation chains, revocation, the continuous-trust heartbeat) applies to the robot unchanged. The hardware-rooted identity is the one piece that only makes sense once the agent has a body.`,
+      },
+      {
+        q: 'Can I stop a robot remotely and prove who issued the stop?',
+        a: `Yes. The kill switch is a signed KillSwitchCredential that names the target robot, the reason, and the issuer. Verification can require the issuer to be on an attested-authority allowlist, so a rogue actor cannot forge a legitimate-looking emergency stop, and the credential itself is a permanent, verifiable record of who triggered it.`,
+        meta: 'Shipped - vouch.robotics.blackbox, PAD-069',
+      },
+      {
+        q: 'Can an auditor check a robot’s black box for tampering without reading the logs?',
+        a: `Yes, that separation is the whole point. The black box is an append-only, AES-256-GCM-encrypted, hash-linked chain. Anyone can verify the chain is intact (no entry was altered, and nothing was reordered) without holding the key, while only the key holder can decrypt the payloads. Tamper-evidence and confidentiality are independent.`,
+        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
+        meta: 'Shipped - vouch.robotics.blackbox, PAD-069',
       },
     ],
   },

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -181,103 +181,211 @@ This is the evidence layer underneath a reputation score. A score can be moved b
     items: [
       {
         q: 'Does Vouch work for robots and embodied agents?',
-        a: `Yes, and it ships today. A robot is an agent with a body, so identity, accountability, and continuous trust matter even more once an agent can cause physical harm. Everything Vouch does for software agents applies, and the \`vouch.robotics\` module adds six capabilities for the parts that only exist when an agent is embodied. They are open formats plus reference implementations, built on the same \`eddsa-jcs-2022\` Verifiable Credentials as the rest of Vouch, so a robotics credential signed in one language verifies in every other.
-
-The headline piece is hardware-rooted identity: the robot's secure element (a TPM, an enclave, or an on-board AI module's secure element) signs a binding over the robot's DID and key, so its identity is provably tied to one piece of hardware rather than a config file that can be copied.`,
+        a: `Yes, and it ships today. A robot is an agent with a body, so identity, accountability, and continuous trust matter even more once an agent can cause physical harm. Everything Vouch does for software agents applies, and the \`vouch.robotics\` module adds six capabilities for the parts that only exist when an agent is embodied. They are open formats plus reference implementations, built on the same \`eddsa-jcs-2022\` Verifiable Credentials as the rest of Vouch, so a robotics credential signed in one language verifies in every other.`,
         helpLinks: [{ label: 'Robotics quickstart', href: '/help/#robotics' }, { label: 'Robotics overview', href: '/robotics/' }],
         meta: 'Shipped - vouch.robotics (Python, TypeScript, Go, Rust core), PAD-064/067/069/070',
       },
       {
         q: 'What exactly can Vouch do for a robot?',
-        a: `Six capabilities, each a signed credential anyone can verify:
-
-- **Hardware-rooted identity**: binds the robot's key to a TPM or secure element, so the identity cannot be cloned to other hardware.
-- **Model and config provenance**: a signed, re-signable record of the model, weights hash, safety policy, and config a robot is running, so you can prove what software it ran even after an over-the-air update.
-- **Physical capability scope**: max force, a slower speed near people, allowed zones, and shift windows, checked before each actuation; a delegated scope can only narrow, never widen.
-- **Robot-to-robot handshake**: two robots from different fleets authenticate and agree a cooperation session whose scope is the intersection of what each offers, gated by a domain trust policy.
-- **Black box and kill switch**: an encrypted, tamper-evident flight recorder plus a verifiable emergency stop that proves who issued it and can require an attested authority.
-- **Scannable passport**: a compact signed passport in a QR or NFC tag, so anyone can check a robot's owner, authorized actions, certification, and standing offline.
-
-Each has its own question below.`,
+        a: `Six capabilities, each a signed credential anyone can verify: hardware-rooted identity, model and config provenance, physical capability scope, a robot-to-robot handshake, a black box with a kill switch, and a scannable passport. Each capability has its own questions in the sections below, and its own guide under Help.`,
         helpLinks: [{ label: 'Robotics capabilities', href: '/help/#robotics-capabilities' }],
         meta: 'Shipped - vouch.robotics, PAD-064/067/069/070',
       },
       {
         q: 'Which languages can I use the robotics capabilities from?',
-        a: `All of them. The six capabilities are implemented once in the Rust core and exposed through the same UniFFI and WebAssembly wrappers as the rest of Vouch, plus byte-identical reference implementations in Python, TypeScript, and Go.
-
-So you can build and verify robot identity, provenance, physical scope, handshakes, the black box and kill switch, and the passport from Python, TypeScript, Go, Swift, Kotlin/JVM, .NET, C/C++, or the browser, and a robotics credential signed in one verifies in all the others, byte for byte.`,
+        a: `All of them. The six capabilities are implemented once in the Rust core and exposed through the same UniFFI and WebAssembly wrappers as the rest of Vouch, plus byte-identical reference implementations in Python, TypeScript, and Go. So you can build and verify them from Python, TypeScript, Go, Swift, Kotlin/JVM, .NET, C/C++, or the browser, and a credential signed in one verifies in all the others.`,
         helpLinks: [{ label: 'Robotics quickstarts', href: '/help/#robotics' }],
         meta: 'Shipped - vouch.robotics across every SDK',
       },
       {
         q: 'How is a robot’s identity different from a software agent’s?',
-        a: `It adds a hardware root. A software agent has a DID and a signing key; a robot has those plus a binding signed by a TPM or secure element, so its identity is provably tied to one physical device and cannot be cloned to another machine.
-
-Everything else Vouch does for a software agent (delegation chains, revocation, the continuous-trust heartbeat) applies to the robot unchanged. The hardware-rooted identity is the one piece that only makes sense once the agent has a body.`,
+        a: `It adds a hardware root. A software agent has a DID and a signing key; a robot has those plus a binding signed by a TPM or secure element, so its identity is tied to one physical device. Everything else (delegation chains, revocation, the continuous-trust heartbeat) applies to the robot unchanged.`,
       },
     ],
   },
 
   // =====================================================================
-  // ROBOTICS, CAPABILITY BY CAPABILITY
+  // ROBOTICS: HARDWARE-ROOTED IDENTITY
   // =====================================================================
   {
-    id: 'robotics-capabilities',
-    audience: 'Robotics, capability by capability',
-    title: 'The six capabilities in detail',
+    id: 'robotics-identity',
+    audience: 'Robotics: hardware identity',
+    title: 'Hardware-rooted identity',
     domain: 'robotics',
     items: [
       {
         q: 'How does hardware-rooted identity stop a robot from being cloned?',
-        a: `A robot self-issues a \`RobotIdentityCredential\` with its own key, and its hardware root (a TPM or secure element) signs a binding over the robot's DID and key, embedded as \`hardwareRoot.attestation\`. Verification checks two independent signatures: the credential proof and that hardware attestation.
-
-Copy the software identity to a different machine and the hardware attestation no longer matches the binding, so verification fails. The identity is tied to one piece of silicon.`,
+        a: `A robot self-issues a \`RobotIdentityCredential\` with its own key, and its hardware root (a TPM or secure element) signs a binding over the robot's DID and key, embedded as \`hardwareRoot.attestation\`. Copy the software identity to a different machine and the hardware attestation no longer matches the binding, so verification fails. The identity is tied to one piece of silicon.`,
         helpLinks: [{ label: 'Hardware-rooted identity guide', href: '/help/#robotics-identity' }],
         meta: 'Shipped - vouch.robotics.identity, PAD-064',
       },
       {
-        q: 'Can I prove what model and safety policy a robot ran, even after an OTA update?',
-        a: `Yes, via a \`ModelProvenanceAttestation\`. It records the model name, weights hash, safety policy, and a hash of the running config (the multibase SHA-256 of the canonical config, reproducible by any verifier). On an over-the-air update the robot re-signs a new attestation with a \`supersedes\` link to the previous one, forming a chain you can walk to answer "what was running at time T."
+        q: 'What does verifying a robot identity actually check?',
+        a: `Two independent signatures. First the credential proof, that the robot's own key signed the document. Second the hardware attestation, that the hardware root signed the canonical binding of the robot DID and key. Verification fails closed on a wrong type, an invalid proof, a missing or non-Ed25519 hardware key, or an attestation that does not match the binding.`,
+        helpLinks: [{ label: 'Hardware-rooted identity guide', href: '/help/#robotics-identity' }],
+        meta: 'Shipped - vouch.robotics.identity, PAD-064',
+      },
+      {
+        q: 'Do I need a real TPM to develop with robot identity?',
+        a: `No. The reference SDKs include a \`SoftwareRootOfTrust\` that stands in for the TPM during development and tests, and a \`HardwareRootOfTrust\` interface a real TPM or secure-element backend implements for production. The credential format is identical either way; only where the attestation is signed changes.`,
+        helpLinks: [{ label: 'Robotics quickstart', href: '/help/#robotics-quickstart-python' }],
+        meta: 'Shipped - vouch.robotics.identity',
+      },
+    ],
+  },
 
-Supply the config to the verifier and it also checks that the recorded config hash reproduces, so a robot running a different config than the one attested is detectable.`,
+  // =====================================================================
+  // ROBOTICS: MODEL AND CONFIG PROVENANCE
+  // =====================================================================
+  {
+    id: 'robotics-provenance',
+    audience: 'Robotics: provenance',
+    title: 'Model and config provenance',
+    domain: 'robotics',
+    items: [
+      {
+        q: 'Can I prove what model and safety policy a robot ran, even after an OTA update?',
+        a: `Yes, via a \`ModelProvenanceAttestation\` recording the model name, weights hash, safety policy, and config hash. On an over-the-air update the robot re-signs a new attestation with a \`supersedes\` link to the previous one, forming a tamper-evident chain you can walk to answer "what was running at any past time."`,
         helpLinks: [{ label: 'Provenance guide', href: '/help/#robotics-provenance' }],
         meta: 'Shipped - vouch.robotics.provenance, PAD-065',
       },
       {
-        q: 'How are a robot’s physical limits enforced, and can a sub-task escalate them?',
-        a: `A \`PhysicalCapabilityScope\` credential carries the limits: max force, max speed, a tighter speed cap near humans, allowed zones, and shift windows. A controller checks each proposed action against the scope before the actuator moves, and gets back a reason for any violated dimension.
+        q: 'What is the config hash, and why can any verifier reproduce it?',
+        a: `The config hash is the multibase SHA-256 of the JCS-canonical config object. Because JCS canonicalization is byte-identical across languages, any verifier holding the expected config recomputes the same hash. Supply the config to the verifier and it checks the recorded hash reproduces, so a robot running a different config than the one attested is detectable.`,
+        helpLinks: [{ label: 'Provenance guide', href: '/help/#robotics-provenance' }],
+        meta: 'Shipped - vouch.robotics.provenance, PAD-065',
+      },
+      {
+        q: 'How does the supersedes chain answer "what was running at time T"?',
+        a: `Each attestation carries the id of the one it replaces. Following the \`supersedes\` links backward gives an ordered, signed history of every model and config the robot ran, each with its own validity window. To answer a question about a past moment, you find the attestation whose window covers it.`,
+        meta: 'Shipped - vouch.robotics.provenance, PAD-065',
+      },
+    ],
+  },
 
-A sub-task cannot escalate. Delegation is narrow-only: a child scope may shrink numeric caps, subset the zones, and fit each window inside a parent window, but a child that raises a cap, drops a cap, adds a new zone, or widens a window is rejected.`,
+  // =====================================================================
+  // ROBOTICS: PHYSICAL CAPABILITY SCOPE
+  // =====================================================================
+  {
+    id: 'robotics-capability',
+    audience: 'Robotics: physical scope',
+    title: 'Physical capability scope',
+    domain: 'robotics',
+    items: [
+      {
+        q: 'How are a robot’s physical limits enforced?',
+        a: `A \`PhysicalCapabilityScope\` credential carries the limits, max force, max speed, a tighter cap near humans, allowed zones, and shift windows. A controller calls \`check_physical_action\` with a proposed action before the actuator moves, and gets back whether it is allowed plus a reason for each violated dimension.`,
         helpLinks: [{ label: 'Capability scope guide', href: '/help/#robotics-capability' }],
         meta: 'Shipped - vouch.robotics.capability, PAD-066',
       },
       {
-        q: 'How do two robots from different fleets cooperate safely?',
-        a: `Through a three-message handshake (HELLO, ACCEPT, CONFIRM). The initiator proposes a scope and a fresh nonce; the responder verifies the HELLO signature, checks the initiator's \`did:web\` domain against its trust policy, and replies with a session whose scope is the intersection of what each side offers, never the union.
+        q: 'What happens if an action exceeds the scope, or if a dimension is not set?',
+        a: `An action that exceeds any granted dimension is rejected, with a reason naming the dimension (for example "near_humans speed_exceeded"). A dimension that is not present in the scope is unconstrained by design: if a scope sets no \`maxForceN\`, force is not bounded by that credential.`,
+        helpLinks: [{ label: 'Capability scope guide', href: '/help/#robotics-capability' }],
+        meta: 'Shipped - vouch.robotics.capability, PAD-066',
+      },
+      {
+        q: 'Can a sub-task escalate the physical limits it was delegated?',
+        a: `No. Delegation is narrow-only, enforced by \`attenuates(parent, child)\`. A child scope may shrink numeric caps, subset the allowed zones, and fit each window inside a parent window, but a child that raises a cap, drops a cap the parent set, adds a zone outside the parent set, or widens a window is rejected. This is the privilege-escalation guard.`,
+        helpLinks: [{ label: 'Capability scope guide', href: '/help/#robotics-capability' }],
+        meta: 'Shipped - vouch.robotics.capability, PAD-066',
+      },
+      {
+        q: 'How does the slower speed near people work?',
+        a: `The scope can carry both a general \`maxSpeedMps\` and a tighter \`maxSpeedNearHumansMps\`. When an action is flagged as near humans, the near-humans cap applies instead of the general one, so the same robot is allowed to move faster in a clear aisle than next to a person.`,
+        meta: 'Shipped - vouch.robotics.capability, PAD-066',
+      },
+    ],
+  },
 
-So neither side can widen the other's grant, the responder only cooperates with domains it trusts, and the nonce binds the acceptance to that specific HELLO. A tampered message fails verification.`,
+  // =====================================================================
+  // ROBOTICS: ROBOT-TO-ROBOT HANDSHAKE
+  // =====================================================================
+  {
+    id: 'robotics-handshake',
+    audience: 'Robotics: handshake',
+    title: 'Robot-to-robot handshake',
+    domain: 'robotics',
+    items: [
+      {
+        q: 'How do two robots from different fleets cooperate safely?',
+        a: `Through a three-message handshake (HELLO, ACCEPT, CONFIRM). The initiator proposes a scope and a fresh nonce; the responder verifies the HELLO signature, checks the initiator's \`did:web\` domain against its \`TrustPolicy\`, and replies with a session scope. No central broker is needed.`,
         helpLinks: [{ label: 'Handshake guide', href: '/help/#robotics-handshake' }],
         meta: 'Shipped - vouch.robotics.handshake, PAD-067',
       },
       {
-        q: 'Can I stop a robot remotely and prove who issued the stop?',
-        a: `Yes. The kill switch is a signed \`KillSwitchCredential\` that names the target robot, the reason, and the issuer. Verification can require the issuer to be on an attested-authority allowlist, so a rogue actor cannot forge a legitimate-looking emergency stop, and the credential itself is a permanent, verifiable record of who triggered it.`,
-        helpLinks: [{ label: 'Black box and kill switch guide', href: '/help/#robotics-blackbox' }],
-        meta: 'Shipped - vouch.robotics.blackbox, PAD-068',
+        q: 'Why is the session scope the intersection and not the union of what each robot offers?',
+        a: `Because cooperation should never grant more than both sides already allow. The bounded session scope is the intersection of the initiator's proposed scope and the responder's offered scope, so neither robot can widen the other's authority by asking. A robot that proposes more than its peer offers simply gets the overlap.`,
+        helpLinks: [{ label: 'Handshake guide', href: '/help/#robotics-handshake' }],
+        meta: 'Shipped - vouch.robotics.handshake, PAD-067',
       },
       {
+        q: 'What stops a replayed or tampered handshake message?',
+        a: `Each message is an \`eddsa-jcs-2022\` signed object, so altering any field breaks its signature. The initiator's nonce is echoed in the ACCEPT and checked, binding the acceptance to that specific HELLO, and the CONFIRM is checked against the agreed session id and nonce. A replayed or edited message fails verification.`,
+        meta: 'Shipped - vouch.robotics.handshake, PAD-067',
+      },
+    ],
+  },
+
+  // =====================================================================
+  // ROBOTICS: BLACK BOX AND KILL SWITCH
+  // =====================================================================
+  {
+    id: 'robotics-blackbox',
+    audience: 'Robotics: black box and kill switch',
+    title: 'Black box and kill switch',
+    domain: 'robotics',
+    items: [
+      {
         q: 'Can a robot’s black box be audited for tampering without reading the logs?',
-        a: `Yes, that separation is the whole point. The black box is an append-only, AES-256-GCM-encrypted, hash-linked chain. Anyone can verify the chain is intact (no entry was altered, and nothing was reordered) without holding the key, while only the key holder can decrypt the payloads. Tamper-evidence and confidentiality are independent.`,
+        a: `Yes, that separation is the whole point. The black box is an append-only, AES-256-GCM-encrypted, hash-linked chain. Anyone can verify the chain is intact (no entry was altered, nothing was reordered) without holding the key, while only the key holder can decrypt the payloads. Tamper-evidence and confidentiality are independent.`,
         helpLinks: [{ label: 'Black box and kill switch guide', href: '/help/#robotics-blackbox' }],
         meta: 'Shipped - vouch.robotics.blackbox, PAD-069',
       },
       {
-        q: 'Can someone scan a robot to check it is legitimate, offline?',
-        a: `Yes. The passport is a signed \`RobotPassport\` encoded into a \`vouch-passport:\` URI for a QR code or NFC tag, so a scanner verifies the signature locally with no network call. It surfaces the robot's owner, authorized actions, certification, and current standing.
+        q: 'What is in a black-box entry, and how is it linked?',
+        a: `Each entry carries a sequence number, a timestamp, the event name, the encrypted payload (the blob is nonce, then ciphertext, then authentication tag), a \`prevHash\` linking it to the previous entry, and an \`entryHash\` over its own canonical body. Altering any recorded field breaks \`entryHash\`; reordering breaks \`prevHash\`.`,
+        helpLinks: [{ label: 'Black box and kill switch guide', href: '/help/#robotics-blackbox' }],
+        meta: 'Shipped - vouch.robotics.blackbox, PAD-069',
+      },
+      {
+        q: 'Can I stop a robot remotely and prove who issued the stop?',
+        a: `Yes. The kill switch is a signed \`KillSwitchCredential\` that names the target robot, the reason, and the issuer. The credential is a permanent, verifiable record of who triggered the stop and over what scope.`,
+        helpLinks: [{ label: 'Black box and kill switch guide', href: '/help/#robotics-blackbox' }],
+        meta: 'Shipped - vouch.robotics.blackbox, PAD-068',
+      },
+      {
+        q: 'Can I stop a rogue actor from forging an emergency stop?',
+        a: `Yes. Verification of a kill switch can require the issuer DID to be on an attested-authority allowlist. A credential signed by anyone not on the list is rejected, so only an attested authority can trigger a stop that controllers will honor.`,
+        meta: 'Shipped - vouch.robotics.blackbox, PAD-068',
+      },
+    ],
+  },
 
-An expired passport fails. A suspended or decommissioned one still verifies but its status is surfaced, so the scanner can refuse cooperation rather than treating it as silently inactive.`,
+  // =====================================================================
+  // ROBOTICS: SCANNABLE PASSPORT
+  // =====================================================================
+  {
+    id: 'robotics-passport',
+    audience: 'Robotics: passport',
+    title: 'Scannable passport',
+    domain: 'robotics',
+    items: [
+      {
+        q: 'Can someone scan a robot to check it is legitimate, offline?',
+        a: `Yes. The passport is a signed \`RobotPassport\` encoded into a \`vouch-passport:\` URI for a QR code or NFC tag, so a scanner verifies the signature locally with no network call. It surfaces the robot's owner, authorized actions, certification, and current standing.`,
         helpLinks: [{ label: 'Passport guide', href: '/help/#robotics-passport' }],
+        meta: 'Shipped - vouch.robotics.passport, PAD-070',
+      },
+      {
+        q: 'What happens if a passport is expired, suspended, or decommissioned?',
+        a: `An expired passport fails verification outright. A suspended or decommissioned passport still verifies cryptographically, but its status is surfaced in the result, so the scanner can refuse cooperation rather than treating a withdrawn robot as silently inactive.`,
+        helpLinks: [{ label: 'Passport guide', href: '/help/#robotics-passport' }],
+        meta: 'Shipped - vouch.robotics.passport, PAD-070',
+      },
+      {
+        q: 'What is inside the vouch-passport URI?',
+        a: `The multibase bytes of the JCS-canonical passport credential, behind the \`vouch-passport:\` scheme. The encoding is deterministic, so a passport encoded in one language decodes and verifies in another, and a reader needs only the issuer's public key to check it, no network and no lookup.`,
         meta: 'Shipped - vouch.robotics.passport, PAD-070',
       },
     ],

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -33,6 +33,8 @@ export interface FAQSection {
   audience: string;
   /** Serif section title, e.g., "Getting Vouch into your codebase" */
   title: string;
+  /** Top-level agent domain for the page toggle. Defaults to 'agents' (software agents). */
+  domain?: 'agents' | 'robotics';
   items: FAQItem[];
 }
 
@@ -156,6 +158,28 @@ The credential format for these renewals ships today (it is called SessionVouche
 A Vouch delegation chain captures all three steps cryptographically. Each step narrows the permission (the travel agent can find flights but not, say, sell your house). At the end, anyone looking at the action can walk the chain backward to the human who started it. "The AI did it" becomes "Person X delegated to assistant Y who delegated to agent Z, and here is each signed step." Real accountability.`,
       },
       {
+        q: 'Can Vouch prove an agent has a track record it cannot fake?',
+        a: `Yes, this ships as outcome evidence (the \`vouch.accountability\` module). It separates two questions that often get blurred: "is this really agent X?" and "does X have a record of being right?" Identity answers the first. Outcome evidence answers the second.
+
+It works in two steps. First the agent commits a verdict, prediction, or recommendation and signs it before the result is known. The commitment can carry only a salted fingerprint of the call, so the content stays private until later while still being locked in. Then, once the outcome is observable, a settlement record (which can be signed by a neutral third party) reveals the original call and binds the real result to it. Anyone can recompute the fingerprint and check it matches, and a settlement dated before its commitment is rejected. So a winning call cannot be invented after the fact, and a losing one cannot quietly disappear.
+
+This is the evidence layer underneath a reputation score. A score can be moved by whoever keeps it; outcome evidence is a per-call artifact the agent cannot rewrite.`,
+        helpLinks: [{ label: 'Outcome evidence how-to', href: '/help/#outcome-evidence' }],
+        meta: 'Shipped on main - vouch.accountability, PAD-071',
+      },
+    ],
+  },
+
+  // =====================================================================
+  // EMBODIED AGENTS (ROBOTICS)
+  // =====================================================================
+  {
+    id: 'robotics',
+    audience: 'Embodied agents (robotics)',
+    title: 'Identity and accountability for robots',
+    domain: 'robotics',
+    items: [
+      {
         q: 'Does Vouch work for robots and embodied agents?',
         a: `Yes, and it ships today. A robot is an agent with a body, so identity, accountability, and continuous trust matter even more once an agent can cause physical harm. Everything Vouch does for software agents applies, and the \`vouch.robotics\` module adds six capabilities for the parts that only exist when an agent is embodied. They are open formats plus reference implementations, built on the same \`eddsa-jcs-2022\` Verifiable Credentials as the rest of Vouch, so a robotics credential signed in one language verifies in every other.
 
@@ -177,16 +201,6 @@ The headline piece is hardware-rooted identity: the robot's secure element (a TP
 All six are implemented and tested across Python, TypeScript, Go, and the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers.`,
         helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
         meta: 'Shipped - vouch.robotics, PAD-064/067/069/070',
-      },
-      {
-        q: 'Can Vouch prove an agent has a track record it cannot fake?',
-        a: `Yes, this ships as outcome evidence (the \`vouch.accountability\` module). It separates two questions that often get blurred: "is this really agent X?" and "does X have a record of being right?" Identity answers the first. Outcome evidence answers the second.
-
-It works in two steps. First the agent commits a verdict, prediction, or recommendation and signs it before the result is known. The commitment can carry only a salted fingerprint of the call, so the content stays private until later while still being locked in. Then, once the outcome is observable, a settlement record (which can be signed by a neutral third party) reveals the original call and binds the real result to it. Anyone can recompute the fingerprint and check it matches, and a settlement dated before its commitment is rejected. So a winning call cannot be invented after the fact, and a losing one cannot quietly disappear.
-
-This is the evidence layer underneath a reputation score. A score can be moved by whoever keeps it; outcome evidence is a per-call artifact the agent cannot rewrite.`,
-        helpLinks: [{ label: 'Outcome evidence how-to', href: '/help/#outcome-evidence' }],
-        meta: 'Shipped on main - vouch.accountability, PAD-071',
       },
     ],
   },

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -184,7 +184,7 @@ This is the evidence layer underneath a reputation score. A score can be moved b
         a: `Yes, and it ships today. A robot is an agent with a body, so identity, accountability, and continuous trust matter even more once an agent can cause physical harm. Everything Vouch does for software agents applies, and the \`vouch.robotics\` module adds six capabilities for the parts that only exist when an agent is embodied. They are open formats plus reference implementations, built on the same \`eddsa-jcs-2022\` Verifiable Credentials as the rest of Vouch, so a robotics credential signed in one language verifies in every other.
 
 The headline piece is hardware-rooted identity: the robot's secure element (a TPM, an enclave, or an on-board AI module's secure element) signs a binding over the robot's DID and key, so its identity is provably tied to one piece of hardware rather than a config file that can be copied.`,
-        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }, { label: 'Robotics overview', href: '/robotics/' }],
+        helpLinks: [{ label: 'Robotics quickstart', href: '/help/#robotics' }, { label: 'Robotics overview', href: '/robotics/' }],
         meta: 'Shipped - vouch.robotics (Python, TypeScript, Go, Rust core), PAD-064/067/069/070',
       },
       {
@@ -195,11 +195,11 @@ The headline piece is hardware-rooted identity: the robot's secure element (a TP
 - **Model and config provenance**: a signed, re-signable record of the model, weights hash, safety policy, and config a robot is running, so you can prove what software it ran even after an over-the-air update.
 - **Physical capability scope**: max force, a slower speed near people, allowed zones, and shift windows, checked before each actuation; a delegated scope can only narrow, never widen.
 - **Robot-to-robot handshake**: two robots from different fleets authenticate and agree a cooperation session whose scope is the intersection of what each offers, gated by a domain trust policy.
-- **Black box and kill switch**: an encrypted, tamper-evident flight recorder (private without the key, tamper-evident without it) plus a verifiable emergency stop that proves who issued it and can require an attested authority.
+- **Black box and kill switch**: an encrypted, tamper-evident flight recorder plus a verifiable emergency stop that proves who issued it and can require an attested authority.
 - **Scannable passport**: a compact signed passport in a QR or NFC tag, so anyone can check a robot's owner, authorized actions, certification, and standing offline.
 
-All six are implemented and tested across Python, TypeScript, Go, and the Rust core, with the Rust core flowing to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers.`,
-        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
+Each has its own question below.`,
+        helpLinks: [{ label: 'Robotics capabilities', href: '/help/#robotics-capabilities' }],
         meta: 'Shipped - vouch.robotics, PAD-064/067/069/070',
       },
       {
@@ -207,7 +207,7 @@ All six are implemented and tested across Python, TypeScript, Go, and the Rust c
         a: `All of them. The six capabilities are implemented once in the Rust core and exposed through the same UniFFI and WebAssembly wrappers as the rest of Vouch, plus byte-identical reference implementations in Python, TypeScript, and Go.
 
 So you can build and verify robot identity, provenance, physical scope, handshakes, the black box and kill switch, and the passport from Python, TypeScript, Go, Swift, Kotlin/JVM, .NET, C/C++, or the browser, and a robotics credential signed in one verifies in all the others, byte for byte.`,
-        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
+        helpLinks: [{ label: 'Robotics quickstarts', href: '/help/#robotics' }],
         meta: 'Shipped - vouch.robotics across every SDK',
       },
       {
@@ -216,16 +216,69 @@ So you can build and verify robot identity, provenance, physical scope, handshak
 
 Everything else Vouch does for a software agent (delegation chains, revocation, the continuous-trust heartbeat) applies to the robot unchanged. The hardware-rooted identity is the one piece that only makes sense once the agent has a body.`,
       },
+    ],
+  },
+
+  // =====================================================================
+  // ROBOTICS, CAPABILITY BY CAPABILITY
+  // =====================================================================
+  {
+    id: 'robotics-capabilities',
+    audience: 'Robotics, capability by capability',
+    title: 'The six capabilities in detail',
+    domain: 'robotics',
+    items: [
+      {
+        q: 'How does hardware-rooted identity stop a robot from being cloned?',
+        a: `A robot self-issues a \`RobotIdentityCredential\` with its own key, and its hardware root (a TPM or secure element) signs a binding over the robot's DID and key, embedded as \`hardwareRoot.attestation\`. Verification checks two independent signatures: the credential proof and that hardware attestation.
+
+Copy the software identity to a different machine and the hardware attestation no longer matches the binding, so verification fails. The identity is tied to one piece of silicon.`,
+        helpLinks: [{ label: 'Hardware-rooted identity guide', href: '/help/#robotics-identity' }],
+        meta: 'Shipped - vouch.robotics.identity, PAD-064',
+      },
+      {
+        q: 'Can I prove what model and safety policy a robot ran, even after an OTA update?',
+        a: `Yes, via a \`ModelProvenanceAttestation\`. It records the model name, weights hash, safety policy, and a hash of the running config (the multibase SHA-256 of the canonical config, reproducible by any verifier). On an over-the-air update the robot re-signs a new attestation with a \`supersedes\` link to the previous one, forming a chain you can walk to answer "what was running at time T."
+
+Supply the config to the verifier and it also checks that the recorded config hash reproduces, so a robot running a different config than the one attested is detectable.`,
+        helpLinks: [{ label: 'Provenance guide', href: '/help/#robotics-provenance' }],
+        meta: 'Shipped - vouch.robotics.provenance, PAD-065',
+      },
+      {
+        q: 'How are a robot’s physical limits enforced, and can a sub-task escalate them?',
+        a: `A \`PhysicalCapabilityScope\` credential carries the limits: max force, max speed, a tighter speed cap near humans, allowed zones, and shift windows. A controller checks each proposed action against the scope before the actuator moves, and gets back a reason for any violated dimension.
+
+A sub-task cannot escalate. Delegation is narrow-only: a child scope may shrink numeric caps, subset the zones, and fit each window inside a parent window, but a child that raises a cap, drops a cap, adds a new zone, or widens a window is rejected.`,
+        helpLinks: [{ label: 'Capability scope guide', href: '/help/#robotics-capability' }],
+        meta: 'Shipped - vouch.robotics.capability, PAD-066',
+      },
+      {
+        q: 'How do two robots from different fleets cooperate safely?',
+        a: `Through a three-message handshake (HELLO, ACCEPT, CONFIRM). The initiator proposes a scope and a fresh nonce; the responder verifies the HELLO signature, checks the initiator's \`did:web\` domain against its trust policy, and replies with a session whose scope is the intersection of what each side offers, never the union.
+
+So neither side can widen the other's grant, the responder only cooperates with domains it trusts, and the nonce binds the acceptance to that specific HELLO. A tampered message fails verification.`,
+        helpLinks: [{ label: 'Handshake guide', href: '/help/#robotics-handshake' }],
+        meta: 'Shipped - vouch.robotics.handshake, PAD-067',
+      },
       {
         q: 'Can I stop a robot remotely and prove who issued the stop?',
-        a: `Yes. The kill switch is a signed KillSwitchCredential that names the target robot, the reason, and the issuer. Verification can require the issuer to be on an attested-authority allowlist, so a rogue actor cannot forge a legitimate-looking emergency stop, and the credential itself is a permanent, verifiable record of who triggered it.`,
+        a: `Yes. The kill switch is a signed \`KillSwitchCredential\` that names the target robot, the reason, and the issuer. Verification can require the issuer to be on an attested-authority allowlist, so a rogue actor cannot forge a legitimate-looking emergency stop, and the credential itself is a permanent, verifiable record of who triggered it.`,
+        helpLinks: [{ label: 'Black box and kill switch guide', href: '/help/#robotics-blackbox' }],
+        meta: 'Shipped - vouch.robotics.blackbox, PAD-068',
+      },
+      {
+        q: 'Can a robot’s black box be audited for tampering without reading the logs?',
+        a: `Yes, that separation is the whole point. The black box is an append-only, AES-256-GCM-encrypted, hash-linked chain. Anyone can verify the chain is intact (no entry was altered, and nothing was reordered) without holding the key, while only the key holder can decrypt the payloads. Tamper-evidence and confidentiality are independent.`,
+        helpLinks: [{ label: 'Black box and kill switch guide', href: '/help/#robotics-blackbox' }],
         meta: 'Shipped - vouch.robotics.blackbox, PAD-069',
       },
       {
-        q: 'Can an auditor check a robot’s black box for tampering without reading the logs?',
-        a: `Yes, that separation is the whole point. The black box is an append-only, AES-256-GCM-encrypted, hash-linked chain. Anyone can verify the chain is intact (no entry was altered, and nothing was reordered) without holding the key, while only the key holder can decrypt the payloads. Tamper-evidence and confidentiality are independent.`,
-        helpLinks: [{ label: 'Robotics guide', href: '/help/#robotics' }],
-        meta: 'Shipped - vouch.robotics.blackbox, PAD-069',
+        q: 'Can someone scan a robot to check it is legitimate, offline?',
+        a: `Yes. The passport is a signed \`RobotPassport\` encoded into a \`vouch-passport:\` URI for a QR code or NFC tag, so a scanner verifies the signature locally with no network call. It surfaces the robot's owner, authorized actions, certification, and current standing.
+
+An expired passport fails. A suspended or decommissioned one still verifies but its status is surfaced, so the scanner can refuse cooperation rather than treating it as silently inactive.`,
+        helpLinks: [{ label: 'Passport guide', href: '/help/#robotics-passport' }],
+        meta: 'Shipped - vouch.robotics.passport, PAD-070',
       },
     ],
   },

--- a/website/src/app/help/HelpClient.tsx
+++ b/website/src/app/help/HelpClient.tsx
@@ -225,15 +225,15 @@ export default function HelpClient({ sections }: { sections: HelpSection[] }) {
     return (
         <div>
             {hasRobotics && (
-                <div className="mb-10 flex flex-wrap gap-1.5 border-b border-rule pb-5">
+                <div className="mb-10 flex flex-wrap gap-1 border-b border-rule">
                     {DOMAINS.map((d) => (
                         <button
                             key={d.key}
                             onClick={() => setDomain(d.key)}
-                            className={`px-4 py-2 text-[0.9rem] rounded-md transition-colors ${
+                            className={`px-4 py-2.5 -mb-px text-[0.92rem] border-b-2 transition-colors ${
                                 domain === d.key
-                                    ? 'bg-ink text-parchment font-medium'
-                                    : 'text-ink-soft hover:text-ink'
+                                    ? 'border-burgundy text-ink font-medium'
+                                    : 'border-transparent text-ink-soft hover:text-ink'
                             }`}
                         >
                             {d.label}

--- a/website/src/app/help/HelpClient.tsx
+++ b/website/src/app/help/HelpClient.tsx
@@ -188,12 +188,20 @@ function renderInline(text: string): React.ReactNode {
 
 export default function HelpClient({ sections }: { sections: HelpSection[] }) {
     const [search, setSearch] = useState('');
+    const [domain, setDomain] = useState<'all' | 'agents' | 'robotics'>('all');
 
     const query = search.toLowerCase().trim();
 
+    const hasRobotics = useMemo(() => sections.some((s) => s.domain === 'robotics'), [sections]);
+
+    const domainSections = useMemo(
+        () => sections.filter((s) => domain === 'all' || (s.domain ?? 'agents') === domain),
+        [sections, domain]
+    );
+
     const filteredSections = useMemo(() => {
-        if (!query) return sections;
-        return sections
+        if (!query) return domainSections;
+        return domainSections
             .map((section) => ({
                 ...section,
                 articles: section.articles.filter(
@@ -204,17 +212,41 @@ export default function HelpClient({ sections }: { sections: HelpSection[] }) {
                 ),
             }))
             .filter((section) => section.articles.length > 0);
-    }, [sections, query]);
+    }, [domainSections, query]);
+
+    const DOMAINS: { key: 'all' | 'agents' | 'robotics'; label: string }[] = [
+        { key: 'all', label: 'All' },
+        { key: 'agents', label: 'AI agents' },
+        { key: 'robotics', label: 'Embodied agents (robotics)' },
+    ];
 
     const totalArticles = filteredSections.reduce((sum, s) => sum + s.articles.length, 0);
 
     return (
-        <div className="grid lg:grid-cols-[240px_1fr] gap-12 lg:gap-16">
+        <div>
+            {hasRobotics && (
+                <div className="mb-10 flex flex-wrap gap-1.5 border-b border-rule pb-5">
+                    {DOMAINS.map((d) => (
+                        <button
+                            key={d.key}
+                            onClick={() => setDomain(d.key)}
+                            className={`px-4 py-2 text-[0.9rem] rounded-md transition-colors ${
+                                domain === d.key
+                                    ? 'bg-ink text-parchment font-medium'
+                                    : 'text-ink-soft hover:text-ink'
+                            }`}
+                        >
+                            {d.label}
+                        </button>
+                    ))}
+                </div>
+            )}
+            <div className="grid lg:grid-cols-[240px_1fr] gap-12 lg:gap-16">
             {/* Marginalia */}
             <aside className="lg:sticky lg:top-8 lg:self-start lg:max-h-[calc(100vh-4rem)] lg:overflow-y-auto">
                 <div className="eyebrow mb-3 border-b border-rule pb-2">Help &amp; Guides</div>
                 <nav>
-                    {sections.map((section) => (
+                    {domainSections.map((section) => (
                         <div key={section.id} className="mb-4">
                             <a href={`#${section.id}`} className="marginalia-link !text-burgundy">
                                 {section.title}
@@ -296,6 +328,7 @@ export default function HelpClient({ sections }: { sections: HelpSection[] }) {
                     ))
                 )}
             </div>
+        </div>
         </div>
     );
 }

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -1928,108 +1928,282 @@ The agent code does not change. What changes is the DID (production agents use a
   },
   {
     id: 'robotics',
-    title: 'Robotics',
+    title: 'Robotics: getting started',
     domain: 'robotics',
-    description: 'The six robotics capabilities for embodied agents: hardware-rooted identity, model and config provenance, physical capability scope, robot-to-robot handshake, an encrypted black box and kill switch, and a scannable passport. Open formats on the same Verifiable Credentials as the rest of Vouch, so a robotics credential signed in any language verifies in every other.',
+    description: 'Pick a language and run the robot identity sign-and-verify loop in your dev env. The six capabilities are byte-identical across every SDK, so a robot credential signed in one verifies in all the others.',
     articles: [
       {
-        id: 'robotics',
-        title: 'Robotics: identity and accountability for robots',
-        summary: 'Build and verify all six robotics credentials, with the mechanism, API, and exactly what each verification checks.',
+        id: 'robotics-quickstart-python',
+        title: 'Robotics Quickstart (Python)',
+        summary: 'Mint a hardware-attested robot identity and verify it, entirely in your dev env.',
         body: `
-Vouch gives robots the same identity, accountability, and continuous trust it gives software agents, and adds the pieces that only matter once an agent has a body. The robotics primitives live in vouch.robotics (Python), packages/sdk-ts/src/robotics (TypeScript), go-sidecar/robotics (Go), and the Rust core, which flows to the Swift, Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers. Every credential is an eddsa-jcs-2022 Verifiable Credential, so a credential signed in one language verifies in all the others (proven by test-vectors/robotics/vector.json).
+## Install
 
-A design rule runs through the module: the core is hardware-agnostic and deterministic. It never reaches for a clock, a random number, or a TPM itself. Timestamps, nonces, and hardware attestations are passed in, so output is reproducible and a real deployment can route signing to a secure element.
+\`\`\`bash
+pip install vouch-protocol
+\`\`\`
 
-## Available in every language
+## Mint and verify a robot identity
 
-The examples below are in Python, but the same six capabilities exist in every Vouch SDK and produce byte-identical credentials, so pick whichever fits your stack:
+A robot self-issues its identity with its own key; a hardware root (a TPM or secure element) signs a binding tying that key to the device. In development, \`SoftwareRootOfTrust\` stands in for the TPM.
 
-- Python: \`pip install vouch-protocol\`, then \`from vouch.robotics import identity\` (and \`provenance\`, \`capability\`, \`handshake\`, \`blackbox\`, \`passport\`). Functions are snake_case: \`mint_robot_identity\`, \`verify_robot_identity\`, and so on.
-- TypeScript (browser and Node): \`import { mintRobotIdentity, verifyRobotIdentity, buildProvenanceAttestation, checkPhysicalAction } from '@vouch-protocol-official/sdk'\`, camelCase throughout.
-- Go: import \`go-sidecar/robotics\`; \`MintRobotIdentity\`, \`VerifyRobotIdentity\`, \`CheckPhysicalAction\`, and the rest in Go's PascalCase.
-- Swift, Kotlin and Java, .NET, C and C++: the same surface over the core's UniFFI and C bindings, as \`roboticsMintIdentity\`, \`roboticsVerifyIdentity\`, \`roboticsCheckAction\`, and so on, JSON in and JSON out with keys passed as bytes.
+\`\`\`python
+from vouch.keys import generate_identity
+from vouch.signer import Signer
+from vouch.robotics import identity
 
-A robotics credential signed in any one of these verifies in all the others, pinned by the shared interop vector. The walkthrough below stays in Python for brevity.
+robot = Signer.from_identity(generate_identity(domain="robot.example.com"))
+root = identity.SoftwareRootOfTrust(kind="TPM")        # production uses the real TPM
 
-## 1. Hardware-rooted identity
+cred = identity.mint_robot_identity(robot, root,
+    make="Acme Robotics", model="AR-7", serial="SN-000123",
+    owner="did:web:owner.example.com")
 
-Binds the robot's software key to a hardware root (a TPM or secure element), so the identity cannot be cloned to other hardware. The hardware root signs a binding over (key, robotDid), embedded as hardwareRoot.attestation. Verification checks both the credential proof and that attestation.
+ok, subject = identity.verify_robot_identity(cred, robot.public_key())
+assert ok and subject["make"] == "Acme Robotics"
+\`\`\`
 
-    from vouch.robotics import identity
+Verification checks both the credential proof and the hardware attestation, so an identity copied to different hardware fails. From here, the other five capabilities (\`provenance\`, \`capability\`, \`handshake\`, \`blackbox\`, \`passport\`) follow the same import-and-call shape; see the Robotics: capabilities guides.
+`,
+      },
+      {
+        id: 'robotics-quickstart-typescript',
+        title: 'Robotics Quickstart (TypeScript)',
+        summary: 'The same robot identity loop in TypeScript, for Node or the browser.',
+        body: `
+## Install
 
-    root = identity.SoftwareRootOfTrust(kind="TPM")     # production uses the real TPM
-    cred = identity.mint_robot_identity(robot_signer, root,
-        make="Acme Robotics", model="AR-7", serial="SN-000123",
-        owner="did:web:owner.example.com")
-    ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+\`\`\`bash
+npm install @vouch-protocol-official/sdk
+\`\`\`
 
-Verification fails closed on a wrong type, an invalid proof, a missing or non-Ed25519 hardware key, or an attestation that does not match the binding. Swapping in an attacker's hardware key and re-signing still fails, because the attestation no longer matches the binding.
+## Mint and verify a robot identity
 
-## 2. Model and config provenance
+\`\`\`ts
+import { Signer, generateIdentity } from '@vouch-protocol-official/sdk';
+import { SoftwareRootOfTrust, mintRobotIdentity, verifyRobotIdentity } from '@vouch-protocol-official/sdk';
 
-A signed record of the model, weights hash, safety policy, and a hash of the config a robot runs, re-signable on every over-the-air update via a supersedes link. The config hash is the multibase SHA-256 of the JCS-canonical config, reproducible by any verifier.
+const robot = await Signer.fromIdentity(generateIdentity('robot.example.com'));
+const root = new SoftwareRootOfTrust('TPM');
 
-    from vouch.robotics import provenance
+const cred = await mintRobotIdentity(robot, root, {
+  make: 'Acme Robotics', model: 'AR-7', serial: 'SN-000123',
+  owner: 'did:web:owner.example.com',
+});
 
-    att = provenance.build_provenance_attestation(signer, robot_did=robot_did,
-        model_name="openvla-7b", weights_hash="u...",
-        safety_policy="did:web:authority#policy-v3",
-        config={"temperature": 0.0, "max_torque": 12.5, "guardrails": ["no_humans_zone"]})
-    ok, subject = provenance.verify_provenance_attestation(att, signer.public_key(), config)
+const { ok, subject } = verifyRobotIdentity(cred, robot.publicKey());
+\`\`\`
 
-Supplying the config to the verifier additionally checks the recorded configHash reproduces, so a robot running a different config than the one attested is detectable.
+Function names are camelCase; everything else matches the Python and Go SDKs byte for byte.
+`,
+      },
+      {
+        id: 'robotics-quickstart-go',
+        title: 'Robotics Quickstart (Go)',
+        summary: 'The robot identity loop in Go, the language of the Identity Sidecar.',
+        body: `
+## Get the module
 
-## 3. Physical capability scope
+\`\`\`bash
+go get github.com/vouch-protocol/vouch/go-sidecar
+\`\`\`
 
-Max force, max speed, a tighter cap near humans, allowed zones, and shift windows, checked before each actuation. A delegated scope must narrow, never broaden.
+## Mint and verify a robot identity
 
-    from vouch.robotics import capability
+\`\`\`go
+root, _ := robotics.NewSoftwareRoot(seed, "TPM")
+cred, _ := robotics.MintRobotIdentity(robotSigner, root, robotics.MintOptions{
+    Make: "Acme Robotics", Model: "AR-7", Serial: "SN-000123",
+    Owner: "did:web:owner.example.com",
+})
+ok, subject := robotics.VerifyRobotIdentity(cred, robotSigner.PublicKeyEd25519())
+\`\`\`
 
-    cred = capability.build_physical_scope_credential(fleet_signer, subject_did=robot_did,
-        max_force_n=80, max_speed_mps=2.0, max_speed_near_humans_mps=0.5,
-        allowed_zones=["warehouse-a"], shift_windows=[{"start": "08:00", "end": "18:00"}])
-    scope = cred["credentialSubject"]["physicalScope"]
-    res = capability.check_physical_action(scope,
-        capability.PhysicalAction(speed_mps=1.5, near_humans=True))
-    # res.ok is False: the near-humans speed cap is 0.5 m/s
+Go uses PascalCase and an options struct; the credential bytes are identical to Python and TypeScript.
+`,
+      },
+      {
+        id: 'robotics-quickstart-languages',
+        title: 'Robotics Quickstart (Swift, Kotlin, JVM, .NET, C, WebAssembly)',
+        summary: 'The robotics surface over the shared core, JSON in and JSON out, for the wrapper languages.',
+        body: `
+The robotics capabilities are implemented once in the Rust core and exposed through the same UniFFI and WebAssembly wrappers as the rest of Vouch. The wrapper functions are JSON-in / JSON-out: keys cross as bytes, everything else as a JSON string, and binary fields (the hardware attestation, the config hash) cross as multibase strings.
 
-attenuates(parent, child) is the escalation guard: a child that raises a cap, drops a cap the parent set, adds a zone outside the parent set, or widens a window is rejected.
+## Browser and Node (WebAssembly)
 
-## 4. Robot-to-robot handshake
+\`\`\`js
+import init, { roboticsMintIdentity, roboticsVerifyIdentity } from '@vouch-protocol-official/core-wasm';
+await init();
 
-Two robots from different domains authenticate over three signed messages (HELLO, ACCEPT, CONFIRM) and agree a session whose scope is the intersection of both offers, gated by a TrustPolicy on the did:web domain. The responder signs an acceptance only if the HELLO verifies and the initiator's domain is trusted. The nonce binds the acceptance to its HELLO; a tampered message fails verification.
+const params = JSON.stringify({
+  robotDid: 'did:web:robot.example.com', make: 'Acme Robotics', model: 'AR-7',
+  serial: 'SN-000123', rootKind: 'TPM', rootPublicMultibase: rootMultibase,
+  attestation: attestationMultibase, validFrom: new Date().toISOString(),
+});
+const credJson = roboticsMintIdentity(seedBytesB64, params);
+const subjectJson = roboticsVerifyIdentity(credJson, robotPublicKeyB64);  // "null" if invalid
+\`\`\`
 
-## 5. Black box and kill switch
+## Swift, Kotlin/Java, .NET, C and C++
 
-The black box is an append-only, AES-256-GCM-encrypted, hash-linked log. The encrypted blob is nonce, then ciphertext, then tag. The chain is tamper-evident without the key (any altered field breaks its entryHash, any reorder breaks prevHash); payloads open only with the key.
+The same functions are generated for each platform from the core's UniFFI interface and C header. The names match the WebAssembly build (\`roboticsMintIdentity\`, \`roboticsVerifyIdentity\`, \`roboticsBuildScope\`, \`roboticsCheckAction\`, \`roboticsBuildHello\`, and so on), and every capability is present. Pass the same JSON params and key bytes; a credential built here verifies in Python, TypeScript, and Go.
+`,
+      },
+    ],
+  },
+  {
+    id: 'robotics-capabilities',
+    title: 'Robotics: capabilities',
+    domain: 'robotics',
+    description: 'One guide per robotics capability: what it is, the problem it closes, how it works, the API, a worked example, and exactly what verification checks.',
+    articles: [
+      {
+        id: 'robotics-identity',
+        title: 'Hardware-rooted identity',
+        summary: 'Bind a robot identity to a TPM or secure element so it cannot be cloned to other hardware.',
+        body: `
+A \`RobotIdentityCredential\` binds a robot's software identity key to a physical hardware root of trust, alongside its make, model, serial, owner, and lifecycle history.
 
-    from vouch.robotics import blackbox
+The problem it closes: a software-only identity in a config file can be copied to a cloned robot. Hardware rooting makes the identity non-transferable: it is provably tied to one piece of silicon.
 
-    log = blackbox.BlackBoxLog(key)                       # 32-byte AES key
-    entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
-    assert blackbox.verify_blackbox_chain(log.entries()).ok
-    payload = log.open_entry(entry)                       # only the key holder can read this
+How it works: the robot self-issues the credential with its own Ed25519 key. The hardware root signs a binding, the JCS canonical bytes of \`{key, robotDid}\`, embedded as \`hardwareRoot.attestation\`. Verification checks two independent signatures: the credential proof and the hardware attestation.
 
-The kill switch (build_killswitch_credential and verify_killswitch_credential) is a verifiable emergency stop that proves who issued it and, with an attested-authority allowlist, rejects any issuer not on the list.
+\`\`\`python
+from vouch.robotics import identity
 
-## 6. Scannable passport
+root = identity.SoftwareRootOfTrust(kind="TPM")        # production uses the real TPM
+cred = identity.mint_robot_identity(robot_signer, root,
+    make="Acme Robotics", model="AR-7", serial="SN-000123",
+    owner="did:web:owner.example.com")
+ok, subject = identity.verify_robot_identity(cred, robot_signer.public_key())
+\`\`\`
 
-A compact signed RobotPassport encoded into a vouch-passport: URI for a QR or NFC tag, so anyone can check the robot's owner, authorized actions, certification, and standing offline.
+Security boundary: verification fails closed on a wrong type, an invalid proof, a missing or non-Ed25519 hardware key, or an attestation that does not match the binding. An attacker who swaps in their own hardware key and re-signs the credential still fails, because the attestation no longer matches \`{key, robotDid}\`.
+`,
+      },
+      {
+        id: 'robotics-provenance',
+        title: 'Model and config provenance',
+        summary: 'Prove which model, weights, safety policy, and config a robot ran, even after an OTA update.',
+        body: `
+A \`ModelProvenanceAttestation\` records the vision-language-action model name, weights hash, safety policy, and a hash of the running configuration.
 
-    from vouch.robotics import passport
+The problem it closes: after an incident, logs alone cannot prove what software and safety policy were running. Provenance makes it cryptographic, and it survives over-the-air updates.
 
-    p = passport.build_passport(signer, robot_did=robot_did, make="Acme Robotics",
-        model="AR-7", owner="did:web:owner.example.com",
-        authorized_actions=["lift", "carry"], certification="ISO-10218")
-    uri = passport.encode_passport(p)                     # "vouch-passport:u..."
-    ok, summary = passport.verify_passport(passport.decode_passport(uri), signer.public_key())
+How it works: the \`vla\` block carries \`modelName\`, \`weightsHash\`, \`safetyPolicy\`, and a \`configHash\` (the multibase SHA-256 of the JCS-canonical config, reproducible by any verifier). On an OTA update the robot re-signs a new attestation with a \`supersedes\` link to the previous one, forming a chain.
 
-Verification is offline. An expired passport fails; a suspended or decommissioned one still verifies but surfaces its status so a scanner can refuse cooperation.
+\`\`\`python
+from vouch.robotics import provenance
 
-## Where to go next
+att = provenance.build_provenance_attestation(signer, robot_did=robot_did,
+    model_name="openvla-7b", weights_hash="u...",
+    safety_policy="did:web:authority#policy-v3",
+    config={"temperature": 0.0, "max_torque": 12.5, "guardrails": ["no_humans_zone"]})
+ok, subject = provenance.verify_provenance_attestation(att, signer.public_key(), config)
+\`\`\`
 
-The defensive disclosures PAD-064 (identity), PAD-067 (handshake), PAD-069 (black box), and PAD-070 (passport) document the novel methods. A runnable demo is in examples/robotics_demo.py, and the canonical write-up is docs/robotics.md.
+Security boundary: verification fails on a wrong type, an invalid proof, or, when a config is supplied, a \`configHash\` that does not reproduce. A robot running a different config than the one attested is detectable by anyone holding the expected config.
+`,
+      },
+      {
+        id: 'robotics-capability',
+        title: 'Physical capability scope',
+        summary: 'Force, speed, near-humans, zone, and shift-window limits, checked before each actuation.',
+        body: `
+A \`PhysicalCapabilityScope\` credential carries physical limits, max force, max speed, a tighter cap near humans, allowed zones, and shift windows, that a controller checks before every actuation.
+
+The problem it closes: a permission like "operate the arm" says nothing about how hard or how fast. Physical scope makes the bound enforceable and makes delegated authority shrink-only.
+
+How it works: a controller calls the check function with a proposed action and gets back whether it is allowed plus a reason for each violated dimension. Delegation is governed by an attenuation rule: a child scope is valid only if every numeric cap is less than or equal to the parent, every zone is a subset, and every window fits inside a parent window.
+
+\`\`\`python
+from vouch.robotics import capability
+
+scope = cred["credentialSubject"]["physicalScope"]
+res = capability.check_physical_action(scope,
+    capability.PhysicalAction(speed_mps=1.5, near_humans=True))
+# res.ok is False: the near-humans speed cap is 0.5 m/s
+\`\`\`
+
+Security boundary: the runtime check rejects an action exceeding any granted dimension (an absent dimension is unconstrained by design). \`attenuates(parent, child)\` is the escalation guard: a child that raises a cap, drops a cap, adds a zone outside the parent set, or widens a window is rejected.
+`,
+      },
+      {
+        id: 'robotics-handshake',
+        title: 'Robot-to-robot handshake',
+        summary: 'Two robots from different fleets authenticate and agree a bounded cooperation session.',
+        body: `
+A three-message exchange (HELLO, ACCEPT, CONFIRM) by which two robots in different trust domains authenticate each other and agree a bounded cooperation session.
+
+The problem it closes: when robots from different fleets meet and must cooperate, each needs to know the other is who it claims and agree on a safe, limited set of shared actions, with no central broker.
+
+How it works: the initiator signs a HELLO proposing a scope and a fresh nonce. The responder verifies the HELLO signature, checks the initiator's \`did:web\` domain against its trust policy, and signs an ACCEPT whose \`boundedScope\` is the intersection of the proposed scope and what the responder offers, never the union. The initiator verifies the ACCEPT, confirms the nonce echoes its HELLO, and signs a CONFIRM.
+
+\`\`\`python
+from vouch.robotics import handshake
+
+policy = handshake.TrustPolicy(trusted_domains={"robot-a.example.com"})
+hello = handshake.build_hello(a_signer, proposed_scope=["lift", "carry", "scan"])
+accept = handshake.build_accept(b_signer, hello, a_signer.public_key(), policy,
+    offered_scope=["carry", "scan", "weld"])
+ok, session = handshake.verify_accept(accept, b_signer.public_key(),
+    expected_nonce=hello["nonce"])
+# session.scope == ["carry", "scan"]  (the intersection)
+\`\`\`
+
+Security boundary: the responder signs an acceptance only if the HELLO signature verifies and the initiator's domain passes the policy. The session scope is the intersection of both offers, so neither side can widen the other's grant. The nonce binds the acceptance to its HELLO, and a tampered message fails verification.
+`,
+      },
+      {
+        id: 'robotics-blackbox',
+        title: 'Black box and kill switch',
+        summary: 'An encrypted, tamper-evident flight recorder, and a verifiable emergency stop.',
+        body: `
+Two related capabilities ship together.
+
+The black box is an append-only, AES-256-GCM-encrypted, hash-linked flight recorder. Each entry encrypts its payload under a 32-byte key; the chain is tamper-evident without the key (any altered field breaks its \`entryHash\`, any reorder breaks \`prevHash\`), and the payloads open only with the key. An auditor can prove nothing was changed without being able to read the contents.
+
+The kill switch is a verifiable emergency stop. A \`KillSwitchCredential\` proves who issued the stop, over what scope, and why. With an attested-authority allowlist, verification rejects any issuer not on the list.
+
+\`\`\`python
+from vouch.robotics import blackbox
+
+log = blackbox.BlackBoxLog(key)                       # 32-byte AES key
+entry = log.append("motion", {"speed": 1.5, "joint": "elbow"})
+assert blackbox.verify_blackbox_chain(log.entries()).ok
+payload = log.open_entry(entry)                       # only the key holder can read this
+
+stop = blackbox.build_killswitch_credential(authority, target=robot_did,
+    reason="human in path", scope=["arm", "drive"])
+ok, subject = blackbox.verify_killswitch_credential(stop, authority.public_key(),
+    trusted_authorities={authority.did})
+\`\`\`
+
+Security boundary: chain verification fails on a seq gap, a broken \`prevHash\` link, or a recomputed \`entryHash\` that does not match. Decryption fails under the wrong key. The kill switch fails on a wrong type, an invalid proof, or an issuer that is not an attested authority.
+`,
+      },
+      {
+        id: 'robotics-passport',
+        title: 'Scannable passport',
+        summary: 'A signed passport in a QR or NFC tag that anyone can verify offline.',
+        body: `
+A compact, signed \`RobotPassport\` encoded into a \`vouch-passport:\` URI for a QR code or NFC tag, so anyone can check a robot's owner, authorized actions, certification, and current standing offline, with no network call.
+
+The problem it closes: a person standing in front of a robot needs to know it is legitimate and what it is allowed to do, often with no connectivity.
+
+How it works: the passport credential carries the robot's identity summary and a \`status\` (active, suspended, or decommissioned). \`encode_passport\` serializes the JCS-canonical credential into a deterministic multibase payload behind the \`vouch-passport:\` scheme, so a scanner verifies the signature locally.
+
+\`\`\`python
+from vouch.robotics import passport
+
+p = passport.build_passport(signer, robot_did=robot_did, make="Acme Robotics",
+    model="AR-7", owner="did:web:owner.example.com",
+    authorized_actions=["lift", "carry"], certification="ISO-10218")
+uri = passport.encode_passport(p)                     # "vouch-passport:u..."
+ok, summary = passport.verify_passport(passport.decode_passport(uri), signer.public_key())
+\`\`\`
+
+Security boundary: verification is fully offline (the verifier supplies the issuer key). An expired passport fails. A suspended or decommissioned passport still verifies but the status is surfaced, so a scanner refuses cooperation rather than treating it as silently inactive. A tampered passport or a wrong type is rejected.
 `,
       },
     ],

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -1941,6 +1941,17 @@ Vouch gives robots the same identity, accountability, and continuous trust it gi
 
 A design rule runs through the module: the core is hardware-agnostic and deterministic. It never reaches for a clock, a random number, or a TPM itself. Timestamps, nonces, and hardware attestations are passed in, so output is reproducible and a real deployment can route signing to a secure element.
 
+## Available in every language
+
+The examples below are in Python, but the same six capabilities exist in every Vouch SDK and produce byte-identical credentials, so pick whichever fits your stack:
+
+- Python: \`pip install vouch-protocol\`, then \`from vouch.robotics import identity\` (and \`provenance\`, \`capability\`, \`handshake\`, \`blackbox\`, \`passport\`). Functions are snake_case: \`mint_robot_identity\`, \`verify_robot_identity\`, and so on.
+- TypeScript (browser and Node): \`import { mintRobotIdentity, verifyRobotIdentity, buildProvenanceAttestation, checkPhysicalAction } from '@vouch-protocol-official/sdk'\`, camelCase throughout.
+- Go: import \`go-sidecar/robotics\`; \`MintRobotIdentity\`, \`VerifyRobotIdentity\`, \`CheckPhysicalAction\`, and the rest in Go's PascalCase.
+- Swift, Kotlin and Java, .NET, C and C++: the same surface over the core's UniFFI and C bindings, as \`roboticsMintIdentity\`, \`roboticsVerifyIdentity\`, \`roboticsCheckAction\`, and so on, JSON in and JSON out with keys passed as bytes.
+
+A robotics credential signed in any one of these verifies in all the others, pinned by the shared interop vector. The walkthrough below stays in Python for brevity.
+
 ## 1. Hardware-rooted identity
 
 Binds the robot's software key to a hardware root (a TPM or secure element), so the identity cannot be cloned to other hardware. The hardware root signs a binding over (key, robotDid), embedded as hardwareRoot.attestation. Verification checks both the credential proof and that attestation.

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -23,6 +23,8 @@ export interface HelpSection {
   id: string;
   title: string;
   description: string;
+  /** Top-level agent domain for the page toggle. Defaults to 'agents' (software agents). */
+  domain?: 'agents' | 'robotics';
   articles: HelpArticle[];
 }
 
@@ -1927,6 +1929,7 @@ The agent code does not change. What changes is the DID (production agents use a
   {
     id: 'robotics',
     title: 'Robotics',
+    domain: 'robotics',
     description: 'The six robotics capabilities for embodied agents: hardware-rooted identity, model and config provenance, physical capability scope, robot-to-robot handshake, an encrypted black box and kill switch, and a scannable passport. Open formats on the same Verifiable Credentials as the rest of Vouch, so a robotics credential signed in any language verifies in every other.',
     articles: [
       {

--- a/website/src/app/robotics/page.tsx
+++ b/website/src/app/robotics/page.tsx
@@ -95,11 +95,34 @@ export default function RoboticsPage() {
                 </div>
             </section>
 
-            {/* Standards + links */}
+            {/* Guides and FAQ */}
             <section className="border-b border-rule">
                 <div className="container-wide py-16">
                     <div className="section-heading mb-6">
                         <span className="num">§ II</span>
+                        <h2>Guides and questions</h2>
+                    </div>
+                    <p className="text-ink-soft leading-relaxed max-w-prose mb-6">
+                        Build and verify each capability with the robotics guide, or browse the
+                        robotics questions. Both live alongside the rest of Vouch&apos;s guides and
+                        FAQ, filtered to embodied agents.
+                    </p>
+                    <div className="flex flex-wrap gap-3">
+                        <Link href="/help/#robotics" className="btn-primary">
+                            Robotics guide
+                        </Link>
+                        <Link href="/faq/#robotics" className="btn-secondary">
+                            Robotics FAQ
+                        </Link>
+                    </div>
+                </div>
+            </section>
+
+            {/* Standards + links */}
+            <section className="border-b border-rule">
+                <div className="container-wide py-16">
+                    <div className="section-heading mb-6">
+                        <span className="num">§ III</span>
                         <h2>Open, and headed for the standards bodies</h2>
                     </div>
                     <p className="text-ink-soft leading-relaxed max-w-prose mb-6">


### PR DESCRIPTION
Brings robotics onto the website, reusing the existing FAQ and Help infrastructure (sidebar + search) so it scales as content grows.

- A top-of-page toggle on `/faq` and `/help` distinguishes **AI agents** from **embodied agents (robotics)**. Each section carries an optional `domain`, defaulting to agents, so one click filters the sidebar and content; the toggle only appears when robotics content exists.
- The robotics FAQ is seven sections (an overview plus one per capability) with question-and-answer clusters, mirroring the per-capability help guides.
- The robotics Help section is two parts: getting started (per-language quickstarts) and capabilities (one guide per capability, each with runnable fenced code and the exact verification boundary).
- The `/robotics` page stays the uniform features showcase and gains a "Guides and questions" section linking into the robotics FAQ and guide.
- Bio fix: removes "banking" from the maintainer's background.

The FAQ/Help data and client components parse clean; em-dash-free.
