### PR TITLE
fix(website): align the nav More button with the flat links

### DIFF
--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -21,7 +21,7 @@ const MORE = [
 ];
 
 const navLinkClass = (active: boolean) =>
-    `font-mono uppercase text-[0.7rem] tracking-[0.14em] no-underline border-b pb-0.5 transition-colors ${
+    `font-mono uppercase text-[0.7rem] leading-none tracking-[0.14em] no-underline border-b pb-0.5 transition-colors ${
         active ? 'text-burgundy border-burgundy' : 'border-transparent text-ink-soft hover:text-burgundy hover:border-burgundy'
     }`;
 


### PR DESCRIPTION
The More dropdown trigger is a `button` (browser default line-height) while the flat nav links are anchors inheriting the 1.65 line-height the page sets, so in the centered flex row More sat slightly lower than Robotics, Onboard, Tools, and Support. Adding `leading-none` to the shared `navLinkClass` normalizes the line-height for both, so they align.

Build-verified.
