### PR TITLE
chore(community): add contributor onboarding and engagement automation

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,17 @@
+{
+  "projectName": "vouch",
+  "projectOwner": "vouch-protocol",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": true,
+  "commitConvention": "angular",
+  "commitType": "docs",
+  "contributorsPerLine": 7,
+  "contributorsSortAlphabetically": false,
+  "skipCi": true,
+  "contributors": []
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "Vouch Protocol",
+  "image": "mcr.microsoft.com/devcontainers/python:3.11-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "python -m pip install --upgrade pip && pip install -e \".[dev]\"",
+  "postAttachCommand": "echo 'Vouch dev container ready. Run: pytest tests/ -v'",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "ms-python.black-formatter",
+        "charliermarsh.ruff"
+      ],
+      "settings": {
+        "python.testing.pytestEnabled": true,
+        "python.testing.pytestArgs": ["tests"],
+        "editor.formatOnSave": true,
+        "[python]": {
+          "editor.defaultFormatter": "ms-python.black-formatter"
+        }
+      }
+    }
+  }
+}

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,36 @@
+# CODEOWNERS: GitHub auto-requests these owners for review when matching files change.
+# Order matters: the LAST matching pattern wins. Docs: https://docs.github.com/articles/about-code-owners
+#
+# How to use this as a contributor-growth tool:
+#   When a contributor lands 2-3 solid PRs in an area, add their @handle next to
+#   that path. Being auto-requested for review on "their" area is what turns a
+#   one-off contributor into a regular. Keep core/crypto under lead review.
+
+# Default owner for anything not matched below.
+*                         @rampyg
+
+# ----------------------------------------------------------------------------
+# Newcomer-friendly areas (good candidates to delegate to active contributors)
+# ----------------------------------------------------------------------------
+/examples/                @rampyg
+/docs/                    @rampyg
+/vouch/integrations/      @rampyg
+
+# Language SDKs
+/packages/sdk-py/         @rampyg
+/packages/sdk-ts/         @rampyg
+
+# ----------------------------------------------------------------------------
+# Core protocol and cryptography: lead review required (do not delegate yet)
+# ----------------------------------------------------------------------------
+/vouch/verifier.py        @rampyg
+/vouch/signer.py          @rampyg
+/vouch/data_integrity.py  @rampyg
+/vouch/vc.py              @rampyg
+/vouch/jcs.py             @rampyg
+
+# CI, community automation, and governance
+/.github/                 @rampyg
+/GOVERNANCE.md            @rampyg
+/MAINTAINERS.md           @rampyg
+/CODEOWNERS               @rampyg

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,57 @@
+# Label taxonomy for vouch-protocol/vouch.
+# Contribution is NOT limited to beginners: there are lanes for every level,
+# from a first patch to protocol-level design work.
+#
+# Apply with a label-sync action (e.g. EndBug/label-sync) or by hand in the
+# repo's Labels page. Colors are hex without the leading '#'.
+
+# --- Contribution difficulty lanes ---
+- name: "good first issue"
+  color: "7057ff"
+  description: "Fully specified, under ~30 minutes. Great for a first contribution."
+
+- name: "good second issue"
+  color: "5319e7"
+  description: "A step up: involves a small design choice. For your second or third PR."
+
+- name: "help wanted"
+  color: "008672"
+  description: "Bounded work open to any contributor."
+
+- name: "complex"
+  color: "b60205"
+  description: "Substantial work that touches core logic. For experienced contributors."
+
+- name: "design"
+  color: "d93f0b"
+  description: "Requires an architecture or API design decision."
+
+- name: "rfc"
+  color: "0e8a16"
+  description: "Protocol-level proposal discussed via an RFC before implementation."
+
+- name: "security"
+  color: "ee0701"
+  description: "Security-sensitive work; reviewed by a maintainer."
+
+- name: "performance"
+  color: "fbca04"
+  description: "Profiling, benchmarking, or optimization work."
+
+# --- Effort sizing (combine with a difficulty lane) ---
+- name: "size: S"
+  color: "c2e0c6"
+  description: "Small: a few lines to a single file."
+
+- name: "size: M"
+  color: "bfd4f2"
+  description: "Medium: multiple files or a focused feature."
+
+- name: "size: L"
+  color: "f9d0c4"
+  description: "Large: spans modules or needs a design discussion first."
+
+# --- Type ---
+- name: "documentation"
+  color: "0075ca"
+  description: "Improvements or additions to documentation."

--- a/.github/workflows/discord-good-first-issue.yml
+++ b/.github/workflows/discord-good-first-issue.yml
@@ -1,0 +1,39 @@
+name: Announce good first issues
+
+# When an issue is labeled "good first issue", post it to the community
+# Discord so newcomers see starter work as soon as it is curated.
+#
+# Setup: add a repository secret named DISCORD_WEBHOOK_URL holding a
+# Discord channel webhook (Channel settings -> Integrations -> Webhooks).
+# The job is a safe no-op if the secret is not set.
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  announce:
+    if: github.event.label.name == 'good first issue'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          if [ -z "$DISCORD_WEBHOOK_URL" ]; then
+            echo "DISCORD_WEBHOOK_URL not set; skipping announcement."
+            exit 0
+          fi
+          # Build the JSON with jq so issue text cannot break out of the payload.
+          payload=$(jq -n \
+            --arg title "$ISSUE_TITLE" \
+            --arg url "$ISSUE_URL" \
+            --arg num "$ISSUE_NUMBER" \
+            '{content: ("**New good first issue** #\($num): \($title)\n\($url)\n\nNew here? Read CONTRIBUTING.md, comment to claim it, and say hi.")}')
+          curl -sf -H "Content-Type: application/json" -X POST "$DISCORD_WEBHOOK_URL" -d "$payload"

--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -1,0 +1,81 @@
+name: Verified Contributor credential
+
+# When a pull request is merged, mint a signed "Vouch Verified Contributor"
+# credential for its author using our own protocol, and post it as a thank-you
+# comment. This dogfoods Vouch and gives contributors an ownable, verifiable
+# badge of their contribution.
+#
+# Setup: add repository secrets VOUCH_PRIVATE_KEY (issuer Ed25519 JWK) and
+# VOUCH_DID (issuer DID). The job is a safe no-op if they are not set.
+#
+# Security note: uses pull_request_target with the default (base) checkout, so
+# only trusted repository code runs. The contributor's PR code is never executed.
+
+on:
+  pull_request_target:
+    types: [closed]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  mint:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install vouch
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Mint credential
+        env:
+          VOUCH_PRIVATE_KEY: ${{ secrets.VOUCH_PRIVATE_KEY }}
+          VOUCH_DID: ${{ secrets.VOUCH_DID }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          if [ -z "$VOUCH_PRIVATE_KEY" ] || [ -z "$VOUCH_DID" ]; then
+            echo "Issuer key not configured; skipping credential minting."
+            exit 0
+          fi
+          python scripts/mint_contributor_credential.py \
+            --subject "$PR_AUTHOR" \
+            --pr-url "$PR_URL" \
+            --pr-number "$PR_NUMBER" \
+            --repo "$REPO" \
+            --out credential.json
+
+      - name: Thank the contributor
+        if: hashFiles('credential.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "### Vouch Verified Contributor :sparkles:"
+            echo ""
+            echo "Thank you @${PR_AUTHOR}. Your merged pull request earns a signed"
+            echo "**Vouch Verified Contributor** credential, minted with our own protocol."
+            echo "Keep it, verify it, and show it off."
+            echo ""
+            echo "<details><summary>Your Verifiable Credential (eddsa-jcs-2022)</summary>"
+            echo ""
+            echo '```json'
+            cat credential.json
+            echo '```'
+            echo ""
+            echo "</details>"
+          } > comment.md
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file comment.md

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,45 @@
+name: Welcome
+
+# Greets first-time issue and pull request authors with a warm, practical
+# pointer to CONTRIBUTING, the dev setup, the DCO sign-off, and Discord.
+# Uses pull_request_target so the greeting can be posted on PRs from forks.
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            Thanks for opening your first issue here, and welcome to Vouch Protocol. :wave:
+
+            A maintainer will take a look shortly. A few things that help us move fast:
+
+            - If you would like to work on this, just say so and we will assign it to you.
+            - New to the codebase? Our [CONTRIBUTING guide](https://github.com/vouch-protocol/vouch/blob/main/CONTRIBUTING.md) gets you from clone to green tests, and you can spin up a ready-made environment with the "Open in GitHub Codespaces" badge in the README.
+            - Want an AI co-pilot for Vouch? We ship a [Claude Code skill](https://github.com/vouch-protocol/vouch/tree/main/claude-skill), a [ChatGPT Custom GPT](https://github.com/vouch-protocol/vouch/tree/main/openai-gpt), and a [Gemini Gem](https://github.com/vouch-protocol/vouch/tree/main/gemini-gem) that know the SDK shapes, cryptosuite ids, and conventions, so future contributions go even faster.
+            - Questions are always welcome in our [Discord](https://discord.gg/mMqx5cG9Y).
+
+            Glad to have you here.
+          pr-message: |
+            Thanks for your first pull request, and welcome to Vouch Protocol. :tada:
+
+            Here is what happens next and how to keep things smooth:
+
+            - A maintainer will review shortly. CI runs automatically once a maintainer approves it for first-time contributors.
+            - Please make sure every commit carries a DCO sign-off (`git commit -s`). If CI flags it, run `git commit --amend -s` then `git push --force-with-lease`. Details are in [CONTRIBUTING](https://github.com/vouch-protocol/vouch/blob/main/CONTRIBUTING.md#dco-sign-off).
+            - New features should include tests. You can run the suite locally with `pytest tests/ -v`, or use the "Open in GitHub Codespaces" badge for a zero-setup environment.
+            - For future work, our [Claude skill](https://github.com/vouch-protocol/vouch/tree/main/claude-skill), [Custom GPT](https://github.com/vouch-protocol/vouch/tree/main/openai-gpt), and [Gemini Gem](https://github.com/vouch-protocol/vouch/tree/main/gemini-gem) can act as a Vouch-aware co-pilot.
+
+            Thank you for helping build the open standard for AI agent identity.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -26,6 +26,29 @@ This project operates under a **Lazy Consensus** model. This means that consensu
 - Report bugs and suggest features
 - Participate in discussions
 
+## Contributor Ladder
+
+Contributors grow into greater ownership as they earn trust. The rungs are
+visible on purpose: people climb ladders they can see. Each rung adds
+recognition and responsibility.
+
+| Rung | How you get here | What you can do | Recognition |
+|------|------------------|-----------------|-------------|
+| **Newcomer** | Open your first issue or PR | Pick up a `good first issue`; ask questions in Discord | Welcomed by the bot |
+| **Contributor** | One merged PR | Keep contributing; claim issues | Listed via all-contributors; receive a signed **Vouch Verified Contributor** credential |
+| **Area Owner / Committer** | 2-3 solid PRs in one area, consistent participation | Added to `CODEOWNERS` for that area; auto-requested for review; can approve PRs (merge by a Maintainer) | Named in `MAINTAINERS.md` as a Committer |
+| **Maintainer** | Sustained expertise over 3+ months; nominated by a Maintainer; approved by the Lead | Write access to specific modules; merge PRs in their area; mentor newcomers; join the release process | Listed as a Maintainer |
+| **Project Lead** | Founding / appointed | Sets direction; final arbiter; manages signing keys and infrastructure | Listed as Project Lead |
+
+How to climb:
+1. **Ship**: multiple accepted PRs in an area (quality over quantity).
+2. **Stay**: consistent participation in issues, reviews, and Discord.
+3. **Be invited**: an existing Maintainer nominates you; the Lead approves.
+
+Maintainers should actively point strong contributors at the next rung: when
+someone lands a clean PR, reply with one specific `good second issue` or
+`help wanted` task that builds on what they just did.
+
 ## Access Continuity (Bus Factor)
 To ensure the project can continue if the project lead is incapacitated:
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 </p>
 
 <p align="center">
+ <a href="https://codespaces.new/vouch-protocol/vouch"><img src="https://github.com/codespaces/badge.svg" alt="Open in GitHub Codespaces" height="28"></a>
+</p>
+
+<p align="center">
  <a href="https://github.com/vouch-protocol/vouch/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="Apache 2.0 License"></a>
 </p>
 
@@ -464,7 +468,7 @@ Built by [Ramprasad Gaddam](https://www.linkedin.com/in/rampy) ([Twitter/X](http
 
 ## Contributing
 
-Contributions welcome. See [CONTRIBUTING.md](https://github.com/vouch-protocol/vouch/blob/main/CONTRIBUTING.md).
+Contributions welcome. See [CONTRIBUTING.md](https://github.com/vouch-protocol/vouch/blob/main/CONTRIBUTING.md). Looking for a place to start? Browse our [good first issues](https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22), and open a ready-made dev environment with one click using the [Open in GitHub Codespaces](https://codespaces.new/vouch-protocol/vouch) badge above.
 
 **Areas where help is most useful:**
 - [ ] Additional framework integrations (Haystack, Semantic Kernel, LlamaIndex, others)
@@ -472,6 +476,20 @@ Contributions welcome. See [CONTRIBUTING.md](https://github.com/vouch-protocol/v
 - [ ] Tutorials and worked examples for regulated-sector deployments
 - [ ] Independent security review and audit
 - [ ] Reference implementations in additional languages (Rust, Java, .NET)
+
+## Contributors
+
+Thanks goes to these wonderful people. This section is maintained automatically by the [all-contributors](https://allcontributors.org/) bot.
+
+<!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+<!-- ALL-CONTRIBUTORS-BADGE:END -->
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+<!-- ALL-CONTRIBUTORS-LIST:END -->
 
 ---
 

--- a/docs/execution/contributor-engagement-playbook.md
+++ b/docs/execution/contributor-engagement-playbook.md
@@ -1,0 +1,128 @@
+# Contributor Engagement Playbook
+
+Execution reference for growing and retaining contributors to Vouch Protocol.
+Consolidates the discovery, onboarding, recognition, responsibility, and
+community ideas in one place. Owner: @rampyg.
+
+## Why this exists
+
+Two strangers self-served starter work within a day of the `good first issue`
+label being applied (PRs #110 and the interest on #92, #107). The recipe that
+worked: a labeled, well-scoped issue with acceptance criteria and a file
+pointer, plus fast labeling. This document scales that recipe and turns
+one-off contributors into stakeholders.
+
+The guiding principle: stars measure attention; stakeholders are made by
+transferring ownership. Recognize publicly, delegate responsibility early,
+give a voice, and let contributors carry a piece of the project's identity.
+
+---
+
+## 1. Discovery: help newcomers find us
+
+- **Keep the queue stocked.** Aim for 5-10 open `good first issue`s at all
+  times, each with: a one-paragraph scope, acceptance criteria, a file or line
+  pointer, and a size label (`size: S/M`). When the queue empties, inflow stops.
+- **Tier the labels** (do not stop at beginners; see section 6):
+  - `good first issue`: under ~30 min, fully specified.
+  - `good second issue` / `help wanted`: needs a small design choice.
+  - `complex` / `design` / `rfc` / `security`: for experienced contributors.
+- **List on aggregators** (each pulls from the `good first issue` label):
+  - up-for-grabs.net: fork `up-for-grabs/up-for-grabs.net`, add
+    `_data/projects/vouch.yml`, open a PR. (Fork-first is expected; they have
+    no form.)
+  - goodfirstissue.dev: PR to `DeepSourceCorp/good-first-issue`, add our path
+    to `data/repositories.toml`. Requires 3+ `good first issue` issues.
+  - goodfirstissues.com: PR to `iedr/goodfirstissues`, add `vouch-protocol/vouch`
+    to `repositories.json` (owner/name, lexicographic order). Requires 3+
+    `good first issue` issues and a README with setup steps.
+  - MunGell/awesome-for-beginners: PR adding a one-line entry.
+  - GitHub's own "For Good First Issue" (forgoodfirstissue.github.com).
+- **Repo topics** (free, instant): `good-first-issue`, `ai-agents`, `web3`,
+  `cryptography`, `decentralized-identity`, plus `hacktoberfest` seasonally.
+
+The label filter URL to share everywhere:
+`https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22`
+
+## 2. Onboarding: get them to green fast
+
+- **Welcome bot** (`.github/workflows/welcome.yml`): greets first-time issue
+  and PR authors with CONTRIBUTING, the DCO sign-off, dev setup, Codespaces, and
+  Discord. Also points to the AI helper tools (Claude skill, Custom GPT, Gemini
+  Gem) so repeat contributors move even faster.
+- **Dev container + Codespaces** (`.devcontainer/devcontainer.json` + README
+  badge): one click gives a Python 3.11 environment with the `dev` extra
+  preinstalled, so a newcomer reaches green tests with zero local setup. This
+  fixes real friction (missing build deps, `pytest` only in the `dev` extra).
+- **AI co-pilots**: `claude-skill/`, `openai-gpt/`, `gemini-gem/` each teach an
+  assistant the SDK shapes, cryptosuite ids, DID conventions, and delegation
+  rules. Point contributors to these for future, faster contributions.
+- **First response is the top retention driver.** Assign quickly, review within
+  24-48h, and always thank.
+
+## 3. Recognition
+
+- **all-contributors bot** (installed; config in `.all-contributorsrc`, markers
+  in README). To credit: comment `@all-contributors please add @user for code`
+  on any issue or PR; merge the bot's PR. (The native GitHub contributors graph
+  is automatic on merge regardless.)
+- **Release-note credit**: name contributors in `CHANGELOG.md` / `RELEASES.md`.
+- **Vouch Verified Contributor credential** (`scripts/mint_contributor_credential.py`
+  + `.github/workflows/verified-contributor.yml`): on merge, mint a signed
+  Verifiable Credential for the PR author and post it as a thank-you. This is
+  the highest-leverage, most on-brand recognition: an ownable badge that also
+  demonstrates the protocol working on humans.
+- **Spotlights**: periodic contributor shout-outs in Discord and on X.
+
+## 4. Responsibility: the biggest stakeholder driver
+
+- **CODEOWNERS** (`.github/CODEOWNERS`): when someone lands 2-3 solid PRs in an
+  area, add their handle so they are auto-requested for review there. Keep
+  core/crypto under lead review.
+- **Contributor ladder** (see `GOVERNANCE.md`): make the rungs and the criteria
+  to climb them visible. People climb ladders they can see.
+- **Let them mentor**: ask a returning contributor to review the next
+  newcomer's PR.
+
+## 5. Agency and belonging
+
+- Invite strong contributors to comment on `ROADMAP.md`, open RFCs and
+  Discussions, and propose their own `good first issue`s.
+- Discord: a `#good-first-issues` channel (fed by the announcer workflow), a
+  `#introductions` channel, and an auto-granted `Contributor` role.
+
+## 6. Beyond beginners: senior and professional contributors
+
+Do not limit everything to `good first issue`. Provide a path for experienced
+people:
+
+- Labels: `help wanted`, `good second issue`, `complex`, `design`, `rfc`,
+  `security`, `performance`.
+- An **RFC / design-proposal** process via Discussions for protocol-level work
+  (e.g. the v1.7 delegation redesign).
+- A `#dev-discussion` channel for architecture and deep dives.
+- Reach senior folks where they are: DIF, W3C Credentials CG, Trust over IP,
+  IIW (identity); LangChain / CrewAI / AutoGen / MCP communities (AI agents).
+
+## 7. On stars and forks
+
+Do not personally solicit stars or forks (forking already happens when someone
+contributes, and incentivized stars violate GitHub's terms and cheapen a
+trust-focused project). Keep the ambient nudges (README footer, welcome bot).
+Sequence matters: deliver value, recognize, then a soft ask at most.
+
+## 8. The flywheel
+
+Stocked, well-scoped issues -> listed on aggregators -> fast warm welcome ->
+frictionless setup -> recognition (credential + all-contributors) -> a slightly
+harder issue -> area ownership via CODEOWNERS -> maintainer. Repeat.
+
+## 9. What is automated vs manual
+
+Automated (in-repo): welcome bot, devcontainer/Codespaces, Discord announcer,
+Verified Contributor credential, all-contributors config.
+
+Manual (owner actions): approve CI for first-time contributors, install the
+all-contributors app, set the `DISCORD_WEBHOOK_URL`, `VOUCH_PRIVATE_KEY`, and
+`VOUCH_DID` secrets, submit the aggregator PRs, and run the `@all-contributors`
+add command per contributor.

--- a/scripts/mint_contributor_credential.py
+++ b/scripts/mint_contributor_credential.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Mint a "Vouch Verified Contributor" credential for a merged-PR author.
+
+This dogfoods the protocol: the project signs a Verifiable Credential
+attesting that a GitHub user contributed a merged pull request. It is
+designed to run in CI (see .github/workflows/verified-contributor.yml) but
+is also runnable locally.
+
+The issuer key is read from the environment:
+  VOUCH_PRIVATE_KEY  Ed25519 private key JWK (JSON string)
+  VOUCH_DID          Issuer DID, e.g. did:web:vouch-protocol.com
+
+Example:
+  export VOUCH_DID='did:web:vouch-protocol.com'
+  export VOUCH_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+  python scripts/mint_contributor_credential.py \\
+      --subject Franflorio \\
+      --pr-url https://github.com/vouch-protocol/vouch/pull/110 \\
+      --pr-number 110 --repo vouch-protocol/vouch
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from vouch import Signer
+
+
+def mint_credential(
+    subject: str,
+    pr_url: str,
+    pr_number: str,
+    repo: str,
+    private_key: str,
+    did: str,
+    valid_days: int = 3650,
+) -> dict:
+    """Return a signed Vouch Credential attesting a merged contribution."""
+    signer = Signer(private_key=private_key, did=did)
+    intent = {
+        "action": "attest",
+        "target": f"github:{subject}",
+        # resource is required by the credential model; bind it to the PR.
+        "resource": pr_url,
+        "role": "verified-contributor",
+        "repository": repo,
+        "pullRequest": int(pr_number) if pr_number.isdigit() else pr_number,
+    }
+    return signer.sign_credential(intent=intent, valid_seconds=valid_days * 86400)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Mint a Vouch Verified Contributor credential",
+    )
+    parser.add_argument("--subject", required=True, help="GitHub handle of the contributor")
+    parser.add_argument("--pr-url", required=True, help="HTML URL of the merged pull request")
+    parser.add_argument("--pr-number", default="", help="Pull request number")
+    parser.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY", ""), help="owner/repo")
+    parser.add_argument("--out", default="-", help="Output file, or - for stdout")
+    args = parser.parse_args(argv)
+
+    private_key = os.getenv("VOUCH_PRIVATE_KEY")
+    did = os.getenv("VOUCH_DID")
+    if not private_key or not did:
+        print(
+            "VOUCH_PRIVATE_KEY and VOUCH_DID must be set to mint a credential.",
+            file=sys.stderr,
+        )
+        return 1
+
+    credential = mint_credential(
+        subject=args.subject,
+        pr_url=args.pr_url,
+        pr_number=args.pr_number,
+        repo=args.repo,
+        private_key=private_key,
+        did=did,
+    )
+
+    text = json.dumps(credential, indent=2)
+    if args.out == "-":
+        print(text)
+    else:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        print(f"Wrote credential for @{args.subject} to {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Infrastructure to grow and retain contributors, building on the inflow that started with the `good first issue` label.

## Changes

- **Welcome bot** (`.github/workflows/welcome.yml`): greets first-time issue and PR authors with CONTRIBUTING, the DCO sign-off, dev setup, Codespaces, Discord, and the AI helper tools.
- **Dev container + Codespaces** (`.devcontainer/devcontainer.json` + README badge): one-click Python 3.11 environment with the `dev` extra preinstalled, so newcomers reach green tests with no local setup.
- **all-contributors** (`.all-contributorsrc` + README markers): credit merged contributors automatically.
- **Discord announcer** (`.github/workflows/discord-good-first-issue.yml`): posts newly labeled good first issues to Discord. Safe no-op without the `DISCORD_WEBHOOK_URL` secret.
- **Label taxonomy** (`.github/labels.yml`): contribution lanes for every level, not just beginners (`good second issue`, `help wanted`, `complex`, `design`, `rfc`, `security`, `performance`, sizing).
- **CODEOWNERS** (`.github/CODEOWNERS`) + a **Contributor Ladder** in `GOVERNANCE.md`.
- **Verified Contributor credential** (`scripts/mint_contributor_credential.py` + `.github/workflows/verified-contributor.yml`): on PR merge, mint a signed Verifiable Credential for the author and post it as a thank-you. Requires `VOUCH_PRIVATE_KEY` and `VOUCH_DID` secrets; safe no-op without them.
- **Playbook** (`docs/execution/contributor-engagement-playbook.md`): the full engagement reference.

## Testing

- `mint_contributor_credential.py` verified locally: mints a credential that round-trips through `Verifier.verify_credential`.
- Workflow YAML and `.all-contributorsrc` / `devcontainer.json` parse cleanly; `ruff` passes on the new script.