### PR TITLE
docs(contributing): add a Recognition section crediting contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,10 @@ git commit --amend -s
 git push --force-with-lease
 ```
 
+## Recognition
+
+All contributors are credited. Merged contributions are recognized in the project's all-contributors list, in release notes, and with a signed Vouch Verified Contributor credential. Authorship of your commits remains yours.
+
 ## Questions?
 
 - Open a [Discussion](https://github.com/vouch-protocol/vouch/discussions)


### PR DESCRIPTION
Adds a short Recognition section to CONTRIBUTING.md so contributors know they are credited (all-contributors list, release notes, and a signed Vouch Verified Contributor credential) and that authorship of their commits remains theirs.