### PR TITLE
chore: add self-documenting Makefile help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,25 +2,21 @@
 # ================================
 # Manage all packages from the root directory
 
-.PHONY: help install-all build-all build-ts clean run-bridge test lint
+.DEFAULT_GOAL := help
+
+.PHONY: help install-all build-all build-ts clean run-bridge test lint dev-setup publish-all
 
 # Default target
-help:
+help: ## Show this help message
 	@echo "🔐 Vouch Protocol Monorepo"
 	@echo "=========================="
 	@echo ""
 	@echo "Available commands:"
-	@echo "  make install-all    Install all Python packages in editable mode"
-	@echo "  make build-all      Build all packages (Python + TypeScript)"
-	@echo "  make build-ts       Build TypeScript SDK only"
-	@echo "  make clean          Remove build artifacts and __pycache__"
-	@echo "  make run-bridge     Start the Vouch Bridge daemon"
-	@echo "  make test           Run all tests"
-	@echo "  make lint           Run linters on all packages"
+	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z0-9_.-]+:.*## / {printf "  make %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 	@echo ""
 
 # Install all Python packages in editable mode
-install-all:
+install-all: ## Install all Python packages in editable mode
 	@echo "📦 Installing Python packages in editable mode..."
 	python -m pip install -e ".[dev]"
 	python -m pip install -e ./packages/bridge[dev]
@@ -28,20 +24,20 @@ install-all:
 	@echo "✅ All packages installed!"
 
 # Build all packages
-build-all: build-ts
+build-all: build-ts ## Build all packages (Python + TypeScript)
 	@echo "📦 Building Python packages..."
 	cd packages/bridge && python -m build
 	cd packages/sdk-py && python -m build
 	@echo "✅ All packages built!"
 
 # Build TypeScript SDK only
-build-ts:
+build-ts: ## Build TypeScript SDK only
 	@echo "📦 Building TypeScript SDK..."
 	cd packages/sdk-ts && npm install && npm run build
 	@echo "✅ TypeScript SDK built!"
 
 # Clean build artifacts
-clean:
+clean: ## Remove build artifacts and caches
 	@echo "🧹 Cleaning build artifacts..."
 	find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
 	find . -type d -name "*.egg-info" -exec rm -rf {} + 2>/dev/null || true
@@ -54,12 +50,12 @@ clean:
 	@echo "✅ Clean complete!"
 
 # Run the Vouch Bridge daemon
-run-bridge:
+run-bridge: ## Start the Vouch Bridge daemon
 	@echo "🚀 Starting Vouch Bridge daemon..."
 	python -m vouch_bridge.main
 
 # Run all tests
-test:
+test: ## Run all tests
 	@echo "🧪 Running tests..."
 	pytest tests/ -v
 	cd packages/bridge && pytest tests/ -v 2>/dev/null || echo "No bridge tests yet"
@@ -67,14 +63,14 @@ test:
 	@echo "✅ Tests complete!"
 
 # Run linters
-lint:
+lint: ## Run linters on all packages
 	@echo "🔍 Running linters..."
 	ruff check .
 	cd packages/sdk-ts && npm run lint 2>/dev/null || echo "TypeScript lint not configured"
 	@echo "✅ Lint complete!"
 
 # Development setup (one command to rule them all)
-dev-setup: clean install-all build-ts
+dev-setup: clean install-all build-ts ## Prepare a local development environment
 	@echo ""
 	@echo "🎉 Development environment ready!"
 	@echo ""
@@ -83,7 +79,7 @@ dev-setup: clean install-all build-ts
 	@echo ""
 
 # Publish all packages (use with caution!)
-publish-all:
+publish-all: ## Publish all packages (maintainers only)
 	@echo "📤 Publishing packages..."
 	@echo "Publishing vouch-bridge to PyPI..."
 	cd packages/bridge && python -m build && twine upload dist/*


### PR DESCRIPTION
## Summary
- add a self-documenting `make help` menu generated from `##` target descriptions
- include all public Makefile targets in the menu, including `dev-setup` and `publish-all`
- set `help` as the default target and update `.PHONY`

## Validation
- `make help`
- `make --no-print-directory`

Closes #129