### PR TITLE
test(jcs): cover canonicalization edge cases

### DIFF
--- a/tests/test_jcs.py
+++ b/tests/test_jcs.py
@@ -57,9 +57,41 @@ def test_object_keys_unicode_sort():
     assert canonical.startswith('{"a":3,"z":2,')
 
 
+def test_object_keys_rfc8785_unicode_sort_order():
+    obj = {
+        "\u20ac": "Euro Sign",
+        "\r": "Carriage Return",
+        "\ufb33": "Hebrew Letter Dalet With Dagesh",
+        "1": "One",
+        "\U0001f600": "Emoji: Grinning Face",
+        "\u0080": "Control",
+        "\u00f6": "Latin Small Letter O With Diaeresis",
+    }
+
+    expected = (
+        '{"\\r":"Carriage Return","1":"One","\u0080":"Control",'
+        '"\u00f6":"Latin Small Letter O With Diaeresis","\u20ac":"Euro Sign",'
+        '"\U0001f600":"Emoji: Grinning Face","\ufb33":"Hebrew Letter Dalet With Dagesh"}'
+    )
+
+    assert jcs.canonicalize(obj) == expected.encode("utf-8")
+
+
 def test_nested_object():
     obj = {"outer": {"y": 2, "x": 1}}
     assert jcs.canonicalize(obj) == b'{"outer":{"x":1,"y":2}}'
+
+
+def test_nested_objects_sort_recursively_inside_arrays():
+    obj = {
+        "z": [{"b": 1, "a": {"d": 4, "c": 3}}],
+        "a": {"y": [{"beta": 2, "alpha": 1}], "x": 0},
+    }
+
+    assert (
+        jcs.canonicalize(obj)
+        == b'{"a":{"x":0,"y":[{"alpha":1,"beta":2}]},"z":[{"a":{"c":3,"d":4},"b":1}]}'
+    )
 
 
 def test_no_whitespace():
@@ -81,6 +113,20 @@ def test_mixed_object_keys_and_values():
     assert '"literals":[null,true,false]' in out
     assert '"string":"hello"' in out
     assert out.index('"literals"') < out.index('"numbers"') < out.index('"string"')
+
+
+def test_rfc8785_number_formatting_edges():
+    obj = {
+        "numbers": [
+            333333333.33333329,
+            1e30,
+            4.50,
+            2e-3,
+            0.000000000000000000000000001,
+        ]
+    }
+
+    assert jcs.canonicalize(obj) == b'{"numbers":[333333333.3333333,1e+30,4.5,0.002,1e-27]}'
 
 
 def test_nan_and_inf_rejected():

--- a/vouch/jcs.py
+++ b/vouch/jcs.py
@@ -16,7 +16,6 @@ import math
 import re
 from typing import Any, Mapping, Sequence
 
-
 _ESCAPE_MAP = {
     0x08: "\\b",
     0x09: "\\t",
@@ -73,7 +72,7 @@ def _emit_number(value: float | int) -> str:
             # is close but emits `1e+20` where ECMAScript emits `100000000000000000000`.
             # Use a shortest-round-trip serialization.
             s = repr(value)
-            # Normalize exponent capitalization and sign formatting per ES.
+            # Normalize exponent capitalization per ES.
             return _normalize_float_repr(s)
     if isinstance(value, bool):  # bool is a subclass of int in Python; guard above.
         raise TypeError("JCS: booleans handled by separate branch")
@@ -82,11 +81,11 @@ def _emit_number(value: float | int) -> str:
 
 def _normalize_float_repr(s: str) -> str:
     # Python repr for floats may produce forms like '1e+20' or '0.5'.
-    # ECMAScript toString uses lowercase 'e', no '+' after 'e' for positive,
+    # ECMAScript toString uses lowercase 'e',
     # and uses positional form for magnitudes between 1e-6 and 1e21 (exclusive).
     # This is a best-effort minimal normalizer; full ES coverage requires a
     # dedicated library if exotic floats are encountered.
-    s = s.lower().replace("e+", "e")
+    s = s.lower()
     return s
 
 


### PR DESCRIPTION
## Description

Adds focused JCS canonicalization edge-case coverage for nested object sorting, RFC 8785 Unicode property ordering, and RFC 8785 number serialization samples. The number-formatting case exposed a tiny normalizer mismatch for positive exponents, so this also preserves the required `e+` form.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #127

## Changes Made

- Added recursive nested-object canonicalization coverage, including objects inside arrays.
- Added the RFC 8785 Unicode property sort-order sample as a byte-for-byte assertion.
- Added RFC 8785 number-formatting edge coverage for rounding, positive exponents, decimals, and tiny exponents.
- Preserved positive exponent signs in JCS float serialization so `1e30` canonicalizes as `1e+30`.

## Testing

- [x] Existing tests pass (`pytest tests/`)
- [x] New tests added for new functionality
- [ ] Manual testing performed

Exact local results:

- `pytest tests/test_jcs.py tests/test_jcs_interop.py -v` - 30 passed in 0.05s
- `black --check vouch/jcs.py tests/test_jcs.py` - 2 files would be left unchanged
- `ruff check vouch/jcs.py tests/test_jcs.py` - All checks passed
- `git diff --check upstream/main...HEAD` - passed with no output

Duplicate check:

- Re-checked open PRs with `gh pr list --repo vouch-protocol/vouch --state open --limit 100` filtered for `jcs`, `canonical`, `127`, `number`, `unicode`, and `nested`; no open PR appears to cover this issue.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)

## Screenshots (if applicable)

N/A
