### PR TITLE
Link robotics page from homepage feature card and footer nav

### DIFF
--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import CodeBlock from '@/components/CodeBlock';
 import LangCodeBlock from '@/components/LangCodeBlock';
 
-const FEATURES = [
+const FEATURES: Array<{ num: string; title: string; body: string; spec: string; href?: string }> = [
   {
     num: 'i.',
     title: 'Cryptographic Agent Identity',
@@ -44,6 +44,7 @@ const FEATURES = [
     title: 'Robots & Embodied Agents',
     body: 'A robot identity rooted in a TPM or secure element, a signed record of the model and safety policy it runs (re-signed on every update), physical limits enforced as cryptographic capability (force, speed near humans, zones), a kill-switch credential only an attested authority can trigger, and a scannable QR/NFC passport.',
     spec: 'Robotics profile',
+    href: '/robotics/',
   },
   {
     num: 'viii.',
@@ -180,7 +181,13 @@ export default function HomePage() {
                 <div className="eyebrow-faint mb-2">{feature.num}</div>
                 <h3 className="font-serif font-semibold text-[1.25rem] mb-3 tracking-tight">{feature.title}</h3>
                 <p className="text-ink-soft text-[0.95rem] leading-relaxed mb-3">{feature.body}</p>
-                <span className="font-mono text-burgundy text-[0.7rem] tracking-wider">{feature.spec}</span>
+                {feature.href ? (
+                  <Link href={feature.href} className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline">
+                    {feature.spec} &rarr;
+                  </Link>
+                ) : (
+                  <span className="font-mono text-burgundy text-[0.7rem] tracking-wider">{feature.spec}</span>
+                )}
               </div>
             ))}
           </div>

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -6,6 +6,7 @@ const FOOTER_GROUPS = [
     title: 'Product',
     links: [
       { label: 'Tools', href: '/tools/' },
+      { label: 'Robotics', href: '/robotics/' },
       { label: 'FAQ', href: '/faq/' },
       { label: 'Help & Guides', href: '/help/' },
       { label: 'Agent Trust Index', href: '/agent-trust-index/' },


### PR DESCRIPTION
Adds the two missing internal links to the robotics page found during a cross-linking audit:

- Homepage feature card vii. (Robots & Embodied Agents) now links to /robotics/ via its label. The other six cards reference spec sections with no destination page, so they stay static; robotics is the one feature with a dedicated page.
- Footer Product group now lists Robotics (was Tools / FAQ / Help / Agent Trust Index / Support).

Already-correct links left unchanged: top nav, tools page, /robotics to /faq and /help, FAQ robotics answers to help guides.

Verified the homepage recompiles with no errors and /robotics/ resolves from nav, card, and footer.