### PR TITLE
feat(badges): publish issuer DID docs and make contributor badges robust

### DIFF
--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -1,15 +1,17 @@
 name: Verified Contributor credential
 
-# When a pull request is merged, mint a signed "Vouch Verified Contributor"
-# credential for its author using our own protocol, and post it as a thank-you
-# comment. This dogfoods Vouch and gives contributors an ownable, verifiable
-# badge of their contribution.
+# When a contributor's FIRST pull request is merged, mint a signed "Vouch
+# Verified Contributor" credential for them using our own protocol, and post it
+# as a thank-you comment. One badge per contributor: later merges are skipped.
 #
-# Setup: add repository secrets VOUCH_PRIVATE_KEY (issuer Ed25519 JWK) and
-# VOUCH_DID (issuer DID). The job is a safe no-op if they are not set.
+# Setup: add repository secrets VOUCH_PRIVATE_KEY (the contributor-issuer
+# Ed25519 JWK) and VOUCH_DID (did:web:vouch-protocol.com:contributors). The job
+# is a safe no-op if they are not set. If contributors/delegation.json is
+# present, the badge is chained back to the root authority automatically.
 #
 # Security note: uses pull_request_target with the default (base) checkout, so
-# only trusted repository code runs. The contributor's PR code is never executed.
+# only trusted repository code runs. The contributor's PR code is never executed,
+# and the issuer key is never exposed to it.
 
 on:
   pull_request_target:
@@ -26,16 +28,36 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - name: One badge per contributor (skip unless this is their first merge)
+        id: firstmerge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          REPO: ${{ github.repository }}
+        run: |
+          count=$(gh pr list --repo "$REPO" --author "$PR_AUTHOR" --state merged \
+            --json number --limit 200 | jq 'length')
+          echo "Merged PRs by @$PR_AUTHOR: $count"
+          if [ "$count" -le 1 ]; then
+            echo "first=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "first=false" >> "$GITHUB_OUTPUT"
+            echo "Already issued a badge to @$PR_AUTHOR; skipping."
+          fi
+
       - uses: actions/setup-python@v6
+        if: steps.firstmerge.outputs.first == 'true'
         with:
           python-version: "3.11"
 
       - name: Install vouch
+        if: steps.firstmerge.outputs.first == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -e .
 
       - name: Mint credential
+        if: steps.firstmerge.outputs.first == 'true'
         env:
           VOUCH_PRIVATE_KEY: ${{ secrets.VOUCH_PRIVATE_KEY }}
           VOUCH_DID: ${{ secrets.VOUCH_DID }}
@@ -48,15 +70,20 @@ jobs:
             echo "Issuer key not configured; skipping credential minting."
             exit 0
           fi
+          PARENT=""
+          if [ -f contributors/delegation.json ]; then
+            PARENT="--parent contributors/delegation.json"
+          fi
           python scripts/mint_contributor_credential.py \
             --subject "$PR_AUTHOR" \
             --pr-url "$PR_URL" \
             --pr-number "$PR_NUMBER" \
             --repo "$REPO" \
+            $PARENT \
             --out credential.json
 
       - name: Thank the contributor
-        if: hashFiles('credential.json') != ''
+        if: steps.firstmerge.outputs.first == 'true' && hashFiles('credential.json') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
@@ -66,9 +93,9 @@ jobs:
           {
             echo "### Vouch Verified Contributor :sparkles:"
             echo ""
-            echo "Thank you @${PR_AUTHOR}. Your merged pull request earns a signed"
+            echo "Thank you @${PR_AUTHOR}. Your first merged pull request earns a signed"
             echo "**Vouch Verified Contributor** credential, minted with our own protocol."
-            echo "Keep it, verify it, and show it off."
+            echo "Keep it, verify it, and show it off. This is a one-time badge."
             echo ""
             echo "<details><summary>Your Verifiable Credential (eddsa-jcs-2022)</summary>"
             echo ""

--- a/scripts/mint_contributor_credential.py
+++ b/scripts/mint_contributor_credential.py
@@ -29,6 +29,12 @@ import sys
 from vouch import Signer
 
 
+# A contributor badge attests a past fact, so it does not meaningfully expire.
+# The verifier requires a validUntil, so we set it far out (100 years) and rely
+# on a revocation status list, not expiry, if a badge ever needs to be pulled.
+DEFAULT_VALID_DAYS = 365 * 100
+
+
 def mint_credential(
     subject: str,
     pr_url: str,
@@ -36,9 +42,14 @@ def mint_credential(
     repo: str,
     private_key: str,
     did: str,
-    valid_days: int = 3650,
+    valid_days: int = DEFAULT_VALID_DAYS,
+    parent_credential: dict | None = None,
 ) -> dict:
-    """Return a signed Vouch Credential attesting a merged contribution."""
+    """Return a signed Vouch Credential attesting a merged contribution.
+
+    If `parent_credential` (the root -> contributor delegation) is provided, it
+    is attached so the badge traces back to the root authority.
+    """
     signer = Signer(private_key=private_key, did=did)
     intent = {
         "action": "attest",
@@ -49,7 +60,11 @@ def mint_credential(
         "repository": repo,
         "pullRequest": int(pr_number) if pr_number.isdigit() else pr_number,
     }
-    return signer.sign_credential(intent=intent, valid_seconds=valid_days * 86400)
+    return signer.sign_credential(
+        intent=intent,
+        valid_seconds=valid_days * 86400,
+        parent_credential=parent_credential,
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -61,6 +76,11 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--pr-number", default="", help="Pull request number")
     parser.add_argument("--repo", default=os.getenv("GITHUB_REPOSITORY", ""), help="owner/repo")
     parser.add_argument("--out", default="-", help="Output file, or - for stdout")
+    parser.add_argument(
+        "--parent",
+        default="",
+        help="Path to the root delegation credential (delegation.json). Optional.",
+    )
     args = parser.parse_args(argv)
 
     private_key = os.getenv("VOUCH_PRIVATE_KEY")
@@ -72,6 +92,11 @@ def main(argv: list[str] | None = None) -> int:
         )
         return 1
 
+    parent_credential = None
+    if args.parent and os.path.exists(args.parent):
+        with open(args.parent, encoding="utf-8") as handle:
+            parent_credential = json.load(handle)
+
     credential = mint_credential(
         subject=args.subject,
         pr_url=args.pr_url,
@@ -79,6 +104,7 @@ def main(argv: list[str] | None = None) -> int:
         repo=args.repo,
         private_key=private_key,
         did=did,
+        parent_credential=parent_credential,
     )
 
     text = json.dumps(credential, indent=2)

--- a/scripts/mint_delegation.py
+++ b/scripts/mint_delegation.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Sign the root -> contributor delegation credential. Run ONCE, locally.
+
+This is signed with the ROOT identity (did:web:vouch-protocol.com), whose
+private key is held offline and never goes into CI. The output, delegation.json,
+is a PUBLIC artifact (signatures and DIDs only, no private key), so it is safe
+to commit. The contributor issuer then attaches it to every badge, so each
+badge traces back to the root authority without the root key ever touching CI.
+
+Set the ROOT identity in the environment before running:
+  $env:VOUCH_DID = "did:web:vouch-protocol.com"
+  $env:VOUCH_PRIVATE_KEY = '<root private-key JWK JSON>'
+  python scripts/mint_delegation.py
+
+Then commit the resulting delegation.json (e.g. to contributors/delegation.json).
+"""
+
+import json
+import os
+import sys
+
+from vouch import Signer
+
+# The issuer being authorized, and the resource the authority is scoped to.
+CONTRIBUTOR_DID = "did:web:vouch-protocol.com:contributors"
+REPO_RESOURCE = "https://github.com/vouch-protocol/vouch"
+# Delegations are an operational authority, so they rotate. Ten years is a
+# generous window; re-run this script to refresh before it lapses.
+VALID_SECONDS = 10 * 365 * 86400
+
+
+def main() -> int:
+    private_key = os.getenv("VOUCH_PRIVATE_KEY")
+    did = os.getenv("VOUCH_DID")
+    if not private_key or not did:
+        print("Set VOUCH_PRIVATE_KEY and VOUCH_DID to the ROOT identity.", file=sys.stderr)
+        return 1
+
+    signer = Signer(private_key=private_key, did=did)
+    delegation = signer.sign_credential(
+        intent={
+            "action": "delegate",
+            "target": CONTRIBUTOR_DID,
+            "resource": REPO_RESOURCE,
+            "role": "verified-contributor-issuer",
+        },
+        valid_seconds=VALID_SECONDS,
+    )
+
+    with open("delegation.json", "w", encoding="utf-8") as handle:
+        json.dump(delegation, handle, indent=2)
+    print("Wrote delegation.json (safe to commit, e.g. contributors/delegation.json)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/public/.well-known/did.json
+++ b/website/public/.well-known/did.json
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:web:vouch-protocol.com",
+  "verificationMethod": [
+    {
+      "id": "did:web:vouch-protocol.com#key-1",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vouch-protocol.com",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "97HvSg41cwFmv5Kan-jpMojwoLHwh8BcygaoN3rptYU"
+      }
+    }
+  ],
+  "authentication": [
+    "did:web:vouch-protocol.com#key-1"
+  ],
+  "assertionMethod": [
+    "did:web:vouch-protocol.com#key-1"
+  ]
+}

--- a/website/public/contributors/did.json
+++ b/website/public/contributors/did.json
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:web:vouch-protocol.com:contributors",
+  "verificationMethod": [
+    {
+      "id": "did:web:vouch-protocol.com:contributors#key-1",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vouch-protocol.com:contributors",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "jwY_F3Voku9N8DzR3HuQcmSW1tjUcuTqhGfYuMiKYkw"
+      }
+    }
+  ],
+  "authentication": [
+    "did:web:vouch-protocol.com:contributors#key-1"
+  ],
+  "assertionMethod": [
+    "did:web:vouch-protocol.com:contributors#key-1"
+  ]
+}


### PR DESCRIPTION
## Summary

Hardens the Verified Contributor badge system and publishes the issuer DID documents so badges are externally verifiable.

## Changes

- **Publish DID documents** under `website/public` (deployed to the domain by the website build):
  - `.well-known/did.json` for the root identity `did:web:vouch-protocol.com`
  - `contributors/did.json` for the issuer `did:web:vouch-protocol.com:contributors`
- **`scripts/mint_delegation.py`**: signs the root -> contributor delegation **once, offline**. Output `delegation.json` is public (no private key) and safe to commit. The root private key never enters CI.
- **`scripts/mint_contributor_credential.py`**: attaches the delegation (`--parent`) when present so each badge chains back to the root authority, and makes badges effectively permanent (100 years), since a badge attests a past fact and is revoked via a status list, not expiry.
- **`verified-contributor.yml`**: one badge per contributor, issued only on their first merged PR (later merges are skipped), chained to the root when `contributors/delegation.json` is present.

## Verified locally

- Delegated badge verifies and carries the root to contributor delegation chain.
- Standalone badge (no delegation yet) still verifies, so the system works before the delegation is added.
- 100-year validity confirmed; ruff clean; workflow YAML and both DID documents parse.

## Still required from a maintainer (only the root-key steps)

1. Generate the root identity offline and run `mint_delegation.py` with the root key, then commit the resulting `contributors/delegation.json`. This step cannot be automated by design: the root private key is held offline.
2. Set the `VOUCH_DID` / `VOUCH_PRIVATE_KEY` secrets to the contributor issuer.
3. After deploy, confirm `https://vouch-protocol.com/.well-known/did.json` and `https://vouch-protocol.com/contributors/did.json` serve.