### PR TITLE
chore(badges): add root delegation for the contributor issuer

### DIFF
--- a/contributors/delegation.json
+++ b/contributors/delegation.json
@@ -1,0 +1,32 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vouch-protocol.com/contexts/v1"
+  ],
+  "id": "urn:uuid:476f908f-dcc2-4ac7-ad12-03ac5beabd97",
+  "type": [
+    "VerifiableCredential",
+    "VouchCredential"
+  ],
+  "issuer": "did:web:vouch-protocol.com",
+  "validFrom": "2026-06-19T04:45:43Z",
+  "validUntil": "2036-06-16T04:45:43Z",
+  "credentialSubject": {
+    "id": "did:web:vouch-protocol.com",
+    "vouchVersion": "1.0",
+    "intent": {
+      "action": "delegate",
+      "target": "did:web:vouch-protocol.com:contributors",
+      "resource": "https://github.com/vouch-protocol/vouch",
+      "role": "verified-contributor-issuer"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-06-19T04:45:43Z",
+    "verificationMethod": "did:web:vouch-protocol.com#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z5g1N4udQdy5asdxnV3qFhApB5cAh28DkMqHjEUSNG6cc8hrDDsxWyVbgn1XXUFRuzPiRMRv37uMaiEQqoYvsLFqv"
+  }
+}


### PR DESCRIPTION
Adds `contributors/delegation.json`: the root identity (`did:web:vouch-protocol.com`) authorizing the contributor issuer (`did:web:vouch-protocol.com:contributors`) to issue Verified Contributor badges.

Verified locally against the published root key: the delegation proof checks out, and a badge minted with it as parent carries the `root -> contributor` chain and verifies. The file is a public artifact and contains no private key.

Once merged, every contributor badge chains back to the root authority. Merge this before merging contributor PRs so the first badges are root-chained.