### PR TITLE
feat(badges): visual contributor badge, contributors page, and badge self-verify

### DIFF
--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -82,6 +82,23 @@ jobs:
             $PARENT \
             --out credential.json
 
+      - name: Verify the badge against the published DID document
+        if: steps.firstmerge.outputs.first == 'true' && hashFiles('credential.json') != ''
+        run: |
+          python - <<'PY'
+          import json, sys
+          from vouch import Verifier
+          cred = open("credential.json").read()
+          doc = json.load(open("website/public/contributors/did.json"))
+          pub = json.dumps(doc["verificationMethod"][0]["publicKeyJwk"])
+          ok, _ = Verifier.verify_credential(cred, public_key=pub)
+          print("Badge self-verify against published DID:", ok)
+          if not ok:
+              print("::error::Minted badge does not verify against the published contributor DID."
+                    " Check that VOUCH_PRIVATE_KEY and VOUCH_DID hold the contributor issuer key.")
+              sys.exit(1)
+          PY
+
       - name: Thank the contributor
         if: steps.firstmerge.outputs.first == 'true' && hashFiles('credential.json') != ''
         env:
@@ -89,13 +106,24 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
+          BADGE: "https://img.shields.io/badge/Vouch-Verified_Contributor-00C853?style=for-the-badge&labelColor=2d2d2d"
         run: |
           {
             echo "### Vouch Verified Contributor :sparkles:"
             echo ""
             echo "Thank you @${PR_AUTHOR}. Your first merged pull request earns a signed"
-            echo "**Vouch Verified Contributor** credential, minted with our own protocol."
-            echo "Keep it, verify it, and show it off. This is a one-time badge."
+            echo "**Vouch Verified Contributor** credential, chained to the project root authority."
+            echo "This is a one-time badge."
+            echo ""
+            echo "[![Vouch Verified Contributor](${BADGE})](https://vouch-protocol.com/contributors)"
+            echo ""
+            echo "**Add it to your profile or site (optional):**"
+            echo ""
+            echo '```markdown'
+            echo "[![Vouch Verified Contributor](${BADGE})](https://vouch-protocol.com/contributors)"
+            echo '```'
+            echo ""
+            echo "Verify it any time at https://vouch-protocol.com/contributors"
             echo ""
             echo "<details><summary>Your Verifiable Credential (eddsa-jcs-2022)</summary>"
             echo ""

--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -106,7 +106,7 @@ jobs:
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
-          BADGE: "https://img.shields.io/badge/Vouch-Verified_Contributor-00C853?style=for-the-badge&labelColor=2d2d2d"
+          BADGE: "https://img.shields.io/badge/Vouch-Verified_Contributor-7C2D3A?style=for-the-badge&labelColor=2d2d2d"
         run: |
           {
             echo "### Vouch Verified Contributor :sparkles:"

--- a/website/src/app/contributors/page.tsx
+++ b/website/src/app/contributors/page.tsx
@@ -1,0 +1,105 @@
+import Link from 'next/link';
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Verified Contributors - Vouch Protocol',
+    description:
+        'People who have contributed to Vouch Protocol, each issued a signed Vouch Verified Contributor credential.',
+};
+
+type Contributor = {
+    login: string;
+    pr: number;
+};
+
+// Verified contributors opt in to appear here. Add an entry when a contributor
+// asks to be listed. The credential itself is issued automatically on first merge.
+const CONTRIBUTORS: Contributor[] = [];
+
+const BADGE_URL =
+    'https://img.shields.io/badge/Vouch-Verified_Contributor-00C853?style=for-the-badge&labelColor=2d2d2d';
+
+const BADGE_SNIPPET = `[![Vouch Verified Contributor](${BADGE_URL})](https://vouch-protocol.com/contributors)`;
+
+export default function ContributorsPage() {
+    return (
+        <main className="min-h-screen bg-parchment text-ink">
+            <div className="max-w-prose-wide mx-auto px-6 py-16 md:py-24">
+                <header className="mb-12">
+                    <p className="eyebrow text-burgundy mb-3">Recognition</p>
+                    <h1 className="font-serif text-[2.2rem] md:text-[2.8rem] leading-tight tracking-tight mb-4">
+                        Vouch Verified Contributors
+                    </h1>
+                    <p className="font-serif italic text-ink-soft text-[1.1rem] max-w-prose leading-relaxed">
+                        Everyone who contributes to Vouch Protocol&trade; earns a signed Verified
+                        Contributor credential, issued with our own protocol and chained back to the
+                        project root authority. The badge is a real Verifiable Credential, not just a
+                        picture: anyone can verify it.
+                    </p>
+                </header>
+
+                <section className="mb-16 bg-parchment-warm border border-rule p-8 md:p-10">
+                    <h2 className="font-serif text-[1.5rem] font-semibold mb-4">The badge</h2>
+                    <p className="mb-6 text-ink leading-relaxed">
+                        Add it to your profile or site if you would like. It is offered, never forced.
+                    </p>
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img src={BADGE_URL} alt="Vouch Verified Contributor" className="mb-6" />
+                    <pre className="bg-ink text-parchment text-[0.85rem] p-4 overflow-x-auto">
+                        <code>{BADGE_SNIPPET}</code>
+                    </pre>
+                </section>
+
+                <section className="mb-16">
+                    <h2 className="font-serif text-[1.5rem] font-semibold mb-4">How it works</h2>
+                    <ul className="list-disc list-outside pl-5 space-y-2 marker:text-burgundy text-ink leading-relaxed">
+                        <li>Land your first merged pull request.</li>
+                        <li>A signed credential is minted automatically and posted on your PR.</li>
+                        <li>
+                            It is issued by <code>did:web:vouch-protocol.com:contributors</code> and
+                            chained to the root identity <code>did:web:vouch-protocol.com</code>.
+                        </li>
+                        <li>Verify it any time with the Vouch verifier or the SDK.</li>
+                    </ul>
+                </section>
+
+                <section>
+                    <h2 className="font-serif text-[1.5rem] font-semibold mb-6">Contributors</h2>
+                    {CONTRIBUTORS.length === 0 ? (
+                        <p className="font-serif italic text-ink-soft leading-relaxed">
+                            The first verified contributors will appear here. Want to be one?{' '}
+                            <Link
+                                href="https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22"
+                                className="text-burgundy underline"
+                            >
+                                Pick up a good first issue
+                            </Link>
+                            .
+                        </p>
+                    ) : (
+                        <ul className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                            {CONTRIBUTORS.map((c) => (
+                                <li key={c.login} className="bg-parchment-warm border border-rule p-4">
+                                    <Link
+                                        href={`https://github.com/${c.login}`}
+                                        className="font-mono text-burgundy no-underline"
+                                    >
+                                        @{c.login}
+                                    </Link>
+                                    <p className="text-ink-faint text-[0.85rem] mt-1">
+                                        <Link
+                                            href={`https://github.com/vouch-protocol/vouch/pull/${c.pr}`}
+                                            className="no-underline text-ink-faint"
+                                        >
+                                            PR #{c.pr}
+                                        </Link>
+                                    </p>
+                                </li>
+                            ))}
+                        </ul>
+                    )}
+                </section>
+            </div>
+        </main>
+    );
+}

--- a/website/src/app/contributors/page.tsx
+++ b/website/src/app/contributors/page.tsx
@@ -17,7 +17,7 @@ type Contributor = {
 const CONTRIBUTORS: Contributor[] = [];
 
 const BADGE_URL =
-    'https://img.shields.io/badge/Vouch-Verified_Contributor-00C853?style=for-the-badge&labelColor=2d2d2d';
+    'https://img.shields.io/badge/Vouch-Verified_Contributor-7C2D3A?style=for-the-badge&labelColor=2d2d2d';
 
 const BADGE_SNIPPET = `[![Vouch Verified Contributor](${BADGE_URL})](https://vouch-protocol.com/contributors)`;
 

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -19,6 +19,7 @@ const MORE = [
     { href: '/blog/', label: 'Blog' },
     { href: '/agent-trust-index/', label: 'Index' },
     { href: '/conformance/', label: 'Conformance' },
+    { href: '/contributors/', label: 'Contributors' },
 ];
 
 const navLinkClass = (active: boolean) =>


### PR DESCRIPTION
## Summary

Turns the Verified Contributor badge into something visual and opt-in, gives it a home, and adds a safety check.

## Changes

- **Visual badge + contributors page** (`website/src/app/contributors/page.tsx`, linked from the nav): explains the badge, shows the burgundy "Vouch Verified Contributor" badge, offers a copy-paste snippet, and lists verified contributors. The list is opt-in: contributors are added when they ask, never automatically.
- **Opt-in delivery**: the badge comment on a merged PR now leads with the visual badge and an "add it to your profile (optional)" snippet, with the credential JSON moved into a collapsible block. We never write to anyone's profile; the badge is offered, not imposed.
- **Self-verify step**: each freshly minted badge is verified against the published `contributors/did.json`. If the issuer key in Secrets does not match (for example, the root key got pasted by mistake), the job fails loudly instead of posting a silently-unverifiable badge.