### PR TITLE
style(website): double the left gutter, leave the right unchanged

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -105,7 +105,8 @@
 
 @layer components {
   .container-wide {
-    @apply max-w-[1400px] mx-auto px-6 md:px-14;
+    /* Asymmetric: left gutter is doubled, right gutter unchanged (pr matches the old px). */
+    @apply max-w-[1400px] mx-auto pl-12 pr-6 md:pl-28 md:pr-14;
   }
 
   .container-prose {


### PR DESCRIPTION
Doubles the left gutter on the shared `container-wide` wrapper (`pl-12` / `md:pl-28`, was `px-6` / `md:px-14`) while leaving the right gutter unchanged (`pr-6` / `md:pr-14`), per the request for more left breathing room without touching the right.

It is asymmetric on a centred container, so on viewports well past 1400px content sits slightly left of centre rather than dead-centre; at typical widths it is exactly "double the left, same right".

Verified locally.
