### PR TITLE
docs(website): fix Swift SDK install and link Swift Package Index

### DIFF
--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -331,14 +331,14 @@ This makes prompt-injection key-exfiltration impossible: even if the LLM is jail
         body: `
 ## Install
 
-VouchCore ships through Swift Package Manager. The native code is a prebuilt XCFramework hosted on the \`swift-v0.1.0\` release, so you do not need a Mac toolchain to build the Rust core yourself.
+VouchCore ships through Swift Package Manager from its own repository, \`vouch-protocol/vouch-swift\` (SwiftPM resolves a package from the repository root). The native code is a prebuilt XCFramework hosted on the \`swift-v0.1.0\` release, so you do not need a Mac toolchain to build the Rust core yourself.
 
-In Xcode use File then Add Package Dependencies and paste the repo URL, or add it to your \`Package.swift\`:
+In Xcode use File then Add Package Dependencies and paste \`https://github.com/vouch-protocol/vouch-swift.git\`, or add it to your \`Package.swift\`:
 
 \`\`\`swift
-.package(url: "https://github.com/vouch-protocol/vouch", from: "swift-v0.1.0"),
+.package(url: "https://github.com/vouch-protocol/vouch-swift", from: "0.1.0"),
 // then depend on the product:
-.product(name: "VouchCore", package: "vouch"),
+.product(name: "VouchCore", package: "vouch-swift"),
 \`\`\`
 
 Supports iOS 13+ and macOS 12+.

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -343,6 +343,8 @@ In Xcode use File then Add Package Dependencies and paste \`https://github.com/v
 
 Supports iOS 13+ and macOS 12+.
 
+VouchCore is listed on the [Swift Package Index](https://swiftpackageindex.com/vouch-protocol/vouch-swift), where you can browse the generated documentation and the platform compatibility matrix.
+
 ## Canonicalize and verify
 
 Everything runs on device. The \`Vouch\` facade gathers the lower-level UniFFI functions behind a discoverable surface:

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -81,9 +81,9 @@ const LANGUAGE_TILES = [
   },
   {
     name: 'Swift (iOS / macOS)',
-    install: 'add VouchCore via Swift Package Manager',
+    install: 'https://github.com/vouch-protocol/vouch-swift',
     repoPath: 'sdks/swift/',
-    note: 'Over the core via UniFFI, packaged as an XCFramework.',
+    note: 'Add via Swift Package Manager. Over the core via UniFFI, packaged as an XCFramework.',
   },
   {
     name: 'JVM (Java / Kotlin)',

--- a/website/src/app/tools/page.tsx
+++ b/website/src/app/tools/page.tsx
@@ -153,7 +153,7 @@ const GROUPS: Group[] = [
             { name: 'Rust', blurb: 'The shared core that every wrapper is built on.', start: 'cargo add vouch-core' },
             { name: 'Java and Kotlin', blurb: 'On the JVM.', start: 'com.vouchprotocol:vouch-core' },
             { name: '.NET', blurb: 'For C#.', start: 'VouchProtocol.Core', tag: 'Preview' },
-            { name: 'Swift', blurb: 'For iOS and macOS.', start: 'VouchCore', tag: 'Preview' },
+            { name: 'Swift', blurb: 'For iOS and macOS.', start: 'github.com/vouch-protocol/vouch-swift', tag: 'Preview' },
             { name: 'C and WebAssembly', blurb: 'For native, embedded, browser, and edge.', tag: 'Preview' },
         ],
     },


### PR DESCRIPTION
## What

Fixes the Swift SDK install instructions on the website and links the now-live Swift Package Index page.

## Changes

- **Swift Quickstart** ([help-data.ts](website/src/app/help/help-data.ts)): point at the standalone `vouch-protocol/vouch-swift` repo with `from: "0.1.0"` and the correct product `package: "vouch-swift"`. The old snippet referenced the monorepo URL with an invalid SemVer (`swift-v0.1.0`) and a wrong package name, which Swift Package Manager cannot resolve.
- **SDK tiles** ([page.tsx](website/src/app/page.tsx), [tools/page.tsx](website/src/app/tools/page.tsx)): reference the `vouch-swift` URL instead of vague prose.
- **SPI link**: the Swift Quickstart now links to `swiftpackageindex.com/vouch-protocol/vouch-swift` for the generated docs and platform compatibility matrix.

## Why

Swift Package Manager resolves a package from the repository root, so VouchCore is published from the standalone `vouch-swift` repository. The previous docs would have sent readers into an unresolvable install.
