### PR TITLE
fix(ci): auto-deploy the website after minting a contributor certificate

### DIFF
--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -22,6 +22,7 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  actions: write
 
 jobs:
   mint:
@@ -87,6 +88,7 @@ jobs:
       - name: Publish the certificate and list the contributor
         if: hashFiles('credential.json') != ''
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_AUTHOR: ${{ github.event.pull_request.user.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -122,6 +124,11 @@ jobs:
               git pull --rebase origin main && git push origin HEAD:main && break
               sleep $((2 ** i))
             done
+            # The commit above is pushed with GITHUB_TOKEN, which does not trigger
+            # the on:push deploy workflow. Dispatch it explicitly so the cert and
+            # the contributors list go live. workflow_dispatch still fires from
+            # GITHUB_TOKEN, unlike push.
+            gh workflow run deploy-website.yml --ref main
           fi
 
       - name: Congratulate the contributor


### PR DESCRIPTION
## Problem

When the Verified Contributor workflow mints a certificate, it commits the cert files to `main` using `GITHUB_TOKEN`. GitHub does not let `GITHUB_TOKEN` pushes trigger other workflows (recursion guard), so `deploy-website` never ran and the certificate page stayed unpublished (404) until someone deployed by hand.

## Fix

After the workflow commits the certificate, it now explicitly dispatches `deploy-website` via `workflow_dispatch`, which still fires from `GITHUB_TOKEN` (unlike `push`). Adds the `actions: write` permission required to dispatch a workflow.

## Effect

Every future contributor certificate and the `/contributors` listing publish automatically, with no manual deploy. No new secrets required.

## Verified

`verified-contributor.yml` parses as valid YAML and the dispatch step is in the publish path, guarded so it only runs when a new certificate was actually committed.
