### PR TITLE
Add robot liveness heartbeat and credential revocation

### DIFF
--- a/tests/test_robot_liveness_revocation.py
+++ b/tests/test_robot_liveness_revocation.py
@@ -344,4 +344,13 @@ class TestDidLevelRevocation:
             await registry.revoke(ROBOT, reason="hardware captured", revoked_by="did:web:fleet.op")
             assert await registry.is_revoked(ROBOT) is True
 
-        asyncio.run(run())
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(run())
+        finally:
+            loop.close()
+            # Leave a usable current event loop behind. On Python 3.9, asyncio.run
+            # (and a bare close) would set the current loop to None, after which a
+            # later test calling the deprecated asyncio.get_event_loop() raises.
+            asyncio.set_event_loop(asyncio.new_event_loop())

--- a/tests/test_robot_liveness_revocation.py
+++ b/tests/test_robot_liveness_revocation.py
@@ -1,0 +1,347 @@
+"""
+Tests for robot liveness heartbeat with safety-envelope conformance and trust
+decay (liveness) and for robot credential revocation (revocation).
+"""
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    MotionCollector,
+    RevocationRegistry,
+    attach_credential_status,
+    build_physical_scope_credential,
+    build_robot_heartbeat,
+    build_status_list_credential,
+    check_credential_status,
+    is_live,
+    validate_motion_digest,
+    verify_robot_heartbeat,
+)
+from vouch.robotics.identity import RoboticsError
+from vouch.status_list import StatusList
+
+ROBOT = "did:web:robot.example.com"
+
+
+@pytest.fixture
+def robot():
+    kp = generate_identity(domain="robot.example.com")
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+@pytest.fixture
+def authority():
+    kp = generate_identity(domain="authority.example.com")
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def _scope():
+    return {
+        "maxForceN": 80.0,
+        "maxSpeedMps": 1.5,
+        "maxSpeedNearHumansMps": 0.25,
+        "allowedZones": ["cell-3", "cell-4"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Motion collector + digest
+# ---------------------------------------------------------------------------
+
+
+class TestMotionCollector:
+    def test_in_envelope_digest(self):
+        c = MotionCollector(scope=_scope())
+        c.record(force_n=12.0, speed_mps=0.4, near_humans=False, zone="cell-3")
+        c.record(force_n=20.0, speed_mps=0.2, near_humans=True, zone="cell-4")
+        d = c.digest()
+        assert d["samples"] == 2
+        assert d["maxForceN"] == 20.0
+        assert d["maxSpeedMps"] == 0.4
+        assert d["maxSpeedNearHumansMps"] == 0.2
+        assert d["breachCount"] == 0
+        assert d["zoneBreaches"] == 0
+        assert d["withinEnvelope"] is True
+
+    def test_force_and_speed_breaches_counted(self):
+        c = MotionCollector(scope=_scope())
+        c.record(force_n=120.0, speed_mps=0.4, zone="cell-3")  # force over cap
+        c.record(force_n=10.0, speed_mps=2.0, zone="cell-3")  # speed over cap
+        c.record(force_n=10.0, speed_mps=0.5, near_humans=True, zone="cell-3")  # near-human speed
+        d = c.digest()
+        assert d["breachCount"] == 3
+        assert d["withinEnvelope"] is False
+        assert d["maxForceN"] == 120.0
+
+    def test_zone_breach_counted_separately(self):
+        c = MotionCollector(scope=_scope())
+        c.record(force_n=10.0, speed_mps=0.4, zone="cell-9")  # not allowed
+        d = c.digest()
+        assert d["breachCount"] == 1
+        assert d["zoneBreaches"] == 1
+        assert d["withinEnvelope"] is False
+
+    def test_without_scope_reports_maxima_but_no_judgement(self):
+        c = MotionCollector()  # no scope
+        c.record(force_n=999.0, speed_mps=9.0)
+        d = c.digest()
+        assert d["maxForceN"] == 999.0
+        assert d["maxSpeedMps"] == 9.0
+        assert d["breachCount"] == 0
+        assert d["withinEnvelope"] is True
+
+    def test_reset_clears(self):
+        c = MotionCollector(scope=_scope())
+        c.record(force_n=120.0, speed_mps=0.4, zone="cell-3")
+        c.reset()
+        d = c.digest()
+        assert d == {
+            "samples": 0,
+            "maxForceN": 0.0,
+            "maxSpeedMps": 0.0,
+            "maxSpeedNearHumansMps": 0.0,
+            "zoneBreaches": 0,
+            "breachCount": 0,
+            "withinEnvelope": True,
+        }
+
+    def test_negative_inputs_rejected(self):
+        c = MotionCollector()
+        with pytest.raises(RoboticsError):
+            c.record(force_n=-1.0)
+        with pytest.raises(RoboticsError):
+            c.record(speed_mps=-0.1)
+
+
+class TestValidateMotionDigest:
+    def test_accepts_well_formed(self):
+        validate_motion_digest(MotionCollector().digest())
+
+    def test_rejects_missing_field(self):
+        d = MotionCollector().digest()
+        del d["withinEnvelope"]
+        with pytest.raises(RoboticsError):
+            validate_motion_digest(d)
+
+    def test_rejects_bad_types(self):
+        d = MotionCollector().digest()
+        d["withinEnvelope"] = "yes"
+        with pytest.raises(RoboticsError):
+            validate_motion_digest(d)
+        d2 = MotionCollector().digest()
+        d2["breachCount"] = True  # bool is not a valid count
+        with pytest.raises(RoboticsError):
+            validate_motion_digest(d2)
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat build / verify
+# ---------------------------------------------------------------------------
+
+
+class TestHeartbeat:
+    def test_build_and_verify(self, robot):
+        kp, s = robot
+        c = MotionCollector(scope=_scope())
+        c.record(force_n=12.0, speed_mps=0.4, zone="cell-3")
+        hb = build_robot_heartbeat(
+            s,
+            session_id="urn:uuid:sess-1",
+            interval_index=0,
+            motion_digest=c.digest(),
+            interval_seconds=30,
+        )
+        assert "RobotHeartbeatCredential" in hb["type"]
+        ok, subject = verify_robot_heartbeat(hb, kp.public_key_jwk)
+        assert ok is True
+        assert subject["sessionId"] == "urn:uuid:sess-1"
+        assert subject["intervalSeconds"] == 30
+
+    def test_tampered_digest_fails_verification(self, robot):
+        kp, s = robot
+        hb = build_robot_heartbeat(
+            s,
+            session_id="s",
+            interval_index=1,
+            motion_digest=MotionCollector().digest(),
+            interval_seconds=30,
+        )
+        hb["credentialSubject"]["motionDigest"]["maxForceN"] = 1.0
+        ok, subject = verify_robot_heartbeat(hb, kp.public_key_jwk)
+        assert ok is False
+        assert subject is None
+
+    def test_wrong_key_fails(self, robot):
+        _, s = robot
+        other = generate_identity(domain="other.example.com")
+        hb = build_robot_heartbeat(
+            s,
+            session_id="s",
+            interval_index=0,
+            motion_digest=MotionCollector().digest(),
+            interval_seconds=30,
+        )
+        ok, _ = verify_robot_heartbeat(hb, other.public_key_jwk)
+        assert ok is False
+
+    def test_build_rejects_bad_inputs(self, robot):
+        _, s = robot
+        good = MotionCollector().digest()
+        with pytest.raises(RoboticsError):
+            build_robot_heartbeat(
+                s, session_id="s", interval_index=-1, motion_digest=good, interval_seconds=30
+            )
+        with pytest.raises(RoboticsError):
+            build_robot_heartbeat(
+                s, session_id="s", interval_index=0, motion_digest=good, interval_seconds=0
+            )
+
+
+# ---------------------------------------------------------------------------
+# Trust decay (is_live)
+# ---------------------------------------------------------------------------
+
+
+class TestIsLive:
+    def _hb(self, signer, *, issued_at, digest=None, interval_seconds=30):
+        return build_robot_heartbeat(
+            signer,
+            session_id="s",
+            interval_index=0,
+            motion_digest=digest or MotionCollector(scope=_scope()).digest(),
+            interval_seconds=interval_seconds,
+            issued_at=issued_at,
+        )
+
+    def test_fresh_and_conformant_is_live(self, robot):
+        _, s = robot
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        hb = self._hb(s, issued_at=now)
+        assert is_live(hb, now=now + timedelta(seconds=10)) is True
+
+    def test_stale_is_not_live(self, robot):
+        _, s = robot
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        hb = self._hb(s, issued_at=now, interval_seconds=30)
+        # 30s cadence, 2 grace intervals = 60s tolerance; 120s later is stale.
+        assert is_live(hb, now=now + timedelta(seconds=120)) is False
+
+    def test_breach_is_never_live_even_if_fresh(self, robot):
+        _, s = robot
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        c = MotionCollector(scope=_scope())
+        c.record(force_n=999.0, speed_mps=0.1, zone="cell-3")  # force breach
+        hb = self._hb(s, issued_at=now, digest=c.digest())
+        assert is_live(hb, now=now + timedelta(seconds=1)) is False
+
+    def test_future_heartbeat_rejected(self, robot):
+        _, s = robot
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        hb = self._hb(s, issued_at=now + timedelta(hours=1))
+        assert is_live(hb, now=now, interval_seconds=30) is False
+
+    def test_grace_intervals_extends_tolerance(self, robot):
+        _, s = robot
+        now = datetime(2026, 6, 20, 12, 0, 0, tzinfo=timezone.utc)
+        hb = self._hb(s, issued_at=now, interval_seconds=30)
+        # 100s later: stale at 2 grace intervals, live at 4.
+        assert is_live(hb, now=now + timedelta(seconds=100), grace_intervals=2) is False
+        assert is_live(hb, now=now + timedelta(seconds=100), grace_intervals=4) is True
+
+
+# ---------------------------------------------------------------------------
+# Revocation: surgical per-credential status
+# ---------------------------------------------------------------------------
+
+
+class TestCredentialStatus:
+    LIST_URL = "https://authority.example.com/status/robots/1"
+
+    def _status_list_cred(self, issuer_did, *, set_index=None):
+        sl = StatusList(status_list_id=self.LIST_URL)
+        if set_index is not None:
+            sl.set_status(set_index, True)
+        return build_status_list_credential(issuer_did=issuer_did, status_list=sl)
+
+    def test_attach_status_resigns_and_verifies(self, robot, authority):
+        kp, s = robot
+        scope_cred = build_physical_scope_credential(s, subject_did=ROBOT, max_force_n=80.0)
+        with_status = attach_credential_status(
+            scope_cred,
+            s,
+            status_list_credential=self.LIST_URL,
+            status_list_index=42,
+        )
+        assert with_status["credentialSubject"]["id"] == ROBOT
+        cs = with_status["credentialStatus"]
+        assert cs["statusListIndex"] == "42"
+        # Proof still verifies after re-signing over the added status.
+        from vouch import data_integrity
+        from vouch.verifier import _coerce_ed25519_public_key
+
+        assert data_integrity.verify_proof(
+            with_status, _coerce_ed25519_public_key(kp.public_key_jwk)
+        )
+
+    def test_not_revoked_when_bit_unset(self, robot, authority):
+        _, s = robot
+        akp, a = authority
+        cred = build_physical_scope_credential(s, subject_did=ROBOT, max_force_n=80.0)
+        cred = attach_credential_status(
+            cred, s, status_list_credential=self.LIST_URL, status_list_index=42
+        )
+        sl_cred = self._status_list_cred(a.get_did(), set_index=None)
+        assert check_credential_status(cred, sl_cred) is False
+
+    def test_revoked_when_bit_set(self, robot, authority):
+        _, s = robot
+        akp, a = authority
+        cred = build_physical_scope_credential(s, subject_did=ROBOT, max_force_n=80.0)
+        cred = attach_credential_status(
+            cred, s, status_list_credential=self.LIST_URL, status_list_index=42
+        )
+        sl_cred = self._status_list_cred(a.get_did(), set_index=42)
+        assert check_credential_status(cred, sl_cred) is True
+
+    def test_no_status_entry_reads_as_not_revoked(self, robot, authority):
+        _, s = robot
+        _, a = authority
+        cred = build_physical_scope_credential(s, subject_did=ROBOT, max_force_n=80.0)
+        sl_cred = self._status_list_cred(a.get_did(), set_index=42)
+        assert check_credential_status(cred, sl_cred) is False
+
+    def test_multiple_status_entries_appended(self, robot):
+        _, s = robot
+        cred = build_physical_scope_credential(s, subject_did=ROBOT, max_force_n=80.0)
+        cred = attach_credential_status(
+            cred, s, status_list_credential=self.LIST_URL, status_list_index=1
+        )
+        cred = attach_credential_status(
+            cred,
+            s,
+            status_list_credential=self.LIST_URL,
+            status_list_index=2,
+            status_purpose="suspension",
+        )
+        assert isinstance(cred["credentialStatus"], list)
+        assert len(cred["credentialStatus"]) == 2
+
+
+# ---------------------------------------------------------------------------
+# Revocation: whole-DID kill via the existing registry
+# ---------------------------------------------------------------------------
+
+
+class TestDidLevelRevocation:
+    def test_robot_did_revokes_and_checks(self):
+        async def run():
+            registry = RevocationRegistry(check_remote=False)
+            assert await registry.is_revoked(ROBOT) is False
+            await registry.revoke(ROBOT, reason="hardware captured", revoked_by="did:web:fleet.op")
+            assert await registry.is_revoked(ROBOT) is True
+
+        asyncio.run(run())

--- a/vouch/robotics/__init__.py
+++ b/vouch/robotics/__init__.py
@@ -10,6 +10,8 @@ robots and embodied agents:
   - handshake: robot-to-robot bounded-trust handshake across domains.
   - blackbox: encrypted append-only flight recorder + kill-switch credential.
   - passport: scannable (QR/NFC) robot passport and verifier.
+  - liveness: robot heartbeat with safety-envelope conformance and trust decay.
+  - revocation: whole-DID kill and surgical per-credential revocation.
 """
 
 from .capability import (
@@ -52,6 +54,21 @@ from .passport import (
     encode_passport,
     verify_passport,
 )
+from .liveness import (
+    MotionCollector,
+    MotionSample,
+    build_robot_heartbeat,
+    is_live,
+    validate_motion_digest,
+    verify_robot_heartbeat,
+)
+from .revocation import (
+    RevocationRegistry,
+    attach_credential_status,
+    build_status_list_credential,
+    build_status_list_entry,
+    check_credential_status,
+)
 
 __all__ = [
     # identity
@@ -88,4 +105,17 @@ __all__ = [
     "encode_passport",
     "decode_passport",
     "verify_passport",
+    # liveness (robot heartbeat + conformance + trust decay)
+    "MotionCollector",
+    "MotionSample",
+    "build_robot_heartbeat",
+    "verify_robot_heartbeat",
+    "validate_motion_digest",
+    "is_live",
+    # revocation
+    "RevocationRegistry",
+    "attach_credential_status",
+    "check_credential_status",
+    "build_status_list_credential",
+    "build_status_list_entry",
 ]

--- a/vouch/robotics/liveness.py
+++ b/vouch/robotics/liveness.py
@@ -1,0 +1,369 @@
+"""
+Robot liveness heartbeat with safety-envelope conformance attestation.
+
+A robot's identity and capability credentials, once minted, are otherwise valid
+until something revokes them. This module makes robot trust living: the robot
+periodically re-attests that it is alive and that its actual motion over the last
+interval stayed inside the physical envelope its capability credential permits. A
+verifier then treats the robot as trusted only while a fresh, conformant
+heartbeat exists, inverting the model from "trusted until revoked" to "untrusted
+until renewed", the same inversion the agent Heartbeat Protocol applies, adapted
+to physical telemetry.
+
+The per-interval "motion digest" is the physical analogue of the agent
+behavioral digest. It carries aggregates of what the robot actually did over the
+interval (peak force, peak speed, peak speed while a human was near, count of
+zone breaches) and asserts whether those stayed inside the declared envelope:
+
+  {
+    "samples": <int>,                  # telemetry samples observed this interval
+    "maxForceN": <number>,             # peak force observed, newtons
+    "maxSpeedMps": <number>,           # peak speed observed, m/s
+    "maxSpeedNearHumansMps": <number>, # peak speed observed while a human was near
+    "zoneBreaches": <int>,             # samples observed outside an allowed zone
+    "breachCount": <int>,              # total samples that violated the envelope
+    "withinEnvelope": <bool>           # breachCount == 0
+  }
+
+A RobotHeartbeatCredential is an eddsa-jcs-2022 VC carrying the robot DID, a
+session id, the interval index, the declared interval length, and the motion
+digest, signed by the robot's own key. Trust freshness is evaluated by
+`is_live`, which requires both a recent heartbeat and an in-envelope digest.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from threading import Lock
+from typing import Any, Dict, List, Optional
+
+from .capability import PhysicalAction, check_physical_action
+from .identity import RoboticsError
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+ROBOT_HEARTBEAT_TYPE = "RobotHeartbeatCredential"
+
+# Default number of missed intervals tolerated before trust is considered stale.
+DEFAULT_GRACE_INTERVALS = 2
+
+
+@dataclass
+class MotionSample:
+    """One observed motion sample, used for testing and audit."""
+
+    force_n: Optional[float]
+    speed_mps: Optional[float]
+    near_humans: bool
+    zone: Optional[str]
+    timestamp_ns: int
+
+
+@dataclass
+class MotionCollector:
+    """
+    Thread-safe collector for per-interval motion telemetry.
+
+    The collector accumulates aggregates of what the robot physically did over a
+    heartbeat interval and, when given the robot's physical scope, counts how
+    many samples fell outside the declared envelope.
+
+    Typical lifecycle:
+
+      collector = MotionCollector(scope=physical_scope_subject["physicalScope"])
+      # ... during the interval, the controller records each commanded motion ...
+      collector.record(force_n=12.0, speed_mps=0.4, near_humans=True, zone="cell-3")
+      # ... heartbeat time ...
+      digest = collector.digest()
+      collector.reset()
+
+    Attributes:
+      scope: Optional physicalScope object (the credentialSubject.physicalScope
+        from a PhysicalCapabilityScope credential). When supplied, each recorded
+        sample is checked against it and breaches are counted. When omitted, the
+        digest still reports observed maxima but cannot judge conformance, so it
+        reports withinEnvelope true with a zero breach count.
+    """
+
+    scope: Optional[Dict[str, Any]] = None
+    _lock: Lock = field(default_factory=Lock, init=False, repr=False)
+    _samples: int = field(default=0, init=False)
+    _max_force: float = field(default=0.0, init=False)
+    _max_speed: float = field(default=0.0, init=False)
+    _max_speed_near: float = field(default=0.0, init=False)
+    _zone_breaches: int = field(default=0, init=False)
+    _breaches: int = field(default=0, init=False)
+    _audit: List[MotionSample] = field(default_factory=list, init=False, repr=False)
+
+    def record(
+        self,
+        *,
+        force_n: Optional[float] = None,
+        speed_mps: Optional[float] = None,
+        near_humans: bool = False,
+        zone: Optional[str] = None,
+        time_hm: Optional[str] = None,
+    ) -> None:
+        """
+        Record a single observed motion sample.
+
+        Args:
+          force_n: Force exerted in this sample, newtons.
+          speed_mps: Speed in this sample, m/s.
+          near_humans: Whether a human was within the safety distance.
+          zone: Zone id the robot was operating in.
+          time_hm: Local "HH:MM" the sample occurred, for shift-window checks.
+        """
+        if force_n is not None and force_n < 0:
+            raise RoboticsError(f"force_n must be non-negative, got {force_n}")
+        if speed_mps is not None and speed_mps < 0:
+            raise RoboticsError(f"speed_mps must be non-negative, got {speed_mps}")
+
+        with self._lock:
+            self._samples += 1
+            if force_n is not None:
+                self._max_force = max(self._max_force, float(force_n))
+            if speed_mps is not None:
+                self._max_speed = max(self._max_speed, float(speed_mps))
+                if near_humans:
+                    self._max_speed_near = max(self._max_speed_near, float(speed_mps))
+
+            if self.scope is not None:
+                action = PhysicalAction(
+                    force_n=force_n,
+                    speed_mps=speed_mps,
+                    near_humans=near_humans,
+                    zone=zone,
+                    time_hm=time_hm,
+                )
+                result = check_physical_action(self.scope, action)
+                if not result.ok:
+                    self._breaches += 1
+                    if any(r.startswith("zone_not_allowed") for r in result.reasons):
+                        self._zone_breaches += 1
+
+            if len(self._audit) < 4096:
+                self._audit.append(
+                    MotionSample(
+                        force_n=float(force_n) if force_n is not None else None,
+                        speed_mps=float(speed_mps) if speed_mps is not None else None,
+                        near_humans=near_humans,
+                        zone=zone,
+                        timestamp_ns=_now_ns(),
+                    )
+                )
+
+    def snapshot_samples(self) -> List[MotionSample]:
+        """Return a copy of the per-sample audit trail (not part of the digest)."""
+        with self._lock:
+            return list(self._audit)
+
+    def digest(self) -> Dict[str, Any]:
+        """Return the motionDigest object for embedding in a heartbeat credential."""
+        with self._lock:
+            return {
+                "samples": self._samples,
+                "maxForceN": self._max_force,
+                "maxSpeedMps": self._max_speed,
+                "maxSpeedNearHumansMps": self._max_speed_near,
+                "zoneBreaches": self._zone_breaches,
+                "breachCount": self._breaches,
+                "withinEnvelope": self._breaches == 0,
+            }
+
+    def reset(self) -> None:
+        """Clear all state. Call after submitting a heartbeat to start fresh."""
+        with self._lock:
+            self._samples = 0
+            self._max_force = 0.0
+            self._max_speed = 0.0
+            self._max_speed_near = 0.0
+            self._zone_breaches = 0
+            self._breaches = 0
+            self._audit.clear()
+
+
+def validate_motion_digest(digest: Dict[str, Any]) -> None:
+    """
+    Structural validation of a motionDigest object. Raises RoboticsError on
+    malformed input. Does not judge whether the values are acceptable; that is
+    policy, expressed through `is_live` and the verifier's thresholds.
+    """
+    if not isinstance(digest, dict):
+        raise RoboticsError("motionDigest must be a dict")
+
+    for name in ("samples", "zoneBreaches", "breachCount"):
+        if name not in digest:
+            raise RoboticsError(f"motionDigest.{name} is required")
+        if not isinstance(digest[name], int) or isinstance(digest[name], bool) or digest[name] < 0:
+            raise RoboticsError(f"motionDigest.{name} must be a non-negative integer")
+
+    for name in ("maxForceN", "maxSpeedMps", "maxSpeedNearHumansMps"):
+        if name not in digest:
+            raise RoboticsError(f"motionDigest.{name} is required")
+        if isinstance(digest[name], bool) or not isinstance(digest[name], (int, float)):
+            raise RoboticsError(f"motionDigest.{name} must be a number")
+        if digest[name] < 0:
+            raise RoboticsError(f"motionDigest.{name} must be non-negative")
+
+    if "withinEnvelope" not in digest:
+        raise RoboticsError("motionDigest.withinEnvelope is required")
+    if not isinstance(digest["withinEnvelope"], bool):
+        raise RoboticsError("motionDigest.withinEnvelope must be a boolean")
+
+
+def build_robot_heartbeat(
+    signer: Any,
+    *,
+    session_id: str,
+    interval_index: int,
+    motion_digest: Dict[str, Any],
+    interval_seconds: int,
+    issued_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed RobotHeartbeatCredential.
+
+    The robot self-issues the credential with its own Vouch key. `motion_digest`
+    is produced by a MotionCollector over the interval; `interval_seconds` is the
+    declared heartbeat cadence, which a verifier uses to judge freshness.
+    """
+    if interval_index < 0:
+        raise RoboticsError("interval_index must be non-negative")
+    if interval_seconds <= 0:
+        raise RoboticsError("interval_seconds must be positive")
+    validate_motion_digest(motion_digest)
+
+    issued = (issued_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    robot_did = signer.get_did()
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "sessionId": session_id,
+        "intervalIndex": interval_index,
+        "intervalSeconds": interval_seconds,
+        "motionDigest": motion_digest,
+    }
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", ROBOT_HEARTBEAT_TYPE],
+        "issuer": robot_did,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    return attach_proof(credential, signer)
+
+
+def verify_robot_heartbeat(
+    credential: Dict[str, Any],
+    robot_public_key: Any,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a RobotHeartbeatCredential: the credential proof (robot key) and the
+    structural validity of the embedded motion digest. Returns (ok, subject).
+
+    This checks authenticity and shape only. Whether the robot is currently
+    trusted is a separate, time-dependent question answered by `is_live`.
+    """
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if ROBOT_HEARTBEAT_TYPE not in type_field:
+        return False, None
+
+    resolved = (
+        _coerce_ed25519_public_key(robot_public_key) if robot_public_key is not None else None
+    )
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = credential.get("credentialSubject") or {}
+    digest = subject.get("motionDigest")
+    try:
+        validate_motion_digest(digest)
+    except RoboticsError:
+        return False, None
+
+    return True, subject
+
+
+def is_live(
+    credential: Dict[str, Any],
+    *,
+    now: Optional[datetime] = None,
+    interval_seconds: Optional[int] = None,
+    grace_intervals: int = DEFAULT_GRACE_INTERVALS,
+) -> bool:
+    """
+    Decide whether a robot is currently trusted, given its most recent heartbeat.
+
+    A robot is live only if BOTH hold:
+      1. Freshness: the heartbeat was issued within `grace_intervals` cadence
+         periods of `now`. A robot that stopped sending heartbeats loses trust.
+      2. Conformance: the heartbeat's motion digest reports withinEnvelope true.
+         A robot that exceeded its physical envelope loses trust even if recent.
+
+    `interval_seconds` defaults to the value the heartbeat itself declares. The
+    caller should still pass the cadence it expects when it does not trust the
+    robot's self-declared interval.
+    """
+    subject = credential.get("credentialSubject") or {}
+    digest = subject.get("motionDigest") or {}
+    if not digest.get("withinEnvelope", False):
+        return False
+
+    cadence = interval_seconds if interval_seconds is not None else subject.get("intervalSeconds")
+    if not isinstance(cadence, int) or cadence <= 0:
+        return False
+    if grace_intervals < 1:
+        raise RoboticsError("grace_intervals must be at least 1")
+
+    raw = credential.get("validFrom")
+    if not raw:
+        return False
+    try:
+        issued = _parse_iso(raw)
+    except (ValueError, TypeError):
+        return False
+
+    moment = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    deadline = issued + timedelta(seconds=cadence * grace_intervals)
+    # A heartbeat from the future (clock skew beyond one cadence) is not trusted.
+    if moment + timedelta(seconds=cadence) < issued:
+        return False
+    return moment <= deadline
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def _now_ns() -> int:
+    import time as _time
+
+    return _time.time_ns()
+
+
+__all__ = [
+    "ROBOT_HEARTBEAT_TYPE",
+    "DEFAULT_GRACE_INTERVALS",
+    "MotionSample",
+    "MotionCollector",
+    "validate_motion_digest",
+    "build_robot_heartbeat",
+    "verify_robot_heartbeat",
+    "is_live",
+]

--- a/vouch/robotics/revocation.py
+++ b/vouch/robotics/revocation.py
@@ -1,0 +1,126 @@
+"""
+Revocation for robot credentials.
+
+Robot identity, provenance, and capability credentials need the same two-level
+revocation the rest of Vouch already provides, applied to physical machines:
+
+  - Whole-DID kill (key compromise): a robot whose identity key is leaked or
+    whose hardware is captured is revoked at the DID level through the existing
+    `vouch.revocation.RevocationRegistry`. A robot DID is an ordinary DID, so the
+    registry and the `.well-known/did-revocations.json` distribution path work
+    unchanged. This is re-exported here for discoverability.
+
+  - Surgical per-credential revocation: a single capability grant, a superseded
+    provenance attestation, or one identity credential is retired without killing
+    the robot's whole identity, by carrying a BitstringStatusList entry. This
+    module adds the ergonomics for putting that entry on any robot credential and
+    checking it, over the existing `vouch.status_list` primitives.
+
+The fleet-scale operation of these (SLA'd propagation, dashboards, cross-fleet
+aggregation) is a service concern layered on top; the formats and the verifier
+here are the open, free protocol surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from .. import status_list as _status_list
+from ..revocation import RevocationRegistry
+from ..status_list import (
+    STATUS_PURPOSE_REVOCATION,
+    StatusListError,
+    build_status_list_credential,
+    build_status_list_entry,
+)
+from .identity import RoboticsError
+from ._signing import attach_proof
+
+
+def attach_credential_status(
+    credential: Dict[str, Any],
+    signer: Any,
+    *,
+    status_list_credential: str,
+    status_list_index: int,
+    status_purpose: str = STATUS_PURPOSE_REVOCATION,
+    entry_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Add a BitstringStatusList `credentialStatus` entry to a robot credential and
+    (re)sign it, so the credential can later be revoked or suspended surgically.
+
+    The entry references a bit index in a published status list credential. The
+    credential is signed after the entry is added, so the proof covers the status
+    binding. Any pre-existing proof is replaced. If the credential already
+    carries a credentialStatus, the new entry is appended (the field becomes a
+    list), matching the Verifiable Credentials data model.
+
+    Returns the signed credential.
+    """
+    entry = build_status_list_entry(
+        status_list_credential=status_list_credential,
+        status_list_index=status_list_index,
+        status_purpose=status_purpose,
+        entry_id=entry_id,
+    )
+
+    existing = credential.get("credentialStatus")
+    if existing is None:
+        credential["credentialStatus"] = entry
+    elif isinstance(existing, list):
+        existing.append(entry)
+    else:
+        credential["credentialStatus"] = [existing, entry]
+
+    # Re-sign: the proof must cover the credentialStatus we just added.
+    credential.pop("proof", None)
+    return attach_proof(credential, signer)
+
+
+def _status_entries(credential: Dict[str, Any]) -> List[Dict[str, Any]]:
+    raw = credential.get("credentialStatus")
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [e for e in raw if isinstance(e, dict)]
+    if isinstance(raw, dict):
+        return [raw]
+    raise RoboticsError("credentialStatus must be a dict or a list of dicts")
+
+
+def check_credential_status(
+    credential: Dict[str, Any],
+    status_list_credential: Dict[str, Any],
+    *,
+    status_purpose: str = STATUS_PURPOSE_REVOCATION,
+) -> bool:
+    """
+    Return True if the robot credential's status bit for `status_purpose` is set
+    (for example, the credential has been revoked) in the supplied status list.
+
+    The caller MUST verify the Data Integrity proof on `status_list_credential`
+    before calling this, exactly as for the agent-side `status_list.verify_status`.
+    Returns False when the credential carries no matching status entry.
+    """
+    referenced_id = status_list_credential.get("id")
+    for entry in _status_entries(credential):
+        if entry.get("statusPurpose") != status_purpose:
+            continue
+        if entry.get("statusListCredential") != referenced_id:
+            continue
+        return _status_list.verify_status(
+            credential_status=entry,
+            status_list_credential=status_list_credential,
+        )
+    return False
+
+
+__all__ = [
+    "RevocationRegistry",
+    "StatusListError",
+    "build_status_list_credential",
+    "build_status_list_entry",
+    "attach_credential_status",
+    "check_credential_status",
+]


### PR DESCRIPTION
Adds two open robotics primitives in vouch/robotics/, both reusing existing Vouch mechanisms.

## Robot liveness heartbeat (liveness.py)
Makes robot trust living instead of one-time. A robot periodically self-signs a RobotHeartbeatCredential carrying a per-interval motion digest (peak force, peak speed, peak speed near humans, zone breaches) aggregated by a MotionCollector against its PhysicalCapabilityScope. is_live treats a robot as trusted only while a fresh AND in-envelope heartbeat exists, the untrusted-until-renewed inversion applied to a physical machine. This mirrors the agent Heartbeat Protocol and behavioral attestation, adapted to physical telemetry.

## Credential revocation (revocation.py)
Two-level revocation for robot credentials: surgical per-credential status via the existing BitstringStatusList (attach_credential_status / check_credential_status), and whole-DID kill via the existing RevocationRegistry (re-exported). A robot DID is an ordinary DID, so the registry and .well-known distribution path work unchanged.

## Tests
28 new tests (tests/test_robot_liveness_revocation.py): motion digest aggregation and conformance, heartbeat build/verify, trust decay (fresh, stale, breach, future skew, grace intervals), per-credential status set/unset, multiple status entries, and DID-level revocation. Full robotics suite: 49 passing. ruff format + lint clean.

Reuses: capability.check_physical_action, status_list, revocation, data_integrity, the robotics _signing helper.