### PR TITLE
Add contributors link and social channels to the footer, fix cert comment formatting

### DIFF
--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -161,6 +161,7 @@ jobs:
             echo ""
             echo '```json'
             cat credential.json
+            echo ""
             echo '```'
             echo ""
             echo "</details>"

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -39,9 +39,13 @@ const FOOTER_GROUPS = [
   {
     title: 'Community',
     links: [
+      { label: 'Contributors', href: '/contributors/' },
       { label: 'Discord', href: 'https://discord.gg/mMqx5cG9Y', external: true },
       { label: 'GitHub issues', href: 'https://github.com/vouch-protocol/vouch/issues', external: true },
       { label: 'X / Twitter', href: 'https://x.com/Vouch_Protocol', external: true },
+      { label: 'Bluesky', href: 'https://bsky.app/profile/vouch-protocol.com', external: true },
+      { label: 'LinkedIn', href: 'https://www.linkedin.com/company/vouch-protocol-ai/', external: true },
+      { label: 'Instagram', href: 'https://www.instagram.com/vouch.protocol/', external: true },
     ],
   },
 ];


### PR DESCRIPTION
## Footer: contributors link and social parity

The `/contributors` page had no navigation link anywhere on the site. This adds **Contributors** to the footer Community group, plus **Bluesky**, **LinkedIn**, and **Instagram**, matching the channels the certificate share rail already uses. All four URLs were checked live (200), and the Bluesky handle `vouch-protocol.com` resolves to its DID.

## CI: keep the certificate comment code fence on its own line

`credential.json` is written without a trailing newline, so `cat credential.json` left the closing ``` glued to the final brace. The JSON block then rendered with a stray ``` and a leaked `</details>`. Added a newline before the closing fence. The already-posted comment on #110 was repaired in place as well.

## Verified

- `npm run build` passes; `/contributors` still compiles.
- `verified-contributor.yml` parses as valid YAML.
- Bluesky, LinkedIn, Instagram, and X all return 200.
