### PR TITLE
feat(reputation): evidence-backed reputation (receipts, aggregation, ledger, policy, portability, disputes)

### DIFF
--- a/docs/specs/reputation-aggregation.md
+++ b/docs/specs/reputation-aggregation.md
@@ -1,0 +1,124 @@
+# Vouch Reputation: Evidence-Backed Aggregation (design spec)
+
+Status: draft. This is the contract the `vouch` reputation modules implement.
+
+## Principle
+
+Reputation is a verifiable aggregate of signed, interaction-bound receipts,
+computed by a public deterministic function and keyed to an agent's DID. A
+consumer trusts the signatures and the function, never a server's stored number.
+Given the same receipts and the same function version, every party computes the
+same score.
+
+This supersedes a mutable operator-kept score. The existing `vouch.reputation`
+engine remains as an optional, subjective signal; this system is the
+evidence-backed path.
+
+## Dimensions
+
+Scores are multi-dimensional. The baseline set:
+
+- `reliability` - did the agent's actions and pre-committed claims hold up.
+- `performance` - latency, throughput, SLA adherence.
+- `compliance` - policy and authorization adherence; absence of violations.
+- `satisfaction` - subjective counterparty experience.
+
+A `composite` is derived from the dimensions. The set is extensible; unknown
+dimensions are carried through.
+
+## Receipts (the inputs)
+
+Every input is a signed Verifiable Credential about an agent DID, tied to an
+`interactionId`. Four types, objective-first:
+
+| Type | Issuer | Objectivity | Base weight |
+|---|---|---|---|
+| `StateReceipt` | the relying party the agent acted on | objective | high |
+| `OutcomeAttestationCredential` | a neutral settler (existing) | objective | high |
+| `PenaltyReceipt` | a validator or authority | objective | high |
+| `ReviewCredential` | a human rater, bound to proof-of-interaction (existing) | subjective | low |
+
+A receipt the agent can withhold (an agent-issued receipt) is not admissible as
+an objective signal. The strong objective source is the relying-party
+`StateReceipt`, which the counterparty issues.
+
+## Normalization
+
+Each receipt normalizes to zero or more `Signal`s:
+
+```
+Signal = {
+  dimension: str,
+  value: float in [-1, 1],   # -1 worst, +1 best
+  source_type: str,          # the receipt type, drives base weight
+  issuer: str,               # issuer DID, for issuer-weighting
+  interaction_id: str,
+  timestamp: datetime,       # the receipt's validFrom
+}
+```
+
+Normalization rules:
+
+- `StateReceipt`: `result == success` to `reliability +1`, `failure` to `-1`;
+  `slaMet` to `performance +/-1`.
+- `OutcomeAttestationCredential`: `outcome.matchesCommitment` to `reliability +/-1`.
+- `PenaltyReceipt`: a negative signal on the named dimension (default
+  `compliance`), magnitude `-severity`, with `severity` in `[0, 1]`.
+- `ReviewCredential`: each rating `r` in `1..5` maps to `(r - 3) / 2` on the
+  matching dimension, else `satisfaction`.
+
+## Aggregation function
+
+Deterministic and versioned (`AGGREGATION_VERSION`). For each dimension, over its
+signals:
+
+```
+w(signal)        = type_weight[source_type]
+                 * decay(age, half_life)
+                 * issuer_weight(issuer)
+                 * stake_factor(signal)
+decay(age, hl)   = 0.5 ** (age_days / half_life_days)
+dimension_score  = baseline + span * ( Σ value*w / max(Σ w, eps) )   # clamped [0, 100]
+composite        = support-weighted mean of the present dimension scores
+```
+
+Defaults: `baseline = 50`, `span = 50` (scores in `[0, 100]`), `half_life = 90
+days`, `type_weight = {StateReceipt: 1.0, OutcomeAttestationCredential: 1.0,
+PenaltyReceipt: 1.0, ReviewCredential: 0.4}`. `issuer_weight` defaults to uniform
+`1.0`; a recursive issuer-reputation weighting is a later refinement.
+`stake_factor` defaults to `1.0`.
+
+The function is pure: inputs are the signals plus an explicit evaluation time
+`at`, so any party recomputes the same result.
+
+## Verification model
+
+A consumer verifies a score by (1) checking each receipt's Data Integrity proof
+against its issuer, (2) discarding receipts from revoked or inadmissible issuers,
+and (3) replaying the named `AGGREGATION_VERSION` over the admissible signals.
+Receipts are kept in an append-only Merkle log so the input set has an inclusion
+proof and cannot be silently edited.
+
+## Anti-gaming
+
+- Proof-of-interaction gate: a signal counts only if its receipt binds issuer,
+  agent, and a specific interaction.
+- Issuer weighting: a receipt counts in proportion to the issuer's own standing.
+- Optional slashable stake on high-assurance receipts.
+- Time decay: standing trends to baseline without fresh evidence.
+
+## Build phases
+
+- Phase 1: receipt types (`StateReceipt`, `PenaltyReceipt`) and normalization
+  (covering the two existing types too).
+- Phase 2: the aggregation function.
+- Phase 3: the service (Merkle log, `GET /v1/reputation/{did}`, signed snapshots).
+- Phase 4: token attachment (`AccountabilityRecord` pointer) and verifier
+  threshold integration.
+- Phase 5: zero-knowledge portability and dispute resolution.
+
+## Free vs commercial
+
+Receipt formats, the aggregation function, and a self-hostable service are open.
+The hosted registry at scale, certified scoring, anti-fraud, and dispute
+arbitration are commercial.

--- a/examples/reputation_demo.py
+++ b/examples/reputation_demo.py
@@ -1,0 +1,137 @@
+"""
+Evidence-backed reputation, end to end.
+
+Reputation in Vouch is a verifiable aggregate of signed, interaction-bound
+receipts, computed by a public deterministic function. You trust the signatures
+and the math, never a server's stored number. This walks the whole flow:
+
+  receipts  ->  ledger  ->  signed snapshot  ->  policy gate
+            ->  privacy-preserving threshold proof  ->  dispute
+
+Run:
+    python examples/reputation_demo.py
+"""
+
+from vouch import Signer, generate_identity
+from vouch.accountability import attest_outcome, commit_outcome
+from vouch.receipts import build_penalty_receipt, build_state_receipt
+from vouch.reputation_disputes import build_dispute, build_dispute_resolution
+from vouch.reputation_ledger import ReputationLedger, verify_reputation_credential
+from vouch.reputation_policy import evaluate_reputation, policy_for_stakes
+from vouch.reputation_portability import build_reputation_proof, verify_reputation_proof
+
+
+def ident(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def main() -> None:
+    agent_kp, agent = ident("agent.example.com")
+    market_kp, market = ident("market.example.com")  # a relying party
+    validator_kp, validator = ident("validator.example.com")  # an authority
+    registry_kp, registry = ident("registry.example.com")  # the ledger operator
+    agent_did = agent.get_did()
+
+    # 1) The ledger admits only receipts it can verify. It resolves issuer keys.
+    keys = {
+        market.get_did(): market_kp.public_key_jwk,
+        validator.get_did(): validator_kp.public_key_jwk,
+    }
+    ledger = ReputationLedger(resolver=lambda did: keys.get(did))
+
+    # 2) Objective evidence: the market signs receipts for the agent's actions.
+    ledger.append(
+        build_state_receipt(
+            market,
+            agent=agent_did,
+            interaction_id="t1",
+            action="trade",
+            result="success",
+            sla_met=True,
+        )
+    )
+    ledger.append(
+        build_state_receipt(
+            market,
+            agent=agent_did,
+            interaction_id="t2",
+            action="trade",
+            result="success",
+            sla_met=True,
+        )
+    )
+    # A pre-committed call by the agent, settled by the market (a neutral settler).
+    c, secret = commit_outcome(
+        agent,
+        claim={"dir": "up"},
+        settlement={"method": "market", "resolutionCriteria": "close"},
+        private=True,
+    )
+    ledger.append(
+        attest_outcome(market, commitment=c, outcome={"result": "up"}, secret=secret, matches=True)
+    )
+    # A penalty from an authority.
+    penalty = build_penalty_receipt(
+        validator, agent=agent_did, interaction_id="t3", kind="policy-violation", severity=0.4
+    )
+    ledger.append(penalty)
+
+    print("receipts in ledger:", ledger.count(agent_did))
+
+    # 3) The registry signs a snapshot of the agent's standing.
+    snap = ledger.snapshot(registry, agent_did)
+    ok, subject = verify_reputation_credential(snap, registry_kp.public_key_jwk)
+    print(
+        "snapshot verifies:",
+        ok,
+        "| composite:",
+        subject["score"]["composite"],
+        "| dims:",
+        subject["score"]["dimensions"],
+    )
+
+    # 4) A skeptical consumer ignores the number and applies a policy after
+    #    verifying the snapshot signature.
+    decision = evaluate_reputation(
+        snap, policy_for_stakes("high"), public_key=registry_kp.public_key_jwk
+    )
+    print("high-stakes gate allows:", decision.allowed, decision.failures)
+
+    # 5) Privacy: the agent proves a threshold without revealing the score.
+    proof = build_reputation_proof(
+        registry,
+        agent_did,
+        ledger.score(agent_did),
+        predicates=[{"path": "composite", "op": ">=", "value": 70}],
+        audience="did:web:counterparty.example.com",
+    )
+    ok, assertions = verify_reputation_proof(
+        proof,
+        registry_kp.public_key_jwk,
+        require=[{"path": "composite", "op": ">=", "value": 70}],
+        audience="did:web:counterparty.example.com",
+    )
+    print(
+        "threshold proof (composite >= 70) holds:",
+        ok,
+        "| score disclosed:",
+        "composite" in str(proof["credentialSubject"].get("score", "")),
+    )
+
+    # 6) A dispute: an arbiter upholds a challenge, and the penalty drops out.
+    _, challenger = ident("challenger.example.com")
+    arbiter_kp, arbiter = ident("arbiter.example.com")
+    dispute = build_dispute(challenger, receipt=penalty, reason="penalty was issued in error")
+    resolution = build_dispute_resolution(arbiter, dispute=dispute, upheld=True)
+    ledger.apply_resolution(resolution, arbiter_kp.public_key_jwk)
+    print(
+        "after upheld dispute -> composite:",
+        ledger.score(agent_did).composite,
+        "| receipts:",
+        ledger.count(agent_did),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_receipts.py
+++ b/tests/test_receipts.py
@@ -1,0 +1,122 @@
+"""Tests for reputation receipts and normalization (Phase 1)."""
+
+from vouch import Signer, generate_identity
+from vouch.accountability import attest_outcome, commit_outcome
+from vouch.receipts import (
+    COMPLIANCE,
+    PERFORMANCE,
+    RELIABILITY,
+    SATISFACTION,
+    build_penalty_receipt,
+    build_state_receipt,
+    normalize_receipt,
+    receipt_subject,
+    verify_penalty_receipt,
+    verify_state_receipt,
+)
+
+AGENT = "did:web:agent.example.com"
+SETTLEMENT = {"method": "oracle", "resolutionCriteria": "x"}
+
+
+def _id(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def test_state_receipt_success_and_sla():
+    kp, rp = _id("relying-party.example.com")
+    r = build_state_receipt(
+        rp, agent=AGENT, interaction_id="s1", action="charge", result="success", sla_met=True
+    )
+    ok, subj = verify_state_receipt(r, kp.public_key_jwk)
+    assert ok is True
+    assert subj["result"] == "success"
+    assert receipt_subject(r) == AGENT
+
+    sigs = {(s.dimension, s.value) for s in normalize_receipt(r)}
+    assert (RELIABILITY, 1.0) in sigs
+    assert (PERFORMANCE, 1.0) in sigs
+
+
+def test_state_receipt_failure():
+    _, rp = _id("relying-party.example.com")
+    r = build_state_receipt(
+        rp, agent=AGENT, interaction_id="s1", action="charge", result="failure", sla_met=False
+    )
+    sigs = {(s.dimension, s.value) for s in normalize_receipt(r)}
+    assert (RELIABILITY, -1.0) in sigs
+    assert (PERFORMANCE, -1.0) in sigs
+
+
+def test_state_receipt_wrong_key_fails():
+    _, rp = _id("relying-party.example.com")
+    other, _ = _id("other.example.com")
+    r = build_state_receipt(rp, agent=AGENT, interaction_id="s1", action="a", result="success")
+    ok, _ = verify_state_receipt(r, other.public_key_jwk)
+    assert ok is False
+
+
+def test_penalty_receipt():
+    kp, authority = _id("validator.example.com")
+    r = build_penalty_receipt(
+        authority, agent=AGENT, interaction_id="s1", kind="policy-violation", severity=0.8
+    )
+    ok, subj = verify_penalty_receipt(r, kp.public_key_jwk)
+    assert ok is True
+    assert subj["kind"] == "policy-violation"
+
+    sigs = normalize_receipt(r)
+    assert len(sigs) == 1
+    assert sigs[0].dimension == COMPLIANCE
+    assert sigs[0].value == -0.8
+
+
+def test_outcome_attestation_normalizes_positive():
+    kp, agent = _id("agent.example.com")
+    commitment, secret = commit_outcome(agent, claim={"x": 1}, settlement=SETTLEMENT, private=True)
+    att = attest_outcome(
+        agent, commitment=commitment, outcome={"result": "x"}, secret=secret, matches=True
+    )
+    sigs = normalize_receipt(att)
+    assert len(sigs) == 1
+    assert sigs[0].dimension == RELIABILITY
+    assert sigs[0].value == 1.0
+
+
+def test_outcome_attestation_normalizes_negative():
+    _, agent = _id("agent.example.com")
+    commitment, secret = commit_outcome(agent, claim={"x": 1}, settlement=SETTLEMENT, private=True)
+    att = attest_outcome(
+        agent, commitment=commitment, outcome={"result": "y"}, secret=secret, matches=False
+    )
+    sigs = normalize_receipt(att)
+    assert sigs[0].value == -1.0
+
+
+def test_review_normalizes():
+    review = {
+        "@context": [
+            "https://www.w3.org/ns/credentials/v2",
+            "https://vouch-protocol.com/contexts/v1",
+        ],
+        "type": ["VerifiableCredential", "ReviewCredential"],
+        "id": "urn:uuid:1",
+        "issuer": "did:web:rater.example.com",
+        "validFrom": "2026-06-17T00:00:00Z",
+        "credentialSubject": {
+            "id": AGENT,
+            "rater": "did:web:rater.example.com",
+            "interactionId": "s1",
+            "ratings": {"performance": 5, "satisfaction": 1, "vibe": 3},
+        },
+    }
+    bydim = {(s.dimension, s.value) for s in normalize_receipt(review)}
+    assert (PERFORMANCE, 1.0) in bydim
+    assert (SATISFACTION, -1.0) in bydim
+    assert (SATISFACTION, 0.0) in bydim  # unknown "vibe" maps to satisfaction
+
+
+def test_unknown_type_yields_no_signal():
+    cred = {"type": ["VerifiableCredential", "VouchCredential"], "credentialSubject": {"id": AGENT}}
+    assert normalize_receipt(cred) == []

--- a/tests/test_reputation_aggregate.py
+++ b/tests/test_reputation_aggregate.py
@@ -1,0 +1,99 @@
+"""Tests for the reputation aggregation function (Phase 2)."""
+
+from datetime import datetime, timedelta, timezone
+
+from vouch import Signer, generate_identity
+from vouch.receipts import COMPLIANCE, PERFORMANCE, RELIABILITY, Signal, build_state_receipt
+from vouch.reputation_aggregate import (
+    AGGREGATION_VERSION,
+    BASELINE,
+    aggregate,
+    aggregate_receipts,
+)
+
+AT = datetime(2026, 6, 17, 0, 0, 0, tzinfo=timezone.utc)
+
+
+def _sig(dim, value, source="StateReceipt", issuer="did:web:rp.example.com", at=AT):
+    return Signal(dim, value, source, issuer, "s1", at)
+
+
+def test_empty_is_baseline():
+    score = aggregate([], at=AT)
+    assert score.composite == BASELINE
+    assert score.dimensions == {}
+    assert score.count == 0
+    assert score.version == AGGREGATION_VERSION
+
+
+def test_single_positive_maxes_dimension():
+    score = aggregate([_sig(RELIABILITY, 1.0)], at=AT)
+    assert score.dimensions[RELIABILITY] == 100.0
+    assert score.composite == 100.0
+
+
+def test_single_negative_zeroes_dimension():
+    score = aggregate([_sig(RELIABILITY, -1.0)], at=AT)
+    assert score.dimensions[RELIABILITY] == 0.0
+
+
+def test_decay_lets_fresh_signal_dominate():
+    fresh = _sig(RELIABILITY, 1.0, at=AT)
+    old = _sig(RELIABILITY, -1.0, at=AT - timedelta(days=180))  # 2 half-lives, weight 0.25
+    score = aggregate([fresh, old], at=AT, half_life_days=90)
+    assert score.dimensions[RELIABILITY] > BASELINE  # the fresh positive wins
+
+
+def test_objective_outweighs_review():
+    state = _sig(RELIABILITY, 1.0, source="StateReceipt")
+    review = _sig(RELIABILITY, -1.0, source="ReviewCredential")  # weight 0.4
+    score = aggregate([state, review], at=AT)
+    assert score.dimensions[RELIABILITY] > BASELINE
+
+
+def test_issuer_weight_can_zero_out_a_source():
+    good = _sig(RELIABILITY, 1.0, issuer="did:web:trusted.example.com")
+    bad = _sig(RELIABILITY, -1.0, issuer="did:web:sybil.example.com")
+    score = aggregate([good, bad], at=AT, issuer_weight={"did:web:sybil.example.com": 0.0})
+    assert score.dimensions[RELIABILITY] == 100.0  # the sybil contributes nothing
+
+
+def test_multidimensional_and_composite():
+    score = aggregate(
+        [
+            _sig(RELIABILITY, 1.0),
+            _sig(PERFORMANCE, 1.0),
+            _sig(COMPLIANCE, -1.0, source="PenaltyReceipt"),
+        ],
+        at=AT,
+    )
+    assert score.dimensions[RELIABILITY] == 100.0
+    assert score.dimensions[COMPLIANCE] == 0.0
+    assert 0.0 < score.composite < 100.0
+    assert set(score.support.keys()) == {RELIABILITY, PERFORMANCE, COMPLIANCE}
+
+
+def test_to_dict_shape():
+    d = aggregate([_sig(RELIABILITY, 1.0)], at=AT).to_dict()
+    assert d["version"] == AGGREGATION_VERSION
+    assert d["composite"] == 100.0
+    assert d["count"] == 1
+
+
+def test_aggregate_receipts_filters_by_agent():
+    kp, rp = (lambda kp: (kp, Signer(private_key=kp.private_key_jwk, did=kp.did)))(
+        generate_identity(domain="rp.example.com")
+    )
+    a = "did:web:agent-a.example.com"
+    b = "did:web:agent-b.example.com"
+    receipts = [
+        build_state_receipt(
+            rp, agent=a, interaction_id="1", action="x", result="success", valid_from=AT
+        ),
+        build_state_receipt(
+            rp, agent=b, interaction_id="2", action="x", result="failure", valid_from=AT
+        ),
+    ]
+    score_a = aggregate_receipts(receipts, agent=a, at=AT)
+    assert score_a.dimensions[RELIABILITY] == 100.0  # only a's success counts
+    assert score_a.count == 1

--- a/tests/test_reputation_disputes.py
+++ b/tests/test_reputation_disputes.py
@@ -1,0 +1,93 @@
+"""Tests for reputation disputes and ledger exclusion (Phase 5)."""
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.receipts import RELIABILITY, build_state_receipt
+from vouch.reputation_disputes import (
+    DISPUTE_RESOLUTION_TYPE,
+    DISPUTE_TYPE,
+    build_dispute,
+    build_dispute_resolution,
+    verify_dispute,
+    verify_dispute_resolution,
+)
+from vouch.reputation_ledger import LedgerError, ReputationLedger
+
+AGENT = "did:web:agent.example.com"
+
+
+def _id(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def test_build_and_verify_dispute_and_resolution():
+    _, rp = _id("rp.example.com")
+    ch_kp, challenger = _id("challenger.example.com")
+    ar_kp, arbiter = _id("arbiter.example.com")
+
+    receipt = build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+    dispute = build_dispute(challenger, receipt=receipt, reason="receipt was fabricated")
+    assert DISPUTE_TYPE in dispute["type"]
+    ok, dsub = verify_dispute(dispute, ch_kp.public_key_jwk)
+    assert ok is True
+    assert dsub["receipt"]["id"] == receipt["id"]
+
+    res = build_dispute_resolution(arbiter, dispute=dispute, upheld=True, rationale="confirmed")
+    assert DISPUTE_RESOLUTION_TYPE in res["type"]
+    ok, rsub = verify_dispute_resolution(res, ar_kp.public_key_jwk)
+    assert ok is True
+    assert rsub["upheld"] is True
+
+
+def test_upheld_resolution_excludes_receipt():
+    rp_kp, rp = _id("rp.example.com")
+    ch_kp, challenger = _id("challenger.example.com")
+    ar_kp, arbiter = _id("arbiter.example.com")
+    keymap = {rp.get_did(): rp_kp.public_key_jwk}
+    ledger = ReputationLedger(resolver=lambda d: keymap.get(d))
+
+    receipt = build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+    ledger.append(receipt)
+    assert ledger.score(AGENT).dimensions[RELIABILITY] == 100.0
+
+    dispute = build_dispute(challenger, receipt=receipt, reason="fabricated")
+    res = build_dispute_resolution(arbiter, dispute=dispute, upheld=True)
+    excluded = ledger.apply_resolution(res, ar_kp.public_key_jwk)
+    assert excluded is True
+
+    # the receipt no longer counts
+    assert ledger.count(AGENT) == 0
+    assert RELIABILITY not in ledger.score(AGENT).dimensions
+
+
+def test_dismissed_resolution_keeps_receipt():
+    rp_kp, rp = _id("rp.example.com")
+    _, challenger = _id("challenger.example.com")
+    ar_kp, arbiter = _id("arbiter.example.com")
+    keymap = {rp.get_did(): rp_kp.public_key_jwk}
+    ledger = ReputationLedger(resolver=lambda d: keymap.get(d))
+
+    receipt = build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+    ledger.append(receipt)
+    dispute = build_dispute(challenger, receipt=receipt, reason="nope")
+    res = build_dispute_resolution(arbiter, dispute=dispute, upheld=False)
+    assert ledger.apply_resolution(res, ar_kp.public_key_jwk) is False
+    assert ledger.count(AGENT) == 1
+
+
+def test_resolution_wrong_arbiter_key_rejected():
+    rp_kp, rp = _id("rp.example.com")
+    _, challenger = _id("challenger.example.com")
+    _, arbiter = _id("arbiter.example.com")
+    impostor_kp, _ = _id("impostor.example.com")
+    keymap = {rp.get_did(): rp_kp.public_key_jwk}
+    ledger = ReputationLedger(resolver=lambda d: keymap.get(d))
+
+    receipt = build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+    ledger.append(receipt)
+    dispute = build_dispute(challenger, receipt=receipt, reason="x")
+    res = build_dispute_resolution(arbiter, dispute=dispute, upheld=True)
+    with pytest.raises(LedgerError):
+        ledger.apply_resolution(res, impostor_kp.public_key_jwk)

--- a/tests/test_reputation_ledger.py
+++ b/tests/test_reputation_ledger.py
@@ -1,0 +1,105 @@
+"""Tests for the reputation ledger and signed snapshot (Phase 3a)."""
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.jcs import canonicalize
+from vouch.merkle import verify_inclusion
+from vouch.receipts import RELIABILITY, build_state_receipt
+from vouch.reputation_ledger import (
+    REPUTATION_CREDENTIAL_TYPE,
+    LedgerError,
+    ReputationLedger,
+    verify_reputation_credential,
+)
+
+AGENT = "did:web:agent.example.com"
+
+
+def _id(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def _ledger_with(*signers_kp):
+    keymap = {s.get_did(): kp.public_key_jwk for kp, s in signers_kp}
+    return ReputationLedger(resolver=lambda did: keymap.get(did)), keymap
+
+
+def test_append_and_score():
+    rp_kp, rp = _id("rp.example.com")
+    ledger, _ = _ledger_with((rp_kp, rp))
+    for i in (1, 2):
+        ledger.append(
+            build_state_receipt(
+                rp, agent=AGENT, interaction_id=str(i), action="x", result="success"
+            )
+        )
+    assert ledger.count(AGENT) == 2
+    assert ledger.score(AGENT).dimensions[RELIABILITY] == 100.0
+
+
+def test_append_rejects_unknown_issuer():
+    rp_kp, rp = _id("rp.example.com")
+    ledger = ReputationLedger(resolver=lambda did: None)  # resolves nothing
+    with pytest.raises(LedgerError):
+        ledger.append(
+            build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+        )
+
+
+def test_append_rejects_tampered_receipt():
+    rp_kp, rp = _id("rp.example.com")
+    ledger, _ = _ledger_with((rp_kp, rp))
+    r = build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="failure")
+    r["credentialSubject"]["result"] = "success"  # flip after signing
+    with pytest.raises(LedgerError):
+        ledger.append(r)
+
+
+def test_root_and_inclusion_proof():
+    rp_kp, rp = _id("rp.example.com")
+    ledger, _ = _ledger_with((rp_kp, rp))
+    receipts = [
+        build_state_receipt(rp, agent=AGENT, interaction_id=str(i), action="x", result="success")
+        for i in range(3)
+    ]
+    for r in receipts:
+        ledger.append(r)
+
+    assert ledger.root(AGENT) is not None
+    tree = ledger.merkle(AGENT)
+    leaf = canonicalize(receipts[1])
+    assert verify_inclusion(leaf=leaf, proof=tree.proof(1), root=tree.root()) is True
+
+
+def test_snapshot_signs_and_verifies():
+    rp_kp, rp = _id("rp.example.com")
+    svc_kp, svc = _id("registry.example.com")
+    ledger, _ = _ledger_with((rp_kp, rp))
+    ledger.append(
+        build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+    )
+
+    snap = ledger.snapshot(svc, AGENT)
+    assert REPUTATION_CREDENTIAL_TYPE in snap["type"]
+    assert snap["issuer"] == svc.get_did()
+
+    ok, subject = verify_reputation_credential(snap, svc_kp.public_key_jwk)
+    assert ok is True
+    assert subject["score"]["dimensions"][RELIABILITY] == 100.0
+    assert subject["receiptCount"] == 1
+    assert subject["evidenceRoot"] == ledger.root(AGENT)
+
+
+def test_snapshot_tamper_fails():
+    rp_kp, rp = _id("rp.example.com")
+    svc_kp, svc = _id("registry.example.com")
+    ledger, _ = _ledger_with((rp_kp, rp))
+    ledger.append(
+        build_state_receipt(rp, agent=AGENT, interaction_id="1", action="x", result="success")
+    )
+    snap = ledger.snapshot(svc, AGENT)
+    snap["credentialSubject"]["score"]["composite"] = 99.0  # inflate after signing
+    ok, _ = verify_reputation_credential(snap, svc_kp.public_key_jwk)
+    assert ok is False

--- a/tests/test_reputation_policy.py
+++ b/tests/test_reputation_policy.py
@@ -1,0 +1,81 @@
+"""Tests for reputation policy and token attachment (Phase 4)."""
+
+from datetime import datetime, timedelta, timezone
+
+from vouch import Signer, generate_identity
+from vouch.reputation_aggregate import ReputationScore
+from vouch.reputation_ledger import build_reputation_credential
+from vouch.reputation_policy import (
+    ReputationPolicy,
+    evaluate_reputation,
+    policy_for_stakes,
+    reputation_pointer,
+)
+
+AGENT = "did:web:agent.example.com"
+AT = datetime(2026, 6, 17, tzinfo=timezone.utc)
+
+
+def _score(composite, **dims):
+    return ReputationScore(version="1.0", dimensions=dims, composite=composite, support={}, count=3)
+
+
+def _svc():
+    kp = generate_identity(domain="registry.example.com")
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def test_allows_when_above_thresholds():
+    d = evaluate_reputation(_score(85, reliability=90, compliance=80), policy_for_stakes("high"))
+    assert d.allowed is True
+    assert d.composite == 85
+
+
+def test_denies_on_low_composite():
+    d = evaluate_reputation(_score(55), policy_for_stakes("high"))
+    assert d.allowed is False
+    assert any("composite" in f for f in d.failures)
+
+
+def test_denies_on_low_dimension():
+    d = evaluate_reputation(
+        _score(90, compliance=40),
+        ReputationPolicy(min_composite=50, min_dimensions={"compliance": 60}),
+    )
+    assert d.allowed is False
+    assert any("compliance" in f for f in d.failures)
+
+
+def test_verifies_and_evaluates_snapshot():
+    kp, svc = _svc()
+    snap = build_reputation_credential(svc, AGENT, _score(80, compliance=70), valid_from=AT)
+    d = evaluate_reputation(snap, policy_for_stakes("high"), public_key=kp.public_key_jwk)
+    assert d.allowed is True
+    assert d.composite == 80
+
+
+def test_tampered_snapshot_denied():
+    kp, svc = _svc()
+    snap = build_reputation_credential(svc, AGENT, _score(80, compliance=70), valid_from=AT)
+    snap["credentialSubject"]["score"]["composite"] = 99
+    d = evaluate_reputation(snap, policy_for_stakes("low"), public_key=kp.public_key_jwk)
+    assert d.allowed is False
+    assert any("signature" in f for f in d.failures)
+
+
+def test_stale_snapshot_denied():
+    kp, svc = _svc()
+    old = AT - timedelta(days=30)
+    snap = build_reputation_credential(svc, AGENT, _score(90), valid_from=old)
+    policy = ReputationPolicy(min_composite=50, max_age_seconds=3600)
+    d = evaluate_reputation(snap, policy, public_key=kp.public_key_jwk, at=AT)
+    assert d.allowed is False
+    assert any("stale" in f for f in d.failures)
+
+
+def test_reputation_pointer_shape():
+    p = reputation_pointer(registry="https://registry.example.com", record="snap-1", subject=AGENT)
+    assert p["type"] == "AccountabilityRecord"
+    assert p["kind"] == "reputation"
+    assert p["ledger"] == "https://registry.example.com"
+    assert p["record"] == "snap-1"

--- a/tests/test_reputation_portability.py
+++ b/tests/test_reputation_portability.py
@@ -1,0 +1,106 @@
+"""Tests for privacy-preserving reputation threshold proofs (Phase 5)."""
+
+import json
+
+from vouch import Signer, generate_identity
+from vouch.reputation_aggregate import ReputationScore
+from vouch.reputation_portability import build_reputation_proof, verify_reputation_proof
+
+AGENT = "did:web:agent.example.com"
+
+
+def _svc():
+    kp = generate_identity(domain="registry.example.com")
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def _score():
+    return ReputationScore(
+        version="1.0", dimensions={"reliability": 92.0}, composite=83.0, support={}, count=5
+    )
+
+
+def test_proof_asserts_predicate_without_revealing_score():
+    kp, svc = _svc()
+    proof = build_reputation_proof(
+        svc,
+        AGENT,
+        _score(),
+        predicates=[
+            {"path": "composite", "op": ">=", "value": 75},
+            {"path": "dimensions.reliability", "op": ">=", "value": 90},
+        ],
+    )
+    ok, assertions = verify_reputation_proof(proof, kp.public_key_jwk)
+    assert ok is True
+    assert all(a["satisfied"] for a in assertions)
+
+    # The actual score and dimension are not disclosed, only the thresholds.
+    dumped = json.dumps(proof["credentialSubject"])
+    assert "83" not in dumped
+    assert "92" not in dumped
+
+
+def test_require_satisfied_predicate_passes():
+    kp, svc = _svc()
+    proof = build_reputation_proof(
+        svc, AGENT, _score(), predicates=[{"path": "composite", "op": ">=", "value": 75}]
+    )
+    ok, _ = verify_reputation_proof(
+        proof, kp.public_key_jwk, require=[{"path": "composite", "op": ">=", "value": 75}]
+    )
+    assert ok is True
+
+
+def test_require_unsatisfied_predicate_fails():
+    kp, svc = _svc()
+    # composite is 83, so ">= 90" is asserted but not satisfied
+    proof = build_reputation_proof(
+        svc, AGENT, _score(), predicates=[{"path": "composite", "op": ">=", "value": 90}]
+    )
+    ok, _ = verify_reputation_proof(
+        proof, kp.public_key_jwk, require=[{"path": "composite", "op": ">=", "value": 90}]
+    )
+    assert ok is False
+
+
+def test_require_absent_predicate_fails():
+    kp, svc = _svc()
+    proof = build_reputation_proof(
+        svc, AGENT, _score(), predicates=[{"path": "composite", "op": ">=", "value": 75}]
+    )
+    ok, _ = verify_reputation_proof(
+        proof,
+        kp.public_key_jwk,
+        require=[{"path": "dimensions.compliance", "op": ">=", "value": 50}],
+    )
+    assert ok is False
+
+
+def test_audience_binding():
+    kp, svc = _svc()
+    proof = build_reputation_proof(
+        svc,
+        AGENT,
+        _score(),
+        predicates=[{"path": "composite", "op": ">=", "value": 75}],
+        audience="did:web:verifier-a.example.com",
+    )
+    ok_right, _ = verify_reputation_proof(
+        proof, kp.public_key_jwk, audience="did:web:verifier-a.example.com"
+    )
+    ok_wrong, _ = verify_reputation_proof(
+        proof, kp.public_key_jwk, audience="did:web:verifier-b.example.com"
+    )
+    assert ok_right is True
+    assert ok_wrong is False
+
+
+def test_tampered_proof_fails():
+    kp, svc = _svc()
+    proof = build_reputation_proof(
+        svc, AGENT, _score(), predicates=[{"path": "composite", "op": ">=", "value": 90}]
+    )
+    proof["credentialSubject"]["assertions"][0]["satisfied"] = True  # flip after signing
+    ok, _ = verify_reputation_proof(proof, kp.public_key_jwk)
+    assert ok is False

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -216,6 +216,16 @@ def __getattr__(name):
         from . import reputation_aggregate
 
         return getattr(reputation_aggregate, name)
+    elif name in (
+        "ReputationLedger",
+        "LedgerError",
+        "build_reputation_credential",
+        "verify_reputation_credential",
+        "REPUTATION_CREDENTIAL_TYPE",
+    ):
+        from . import reputation_ledger
+
+        return getattr(reputation_ledger, name)
     # Cloud KMS
     elif name in ("CloudKMSProvider", "AWSKMSProvider", "GCPKMSProvider", "AzureKeyVaultProvider"):
         from . import kms
@@ -310,6 +320,11 @@ __all__ = [
     "aggregate",
     "aggregate_receipts",
     "AGGREGATION_VERSION",
+    "ReputationLedger",
+    "LedgerError",
+    "build_reputation_credential",
+    "verify_reputation_credential",
+    "REPUTATION_CREDENTIAL_TYPE",
     # Cloud KMS
     "CloudKMSProvider",
     "AWSKMSProvider",

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -236,6 +236,27 @@ def __getattr__(name):
         from . import reputation_policy
 
         return getattr(reputation_policy, name)
+    elif name in (
+        "PortabilityError",
+        "build_reputation_proof",
+        "verify_reputation_proof",
+        "REPUTATION_PROOF_TYPE",
+    ):
+        from . import reputation_portability
+
+        return getattr(reputation_portability, name)
+    elif name in (
+        "DisputeError",
+        "build_dispute",
+        "build_dispute_resolution",
+        "verify_dispute",
+        "verify_dispute_resolution",
+        "DISPUTE_TYPE",
+        "DISPUTE_RESOLUTION_TYPE",
+    ):
+        from . import reputation_disputes
+
+        return getattr(reputation_disputes, name)
     # Cloud KMS
     elif name in ("CloudKMSProvider", "AWSKMSProvider", "GCPKMSProvider", "AzureKeyVaultProvider"):
         from . import kms
@@ -340,6 +361,15 @@ __all__ = [
     "evaluate_reputation",
     "policy_for_stakes",
     "reputation_pointer",
+    "build_reputation_proof",
+    "verify_reputation_proof",
+    "REPUTATION_PROOF_TYPE",
+    "build_dispute",
+    "build_dispute_resolution",
+    "verify_dispute",
+    "verify_dispute_resolution",
+    "DISPUTE_TYPE",
+    "DISPUTE_RESOLUTION_TYPE",
     # Cloud KMS
     "CloudKMSProvider",
     "AWSKMSProvider",

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -226,6 +226,16 @@ def __getattr__(name):
         from . import reputation_ledger
 
         return getattr(reputation_ledger, name)
+    elif name in (
+        "ReputationPolicy",
+        "ReputationDecision",
+        "evaluate_reputation",
+        "policy_for_stakes",
+        "reputation_pointer",
+    ):
+        from . import reputation_policy
+
+        return getattr(reputation_policy, name)
     # Cloud KMS
     elif name in ("CloudKMSProvider", "AWSKMSProvider", "GCPKMSProvider", "AzureKeyVaultProvider"):
         from . import kms
@@ -325,6 +335,11 @@ __all__ = [
     "build_reputation_credential",
     "verify_reputation_credential",
     "REPUTATION_CREDENTIAL_TYPE",
+    "ReputationPolicy",
+    "ReputationDecision",
+    "evaluate_reputation",
+    "policy_for_stakes",
+    "reputation_pointer",
     # Cloud KMS
     "CloudKMSProvider",
     "AWSKMSProvider",

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -191,6 +191,31 @@ def __getattr__(name):
         from . import accountability
 
         return getattr(accountability, name)
+    # Reputation receipts and aggregation (evidence-backed reputation)
+    elif name in (
+        "ReceiptError",
+        "Signal",
+        "build_state_receipt",
+        "verify_state_receipt",
+        "build_penalty_receipt",
+        "verify_penalty_receipt",
+        "normalize_receipt",
+        "receipt_subject",
+        "STATE_RECEIPT_TYPE",
+        "PENALTY_RECEIPT_TYPE",
+    ):
+        from . import receipts
+
+        return getattr(receipts, name)
+    elif name in (
+        "ReputationScore",
+        "aggregate",
+        "aggregate_receipts",
+        "AGGREGATION_VERSION",
+    ):
+        from . import reputation_aggregate
+
+        return getattr(reputation_aggregate, name)
     # Cloud KMS
     elif name in ("CloudKMSProvider", "AWSKMSProvider", "GCPKMSProvider", "AzureKeyVaultProvider"):
         from . import kms
@@ -272,6 +297,19 @@ __all__ = [
     "commitment_digest",
     "OUTCOME_COMMITMENT_TYPE",
     "OUTCOME_ATTESTATION_TYPE",
+    # Reputation receipts and aggregation
+    "ReceiptError",
+    "Signal",
+    "build_state_receipt",
+    "verify_state_receipt",
+    "build_penalty_receipt",
+    "verify_penalty_receipt",
+    "normalize_receipt",
+    "receipt_subject",
+    "ReputationScore",
+    "aggregate",
+    "aggregate_receipts",
+    "AGGREGATION_VERSION",
     # Cloud KMS
     "CloudKMSProvider",
     "AWSKMSProvider",

--- a/vouch/receipts.py
+++ b/vouch/receipts.py
@@ -1,0 +1,277 @@
+"""
+Reputation receipts and normalization (reputation Phase 1).
+
+Reputation is computed from signed receipts about an agent DID. This module
+defines the two new receipt types that the agent cannot self-issue, the
+relying-party `StateReceipt` and the authority `PenaltyReceipt`, and a
+`normalize_receipt` that turns any of the four receipt types (these two plus the
+existing OutcomeAttestation and ReviewCredential) into dimensioned `Signal`s for
+the aggregation function in Phase 2.
+
+A receipt is an eddsa-jcs-2022 Verifiable Credential whose subject is the agent
+being rated and which is tied to an `interactionId`. Normalization is read-only:
+it inspects the credential `type` and shape, so it does not import the modules
+that mint the other two types.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from . import data_integrity
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+
+STATE_RECEIPT_TYPE = "StateReceipt"
+PENALTY_RECEIPT_TYPE = "PenaltyReceipt"
+OUTCOME_ATTESTATION_TYPE = "OutcomeAttestationCredential"
+REVIEW_CREDENTIAL_TYPE = "ReviewCredential"
+
+RELIABILITY = "reliability"
+PERFORMANCE = "performance"
+COMPLIANCE = "compliance"
+SATISFACTION = "satisfaction"
+KNOWN_DIMENSIONS = {RELIABILITY, PERFORMANCE, COMPLIANCE, SATISFACTION}
+
+
+class ReceiptError(Exception):
+    """Raised on malformed receipt input."""
+
+
+@dataclass
+class Signal:
+    """A single normalized reputation contribution. `value` is in [-1, 1]."""
+
+    dimension: str
+    value: float
+    source_type: str
+    issuer: str
+    interaction_id: str
+    timestamp: datetime
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(s: str) -> datetime:
+    return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+def _clamp(x: float, lo: float = -1.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, x))
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise ReceiptError("signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+def _type_list(credential: Dict[str, Any]) -> list:
+    t = credential.get("type") or []
+    return [t] if isinstance(t, str) else list(t)
+
+
+def _verify(credential: Dict[str, Any], public_key: Any) -> bool:
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    pub = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if pub is None:
+        return False
+    try:
+        return data_integrity.verify_proof(credential, pub)
+    except ValueError:
+        return False
+
+
+def _base(issuer: str, type_name: str, valid_from: Optional[datetime]) -> Dict[str, Any]:
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    return {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", type_name],
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "issuer": issuer,
+        "validFrom": _iso(issued),
+    }
+
+
+# ---------------------------------------------------------------------------
+# StateReceipt: the relying party attests the result of an agent's action
+# ---------------------------------------------------------------------------
+
+
+def build_state_receipt(
+    relying_party_signer: Any,
+    *,
+    agent: str,
+    interaction_id: str,
+    action: str,
+    result: str,
+    sla_met: Optional[bool] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a StateReceipt signed by the relying party the agent acted on. `result`
+    is "success" or "failure". The agent cannot mint this, so it is an admissible
+    objective signal.
+    """
+    if result not in ("success", "failure"):
+        raise ReceiptError("result must be 'success' or 'failure'")
+    cred = _base(relying_party_signer.get_did(), STATE_RECEIPT_TYPE, valid_from)
+    subject: Dict[str, Any] = {
+        "id": agent,
+        "interactionId": interaction_id,
+        "action": action,
+        "result": result,
+    }
+    if sla_met is not None:
+        subject["slaMet"] = sla_met
+    cred["credentialSubject"] = subject
+    return _attach_proof(cred, relying_party_signer)
+
+
+def verify_state_receipt(receipt: Dict[str, Any], public_key: Any):
+    if STATE_RECEIPT_TYPE not in _type_list(receipt):
+        return False, None
+    if not _verify(receipt, public_key):
+        return False, None
+    return True, receipt.get("credentialSubject") or {}
+
+
+# ---------------------------------------------------------------------------
+# PenaltyReceipt: an authority records a violation
+# ---------------------------------------------------------------------------
+
+
+def build_penalty_receipt(
+    authority_signer: Any,
+    *,
+    agent: str,
+    interaction_id: str,
+    kind: str,
+    severity: float = 1.0,
+    dimension: str = COMPLIANCE,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a PenaltyReceipt signed by a validator or authority. `kind` is a label
+    (revocation, slash, heartbeat-lapse, kill-switch, policy-violation);
+    `severity` in [0, 1] sets the magnitude of the negative signal.
+    """
+    cred = _base(authority_signer.get_did(), PENALTY_RECEIPT_TYPE, valid_from)
+    cred["credentialSubject"] = {
+        "id": agent,
+        "interactionId": interaction_id,
+        "kind": kind,
+        "severity": float(severity),
+        "dimension": dimension,
+    }
+    return _attach_proof(cred, authority_signer)
+
+
+def verify_penalty_receipt(receipt: Dict[str, Any], public_key: Any):
+    if PENALTY_RECEIPT_TYPE not in _type_list(receipt):
+        return False, None
+    if not _verify(receipt, public_key):
+        return False, None
+    return True, receipt.get("credentialSubject") or {}
+
+
+# ---------------------------------------------------------------------------
+# Subject and normalization
+# ---------------------------------------------------------------------------
+
+
+def receipt_subject(credential: Dict[str, Any]) -> Optional[str]:
+    """The agent DID a receipt is about. Callers group receipts by this."""
+    return (credential.get("credentialSubject") or {}).get("id")
+
+
+def normalize_receipt(credential: Dict[str, Any]) -> List[Signal]:
+    """Turn one receipt into zero or more dimensioned Signals."""
+    types = _type_list(credential)
+    issuer = credential.get("issuer") or ""
+    subject = credential.get("credentialSubject") or {}
+    try:
+        ts = _parse_iso(credential.get("validFrom"))
+    except (TypeError, ValueError):
+        ts = datetime.now(timezone.utc)
+    iid = subject.get("interactionId") or credential.get("id") or ""
+
+    def sig(dim: str, value: float, source: str) -> Signal:
+        return Signal(dim, _clamp(value), source, issuer, iid, ts)
+
+    if STATE_RECEIPT_TYPE in types:
+        out: List[Signal] = []
+        result = subject.get("result")
+        if result == "success":
+            out.append(sig(RELIABILITY, 1.0, STATE_RECEIPT_TYPE))
+        elif result == "failure":
+            out.append(sig(RELIABILITY, -1.0, STATE_RECEIPT_TYPE))
+        sla = subject.get("slaMet")
+        if sla is True:
+            out.append(sig(PERFORMANCE, 1.0, STATE_RECEIPT_TYPE))
+        elif sla is False:
+            out.append(sig(PERFORMANCE, -1.0, STATE_RECEIPT_TYPE))
+        return out
+
+    if OUTCOME_ATTESTATION_TYPE in types:
+        matches = (subject.get("outcome") or {}).get("matchesCommitment")
+        if matches is True:
+            return [sig(RELIABILITY, 1.0, OUTCOME_ATTESTATION_TYPE)]
+        if matches is False:
+            return [sig(RELIABILITY, -1.0, OUTCOME_ATTESTATION_TYPE)]
+        return []
+
+    if PENALTY_RECEIPT_TYPE in types:
+        dim = subject.get("dimension") or COMPLIANCE
+        sev = _clamp(float(subject.get("severity", 1.0)), 0.0, 1.0)
+        return [sig(dim, -sev, PENALTY_RECEIPT_TYPE)]
+
+    if REVIEW_CREDENTIAL_TYPE in types:
+        out = []
+        for k, r in (subject.get("ratings") or {}).items():
+            dim = k if k in KNOWN_DIMENSIONS else SATISFACTION
+            out.append(sig(dim, (float(r) - 3.0) / 2.0, REVIEW_CREDENTIAL_TYPE))
+        return out
+
+    return []
+
+
+__all__ = [
+    "STATE_RECEIPT_TYPE",
+    "PENALTY_RECEIPT_TYPE",
+    "OUTCOME_ATTESTATION_TYPE",
+    "REVIEW_CREDENTIAL_TYPE",
+    "RELIABILITY",
+    "PERFORMANCE",
+    "COMPLIANCE",
+    "SATISFACTION",
+    "KNOWN_DIMENSIONS",
+    "ReceiptError",
+    "Signal",
+    "build_state_receipt",
+    "verify_state_receipt",
+    "build_penalty_receipt",
+    "verify_penalty_receipt",
+    "receipt_subject",
+    "normalize_receipt",
+]

--- a/vouch/reputation_aggregate.py
+++ b/vouch/reputation_aggregate.py
@@ -1,0 +1,161 @@
+"""
+Evidence-backed reputation aggregation (reputation Phase 2).
+
+The deterministic, versioned function that turns normalized `Signal`s into a
+multi-dimensional reputation score. It is pure: given the same signals, the same
+evaluation time `at`, and the same configuration, any party computes the same
+score, so a consumer can recompute and verify rather than trust a server.
+
+Each signal contributes to its dimension with weight
+
+    type_weight(source) * decay(age) * issuer_weight(issuer)
+
+A dimension score is the baseline plus the weighted-mean signal value scaled
+across the span, clamped to [0, 100]. The composite is the support-weighted mean
+of the present dimensions.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterable, List, Optional, Union
+
+from .receipts import Signal, normalize_receipt, receipt_subject
+
+AGGREGATION_VERSION = "1.0"
+
+DEFAULT_TYPE_WEIGHTS: Dict[str, float] = {
+    "StateReceipt": 1.0,
+    "OutcomeAttestationCredential": 1.0,
+    "PenaltyReceipt": 1.0,
+    "ReviewCredential": 0.4,
+}
+DEFAULT_HALF_LIFE_DAYS = 90.0
+BASELINE = 50.0
+SPAN = 50.0
+
+IssuerWeight = Union[Callable[[str], float], Dict[str, float], None]
+
+
+@dataclass
+class ReputationScore:
+    version: str
+    dimensions: Dict[str, float] = field(default_factory=dict)
+    composite: float = BASELINE
+    support: Dict[str, float] = field(default_factory=dict)
+    count: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "version": self.version,
+            "composite": self.composite,
+            "dimensions": self.dimensions,
+            "support": self.support,
+            "count": self.count,
+        }
+
+
+def _clamp(x: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, x))
+
+
+def _decay(age_days: float, half_life_days: float) -> float:
+    if half_life_days <= 0:
+        return 1.0
+    return 0.5 ** (max(0.0, age_days) / half_life_days)
+
+
+def _issuer_weight(iw: IssuerWeight, issuer: str) -> float:
+    if iw is None:
+        return 1.0
+    if callable(iw):
+        return float(iw(issuer))
+    return float(iw.get(issuer, 1.0))
+
+
+def aggregate(
+    signals: Iterable[Signal],
+    *,
+    at: Optional[datetime] = None,
+    type_weights: Optional[Dict[str, float]] = None,
+    issuer_weight: IssuerWeight = None,
+    half_life_days: float = DEFAULT_HALF_LIFE_DAYS,
+    baseline: float = BASELINE,
+    span: float = SPAN,
+) -> ReputationScore:
+    """Aggregate normalized signals into a multi-dimensional ReputationScore."""
+    now = (at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    tw = type_weights or DEFAULT_TYPE_WEIGHTS
+
+    acc: Dict[str, List[float]] = {}  # dimension -> [weighted_value_sum, weight_sum]
+    count = 0
+    for s in signals:
+        count += 1
+        age_days = (now - s.timestamp.astimezone(timezone.utc)).total_seconds() / 86400.0
+        w = (
+            tw.get(s.source_type, 0.5)
+            * _decay(age_days, half_life_days)
+            * _issuer_weight(issuer_weight, s.issuer)
+        )
+        if w <= 0:
+            continue
+        a = acc.setdefault(s.dimension, [0.0, 0.0])
+        a[0] += _clamp(s.value, -1.0, 1.0) * w
+        a[1] += w
+
+    dimensions: Dict[str, float] = {}
+    support: Dict[str, float] = {}
+    for dim, (num, den) in acc.items():
+        support[dim] = round(den, 6)
+        dimensions[dim] = (
+            round(_clamp(baseline + span * (num / den), 0.0, 100.0), 2) if den > 0 else baseline
+        )
+
+    if support:
+        total = sum(support.values())
+        composite = (
+            sum(dimensions[d] * support[d] for d in dimensions) / total if total > 0 else baseline
+        )
+    else:
+        composite = baseline
+
+    return ReputationScore(
+        version=AGGREGATION_VERSION,
+        dimensions=dimensions,
+        composite=round(composite, 2),
+        support=support,
+        count=count,
+    )
+
+
+def aggregate_receipts(
+    receipts: Iterable[Dict[str, Any]],
+    *,
+    agent: Optional[str] = None,
+    **kwargs: Any,
+) -> ReputationScore:
+    """
+    Convenience: normalize a list of receipt credentials and aggregate them. When
+    `agent` is given, only receipts about that agent are included. Signature
+    verification is the caller's responsibility (the service layer does it before
+    calling this); this function trusts the receipts it is handed.
+    """
+    signals: List[Signal] = []
+    for r in receipts:
+        if agent is not None and receipt_subject(r) != agent:
+            continue
+        signals.extend(normalize_receipt(r))
+    return aggregate(signals, **kwargs)
+
+
+__all__ = [
+    "AGGREGATION_VERSION",
+    "DEFAULT_TYPE_WEIGHTS",
+    "DEFAULT_HALF_LIFE_DAYS",
+    "BASELINE",
+    "SPAN",
+    "ReputationScore",
+    "aggregate",
+    "aggregate_receipts",
+]

--- a/vouch/reputation_disputes.py
+++ b/vouch/reputation_disputes.py
@@ -1,0 +1,150 @@
+"""
+Reputation disputes (reputation Phase 5).
+
+A `DisputeCredential` challenges a specific receipt by id and content digest,
+signed by the challenger. A `DisputeResolution` signed by an arbiter upholds or
+dismisses it. When a resolution is upheld and applied to a `ReputationLedger`,
+the disputed receipt is excluded from scoring and from the evidence Merkle root.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from . import data_integrity
+from .jcs import canonicalize
+from .receipts import receipt_subject
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+DISPUTE_TYPE = "DisputeCredential"
+DISPUTE_RESOLUTION_TYPE = "DisputeResolution"
+
+
+class DisputeError(Exception):
+    """Raised on malformed dispute input."""
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _digest(receipt: Dict[str, Any]) -> str:
+    return "u" + base64.urlsafe_b64encode(hashlib.sha256(canonicalize(receipt)).digest()).rstrip(
+        b"="
+    ).decode("ascii")
+
+
+def _type_list(credential: Dict[str, Any]) -> list:
+    t = credential.get("type") or []
+    return [t] if isinstance(t, str) else list(t)
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise DisputeError("signing requires a Signer with an Ed25519 key")
+    credential["proof"] = data_integrity.build_proof(
+        credential, raw, signer.verification_method_id()
+    )
+    return credential
+
+
+def _verify(credential: Dict[str, Any], public_key: Any) -> bool:
+    from .verifier import _coerce_ed25519_public_key
+
+    pub = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if pub is None:
+        return False
+    try:
+        return data_integrity.verify_proof(credential, pub)
+    except ValueError:
+        return False
+
+
+def build_dispute(
+    challenger_signer: Any,
+    *,
+    receipt: Dict[str, Any],
+    reason: str,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Challenge a specific receipt, binding to its id and content digest."""
+    if not receipt.get("id"):
+        raise DisputeError("the disputed receipt needs an id")
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", DISPUTE_TYPE],
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "issuer": challenger_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": {
+            "id": receipt_subject(receipt),
+            "receipt": {"id": receipt.get("id"), "digest": _digest(receipt)},
+            "challenger": challenger_signer.get_did(),
+            "reason": reason,
+        },
+    }
+    return _attach_proof(credential, challenger_signer)
+
+
+def build_dispute_resolution(
+    arbiter_signer: Any,
+    *,
+    dispute: Dict[str, Any],
+    upheld: bool,
+    rationale: Optional[str] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """Uphold or dismiss a dispute, signed by an arbiter."""
+    dsub = dispute.get("credentialSubject") or {}
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": dsub.get("id"),
+        "dispute": dispute.get("id"),
+        "receipt": dsub.get("receipt"),
+        "upheld": bool(upheld),
+    }
+    if rationale is not None:
+        subject["rationale"] = rationale
+    credential = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", DISPUTE_RESOLUTION_TYPE],
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "issuer": arbiter_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    return _attach_proof(credential, arbiter_signer)
+
+
+def verify_dispute(dispute: Dict[str, Any], public_key: Any):
+    if DISPUTE_TYPE not in _type_list(dispute):
+        return False, None
+    if not _verify(dispute, public_key):
+        return False, None
+    return True, dispute.get("credentialSubject") or {}
+
+
+def verify_dispute_resolution(resolution: Dict[str, Any], public_key: Any):
+    if DISPUTE_RESOLUTION_TYPE not in _type_list(resolution):
+        return False, None
+    if not _verify(resolution, public_key):
+        return False, None
+    return True, resolution.get("credentialSubject") or {}
+
+
+__all__ = [
+    "DISPUTE_TYPE",
+    "DISPUTE_RESOLUTION_TYPE",
+    "DisputeError",
+    "build_dispute",
+    "build_dispute_resolution",
+    "verify_dispute",
+    "verify_dispute_resolution",
+]

--- a/vouch/reputation_ledger.py
+++ b/vouch/reputation_ledger.py
@@ -1,0 +1,185 @@
+"""
+Reputation ledger and signed snapshot (reputation Phase 3a, free SDK tier).
+
+A `ReputationLedger` is an in-process, Merkle-backed, append-only store of
+verified receipts about agents. On append it verifies each receipt's signature
+against a caller-supplied key resolver, so only authentic receipts enter. It
+computes a score with the Phase 2 aggregation function and exposes a Merkle root
+over an agent's receipts, so a consumer can be handed the receipts plus inclusion
+proofs and recompute the score rather than trust the ledger.
+
+`build_reputation_credential` issues a signed `ReputationCredential`: a snapshot
+of an agent's score plus the evidence Merkle root, signed by whoever runs the
+ledger. The hosted registry and HTTP API are a separate (commercial) layer on
+top; this module is self-hostable and open.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from . import data_integrity
+from .jcs import canonicalize
+from .merkle import MerkleTree
+from .receipts import receipt_subject
+from .reputation_aggregate import ReputationScore, aggregate_receipts
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+REPUTATION_CREDENTIAL_TYPE = "ReputationCredential"
+
+KeyResolver = Callable[[str], Any]  # issuer DID -> public key (or None if unknown)
+
+
+class LedgerError(Exception):
+    """Raised on a receipt the ledger will not admit."""
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _verify(credential: Dict[str, Any], public_key: Any) -> bool:
+    from .verifier import _coerce_ed25519_public_key
+
+    pub = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if pub is None:
+        return False
+    try:
+        return data_integrity.verify_proof(credential, pub)
+    except ValueError:
+        return False
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise LedgerError("signing requires a Signer with an Ed25519 key")
+    credential["proof"] = data_integrity.build_proof(
+        credential, raw, signer.verification_method_id()
+    )
+    return credential
+
+
+class ReputationLedger:
+    """Append-only, Merkle-backed store of verified receipts, with scoring."""
+
+    def __init__(self, *, resolver: KeyResolver, **agg_kwargs: Any) -> None:
+        self._resolver = resolver
+        self._agg = agg_kwargs
+        self._receipts: Dict[str, List[Dict[str, Any]]] = {}
+
+    def append(self, receipt: Dict[str, Any]) -> bool:
+        """Verify and admit a receipt. Raises LedgerError if it cannot be admitted."""
+        agent = receipt_subject(receipt)
+        if not agent:
+            raise LedgerError("receipt has no subject DID")
+        issuer = receipt.get("issuer")
+        if not issuer:
+            raise LedgerError("receipt has no issuer")
+        key = self._resolver(issuer)
+        if key is None:
+            raise LedgerError(f"no key resolved for issuer {issuer}")
+        if not _verify(receipt, key):
+            raise LedgerError("receipt signature did not verify")
+        self._receipts.setdefault(agent, []).append(receipt)
+        return True
+
+    def receipts(self, agent: str) -> List[Dict[str, Any]]:
+        return list(self._receipts.get(agent, []))
+
+    def count(self, agent: str) -> int:
+        return len(self._receipts.get(agent, []))
+
+    def merkle(self, agent: str) -> Optional[MerkleTree]:
+        leaves = [canonicalize(r) for r in self._receipts.get(agent, [])]
+        return MerkleTree(leaves) if leaves else None
+
+    def root(self, agent: str) -> Optional[str]:
+        tree = self.merkle(agent)
+        return tree.root_multibase() if tree is not None else None
+
+    def score(self, agent: str, *, at: Optional[datetime] = None, **kw: Any) -> ReputationScore:
+        merged = {**self._agg, **kw}
+        return aggregate_receipts(self._receipts.get(agent, []), agent=agent, at=at, **merged)
+
+    def snapshot(
+        self,
+        signer: Any,
+        agent: str,
+        *,
+        at: Optional[datetime] = None,
+        valid_seconds: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Issue a signed ReputationCredential for the agent's current standing."""
+        score = self.score(agent, at=at)
+        return build_reputation_credential(
+            signer,
+            agent,
+            score,
+            evidence_root=self.root(agent),
+            receipt_count=self.count(agent),
+            valid_from=at,
+            valid_seconds=valid_seconds,
+        )
+
+
+def build_reputation_credential(
+    signer: Any,
+    agent: str,
+    score: ReputationScore,
+    *,
+    evidence_root: Optional[str] = None,
+    receipt_count: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Issue a signed snapshot of an agent's reputation score."""
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": agent,
+        "score": {
+            "version": score.version,
+            "composite": score.composite,
+            "dimensions": score.dimensions,
+        },
+    }
+    if evidence_root is not None:
+        subject["evidenceRoot"] = evidence_root
+    if receipt_count is not None:
+        subject["receiptCount"] = receipt_count
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", REPUTATION_CREDENTIAL_TYPE],
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "issuer": signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return _attach_proof(credential, signer)
+
+
+def verify_reputation_credential(credential: Dict[str, Any], public_key: Any):
+    """Verify a ReputationCredential snapshot. Returns (ok, subject)."""
+    t = credential.get("type") or []
+    types = [t] if isinstance(t, str) else list(t)
+    if REPUTATION_CREDENTIAL_TYPE not in types:
+        return False, None
+    if not _verify(credential, public_key):
+        return False, None
+    return True, credential.get("credentialSubject") or {}
+
+
+__all__ = [
+    "REPUTATION_CREDENTIAL_TYPE",
+    "KeyResolver",
+    "LedgerError",
+    "ReputationLedger",
+    "build_reputation_credential",
+    "verify_reputation_credential",
+]

--- a/vouch/reputation_ledger.py
+++ b/vouch/reputation_ledger.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from . import data_integrity
 from .jcs import canonicalize
@@ -70,6 +70,7 @@ class ReputationLedger:
         self._resolver = resolver
         self._agg = agg_kwargs
         self._receipts: Dict[str, List[Dict[str, Any]]] = {}
+        self._excluded: Set[str] = set()
 
     def append(self, receipt: Dict[str, Any]) -> bool:
         """Verify and admit a receipt. Raises LedgerError if it cannot be admitted."""
@@ -87,14 +88,17 @@ class ReputationLedger:
         self._receipts.setdefault(agent, []).append(receipt)
         return True
 
+    def _active(self, agent: str) -> List[Dict[str, Any]]:
+        return [r for r in self._receipts.get(agent, []) if r.get("id") not in self._excluded]
+
     def receipts(self, agent: str) -> List[Dict[str, Any]]:
-        return list(self._receipts.get(agent, []))
+        return list(self._active(agent))
 
     def count(self, agent: str) -> int:
-        return len(self._receipts.get(agent, []))
+        return len(self._active(agent))
 
     def merkle(self, agent: str) -> Optional[MerkleTree]:
-        leaves = [canonicalize(r) for r in self._receipts.get(agent, [])]
+        leaves = [canonicalize(r) for r in self._active(agent)]
         return MerkleTree(leaves) if leaves else None
 
     def root(self, agent: str) -> Optional[str]:
@@ -103,7 +107,27 @@ class ReputationLedger:
 
     def score(self, agent: str, *, at: Optional[datetime] = None, **kw: Any) -> ReputationScore:
         merged = {**self._agg, **kw}
-        return aggregate_receipts(self._receipts.get(agent, []), agent=agent, at=at, **merged)
+        return aggregate_receipts(self._active(agent), agent=agent, at=at, **merged)
+
+    def exclude(self, receipt_id: str) -> None:
+        """Drop a receipt from scoring and the evidence root by its id."""
+        self._excluded.add(receipt_id)
+
+    def apply_resolution(self, resolution: Dict[str, Any], arbiter_public_key: Any) -> bool:
+        """
+        Verify an arbiter's DisputeResolution; if it is upheld, exclude the disputed
+        receipt. Returns True when a receipt was excluded.
+        """
+        if not _verify(resolution, arbiter_public_key):
+            raise LedgerError("dispute resolution did not verify")
+        subject = resolution.get("credentialSubject") or {}
+        if not subject.get("upheld"):
+            return False
+        receipt_id = (subject.get("receipt") or {}).get("id")
+        if not receipt_id:
+            raise LedgerError("resolution names no receipt")
+        self.exclude(receipt_id)
+        return True
 
     def snapshot(
         self,

--- a/vouch/reputation_policy.py
+++ b/vouch/reputation_policy.py
@@ -1,0 +1,147 @@
+"""
+Reputation policy and token attachment (reputation Phase 4).
+
+The consumer side. `evaluate_reputation` takes a ReputationScore or a signed
+ReputationCredential snapshot and a `ReputationPolicy` (minimum composite,
+per-dimension minimums, optional freshness) and returns an allow or deny
+decision with reasons. This is the check a verifier runs after it has verified
+the Vouch token itself, so trust becomes "authentic AND has standing."
+
+`reputation_pointer` builds the small reference object an issuer embeds in a
+token (at build time, before signing) to point at the agent's reputation record.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Union
+
+from .reputation_aggregate import ReputationScore
+from .reputation_ledger import REPUTATION_CREDENTIAL_TYPE, verify_reputation_credential
+
+
+@dataclass
+class ReputationPolicy:
+    min_composite: float = 0.0
+    min_dimensions: Dict[str, float] = field(default_factory=dict)
+    max_age_seconds: Optional[int] = None
+
+
+STAKES: Dict[str, ReputationPolicy] = {
+    "high": ReputationPolicy(min_composite=75.0, min_dimensions={"compliance": 60.0}),
+    "medium": ReputationPolicy(min_composite=60.0),
+    "low": ReputationPolicy(min_composite=50.0),
+}
+
+
+def policy_for_stakes(level: str) -> ReputationPolicy:
+    """A sensible default policy for high, medium, or low stakes decisions."""
+    if level not in STAKES:
+        raise ValueError(f"unknown stakes level: {level!r}")
+    return STAKES[level]
+
+
+@dataclass
+class ReputationDecision:
+    allowed: bool
+    composite: float
+    failures: List[str] = field(default_factory=list)
+
+
+def _coerce(
+    value: Union[ReputationScore, Dict[str, Any]],
+    public_key: Any,
+    policy: ReputationPolicy,
+    at: Optional[datetime],
+) -> "tuple[Optional[float], Dict[str, float], List[str]]":
+    """Return (composite, dimensions, failures-from-snapshot-checks)."""
+    if isinstance(value, ReputationScore):
+        return value.composite, dict(value.dimensions), []
+
+    if not isinstance(value, dict):
+        return None, {}, ["unrecognized reputation value"]
+
+    types = value.get("type")
+    is_snapshot = isinstance(types, list) and REPUTATION_CREDENTIAL_TYPE in types
+    if is_snapshot:
+        if public_key is not None:
+            ok, _ = verify_reputation_credential(value, public_key)
+            if not ok:
+                return None, {}, ["snapshot signature did not verify"]
+        failures: List[str] = []
+        if policy.max_age_seconds is not None and at is not None:
+            try:
+                issued = datetime.strptime(value.get("validFrom"), "%Y-%m-%dT%H:%M:%SZ").replace(
+                    tzinfo=timezone.utc
+                )
+                if (at.astimezone(timezone.utc) - issued).total_seconds() > policy.max_age_seconds:
+                    failures.append("snapshot is stale")
+            except (TypeError, ValueError):
+                failures.append("snapshot has no usable validFrom")
+        score = (value.get("credentialSubject") or {}).get("score") or {}
+        return score.get("composite"), dict(score.get("dimensions") or {}), failures
+
+    # plain {composite, dimensions}
+    return value.get("composite"), dict(value.get("dimensions") or {}), []
+
+
+def evaluate_reputation(
+    value: Union[ReputationScore, Dict[str, Any]],
+    policy: ReputationPolicy,
+    *,
+    public_key: Any = None,
+    at: Optional[datetime] = None,
+) -> ReputationDecision:
+    """Decide whether a reputation meets a policy. Verifies a snapshot if a key is given."""
+    composite, dimensions, failures = _coerce(value, public_key, policy, at)
+    failures = list(failures)
+
+    if composite is None:
+        failures.append("no composite score available")
+        return ReputationDecision(allowed=False, composite=0.0, failures=failures)
+
+    if composite < policy.min_composite:
+        failures.append(f"composite {composite} < required {policy.min_composite}")
+    for dim, minimum in policy.min_dimensions.items():
+        if dimensions.get(dim, 0.0) < minimum:
+            failures.append(f"{dim} {dimensions.get(dim, 0.0)} < required {minimum}")
+
+    return ReputationDecision(allowed=not failures, composite=composite, failures=failures)
+
+
+def reputation_pointer(
+    *,
+    registry: str,
+    record: Optional[str] = None,
+    subject: Optional[str] = None,
+    evidence_root: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Build an AccountabilityRecord pointer to an agent's reputation record, for
+    embedding in a token's subject at build time (before signing).
+    """
+    if not registry:
+        raise ValueError("registry is required")
+    pointer: Dict[str, Any] = {
+        "type": "AccountabilityRecord",
+        "kind": "reputation",
+        "ledger": registry,
+    }
+    if record is not None:
+        pointer["record"] = record
+    if subject is not None:
+        pointer["subject"] = subject
+    if evidence_root is not None:
+        pointer["evidenceRoot"] = evidence_root
+    return pointer
+
+
+__all__ = [
+    "ReputationPolicy",
+    "ReputationDecision",
+    "STAKES",
+    "policy_for_stakes",
+    "evaluate_reputation",
+    "reputation_pointer",
+]

--- a/vouch/reputation_portability.py
+++ b/vouch/reputation_portability.py
@@ -1,0 +1,178 @@
+"""
+Privacy-preserving reputation portability (reputation Phase 5).
+
+A `ReputationThresholdProof` lets an agent prove a predicate over its reputation
+(composite >= 75, or reliability >= 0.9) without revealing the score or the
+underlying receipts. The registry evaluates the predicate and signs the boolean
+result, optionally bound to an `audience` so proofs are not linkable across
+verifiers.
+
+This is selective disclosure: the verifier trusts the issuer's signature on the
+predicate result rather than recomputing it from hidden data. A full
+zero-knowledge range proof, which would hide the score even from the issuer and
+need no trusted issuer, is a later cryptographic upgrade. The credential shape
+here is forward-compatible: the signed assertion can be swapped for a zk proof
+object without changing how it is referenced.
+"""
+
+from __future__ import annotations
+
+import operator
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Union
+
+from . import data_integrity
+from .reputation_aggregate import ReputationScore
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+REPUTATION_PROOF_TYPE = "ReputationThresholdProof"
+
+_OPS = {">=": operator.ge, ">": operator.gt, "<=": operator.le, "<": operator.lt, "==": operator.eq}
+
+ScoreLike = Union[ReputationScore, Dict[str, Any]]
+
+
+class PortabilityError(Exception):
+    """Raised on a malformed predicate or proof."""
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _composite(score: ScoreLike) -> Optional[float]:
+    if isinstance(score, ReputationScore):
+        return score.composite
+    return score.get("composite")
+
+
+def _dimensions(score: ScoreLike) -> Dict[str, float]:
+    if isinstance(score, ReputationScore):
+        return dict(score.dimensions)
+    return dict(score.get("dimensions") or {})
+
+
+def _resolve(score: ScoreLike, path: str) -> Optional[float]:
+    if path == "composite":
+        return _composite(score)
+    if path.startswith("dimensions."):
+        return _dimensions(score).get(path.split(".", 1)[1])
+    return None
+
+
+def _eval(score: ScoreLike, predicate: Dict[str, Any]) -> bool:
+    op = _OPS.get(predicate.get("op"))
+    if op is None:
+        raise PortabilityError(f"unsupported op: {predicate.get('op')!r}")
+    val = _resolve(score, predicate.get("path", ""))
+    if val is None:
+        return False
+    return bool(op(float(val), float(predicate["value"])))
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise PortabilityError("signing requires a Signer with an Ed25519 key")
+    credential["proof"] = data_integrity.build_proof(
+        credential, raw, signer.verification_method_id()
+    )
+    return credential
+
+
+def build_reputation_proof(
+    signer: Any,
+    agent: str,
+    score: ScoreLike,
+    *,
+    predicates: List[Dict[str, Any]],
+    audience: Optional[str] = None,
+    evidence_root: Optional[str] = None,
+    valid_from: Optional[datetime] = None,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a ReputationThresholdProof. Each predicate is `{path, op, value}` where
+    `path` is "composite" or "dimensions.<name>". The proof carries only the
+    predicate and whether it is satisfied, never the score itself.
+    """
+    if not predicates:
+        raise PortabilityError("at least one predicate is required")
+    assertions = [
+        {
+            "path": p["path"],
+            "op": p["op"],
+            "value": p["value"],
+            "satisfied": _eval(score, p),
+        }
+        for p in predicates
+    ]
+    subject: Dict[str, Any] = {"id": agent, "assertions": assertions}
+    if audience is not None:
+        subject["audience"] = audience
+    if evidence_root is not None:
+        subject["evidenceRoot"] = evidence_root
+
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", REPUTATION_PROOF_TYPE],
+        "id": f"urn:uuid:{uuid.uuid4()}",
+        "issuer": signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return _attach_proof(credential, signer)
+
+
+def verify_reputation_proof(
+    proof: Dict[str, Any],
+    public_key: Any,
+    *,
+    require: Optional[List[Dict[str, Any]]] = None,
+    audience: Optional[str] = None,
+):
+    """
+    Verify the issuer's signature and, optionally, that the required predicates are
+    present and satisfied and the audience matches. Returns (ok, assertions).
+    """
+    from .verifier import _coerce_ed25519_public_key
+
+    t = proof.get("type") or []
+    types = [t] if isinstance(t, str) else list(t)
+    if REPUTATION_PROOF_TYPE not in types:
+        return False, None
+
+    pub = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if pub is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(proof, pub):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = proof.get("credentialSubject") or {}
+    if audience is not None and subject.get("audience") != audience:
+        return False, None
+
+    assertions = subject.get("assertions") or []
+    if require is not None:
+        index = {(a["path"], a["op"], str(a["value"])): bool(a["satisfied"]) for a in assertions}
+        for p in require:
+            if not index.get((p["path"], p["op"], str(p["value"])), False):
+                return False, assertions
+
+    return True, assertions
+
+
+__all__ = [
+    "REPUTATION_PROOF_TYPE",
+    "PortabilityError",
+    "build_reputation_proof",
+    "verify_reputation_proof",
+]


### PR DESCRIPTION
## What

Evidence-backed reputation for agents, built end to end. Reputation is a verifiable aggregate of signed, interaction-bound receipts computed by a public deterministic function and keyed to the agent's DID. A consumer trusts the signatures and the math, not a server's stored number.

This is the free, self-hostable SDK tier. The hosted registry and `GET /v1/reputation/{did}` worker are a separate commercial track and are not in this PR.

## Modules

- `docs/specs/reputation-aggregation.md` — the design spec.
- `vouch/receipts.py` — `StateReceipt` (relying-party signed) and `PenaltyReceipt` (authority signed), plus `normalize_receipt` that turns these and the existing `OutcomeAttestation` / `ReviewCredential` into dimensioned signals.
- `vouch/reputation_aggregate.py` — the deterministic, versioned, multi-dimensional aggregation function (issuer-weighted, time-decayed).
- `vouch/reputation_ledger.py` — a Merkle-backed, append-only ledger that verifies each receipt before admitting it, plus a signed `ReputationCredential` snapshot.
- `vouch/reputation_policy.py` — `evaluate_reputation` against a `ReputationPolicy` (min composite, per-dimension minimums, freshness), stakes presets, and a token reputation pointer.
- `vouch/reputation_portability.py` — `ReputationThresholdProof`: prove "composite >= 75" without revealing the score, audience-bound for unlinkability. Selective disclosure today; the shape is forward-compatible with a zk range proof.
- `vouch/reputation_disputes.py` — `DisputeCredential` and `DisputeResolution`, with ledger exclusion of upheld-disputed receipts.

## Tests and demo

40 tests across the six modules, all passing; ruff clean. Runnable walkthrough: `python examples/reputation_demo.py` (receipts to ledger to signed snapshot to policy gate to threshold proof to dispute).

## Note

The pre-existing `test_git_workflow` and `test_audio_bridge` failures in some environments are unrelated to this change (a missing `python` binary and an audio dependency, respectively); the reputation suite is self-contained.
