### PR TITLE
docs(website): add evidence-backed reputation to the site and assistant surfaces

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -252,6 +252,7 @@ For depth on any topic, read the relevant file under `reference/`:
 - `reference/revocation.md` - DID-level and credential-level revocation
 - `reference/state-verifiability.md` - Heartbeat, validator quorum, behavioral attestation
 - `reference/outcome-evidence.md` - Commit-before-outcome verdicts, settlement, track record
+- `reference/reputation-evidence.md` - Evidence-backed reputation: receipts, aggregation, ledger, policy, threshold proofs, disputes
 - `reference/robotics.md` - Robot identity, provenance, physical scope, handshake, black box and kill switch, passport
 - `reference/integrations.md` - LangChain, CrewAI, MCP, AutoGen, Vertex AI patterns
 - `reference/sidecar.md` - Identity Sidecar architecture and deployment

--- a/claude-skill/skills/vouch-protocol/reference/reputation-evidence.md
+++ b/claude-skill/skills/vouch-protocol/reference/reputation-evidence.md
@@ -1,0 +1,79 @@
+# Evidence-Backed Reputation Reference
+
+Reputation in Vouch is a verifiable aggregate of signed, interaction-bound
+receipts, computed by a public deterministic function and keyed to the agent's
+DID. A consumer trusts the signatures and the math, never a server's stored
+number: given the same receipts and the same function version, every party
+computes the same score. It ships in the Python SDK across `vouch.receipts`,
+`vouch.reputation_aggregate`, `vouch.reputation_ledger`, `vouch.reputation_policy`,
+`vouch.reputation_portability`, and `vouch.reputation_disputes`.
+
+This is distinct from the older `vouch.reputation` engine, which keeps a mutable
+operator-set score. The evidence-backed path is the one to lead with.
+
+## The signals (objective-first)
+
+Every input is a signed Verifiable Credential about an agent DID, tied to an
+`interactionId`:
+
+- `StateReceipt`: the relying party the agent acted on signs the result of an
+  action (success or failure, SLA met). The agent cannot withhold it. Objective.
+- `OutcomeAttestationCredential`: a settled commit-before-outcome verdict (from
+  `vouch.accountability`). Objective.
+- `PenaltyReceipt`: a validator or authority records a violation. Negative.
+- `ReviewCredential`: a human rater's multi-dimensional rating, bound to proof of
+  interaction. Subjective, low weight.
+
+Each receipt normalizes to dimensioned signals (`reliability`, `performance`,
+`compliance`, `satisfaction`) in [-1, 1].
+
+## The aggregation function
+
+Deterministic and versioned. A signal contributes to its dimension with weight
+`type_weight(source) * decay(age) * issuer_weight(issuer)`. A dimension score is
+the baseline plus the weighted-mean signal value scaled across the span, clamped
+to [0, 100]; the composite is the support-weighted mean of the dimensions.
+
+```python
+from vouch.reputation_aggregate import aggregate_receipts
+
+score = aggregate_receipts(receipts, agent="did:web:agent.example.com")
+print(score.composite, score.dimensions)
+```
+
+## The ledger and a signed snapshot
+
+```python
+from vouch.reputation_ledger import ReputationLedger, verify_reputation_credential
+
+ledger = ReputationLedger(resolver=lambda did: public_key_for(did))
+ledger.append(state_receipt)   # verifies the signature before admitting it
+snapshot = ledger.snapshot(registry_signer, agent_did)   # a signed ReputationCredential
+```
+
+The ledger keeps receipts in a Merkle log, so a consumer can be handed the
+receipts plus inclusion proofs and recompute the score rather than trust the
+snapshot's number.
+
+## Policy gate, portability, disputes
+
+```python
+from vouch.reputation_policy import evaluate_reputation, policy_for_stakes
+decision = evaluate_reputation(snapshot, policy_for_stakes("high"), public_key=registry_pub)
+
+from vouch.reputation_portability import build_reputation_proof
+proof = build_reputation_proof(registry_signer, agent_did, score,
+    predicates=[{"path": "composite", "op": ">=", "value": 75}], audience=verifier_did)
+# proves the threshold without revealing the score
+
+from vouch.reputation_disputes import build_dispute, build_dispute_resolution
+ledger.apply_resolution(resolution, arbiter_pub)   # an upheld dispute drops the receipt
+```
+
+## Where it sits
+
+Reviews and ratings are a subjective, application-level signal and easy to game;
+objective receipts (relying-party state, settled outcomes) carry the score.
+Demo: `python examples/reputation_demo.py`. The hosted registry and a public
+`GET /v1/reputation/{did}` API are a separate commercial layer; the formats, the
+aggregation function, and a self-hostable ledger are open.

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -60,6 +60,11 @@ Never share user data with external sites.
   evidence (`vouch.accountability`): commit the verdict before the outcome with
   `commit_outcome`, settle it later with `attest_outcome`. Verification rejects a
   settlement timestamped before its commitment. See `outcome-evidence.md`.
+- "How does agent reputation work?" -> Evidence-backed reputation: signed
+  receipts (`vouch.receipts`) aggregated by a public deterministic function
+  (`vouch.reputation_aggregate`) over a verified ledger (`vouch.reputation_ledger`),
+  with policy gates, threshold proofs, and disputes. The consumer recomputes the
+  score rather than trusting a server. See `reputation-evidence.md`.
 - "How do I give a robot identity, prove what model it runs, or enforce physical
   limits?" -> The robotics capabilities (`vouch.robotics`): hardware-rooted
   identity, model and config provenance, physical capability scope (force/speed/

--- a/gemini-gem/knowledge/reputation-evidence.md
+++ b/gemini-gem/knowledge/reputation-evidence.md
@@ -1,0 +1,79 @@
+# Evidence-Backed Reputation Reference
+
+Reputation in Vouch is a verifiable aggregate of signed, interaction-bound
+receipts, computed by a public deterministic function and keyed to the agent's
+DID. A consumer trusts the signatures and the math, never a server's stored
+number: given the same receipts and the same function version, every party
+computes the same score. It ships in the Python SDK across `vouch.receipts`,
+`vouch.reputation_aggregate`, `vouch.reputation_ledger`, `vouch.reputation_policy`,
+`vouch.reputation_portability`, and `vouch.reputation_disputes`.
+
+This is distinct from the older `vouch.reputation` engine, which keeps a mutable
+operator-set score. The evidence-backed path is the one to lead with.
+
+## The signals (objective-first)
+
+Every input is a signed Verifiable Credential about an agent DID, tied to an
+`interactionId`:
+
+- `StateReceipt`: the relying party the agent acted on signs the result of an
+  action (success or failure, SLA met). The agent cannot withhold it. Objective.
+- `OutcomeAttestationCredential`: a settled commit-before-outcome verdict (from
+  `vouch.accountability`). Objective.
+- `PenaltyReceipt`: a validator or authority records a violation. Negative.
+- `ReviewCredential`: a human rater's multi-dimensional rating, bound to proof of
+  interaction. Subjective, low weight.
+
+Each receipt normalizes to dimensioned signals (`reliability`, `performance`,
+`compliance`, `satisfaction`) in [-1, 1].
+
+## The aggregation function
+
+Deterministic and versioned. A signal contributes to its dimension with weight
+`type_weight(source) * decay(age) * issuer_weight(issuer)`. A dimension score is
+the baseline plus the weighted-mean signal value scaled across the span, clamped
+to [0, 100]; the composite is the support-weighted mean of the dimensions.
+
+```python
+from vouch.reputation_aggregate import aggregate_receipts
+
+score = aggregate_receipts(receipts, agent="did:web:agent.example.com")
+print(score.composite, score.dimensions)
+```
+
+## The ledger and a signed snapshot
+
+```python
+from vouch.reputation_ledger import ReputationLedger, verify_reputation_credential
+
+ledger = ReputationLedger(resolver=lambda did: public_key_for(did))
+ledger.append(state_receipt)   # verifies the signature before admitting it
+snapshot = ledger.snapshot(registry_signer, agent_did)   # a signed ReputationCredential
+```
+
+The ledger keeps receipts in a Merkle log, so a consumer can be handed the
+receipts plus inclusion proofs and recompute the score rather than trust the
+snapshot's number.
+
+## Policy gate, portability, disputes
+
+```python
+from vouch.reputation_policy import evaluate_reputation, policy_for_stakes
+decision = evaluate_reputation(snapshot, policy_for_stakes("high"), public_key=registry_pub)
+
+from vouch.reputation_portability import build_reputation_proof
+proof = build_reputation_proof(registry_signer, agent_did, score,
+    predicates=[{"path": "composite", "op": ">=", "value": 75}], audience=verifier_did)
+# proves the threshold without revealing the score
+
+from vouch.reputation_disputes import build_dispute, build_dispute_resolution
+ledger.apply_resolution(resolution, arbiter_pub)   # an upheld dispute drops the receipt
+```
+
+## Where it sits
+
+Reviews and ratings are a subjective, application-level signal and easy to game;
+objective receipts (relying-party state, settled outcomes) carry the score.
+Demo: `python examples/reputation_demo.py`. The hosted registry and a public
+`GET /v1/reputation/{did}` API are a separate commercial layer; the formats, the
+aggregation function, and a self-hostable ledger are open.

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -61,9 +61,14 @@ implement the same wire format. Default cryptosuite is `eddsa-jcs-2022`
   regulated production, M-of-N with role-tagged validators.
 - "How do I prove an agent was right, or track a record I cannot fake?" ->
   Outcome evidence (`vouch.accountability`): commit the verdict before the
-  outcome with `commit_outcome`, settle it later with `attest_outcome`. The
-  reputation engine is a mutable score; outcome evidence is the tamper-evident
-  record underneath it. See `outcome-evidence.md`.
+  outcome with `commit_outcome`, settle it later with `attest_outcome`. See
+  `outcome-evidence.md`.
+- "How does agent reputation work, or how do I score an agent?" ->
+  Evidence-backed reputation: signed receipts (`vouch.receipts`) aggregated by a
+  public deterministic function (`vouch.reputation_aggregate`) over a verified
+  ledger (`vouch.reputation_ledger`), with policy gates, threshold proofs, and
+  disputes. A consumer recomputes the score rather than trusting a server. See
+  `reputation-evidence.md`.
 - "How do I give a robot identity, prove what model it runs, or enforce
   physical limits?" -> The robotics capabilities (`vouch.robotics`):
   hardware-rooted identity, model and config provenance, physical capability

--- a/openai-gpt/knowledge/reputation-evidence.md
+++ b/openai-gpt/knowledge/reputation-evidence.md
@@ -1,0 +1,79 @@
+# Evidence-Backed Reputation Reference
+
+Reputation in Vouch is a verifiable aggregate of signed, interaction-bound
+receipts, computed by a public deterministic function and keyed to the agent's
+DID. A consumer trusts the signatures and the math, never a server's stored
+number: given the same receipts and the same function version, every party
+computes the same score. It ships in the Python SDK across `vouch.receipts`,
+`vouch.reputation_aggregate`, `vouch.reputation_ledger`, `vouch.reputation_policy`,
+`vouch.reputation_portability`, and `vouch.reputation_disputes`.
+
+This is distinct from the older `vouch.reputation` engine, which keeps a mutable
+operator-set score. The evidence-backed path is the one to lead with.
+
+## The signals (objective-first)
+
+Every input is a signed Verifiable Credential about an agent DID, tied to an
+`interactionId`:
+
+- `StateReceipt`: the relying party the agent acted on signs the result of an
+  action (success or failure, SLA met). The agent cannot withhold it. Objective.
+- `OutcomeAttestationCredential`: a settled commit-before-outcome verdict (from
+  `vouch.accountability`). Objective.
+- `PenaltyReceipt`: a validator or authority records a violation. Negative.
+- `ReviewCredential`: a human rater's multi-dimensional rating, bound to proof of
+  interaction. Subjective, low weight.
+
+Each receipt normalizes to dimensioned signals (`reliability`, `performance`,
+`compliance`, `satisfaction`) in [-1, 1].
+
+## The aggregation function
+
+Deterministic and versioned. A signal contributes to its dimension with weight
+`type_weight(source) * decay(age) * issuer_weight(issuer)`. A dimension score is
+the baseline plus the weighted-mean signal value scaled across the span, clamped
+to [0, 100]; the composite is the support-weighted mean of the dimensions.
+
+```python
+from vouch.reputation_aggregate import aggregate_receipts
+
+score = aggregate_receipts(receipts, agent="did:web:agent.example.com")
+print(score.composite, score.dimensions)
+```
+
+## The ledger and a signed snapshot
+
+```python
+from vouch.reputation_ledger import ReputationLedger, verify_reputation_credential
+
+ledger = ReputationLedger(resolver=lambda did: public_key_for(did))
+ledger.append(state_receipt)   # verifies the signature before admitting it
+snapshot = ledger.snapshot(registry_signer, agent_did)   # a signed ReputationCredential
+```
+
+The ledger keeps receipts in a Merkle log, so a consumer can be handed the
+receipts plus inclusion proofs and recompute the score rather than trust the
+snapshot's number.
+
+## Policy gate, portability, disputes
+
+```python
+from vouch.reputation_policy import evaluate_reputation, policy_for_stakes
+decision = evaluate_reputation(snapshot, policy_for_stakes("high"), public_key=registry_pub)
+
+from vouch.reputation_portability import build_reputation_proof
+proof = build_reputation_proof(registry_signer, agent_did, score,
+    predicates=[{"path": "composite", "op": ">=", "value": 75}], audience=verifier_did)
+# proves the threshold without revealing the score
+
+from vouch.reputation_disputes import build_dispute, build_dispute_resolution
+ledger.apply_resolution(resolution, arbiter_pub)   # an upheld dispute drops the receipt
+```
+
+## Where it sits
+
+Reviews and ratings are a subjective, application-level signal and easy to game;
+objective receipts (relying-party state, settled outcomes) carry the score.
+Demo: `python examples/reputation_demo.py`. The hosted registry and a public
+`GET /v1/reputation/{did}` API are a separate commercial layer; the formats, the
+aggregation function, and a self-hostable ledger are open.

--- a/website-agent/backend/knowledge/reputation-evidence.md
+++ b/website-agent/backend/knowledge/reputation-evidence.md
@@ -1,0 +1,79 @@
+# Evidence-Backed Reputation Reference
+
+Reputation in Vouch is a verifiable aggregate of signed, interaction-bound
+receipts, computed by a public deterministic function and keyed to the agent's
+DID. A consumer trusts the signatures and the math, never a server's stored
+number: given the same receipts and the same function version, every party
+computes the same score. It ships in the Python SDK across `vouch.receipts`,
+`vouch.reputation_aggregate`, `vouch.reputation_ledger`, `vouch.reputation_policy`,
+`vouch.reputation_portability`, and `vouch.reputation_disputes`.
+
+This is distinct from the older `vouch.reputation` engine, which keeps a mutable
+operator-set score. The evidence-backed path is the one to lead with.
+
+## The signals (objective-first)
+
+Every input is a signed Verifiable Credential about an agent DID, tied to an
+`interactionId`:
+
+- `StateReceipt`: the relying party the agent acted on signs the result of an
+  action (success or failure, SLA met). The agent cannot withhold it. Objective.
+- `OutcomeAttestationCredential`: a settled commit-before-outcome verdict (from
+  `vouch.accountability`). Objective.
+- `PenaltyReceipt`: a validator or authority records a violation. Negative.
+- `ReviewCredential`: a human rater's multi-dimensional rating, bound to proof of
+  interaction. Subjective, low weight.
+
+Each receipt normalizes to dimensioned signals (`reliability`, `performance`,
+`compliance`, `satisfaction`) in [-1, 1].
+
+## The aggregation function
+
+Deterministic and versioned. A signal contributes to its dimension with weight
+`type_weight(source) * decay(age) * issuer_weight(issuer)`. A dimension score is
+the baseline plus the weighted-mean signal value scaled across the span, clamped
+to [0, 100]; the composite is the support-weighted mean of the dimensions.
+
+```python
+from vouch.reputation_aggregate import aggregate_receipts
+
+score = aggregate_receipts(receipts, agent="did:web:agent.example.com")
+print(score.composite, score.dimensions)
+```
+
+## The ledger and a signed snapshot
+
+```python
+from vouch.reputation_ledger import ReputationLedger, verify_reputation_credential
+
+ledger = ReputationLedger(resolver=lambda did: public_key_for(did))
+ledger.append(state_receipt)   # verifies the signature before admitting it
+snapshot = ledger.snapshot(registry_signer, agent_did)   # a signed ReputationCredential
+```
+
+The ledger keeps receipts in a Merkle log, so a consumer can be handed the
+receipts plus inclusion proofs and recompute the score rather than trust the
+snapshot's number.
+
+## Policy gate, portability, disputes
+
+```python
+from vouch.reputation_policy import evaluate_reputation, policy_for_stakes
+decision = evaluate_reputation(snapshot, policy_for_stakes("high"), public_key=registry_pub)
+
+from vouch.reputation_portability import build_reputation_proof
+proof = build_reputation_proof(registry_signer, agent_did, score,
+    predicates=[{"path": "composite", "op": ">=", "value": 75}], audience=verifier_did)
+# proves the threshold without revealing the score
+
+from vouch.reputation_disputes import build_dispute, build_dispute_resolution
+ledger.apply_resolution(resolution, arbiter_pub)   # an upheld dispute drops the receipt
+```
+
+## Where it sits
+
+Reviews and ratings are a subjective, application-level signal and easy to game;
+objective receipts (relying-party state, settled outcomes) carry the score.
+Demo: `python examples/reputation_demo.py`. The hosted registry and a public
+`GET /v1/reputation/{did}` API are a separate commercial layer; the formats, the
+aggregation function, and a self-hostable ledger are open.

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -163,9 +163,17 @@ A Vouch delegation chain captures all three steps cryptographically. Each step n
 
 It works in two steps. First the agent commits a verdict, prediction, or recommendation and signs it before the result is known. The commitment can carry only a salted fingerprint of the call, so the content stays private until later while still being locked in. Then, once the outcome is observable, a settlement record (which can be signed by a neutral third party) reveals the original call and binds the real result to it. Anyone can recompute the fingerprint and check it matches, and a settlement dated before its commitment is rejected. So a winning call cannot be invented after the fact, and a losing one cannot quietly disappear.
 
-This is the evidence layer underneath a reputation score. A score can be moved by whoever keeps it; outcome evidence is a per-call artifact the agent cannot rewrite.`,
+This is the evidence layer underneath reputation. Vouch reputation is itself evidence-backed: a score recomputed from signed receipts, not a number a server keeps.`,
         helpLinks: [{ label: 'Outcome evidence how-to', href: '/help/#outcome-evidence' }],
         meta: 'Shipped on main - vouch.accountability, PAD-071',
+      },
+      {
+        q: 'How does Vouch reputation avoid being gamed?',
+        a: `Reputation is computed from signed receipts, each tied to a real interaction, by a public function anyone can rerun. The relying party the agent acted on signs the result of an action, a settled prediction signs whether it came true, and an authority signs a penalty. The score is the weighted, time-decayed aggregate of those across dimensions like reliability, performance, and compliance.
+
+A consumer does not trust a server's number: it fetches the receipts and recomputes the score itself. Anonymous star ratings carry almost no weight, and a human review only counts when it is bound to proof the rater actually used the agent. An agent can prove it clears a bar, say a composite of at least 75, without revealing its score, and a receipt issued in error can be disputed and dropped by an arbiter.`,
+        helpLinks: [{ label: 'Evidence-backed reputation', href: '/help/#reputation-evidence' }],
+        meta: 'Shipped on main - vouch.receipts, vouch.reputation_aggregate, vouch.reputation_ledger',
       },
     ],
   },

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -971,7 +971,29 @@ Verification recomputes the fingerprint from the revealed call, confirms it matc
 
 ## Where it sits
 
-This is the per-verdict evidence layer underneath the reputation engine. Feed settled attestations into \`vouch.reputation\` rather than trusting a self-reported score. Full demo: \`python examples/accountability_demo.py\`. Defensive disclosure: PAD-071.
+This is the per-verdict evidence layer underneath reputation. Vouch reputation aggregates settled attestations and other signed receipts into a score anyone can recompute, covered in Evidence-Backed Reputation below. Full demo: \`python examples/accountability_demo.py\`. Defensive disclosure: PAD-071.
+`,
+      },
+      {
+        id: 'reputation-evidence',
+        title: 'Evidence-Backed Reputation',
+        summary: 'Compute an agent reputation from signed receipts with a public function, so anyone can recompute it instead of trusting a server.',
+        body: `
+## What it is
+
+Reputation is a verifiable aggregate of signed, interaction-bound receipts, keyed to the agent DID and computed by a public deterministic function. A consumer trusts the signatures and the math, not a server's stored number.
+
+## The signals (objective first)
+
+The relying party the agent acted on signs the result of an action (a StateReceipt), a settled prediction signs whether it came true (an OutcomeAttestationCredential), and an authority signs a violation (a PenaltyReceipt). A human ReviewCredential counts only when bound to proof the rater used the agent, and carries low weight.
+
+## How it works
+
+A ReputationLedger verifies each receipt before admitting it and keeps them in a Merkle log, so a consumer can recompute the score from the receipts and inclusion proofs rather than trust the registry signed snapshot. evaluate_reputation gates a decision against a policy of minimum composite, per-dimension minimums, and freshness. build_reputation_proof proves the agent clears a threshold without revealing its score, and apply_resolution drops a receipt an arbiter has ruled invalid.
+
+## Demo
+
+Run python examples/reputation_demo.py for the full path: receipts to ledger to signed snapshot to policy gate to threshold proof to dispute. The formats and the aggregation function are open; a hosted registry is a separate commercial layer.
 `,
       },
       {

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -58,6 +58,12 @@ const FEATURES: Array<{ num: string; title: string; body: string; spec: string; 
     body: 'A verdict, prediction, or recommendation committed and signed before its outcome is known, then settled by a separate attestation that binds the real result back to it. A salted commitment keeps the call private until settlement, and verification rejects a backdated settlement, so an agent track record cannot be cherry-picked or rewritten after the fact.',
     spec: 'Outcome Evidence',
   },
+  {
+    num: 'x.',
+    title: 'Evidence-Backed Reputation',
+    body: 'Reputation as a verifiable aggregate of signed receipts, the relying party attesting an action, a settled outcome, an authority recording a penalty, computed by a public deterministic function and keyed to the agent DID. A consumer recomputes the score from the receipts rather than trusting a server, with multi-dimensional scores, decay, threshold proofs that reveal nothing but the threshold, and disputes that exclude bad receipts.',
+    spec: 'Reputation',
+  },
 ];
 
 const LANGUAGE_TILES = [

--- a/website/src/app/tools/page.tsx
+++ b/website/src/app/tools/page.tsx
@@ -94,6 +94,11 @@ const GROUPS: Group[] = [
                 blurb: "Commit an agent's verdict or prediction before the result is known, then settle it later against what actually happened. A salted commitment keeps the call private until settlement, and a backdated settlement is rejected, so a track record cannot be cherry-picked. The settler can be a neutral third party.",
                 start: 'python examples/accountability_demo.py',
             },
+            {
+                name: 'Evidence-backed reputation',
+                blurb: "Reputation built from signed receipts, a relying party attesting an action, a settled outcome, an authority recording a penalty, scored by a public deterministic function. A consumer recomputes the score from the receipts rather than trusting a server. Includes multi-dimensional scores, threshold proofs that reveal nothing but the threshold, and disputes that drop bad receipts.",
+                start: 'python examples/reputation_demo.py',
+            },
         ],
     },
     {


### PR DESCRIPTION
Adds the evidence-backed reputation capability across the website and the four assistant knowledge mirrors, now that the SDK shipped in #150.

- Homepage: a new Evidence-Backed Reputation feature card.
- Tools page: an Evidence-backed reputation card under For your agents, pointing at examples/reputation_demo.py.
- FAQ: a How does Vouch reputation avoid being gamed entry, and a fix to the older line that described reputation as a server-kept score.
- Help: an Evidence-Backed Reputation guide, and the same fix in the outcome-evidence guide.
- Knowledge base: reputation-evidence.md added to all four mirrors (Claude skill, OpenAI GPT, Gemini gem, hosted assistant), plus the SKILL reference list and OpenAI/Gemini instruction triggers.

FAQ and Help data files type-check clean; no em-dashes.