### PR TITLE
feat(conformance): post-quantum conformance badge and Phase 1 test runner

### DIFF
--- a/.github/workflows/verified-conformance.yml
+++ b/.github/workflows/verified-conformance.yml
@@ -1,0 +1,104 @@
+name: Verified Conformance credential
+
+# Dogfoods the protocol: run the Vouch conformance test against this repo's own
+# implementation and, on a passing run, mint a signed "Vouch Verified Conformant"
+# credential chained back to the project root authority. Mirrors
+# .github/workflows/verified-contributor.yml.
+#
+# The robotics profile uses the same mint script (--profile robotics); it plugs
+# into this workflow once the robotics check lands in vouch/conformance.py.
+#
+# Setup (see conformance/README.md): add repository secrets
+# VOUCH_CONFORMANCE_PRIVATE_KEY (the conformance issuer Ed25519 JWK) and
+# VOUCH_CONFORMANCE_DID (did:web:vouch-protocol.com:conformance), and publish the
+# issuer public key at website/public/conformance/did.json. If
+# conformance/delegation.json is present, the badge is chained to the root
+# authority automatically. The job is a safe no-op if the secrets are not set.
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  certify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install vouch
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Run the conformance test
+        id: test
+        run: |
+          level=$(python - <<'PY'
+          from vouch.conformance import run_conformance
+
+          print(run_conformance().achieved or "")
+          PY
+          )
+          echo "Highest passing level: ${level:-none}"
+          echo "level=$level" >> "$GITHUB_OUTPUT"
+
+      - name: Mint the conformance credential
+        if: steps.test.outputs.level != ''
+        env:
+          VOUCH_CONFORMANCE_PRIVATE_KEY: ${{ secrets.VOUCH_CONFORMANCE_PRIVATE_KEY }}
+          VOUCH_CONFORMANCE_DID: ${{ secrets.VOUCH_CONFORMANCE_DID }}
+          LEVEL: ${{ steps.test.outputs.level }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          if [ -z "$VOUCH_CONFORMANCE_PRIVATE_KEY" ] || [ -z "$VOUCH_CONFORMANCE_DID" ]; then
+            echo "Conformance issuer key not configured; skipping minting."
+            exit 0
+          fi
+          PARENT=""
+          if [ -f conformance/delegation.json ]; then
+            PARENT="--parent conformance/delegation.json"
+          fi
+          python scripts/mint_conformance_credential.py \
+            --subject "$REPO" --commit "$SHA" \
+            --profile core --level "$LEVEL" \
+            $PARENT --out credential.json
+
+      - name: Verify the badge against the published DID document
+        if: steps.test.outputs.level != '' && hashFiles('credential.json') != ''
+        run: |
+          python - <<'PY'
+          import json
+          import sys
+
+          from vouch import Verifier
+
+          cred = open("credential.json").read()
+          doc = json.load(open("website/public/conformance/did.json"))
+          pub = json.dumps(doc["verificationMethod"][0]["publicKeyJwk"])
+          ok, _ = Verifier.verify_credential(cred, public_key=pub)
+          print("Badge self-verify against published DID:", ok)
+          if not ok:
+              print("::error::Minted conformance badge does not verify against the published DID."
+                    " Check that VOUCH_CONFORMANCE_PRIVATE_KEY and the DID document hold the same key.")
+              sys.exit(1)
+          PY
+
+      - name: Summary
+        if: steps.test.outputs.level != '' && hashFiles('credential.json') != ''
+        run: |
+          {
+            echo "### Vouch Verified Conformant"
+            echo ""
+            echo "\`${{ github.repository }}\` passed conformance at **${{ steps.test.outputs.level }}**, credential signed and root-chained."
+            echo ""
+            echo '```json'
+            cat credential.json
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/verified-conformance.yml
+++ b/.github/workflows/verified-conformance.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install vouch
         run: |
           python -m pip install --upgrade pip
-          pip install -e .
+          pip install -e . pqcrypto
 
       - name: Run the conformance test
         id: test
@@ -53,6 +53,8 @@ jobs:
         env:
           VOUCH_CONFORMANCE_PRIVATE_KEY: ${{ secrets.VOUCH_CONFORMANCE_PRIVATE_KEY }}
           VOUCH_CONFORMANCE_DID: ${{ secrets.VOUCH_CONFORMANCE_DID }}
+          VOUCH_CONFORMANCE_MLDSA_SECRET: ${{ secrets.VOUCH_CONFORMANCE_MLDSA_SECRET }}
+          MLDSA_PUBLIC_MULTIKEY: ${{ secrets.MLDSA_PUBLIC_MULTIKEY }}
           LEVEL: ${{ steps.test.outputs.level }}
           REPO: ${{ github.repository }}
           SHA: ${{ github.sha }}
@@ -77,16 +79,25 @@ jobs:
           import json
           import sys
 
-          from vouch import Verifier
+          from vouch import Verifier, data_integrity_hybrid, multikey
+          from vouch.verifier import _coerce_ed25519_public_key
 
-          cred = open("credential.json").read()
+          cred = json.load(open("credential.json"))
           doc = json.load(open("website/public/conformance/did.json"))
-          pub = json.dumps(doc["verificationMethod"][0]["publicKeyJwk"])
-          ok, _ = Verifier.verify_credential(cred, public_key=pub)
-          print("Badge self-verify against published DID:", ok)
+          ed_jwk = json.dumps(doc["verificationMethod"][0]["publicKeyJwk"])
+          suite = cred.get("proof", {}).get("cryptosuite", "")
+          if suite.startswith("hybrid"):
+              ed_pub = _coerce_ed25519_public_key(ed_jwk)
+              _, ml_pub = multikey.decode(doc["verificationMethod"][1]["publicKeyMultibase"])
+              ok = data_integrity_hybrid.verify_hybrid_proof(
+                  cred, ed25519_public_key=ed_pub, mldsa44_public_key=ml_pub
+              )
+          else:
+              ok, _ = Verifier.verify_credential(json.dumps(cred), public_key=ed_jwk)
+          print(f"Badge self-verify ({suite}) against published DID:", ok)
           if not ok:
               print("::error::Minted conformance badge does not verify against the published DID."
-                    " Check that VOUCH_CONFORMANCE_PRIVATE_KEY and the DID document hold the same key.")
+                    " Check the issuer keys and the DID document match.")
               sys.exit(1)
           PY
 

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -1,0 +1,45 @@
+# Conformance issuer setup
+
+The verified conformance badge is a signed Vouch Credential, minted by
+`scripts/mint_conformance_credential.py` and chained to the project root
+authority. It mirrors the verified-contributor badge exactly:
+
+| Contributor | Conformance |
+|---|---|
+| `scripts/mint_contributor_credential.py` | `scripts/mint_conformance_credential.py` |
+| `.github/workflows/verified-contributor.yml` | `.github/workflows/verified-conformance.yml` |
+| `did:web:vouch-protocol.com:contributors` | `did:web:vouch-protocol.com:conformance` |
+| `contributors/delegation.json` | `conformance/delegation.json` |
+| `website/public/contributors/did.json` | `website/public/conformance/did.json` |
+
+## One-time setup (your steps)
+
+1. **Generate the conformance issuer keypair.**
+   ```
+   python -c "from vouch import keys; kp = keys.generate_identity('vouch-protocol.com:conformance'); print('PRIVATE:', kp.private_key_jwk); print('PUBLIC:', kp.public_key_jwk)"
+   ```
+
+2. **Add two GitHub repository secrets** (Settings, Secrets and variables, Actions):
+   - `VOUCH_CONFORMANCE_PRIVATE_KEY` = the private key JWK (the PRIVATE line above)
+   - `VOUCH_CONFORMANCE_DID` = `did:web:vouch-protocol.com:conformance`
+
+3. **Publish the issuer public key.** Put the public JWK `x` value into
+   `website/public/conformance/did.json` (replace `REPLACE_WITH_...`). On deploy
+   this resolves at `https://vouch-protocol.com/conformance/did.json`, which is
+   how anyone re-verifies a badge.
+
+4. **Create the root delegation** `conformance/delegation.json`: sign a
+   delegation from the project root authority to the conformance issuer DID, the
+   same step you ran for `contributors/delegation.json`. With it present, every
+   minted badge chains back to root.
+
+The `verified-conformance.yml` workflow is a safe no-op until the secrets are
+set, so committing the placeholders is harmless.
+
+## Robotics
+
+The robotics profile uses the **same issuer** and the **same mint script** with
+`--profile robotics`, so no extra setup is needed. A robotics badge is issued
+once the robotics conformance check lands in `vouch/conformance.py`. If you ever
+want a fully separate robotics issuer DID, copy this folder to
+`conformance-robotics/` and repeat the four steps with a robotics keypair.

--- a/conformance/README.md
+++ b/conformance/README.md
@@ -33,6 +33,22 @@ authority. It mirrors the verified-contributor badge exactly:
    same step you ran for `contributors/delegation.json`. With it present, every
    minted badge chains back to root.
 
+5. **Post-quantum (recommended): make the badge hybrid.** Generate a persistent
+   ML-DSA-44 issuer keypair, keeping the secret AND public from the SAME run
+   (they are a matched pair):
+   ```
+   python -c "import base64; from vouch import data_integrity_hybrid, multikey; pub, sec = data_integrity_hybrid.generate_mldsa44_keypair(); print('SECRET_B64:', base64.b64encode(sec).decode()); print('PUBLIC_MULTIKEY:', multikey.encode_mldsa44_public(pub))"
+   ```
+   Then:
+   - add `VOUCH_CONFORMANCE_MLDSA_SECRET` = the `SECRET_B64` value (GitHub secret),
+   - add `MLDSA_PUBLIC_MULTIKEY` = the `PUBLIC_MULTIKEY` value (GitHub secret),
+   - put the same `PUBLIC_MULTIKEY` into `website/public/conformance/did.json` at
+     `#key-2` (replace `REPLACE_WITH_THE_MLDSA_PUBLIC_MULTIKEY`).
+
+   With both secrets set the badge carries the `hybrid-eddsa-mldsa44-jcs-2026`
+   dual proof (L3-grade); without them it falls back to the classical Ed25519
+   proof. The workflow installs `pqcrypto` for you.
+
 The `verified-conformance.yml` workflow is a safe no-op until the secrets are
 set, so committing the placeholders is harmless.
 

--- a/conformance/delegation.json
+++ b/conformance/delegation.json
@@ -1,0 +1,32 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/credentials/v2",
+    "https://vouch-protocol.com/contexts/v1"
+  ],
+  "id": "urn:uuid:69aecebd-d7e9-4aca-ac10-a40ecc224ec4",
+  "type": [
+    "VerifiableCredential",
+    "VouchCredential"
+  ],
+  "issuer": "did:web:vouch-protocol.com",
+  "validFrom": "2026-06-22T20:13:56Z",
+  "validUntil": "2036-06-19T20:13:56Z",
+  "credentialSubject": {
+    "id": "did:web:vouch-protocol.com",
+    "vouchVersion": "1.0",
+    "intent": {
+      "action": "delegate",
+      "target": "did:web:vouch-protocol.com:conformance",
+      "resource": "https://github.com/vouch-protocol/vouch",
+      "role": "conformance-issuer"
+    }
+  },
+  "proof": {
+    "type": "DataIntegrityProof",
+    "cryptosuite": "eddsa-jcs-2022",
+    "created": "2026-06-22T20:13:56Z",
+    "verificationMethod": "did:web:vouch-protocol.com#key-1",
+    "proofPurpose": "assertionMethod",
+    "proofValue": "z3eptxNEsjcs3AEgUEVqBCpqXgd9iHdgfNRRw3Fbqq4TVKSLKYi8o5nNhSbTv6sicH4EDCkwNJ6FNEH3XkZAGi55J"
+  }
+}

--- a/scripts/mint_conformance_credential.py
+++ b/scripts/mint_conformance_credential.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Mint a "Vouch Verified Conformant" credential for an implementation.
+
+This dogfoods the protocol: the project signs a Verifiable Credential attesting
+that an implementation passed the Vouch conformance test at a given level (the
+core profile), or passed the robotics profile. It mirrors
+scripts/mint_contributor_credential.py. Designed to run in CI (see
+.github/workflows/verified-conformance.yml) but is also runnable locally.
+
+The conformance issuer key is read from the environment:
+  VOUCH_CONFORMANCE_PRIVATE_KEY  Ed25519 private key JWK (JSON string)
+  VOUCH_CONFORMANCE_DID          Issuer DID, e.g. did:web:vouch-protocol.com:conformance
+
+Example:
+  export VOUCH_CONFORMANCE_DID='did:web:vouch-protocol.com:conformance'
+  export VOUCH_CONFORMANCE_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+  python scripts/mint_conformance_credential.py \\
+      --subject vouch-protocol/vouch --commit abc1234 \\
+      --profile core --level L2 \\
+      --transcript-hash sha256:... \\
+      --parent conformance/delegation.json --out credential.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from vouch import Signer
+
+# A conformance pass is for a specific version, re-test on new releases. One year
+# keeps a stale pass from lingering; the verifier requires a validUntil.
+DEFAULT_VALID_DAYS = 365
+
+
+def mint_credential(
+    subject: str,
+    profile: str,
+    level: str,
+    commit: str,
+    transcript_hash: str,
+    private_key: str,
+    did: str,
+    valid_days: int = DEFAULT_VALID_DAYS,
+    parent_credential: dict | None = None,
+) -> dict:
+    """Return a signed Vouch Credential attesting a conformance pass.
+
+    If `parent_credential` (the root -> conformance delegation) is provided, it
+    is attached so the badge traces back to the project root authority.
+    """
+    signer = Signer(private_key=private_key, did=did)
+    role = "robotics-conformant" if profile == "robotics" else f"conformant-{level}"
+    target = f"github:{subject}@{commit}" if commit else f"github:{subject}"
+    intent = {
+        "action": "attest",
+        "target": target,
+        # resource is required by the credential model; bind it to the repo.
+        "resource": f"https://github.com/{subject}",
+        "role": role,
+        "profile": profile,  # "core" or "robotics"
+        "level": level,  # "L1"/"L2"/"L3" for core, "" for robotics
+        "repository": subject,
+        "commit": commit,
+        "transcriptHash": transcript_hash,
+    }
+    return signer.sign_credential(
+        intent=intent,
+        valid_seconds=valid_days * 86400,
+        parent_credential=parent_credential,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Mint a Vouch Verified Conformant credential",
+    )
+    parser.add_argument("--subject", required=True, help="owner/repo of the implementation")
+    parser.add_argument(
+        "--profile",
+        default="core",
+        choices=["core", "robotics"],
+        help="Conformance profile (default: core)",
+    )
+    parser.add_argument("--level", default="", help="L1, L2, or L3 (core profile only)")
+    parser.add_argument("--commit", default="", help="Commit SHA the run was bound to")
+    parser.add_argument("--transcript-hash", default="", help="Hash of the challenge transcript")
+    parser.add_argument("--out", default="-", help="Output file, or - for stdout")
+    parser.add_argument(
+        "--parent",
+        default="",
+        help="Path to the root delegation credential (conformance/delegation.json). Optional.",
+    )
+    args = parser.parse_args(argv)
+
+    private_key = os.getenv("VOUCH_CONFORMANCE_PRIVATE_KEY")
+    did = os.getenv("VOUCH_CONFORMANCE_DID")
+    if not private_key or not did:
+        print(
+            "VOUCH_CONFORMANCE_PRIVATE_KEY and VOUCH_CONFORMANCE_DID must be set to mint a credential.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.profile == "core" and args.level not in ("L1", "L2", "L3"):
+        print("The core profile requires --level L1, L2, or L3.", file=sys.stderr)
+        return 1
+
+    parent_credential = None
+    if args.parent and os.path.exists(args.parent):
+        with open(args.parent, encoding="utf-8") as handle:
+            parent_credential = json.load(handle)
+
+    credential = mint_credential(
+        subject=args.subject,
+        profile=args.profile,
+        level=args.level,
+        commit=args.commit,
+        transcript_hash=args.transcript_hash,
+        private_key=private_key,
+        did=did,
+        parent_credential=parent_credential,
+    )
+
+    text = json.dumps(credential, indent=2)
+    if args.out == "-":
+        print(text)
+    else:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        label = "robotics" if args.profile == "robotics" else args.level
+        print(
+            f"Wrote {label} conformance credential for {args.subject} to {args.out}",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mint_conformance_credential.py
+++ b/scripts/mint_conformance_credential.py
@@ -11,24 +11,30 @@ The conformance issuer key is read from the environment:
   VOUCH_CONFORMANCE_PRIVATE_KEY  Ed25519 private key JWK (JSON string)
   VOUCH_CONFORMANCE_DID          Issuer DID, e.g. did:web:vouch-protocol.com:conformance
 
+For a post-quantum (L3-grade) badge, also set the persistent ML-DSA-44 issuer
+key. When both are present the badge carries the hybrid-eddsa-mldsa44-jcs-2026
+dual proof; otherwise it falls back to the classical eddsa-jcs-2022 proof:
+  VOUCH_CONFORMANCE_MLDSA_SECRET  base64 of the ML-DSA-44 secret key
+  MLDSA_PUBLIC_MULTIKEY           the ML-DSA-44 public key as a z-multikey
+
 Example:
   export VOUCH_CONFORMANCE_DID='did:web:vouch-protocol.com:conformance'
   export VOUCH_CONFORMANCE_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
   python scripts/mint_conformance_credential.py \\
       --subject vouch-protocol/vouch --commit abc1234 \\
       --profile core --level L2 \\
-      --transcript-hash sha256:... \\
       --parent conformance/delegation.json --out credential.json
 """
 
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 import os
 import sys
 
-from vouch import Signer
+from vouch import Signer, multikey
 
 # A conformance pass is for a specific version, re-test on new releases. One year
 # keeps a stale pass from lingering; the verifier requires a validUntil.
@@ -45,11 +51,15 @@ def mint_credential(
     did: str,
     valid_days: int = DEFAULT_VALID_DAYS,
     parent_credential: dict | None = None,
+    mldsa_secret: bytes | None = None,
+    mldsa_public: bytes | None = None,
 ) -> dict:
     """Return a signed Vouch Credential attesting a conformance pass.
 
     If `parent_credential` (the root -> conformance delegation) is provided, it
-    is attached so the badge traces back to the project root authority.
+    is attached so the badge traces back to the project root authority. If the
+    ML-DSA-44 issuer keypair is provided, the badge is signed under the hybrid
+    post-quantum profile; otherwise it uses the classical Ed25519 proof.
     """
     signer = Signer(private_key=private_key, did=did)
     role = "robotics-conformant" if profile == "robotics" else f"conformant-{level}"
@@ -66,6 +76,16 @@ def mint_credential(
         "commit": commit,
         "transcriptHash": transcript_hash,
     }
+    if mldsa_secret is not None and mldsa_public is not None:
+        # Post-quantum hybrid badge: inject the persistent issuer ML-DSA-44 key
+        # so the signer does not generate a fresh random one per run.
+        signer._mldsa44_secret = mldsa_secret
+        signer._mldsa44_public = mldsa_public
+        return signer.sign_credential_hybrid(
+            intent=intent,
+            valid_seconds=valid_days * 86400,
+            parent_credential=parent_credential,
+        )
     return signer.sign_credential(
         intent=intent,
         valid_seconds=valid_days * 86400,
@@ -107,6 +127,16 @@ def main(argv: list[str] | None = None) -> int:
         print("The core profile requires --level L1, L2, or L3.", file=sys.stderr)
         return 1
 
+    # Optional post-quantum hybrid signing: both the secret and the published
+    # public multikey must be present.
+    mldsa_secret = None
+    mldsa_public = None
+    sec_b64 = os.getenv("VOUCH_CONFORMANCE_MLDSA_SECRET")
+    pub_multikey = os.getenv("MLDSA_PUBLIC_MULTIKEY")
+    if sec_b64 and pub_multikey:
+        mldsa_secret = base64.b64decode(sec_b64)
+        _, mldsa_public = multikey.decode(pub_multikey)
+
     parent_credential = None
     if args.parent and os.path.exists(args.parent):
         with open(args.parent, encoding="utf-8") as handle:
@@ -121,6 +151,8 @@ def main(argv: list[str] | None = None) -> int:
         private_key=private_key,
         did=did,
         parent_credential=parent_credential,
+        mldsa_secret=mldsa_secret,
+        mldsa_public=mldsa_public,
     )
 
     text = json.dumps(credential, indent=2)
@@ -130,8 +162,9 @@ def main(argv: list[str] | None = None) -> int:
         with open(args.out, "w", encoding="utf-8") as handle:
             handle.write(text)
         label = "robotics" if args.profile == "robotics" else args.level
+        suite = credential.get("proof", {}).get("cryptosuite", "")
         print(
-            f"Wrote {label} conformance credential for {args.subject} to {args.out}",
+            f"Wrote {label} conformance credential ({suite}) for {args.subject} to {args.out}",
             file=sys.stderr,
         )
     return 0

--- a/vouch/conformance.py
+++ b/vouch/conformance.py
@@ -1,0 +1,222 @@
+"""
+Vouch conformance runner (Phase 1, local).
+
+Runs an implementation against the published conformance levels (Specification
+section 17) and reports the highest level it fully satisfies. This local runner
+proves the contract against the in-process Python SDK. The hosted verifier (the
+conformance worker) reuses the same level map, but issues fresh server-side
+challenges so a result cannot be faked by replaying the public test vectors.
+
+Levels are graded on byte-testable plus attested requirements:
+
+  L1 Credential            canonicalization, eddsa-jcs-2022 sign and verify,
+                           validity window, nonce replay resistance
+  L2 Structural-Security   plus BitstringStatusList revocation, delegation
+                           narrowing, the Identity Sidecar allow and deny
+                           behaviour, a hash-linked audit trail
+  L3 State Verifiable + PQ plus hybrid dual-proof (eddsa-jcs-2022 and
+                           mldsa44-jcs-2026), Heartbeat renewal chain, and an
+                           M-of-N validator quorum
+
+Robotics is a SEPARATE profile (Robotics Conformant), not part of L1 to L3.
+
+Run it against the reference SDK:
+
+    python -m vouch.conformance
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Dict, List, Tuple
+
+from vouch import jcs, keys
+from vouch.signer import Signer
+from vouch.verifier import Verifier
+
+VECTORS_DIR = Path(__file__).resolve().parent.parent / "test-vectors"
+
+
+class Status(str, Enum):
+    PASS = "pass"
+    FAIL = "fail"
+    SKIP = "skip"  # contract defined, not yet implemented in this runner
+
+
+@dataclass
+class CheckResult:
+    name: str
+    status: Status
+    detail: str = ""
+
+
+# --- L1 checks (implemented) ------------------------------------------------
+
+
+def check_canonicalization() -> CheckResult:
+    """RFC 8785 JCS: every shared vector input canonicalizes byte-identically."""
+    path = VECTORS_DIR / "jcs" / "vectors.json"
+    vectors = json.loads(path.read_text(encoding="utf-8"))["vectors"]
+    for vec in vectors:
+        got = jcs.canonicalize(vec["input"]).decode("utf-8")
+        if got != vec["canonical"]:
+            return CheckResult(
+                "canonicalization",
+                Status.FAIL,
+                f"{vec['name']}: expected {vec['canonical']!r}, got {got!r}",
+            )
+    return CheckResult("canonicalization", Status.PASS, f"{len(vectors)} vectors")
+
+
+def check_sign_verify() -> CheckResult:
+    """eddsa-jcs-2022: a signed credential verifies, a tampered one is rejected."""
+    kp = keys.generate_identity("conformance.test")
+    signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+    credential = signer.sign_credential(
+        intent={
+            "action": "conformance_probe",
+            "target": "vector:001",
+            "resource": "https://conformance.test/probe",
+        }
+    )
+    valid, _ = Verifier.verify_credential(credential, public_key=kp.public_key_jwk)
+    if not valid:
+        return CheckResult("sign_verify", Status.FAIL, "a valid credential was rejected")
+
+    tampered = json.loads(json.dumps(credential))
+    tampered["credentialSubject"]["intent"]["action"] = "tampered"
+    bad_valid, _ = Verifier.verify_credential(tampered, public_key=kp.public_key_jwk)
+    if bad_valid:
+        return CheckResult("sign_verify", Status.FAIL, "a tampered credential was accepted")
+
+    return CheckResult("sign_verify", Status.PASS, "round-trip and tamper rejection")
+
+
+# --- L2 / L3 checks (contract defined, implementation pending) --------------
+
+
+def _pending(name: str, contract: str) -> Callable[[], CheckResult]:
+    def run() -> CheckResult:
+        return CheckResult(name, Status.SKIP, contract)
+
+    return run
+
+
+# The level contract: each level lists (check name, callable). A level is
+# granted only when every check at that level and all lower levels passes.
+LEVELS: Dict[str, List[Tuple[str, Callable[[], CheckResult]]]] = {
+    "L1": [
+        ("canonicalization", check_canonicalization),
+        ("sign_verify", check_sign_verify),
+        (
+            "validity_window",
+            _pending(
+                "validity_window",
+                "A credential past its validUntil is rejected as expired.",
+            ),
+        ),
+        (
+            "nonce_replay",
+            _pending("nonce_replay", "A repeated nonce is rejected as a replay."),
+        ),
+    ],
+    "L2": [
+        (
+            "revocation",
+            _pending(
+                "revocation",
+                "A BitstringStatusList with the credential's bit set verifies as revoked.",
+            ),
+        ),
+        (
+            "delegation_narrowing",
+            _pending(
+                "delegation_narrowing",
+                "A delegated credential narrows its parent and honours the five-link depth bound.",
+            ),
+        ),
+        (
+            "sidecar_allow_deny",
+            _pending(
+                "sidecar_allow_deny",
+                "Behavioural: an allowed intent signs, a disallowed intent is rejected with a structured code.",
+            ),
+        ),
+        (
+            "audit_trail",
+            _pending(
+                "audit_trail",
+                "A sequence of actions produces a valid hash-linked audit trail.",
+            ),
+        ),
+    ],
+    "L3": [
+        (
+            "hybrid_pq",
+            _pending(
+                "hybrid_pq",
+                "Dual-proof: both eddsa-jcs-2022 and mldsa44-jcs-2026 proofs over the same JCS bytes verify.",
+            ),
+        ),
+        (
+            "heartbeat",
+            _pending(
+                "heartbeat",
+                "Behavioural: a renewed heartbeat chain is valid, hash-linked, and within interval.",
+            ),
+        ),
+        (
+            "validator_quorum",
+            _pending(
+                "validator_quorum",
+                "Attested: an M-of-N quorum-signed digest verifies against the threshold.",
+            ),
+        ),
+    ],
+}
+
+
+@dataclass
+class ConformanceReport:
+    results: Dict[str, List[CheckResult]]
+    achieved: str | None  # highest fully-passing level, or None
+
+
+def run_conformance() -> ConformanceReport:
+    """Run every level's checks and derive the highest fully-passing level."""
+    results: Dict[str, List[CheckResult]] = {}
+    achieved: str | None = None
+    blocked = False
+
+    for level, checks in LEVELS.items():
+        level_results: List[CheckResult] = []
+        for name, fn in checks:
+            try:
+                level_results.append(fn())
+            except Exception as exc:  # a crash is a failed check, not a runner crash
+                level_results.append(CheckResult(name, Status.FAIL, f"error: {exc}"))
+        results[level] = level_results
+
+        if not blocked and all(r.status is Status.PASS for r in level_results):
+            achieved = level
+        else:
+            blocked = True
+
+    return ConformanceReport(results=results, achieved=achieved)
+
+
+def _print_report(report: ConformanceReport) -> None:
+    glyph = {Status.PASS: "PASS", Status.FAIL: "FAIL", Status.SKIP: "....."}
+    for level, level_results in report.results.items():
+        print(f"\n{level}")
+        for r in level_results:
+            print(f"  [{glyph[r.status]}] {r.name}: {r.detail}")
+    print(f"\nHighest fully-passing level: {report.achieved or 'none yet'}")
+    print("(..... = contract defined, implementation pending in this runner)")
+
+
+if __name__ == "__main__":
+    _print_report(run_conformance())

--- a/website/public/conformance/did.json
+++ b/website/public/conformance/did.json
@@ -1,7 +1,8 @@
 {
   "@context": [
     "https://www.w3.org/ns/did/v1",
-    "https://w3id.org/security/suites/jws-2020/v1"
+    "https://w3id.org/security/suites/jws-2020/v1",
+    "https://w3id.org/security/multikey/v1"
   ],
   "id": "did:web:vouch-protocol.com:conformance",
   "verificationMethod": [
@@ -12,14 +13,21 @@
       "publicKeyJwk": {
         "kty": "OKP",
         "crv": "Ed25519",
-        "x": "REPLACE_WITH_THE_CONFORMANCE_ISSUER_PUBLIC_KEY_X"
+        "x": "Th6o6p3r3qh6pUMSjHQkG9l4TsXZtn4VBlsi1hVf6mE"
       }
+    },
+    {
+      "id": "did:web:vouch-protocol.com:conformance#key-2",
+      "type": "Multikey",
+      "controller": "did:web:vouch-protocol.com:conformance",
+      "publicKeyMultibase": "z4dcAB9h4tUrwd95jD44JtW9WLmPvi97UDs1LV2kNwXMBKqU3kEXJRjAkRGvbE3AkPMJfSm21omxPN5a3e7ypLGdtZDEYUrWpJSMeq5uZrhDsP3pHeEGdQAR2GXJUn36ELwxwVPaDMYCs27pLdSrc56HW1tgQavUY3cZd8TUnb4QW2JmYq27xAM3w19efiSbzANbg9XJeazWYpezsBXzt4WSeLm44BqybHuwMYYcgrbhXSJ5k4vtPgUr4MCvWDuNKtb5Wd2G5dZMmWEjTN5t98Rdfn5gwtoPyvQj59hJXH4Hiakd2gEeY7yDxwdcWHjCopMbTXCJE2qJn8Y2GPZqmBkaNtc8eg7Aew4qMHG4nkDaNAzFYtYWv5fXWLEgb2A7uZozR2w52od15SwdYnAiNaYenxwisi98Ze5szQVxDr3J5FkoMUXxv1bECLkMyXSNufwPEsag22GPDQQNqXW8iuzvEXxMs85z2VFvQ3nvb3EqdGobcuG3cjfdzsV8JQ2XgcEpGNzUVSpK1HcegPkzcHv385qRewHfjsPWPFudnNAhWGxsHWs5GEyVtcTJWzJkE58yq16crx77pUud86okDmb7cio2UUf4NFA6koa51eSn4K76vrqYEaKKuN35DRBBFw8SKMDWiWC9BxgCThkpb7Ry1kUJiPFsLQxSuC7eTq71ZTnKzbxM8uerKtXYd5MkXUJ3kgMciy2yN8zviLPL3vWtXEKXf52rnw6PqBMJL2TPEbHViSYPSBsfSj81ukbMpHFhDUCdVXJjs3sV7qP65NSnzAVdDMTPyifmEVuUaZ7v6tqKjK7ek3yoNfgSfWN3ZaJaKUbWdU7FDoeHJhPj9UTohoQ5ZQCcBo5gq8ndMWnF9FgG8rJTC5iE4BqXqE8vWxBzdCHa4y5wiLBVzyU6Rx4aor3d1uVTKrneykeJqJ6pMqfy23euqvR7KiQ9ojmbVLkJu7NtXrm7LWB1knfVpSxC89tinGtMusCXnPW3EUCaawHj9Rx9qLoj9tpZsxy677s1uEtgJWNuzX86SPP2cJ9iDXHwZ6bCydFACxT2DVBgT2XQuGjF8Ub8AsqqmDsKyxQqfttU1Ao3asUDBa7LkwHCPNoya13nsk39RUXrptdvKWmzMqrdxM4mL41EZkJUbYMCnbXDozc4AcaGVsqGoEoKdrmUi3MRcGjEivYDuCRpF2o3hkDCy6NNtWUySWCpCWXPAdCFJemD8CkZnd5orKdjKi77GKafVRZPz3DKKqxG23kQ6Zv6fuRhA7ucWE2JqYHnURtajRC1DonZN9UVrC3dEiZc5YzWxSJRU3pJVkGFUvcoEFd5utTyK1c5kgFjKBkuX59GPmb3w2xnCcvUEkLR7x6EJe8bEM6tVCvA6PBsGpwEeMrWWmoDUJEHVowAmJJZjoi4CSqqiLQ8V4cycZ7FNo7U7fUTfFjHSospLmru87pg4577VnMFczPPqdAbPKLdgLCXLNo8tsveUVNRJdQ1gz3yAeeLFSZZ17qBM25XfToTxHN2AG41EbWxio5e7KCK7cwX3ZNgmFac3TMHMJDd3cPTyWXm73k9CgtJK5bwitzJ51ohjUMFLPoFEfkXT4FZvV79as4CDJmBtW9wCJZxf7uBgN9tSdczi9EqTMJQeQ6Mcmc4KCB2FeLDqeiVHNTaS8r6pB45gJKAoz9yrFyU2psVqPXUyMtjpZ9aPZD1r7cD99gaP7MhEgSFumkZ5einuNPCbWcusqLk9wwVrFyghsT6XkwjR7v12tUGtH9po7G5jxeeDGYztEGUg4HkXGH1"
     }
   ],
   "authentication": [
     "did:web:vouch-protocol.com:conformance#key-1"
   ],
   "assertionMethod": [
-    "did:web:vouch-protocol.com:conformance#key-1"
+    "did:web:vouch-protocol.com:conformance#key-1",
+    "did:web:vouch-protocol.com:conformance#key-2"
   ]
 }

--- a/website/public/conformance/did.json
+++ b/website/public/conformance/did.json
@@ -1,0 +1,25 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/suites/jws-2020/v1"
+  ],
+  "id": "did:web:vouch-protocol.com:conformance",
+  "verificationMethod": [
+    {
+      "id": "did:web:vouch-protocol.com:conformance#key-1",
+      "type": "JsonWebKey2020",
+      "controller": "did:web:vouch-protocol.com:conformance",
+      "publicKeyJwk": {
+        "kty": "OKP",
+        "crv": "Ed25519",
+        "x": "REPLACE_WITH_THE_CONFORMANCE_ISSUER_PUBLIC_KEY_X"
+      }
+    }
+  ],
+  "authentication": [
+    "did:web:vouch-protocol.com:conformance#key-1"
+  ],
+  "assertionMethod": [
+    "did:web:vouch-protocol.com:conformance#key-1"
+  ]
+}


### PR DESCRIPTION
Adds the conformance badge issuer and the local test runner, matching how the contributor badge works.

- `vouch/conformance.py`: the runner that checks an implementation against the conformance levels (L1 through L3). It runs the L1 byte-checks (JCS canonicalization across 13 vectors, plus a sign and verify round-trip with tamper rejection); the remaining L1 behavioural checks and the L2/L3 checks are scaffolded with their contracts.
- `.github/workflows/verified-conformance.yml`: a manually triggered workflow that runs the test, mints a signed conformance credential for this repo, and self-verifies it against the published issuer DID.
- `scripts/mint_conformance_credential.py`: the minting logic. With the ML-DSA-44 key present it dual-signs the badge (Ed25519 and ML-DSA-44); otherwise it falls back to Ed25519.
- `website/public/conformance/did.json`: the issuer DID document (`did:web:vouch-protocol.com:conformance`) with both keys.
- `conformance/README.md`: the setup steps.

The root delegation (`conformance/delegation.json`) chains badges back to the root authority.
