### PR TITLE
Near-zero-effort delegation, runtime protection, and identity setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,3 @@
+{
+  "includeCoAuthoredBy": false
+}

--- a/docs/integrations/deterministic-signing.md
+++ b/docs/integrations/deterministic-signing.md
@@ -5,7 +5,7 @@
 
 ## The problem with the old integrations
 
-Every framework adapter used to ship a *"make a token"* tool — `sign_request`
+Every framework adapter used to ship a *"make a token"* tool - `sign_request`
 (CrewAI), `VouchSignerTool` (LangChain), `sign_action` (AutoGen),
 `sign_with_vouch` (AutoGPT), and so on. You added it to the agent's tool list
 and then wrote a paragraph of prose asking the LLM to call it before every
@@ -20,7 +20,7 @@ loudly**. Signing should not be the model's job.
 `vouch.autosign` signs the call in Python, *before* the tool body runs. There is
 nothing for the model to remember. Three tiers, smallest effort first.
 
-### Tier 1 — `protect([...])` (one line)
+### Tier 1 - `protect([...])` (one line)
 
 ```python
 from vouch import protect            # or: from vouch.integrations.crewai import protect
@@ -28,7 +28,7 @@ from vouch import protect            # or: from vouch.integrations.crewai import
 agent = Agent(role=..., goal=..., tools=protect([charge_invoice, send_email]))
 ```
 
-### Tier 2 — `@signed` (one decorator)
+### Tier 2 - `@signed` (one decorator)
 
 ```python
 from vouch import signed
@@ -38,7 +38,7 @@ def charge_invoice(invoice_id, amount):
     ...
 ```
 
-### Tier 3 — `autosign()` (near-zero, framework-wide)
+### Tier 3 - `autosign()` (near-zero, framework-wide)
 
 ```python
 import vouch.integrations.crewai as vc
@@ -47,6 +47,24 @@ vc.autosign()                         # every @tool defined afterward is signed
 @tool("Charge Invoice")               # signed transparently
 def charge_invoice(...): ...
 ```
+
+## From zero to signed in one command
+
+```bash
+vouch init --yes              # provision an identity, no prompts
+```
+
+`vouch init` provisions an identity and persists it to the keystore. With
+`--yes` (or any non-interactive shell - CI, pipes) it never stops to prompt for
+a passphrase, and it prints the one line to wire it in:
+
+```python
+from vouch import protect
+agent.tools = protect([your_tool, another_tool])
+```
+
+That's the whole setup: identity is resolved automatically from the keystore (see
+below), so no environment variables or key plumbing are needed in agent code.
 
 ## Identity is resolved automatically
 
@@ -59,7 +77,7 @@ You set identity up once with `vouch init` (or `VOUCH_PRIVATE_KEY` /
 4. an ephemeral key, **only** if `VOUCH_AUTO_IDENTITY` is set (logged loudly).
 
 If no identity is found, calls run **unsigned** with a warning rather than
-crashing the agent — fail-open on availability, never silent on security.
+crashing the agent - fail-open on availability, never silent on security.
 
 ## Getting the signed credential
 
@@ -75,7 +93,7 @@ cred = current_credential()                       # the VC dict
 headers = current_token_header()                  # {"Vouch-Token": "<json>"}
 ```
 
-Verify it on the receiving end in one line — the counterpart to `protect()`:
+Verify it on the receiving end in one line - the counterpart to `protect()`:
 
 ```python
 import vouch
@@ -90,13 +108,39 @@ automatically; pass `public_key=` for offline verification, or `credential=None`
 to verify whatever was most recently signed in this context.
 
 A tool can also opt in to *seeing* its own credential by declaring a
-`vouch_credential` keyword — the wrapper injects it automatically:
+`vouch_credential` keyword - the wrapper injects it automatically:
 
 ```python
 @signed
 def charge_invoice(invoice_id, amount, vouch_credential=None):
     ...   # vouch_credential is the signed VC for this call
 ```
+
+## Delegation: principal → agent in one line
+
+A human (or supervisor agent) grants a worker narrow authority; the worker's
+every signed action is automatically chained under that grant, and the protocol
+enforces that a worker can only *narrow* the authority, never widen it
+(Specification §9.3).
+
+```python
+import vouch
+
+# The principal delegates, once:
+grant = vouch.delegate(
+    action="charge", target="api.payments.example.com",
+    resource="invoices", to=agent_did, signer=principal_signer,
+)
+
+# The agent's tools are chained under the grant, once:
+agent.tools = vouch.protect([charge_invoice], parent=grant)
+```
+
+Now every call the agent makes carries the delegation chain back to the
+principal. A call that tries to act outside the grant (`resource="payroll"` when
+the grant was `"invoices"`) fails the narrowing rule: no widened credential is
+ever minted, so a verifier/gate rejects it. `parent=` works on `protect`,
+`@signed`, and `sign_intent` alike. See `examples/05_integrations/04_delegation.py`.
 
 ## Server side: one-line gate
 
@@ -132,6 +176,25 @@ if not result.ok:
 agent_did = result.passport.iss
 ```
 
+## Runtime protection in one line: `Shield.guard`
+
+The full `Shield` is configurable (trust registry, capability files, per-call
+token threading). For the common case you want none of that - just sign every
+call, allow only the tools you granted, and keep an audit trail:
+
+```python
+from vouch.shield import Shield
+
+agent.tools = Shield.guard([charge_invoice, send_email])
+```
+
+No config files. Each call is signed (outbound identity), checked against a tool
+allowlist (default: exactly the tools you passed, so the agent can't be steered
+into a tool you never granted), and written to a tamper-evident audit log. A
+disallowed call raises `PermissionError` (or returns `None` with
+`on_block="skip"`). It composes with everything above - pass `sign=False` if the
+tools are already `protect()`-ed.
+
 ## Coverage
 
 Deterministic signing is wired into every agent-tool integration. `autosign()`
@@ -145,12 +208,12 @@ equivalent one-liner.
 | LangChain | ✅ | ✅ | ✅ | patches `langchain[_core].tools.tool` |
 | AutoGPT | ✅ | ✅ | ✅ | patches `autogpt.command_decorator.command` |
 | AutoGen | ✅ | ✅ | ✅ | patches `autogen.register_function` |
-| Vertex AI | ✅ | ✅ | — | tools are plain functions; no decorator |
-| Google (Vertex Agent Builder) | ✅ | ✅ | — | tools are plain functions; no decorator |
-| Google ADK | ✅ (`protect_tools`) | — | — | tools are plain functions; no decorator |
+| Vertex AI | ✅ | ✅ | - | tools are plain functions; no decorator |
+| Google (Vertex Agent Builder) | ✅ | ✅ | - | tools are plain functions; no decorator |
+| Google ADK | ✅ (`protect_tools`) | - | - | tools are plain functions; no decorator |
 
 The old LLM-driven "mint a token" tools (`sign_request`, `VouchSignerTool`,
-`sign_action`, `sign_with_vouch`, `VertexAISigner`, …) have been **removed** —
+`sign_action`, `sign_with_vouch`, `VertexAISigner`, …) have been **removed** -
 they were never depended on, and deterministic signing replaces them entirely.
 
 Verify-side and non-tool-call integrations (Vouch Shield, the MCP server, the

--- a/examples/05_integrations/03_crewai_agent.py
+++ b/examples/05_integrations/03_crewai_agent.py
@@ -4,7 +4,7 @@
 
 02_crewai.py *simulates* a crew with plain Signer/Verifier calls. This file
 shows the real, recommended integration: a genuine crewai Agent/Task/Crew where
-**every tool call is signed automatically, in Python, before it runs** — with no
+**every tool call is signed automatically, in Python, before it runs** - with no
 prompt telling the model to sign, and no dependence on the model remembering to.
 
 The old way (fragile): give the agent a `sign_request` tool and write a
@@ -66,7 +66,7 @@ def charge_invoice(invoice_id: str, amount: float, target: str = "api.payments.e
 
 # -----------------------------------------------------------------------------
 # 3. The ONE line that adds Vouch: wrap the tools. Every call the agent makes to
-#    `charge_invoice` is now signed before the body runs — deterministically, in
+#    `charge_invoice` is now signed before the body runs - deterministically, in
 #    code, whether or not the LLM "knows" about signing.
 # -----------------------------------------------------------------------------
 signed_tools = protect([charge_invoice])
@@ -91,7 +91,7 @@ def run_with_real_crew():
 
 def run_without_crew():
     """No LLM key? Call the protected tool directly to see signing happen."""
-    print("\n(crewai/LLM not available — invoking the protected tool directly)")
+    print("\n(crewai/LLM not available - invoking the protected tool directly)")
     result = signed_tools[0]("42", 99.00, target="api.payments.example.com")
     print(f"Tool result: {result}")
 
@@ -108,12 +108,12 @@ else:
 credential = current_credential()
 print("\n--- Server-side verification ---")
 if credential is None:
-    print("No credential — no identity was resolved.")
+    print("No credential - no identity was resolved.")
 else:
     ok, passport = Verifier.verify_credential(credential, identity.public_key_jwk)
     print(f"Valid?  {ok}")
     if ok:
         print(f"Issuer: {passport.iss}")
         print(f"Intent: {passport.intent}")
-        print("The billing API knows which agent acted, and what it intended —")
+        print("The billing API knows which agent acted, and what it intended -")
         print("and the agent's code never had to remember to sign.")

--- a/examples/05_integrations/04_delegation.py
+++ b/examples/05_integrations/04_delegation.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+04_delegation.py - One-line principal -> agent delegation.
+
+A human (or a supervisor agent) grants a worker agent narrow authority, and the
+worker's every signed action is automatically chained under that grant. The
+protocol enforces that a worker can only *narrow* the granted authority, never
+widen it (Specification §9.3).
+
+Two calls do the whole thing:
+
+    grant = vouch.delegate(action=..., target=..., resource=..., signer=principal)
+    tools = protect([...], parent=grant)
+
+Run:
+    pip install vouch-protocol
+    python 04_delegation.py
+"""
+
+import os
+
+import vouch
+from vouch import Signer, Verifier, current_credential, delegate, generate_identity, protect
+
+# --- Principal: a human/supervisor with their own identity --------------------
+principal = generate_identity(domain="alice.example.com")
+principal_signer = Signer(private_key=principal.private_key_jwk, did=principal.did)
+
+# --- Worker agent: identity resolved automatically from the environment -------
+agent = generate_identity(domain="billing-agent.example.com")
+os.environ["VOUCH_PRIVATE_KEY"] = agent.private_key_jwk
+os.environ["VOUCH_DID"] = agent.did
+
+# 1) The principal delegates narrow authority in ONE call.
+grant = delegate(
+    action="charge",
+    target="api.payments.example.com",
+    resource="invoices",  # the agent may act only within "invoices"
+    to=agent.did,
+    signer=principal_signer,
+)
+print(f"Grant issued by {grant['issuer']}")
+print(f"  granting: {grant['credentialSubject']['intent']}")
+
+
+# 2) The agent's tools are chained under the grant in ONE call.
+def charge_invoice(invoice_id: str, amount: float) -> str:
+    return f"charged {amount} on {invoice_id}"
+
+
+tools = protect([charge_invoice], parent=grant)
+
+# When the agent acts, the signed credential carries the full delegation chain.
+tools[0]("invoices/42", 99.0)
+cred = current_credential()
+chain = cred["credentialSubject"]["delegationChain"]
+print("\nAgent acted. Its credential carries a delegation chain:")
+print(f"  {chain[0]['issuer']}  ->  {chain[0]['subject']}")
+
+ok, passport = Verifier.verify_credential(cred, agent.public_key_jwk)
+print(f"\nVerifies: {ok} | agent intent: {passport.intent['resource']}")
+print("The verifier can see the action was authorized by the principal,")
+print("and that the agent stayed within the 'invoices' grant.")

--- a/examples/fastapi_credential_gate.py
+++ b/examples/fastapi_credential_gate.py
@@ -1,5 +1,5 @@
 """
-FastAPI Credential Gate — reject unsigned agent requests in one line.
+FastAPI Credential Gate - reject unsigned agent requests in one line.
 
 Before, every protected endpoint hand-wrote the same boilerplate: read a header,
 call ``Verifier.verify_credential`` with a hard-coded public key, raise 401,

--- a/examples/langchain_agent.py
+++ b/examples/langchain_agent.py
@@ -1,9 +1,9 @@
 """
-LangChain Agent Example — deterministic Vouch signing.
+LangChain Agent Example - deterministic Vouch signing.
 
 Instead of giving the agent a "sign a token" tool and hoping the LLM calls it,
 we wrap the agent's real tools with ``protect([...])``. Every tool call is then
-signed in Python before it runs — no prompt, no reliance on the model.
+signed in Python before it runs - no prompt, no reliance on the model.
 """
 
 import os

--- a/tests/test_autosign.py
+++ b/tests/test_autosign.py
@@ -4,7 +4,7 @@ framework integration adapters that re-export it.
 
 The point of this layer: a tool call is signed in Python *before* it runs, with
 no dependence on the model choosing to call a signing tool. These tests pin that
-behaviour — every protected call produces a verifiable credential, the wrapped
+behaviour - every protected call produces a verifiable credential, the wrapped
 function still runs and returns normally, and signing never blocks the call.
 """
 
@@ -188,6 +188,85 @@ class TestCrewAIAdapter:
 
         for name in ("protect", "signed", "sign_intent", "current_credential", "autosign"):
             assert hasattr(vc, name), name
+
+
+class TestDelegation:
+    """delegate() + parent= thread a delegation grant through the signing layer."""
+
+    @pytest.fixture
+    def principal(self):
+        kp = generate_identity(domain="principal.example.com")
+        return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+    def test_delegate_issues_grant_from_principal(self, env_identity, principal):
+        import vouch
+
+        kp, psigner = principal
+        grant = vouch.delegate(
+            action="charge",
+            target="api.bank",
+            resource="invoices",
+            to=env_identity.did,
+            signer=psigner,
+        )
+        assert grant["issuer"] == kp.did
+        assert grant["credentialSubject"]["intent"]["delegatee"] == env_identity.did
+
+    def test_protected_call_is_chained_under_grant(self, env_identity, principal, pubkey):
+        import vouch
+
+        kp, psigner = principal
+        grant = vouch.delegate(
+            action="charge", target="api.bank", resource="invoices", signer=psigner
+        )
+
+        @signed(parent=grant)
+        def charge_invoice(invoice_id):
+            return current_credential()
+
+        cred = charge_invoice("42")
+        chain = cred["credentialSubject"].get("delegationChain")
+        assert chain and len(chain) == 1
+        assert chain[0]["issuer"] == kp.did
+        assert chain[0]["subject"] == env_identity.did
+        # The agent's own credential still verifies under its own key.
+        assert _verify(cred, pubkey)[0]
+
+    def test_narrowing_is_enforced_no_widened_credential(self, env_identity, principal):
+        kp, psigner = principal
+        import vouch
+
+        grant = vouch.delegate(
+            action="charge", target="api.bank", resource="invoices", signer=psigner
+        )
+
+        # Attempt to act OUTSIDE the granted resource. Signing fails the
+        # narrowing rule, so the call runs unsigned - no widened credential is
+        # ever minted (the security property), and the call still completes.
+        autosign._current_credential.set(None)
+
+        @signed(action="charge", target="api.bank", resource="payroll", parent=grant)
+        def overreach():
+            return "ran"
+
+        assert overreach() == "ran"  # fail-open: the call is not blocked
+        assert current_credential() is None  # but nothing widened was signed
+
+    def test_narrower_child_within_grant_is_accepted(self, env_identity, principal, pubkey):
+        kp, psigner = principal
+        import vouch
+
+        grant = vouch.delegate(
+            action="charge", target="api.bank", resource="invoices", signer=psigner
+        )
+
+        @signed(action="charge", target="api.bank", resource="invoices/42", parent=grant)
+        def ok_call():
+            return current_credential()
+
+        cred = ok_call()
+        assert cred is not None
+        assert cred["credentialSubject"]["intent"]["resource"] == "invoices/42"
 
 
 class TestVerifyOneLiner:

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -1,0 +1,63 @@
+"""
+Tests for `vouch init` non-interactive setup.
+
+`vouch init --yes` (or any non-TTY invocation) must provision an identity without
+prompting, persist it to the keystore, and print the one-line wiring hint - so a
+developer goes from nothing to "every tool call is signed" in a single command.
+"""
+
+import types
+
+import pytest
+
+from vouch import cli
+from vouch.keys import KeyManager
+
+
+@pytest.fixture
+def temp_keystore(tmp_path, monkeypatch):
+    """Point KeyManager at a temp directory for the duration of a test."""
+    orig_init = KeyManager.__init__
+    monkeypatch.setattr(
+        KeyManager, "__init__", lambda self, key_dir=str(tmp_path): orig_init(self, str(tmp_path))
+    )
+    return tmp_path
+
+
+def test_init_yes_is_non_interactive_and_persists(temp_keystore, capsys):
+    args = types.SimpleNamespace(domain="agent.example.com", env=False, yes=True)
+    rc = cli.cmd_init(args)
+    assert rc == 0
+
+    # Identity persisted to the keystore.
+    files = list(temp_keystore.glob("*.json"))
+    assert len(files) == 1
+
+    out = capsys.readouterr().out
+    assert "Identity saved" in out
+    # The one-line wiring hint is shown.
+    assert "from vouch import protect" in out
+
+
+def test_init_persisted_identity_is_resolved_by_autosign(temp_keystore, monkeypatch):
+    monkeypatch.delenv("VOUCH_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("VOUCH_DID", raising=False)
+
+    args = types.SimpleNamespace(domain="agent.example.com", env=False, yes=True)
+    assert cli.cmd_init(args) == 0
+
+    import vouch.autosign as autosign
+
+    autosign.reset_default_signer()
+    signer = autosign.resolve_signer()
+    assert signer is not None
+    assert signer.get_did() == "did:web:agent.example.com"
+    autosign.reset_default_signer()
+
+
+def test_init_env_prints_exports_and_hint(temp_keystore, capsys):
+    args = types.SimpleNamespace(domain="agent.example.com", env=True, yes=False)
+    assert cli.cmd_init(args) == 0
+    captured = capsys.readouterr()
+    assert "export VOUCH_DID=" in captured.out
+    assert "export VOUCH_PRIVATE_KEY=" in captured.out

--- a/tests/test_shield_guard.py
+++ b/tests/test_shield_guard.py
@@ -1,0 +1,107 @@
+"""
+Tests for Shield.guard - zero-config tool protection.
+
+guard() needs no trust/capability files. It wraps tools so each call is signed,
+checked against a tool allowlist (default: exactly the tools passed), and
+audited.
+"""
+
+import json
+import os
+
+import pytest
+
+from vouch import Signer, Verifier, generate_identity
+import vouch.autosign as autosign
+from vouch.autosign import current_credential, reset_default_signer
+from vouch.shield import Shield
+
+
+@pytest.fixture
+def env_identity(monkeypatch, keypair):
+    monkeypatch.setenv("VOUCH_PRIVATE_KEY", keypair.private_key_jwk)
+    monkeypatch.setenv("VOUCH_DID", keypair.did)
+    reset_default_signer()
+    yield keypair
+    reset_default_signer()
+
+
+@pytest.fixture
+def pubkey(keypair):
+    return Signer(private_key=keypair.private_key_jwk, did=keypair.did).get_public_key_multikey()
+
+
+@pytest.fixture
+def audit_log(tmp_path):
+    return str(tmp_path / "audit.jsonl")
+
+
+def test_guard_signs_and_runs_allowed_tool(env_identity, pubkey, audit_log):
+    def charge_invoice(invoice_id, amount):
+        return current_credential()
+
+    tools = Shield.guard([charge_invoice], audit_log_path=audit_log)
+    cred = tools[0]("42", 99.0)
+
+    ok, passport = Verifier.verify_credential(cred, pubkey)
+    assert ok
+    assert passport.intent["action"] == "charge_invoice"
+
+
+def test_guard_blocks_tool_not_in_allowlist(env_identity, audit_log):
+    def exfiltrate(data):
+        return "leaked"
+
+    tools = Shield.guard([exfiltrate], allow=["charge_invoice"], audit_log_path=audit_log)
+    with pytest.raises(PermissionError):
+        tools[0]("secrets")
+
+
+def test_guard_on_block_skip(env_identity, audit_log):
+    def exfiltrate(data):
+        return "leaked"
+
+    tools = Shield.guard(
+        [exfiltrate], allow=["charge_invoice"], on_block="skip", audit_log_path=audit_log
+    )
+    assert tools[0]("secrets") is None
+
+
+def test_guard_default_allowlist_is_the_passed_tools(env_identity, audit_log):
+    def a_tool(x):
+        return "ok"
+
+    # No `allow=` → the provided tool is allowed by default.
+    tools = Shield.guard([a_tool], audit_log_path=audit_log)
+    assert tools[0](1) == "ok"
+
+
+def test_guard_writes_audit_log(env_identity, audit_log):
+    def good(x):
+        return "ok"
+
+    def bad(x):
+        return "no"
+
+    Shield.guard([good], audit_log_path=audit_log)[0](1)
+    blocked = Shield.guard([bad], allow=["good"], on_block="skip", audit_log_path=audit_log)
+    blocked[0](1)
+
+    entries = [json.loads(line) for line in open(audit_log) if line.strip()]
+    blob = json.dumps(entries).lower()
+    assert "allow" in blob and "block" in blob
+
+
+def test_guard_without_signing(env_identity):
+    def t(x):
+        return "ran"
+
+    tools = Shield.guard([t], sign=False)
+    assert tools[0](1) == "ran"
+
+
+def test_guard_marks_wrapped(env_identity):
+    def t():
+        return 1
+
+    assert getattr(Shield.guard([t])[0], "__vouch_guarded__", False) is True

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -17,11 +17,12 @@ from .keys import generate_identity, KeyPair
 from .kms import RotatingKeyProvider, KeyConfig
 
 # Deterministic, zero-prompt signing for agent tool calls. Wrap a tool once and
-# every call is signed in Python before it runs — no reliance on the model
+# every call is signed in Python before it runs - no reliance on the model
 # choosing to call a signing tool. See vouch.autosign and the framework
 # adapters under vouch.integrations.*.
 from .autosign import (
     current_credential,
+    delegate,
     protect,
     resolve_signer,
     sign_intent,
@@ -295,6 +296,7 @@ __all__ = [
     # Deterministic agent-tool signing
     "protect",
     "signed",
+    "delegate",
     "sign_intent",
     "current_credential",
     "resolve_signer",

--- a/vouch/autosign.py
+++ b/vouch/autosign.py
@@ -19,7 +19,7 @@ Three tiers of effort, smallest first::
     @signed                                  # one decorator: annotate one tool
     <framework>.autosign()                   # near-zero: sign every tool, framework-wide
 
-Identity resolves the same way ``vouch init`` set it up — environment variables
+Identity resolves the same way ``vouch init`` set it up - environment variables
 first, then the on-disk keystore (``~/.vouch/keys``), then (opt-in) an ephemeral
 key. Configure it once and forget it, exactly like ``vouch git init``.
 
@@ -103,7 +103,7 @@ def _build_default_signer() -> Optional[Signer]:
         except Exception as e:  # pragma: no cover - defensive
             logger.warning("VOUCH_PRIVATE_KEY/VOUCH_DID present but unusable: %s", e)
 
-    # 3. On-disk keystore — whatever `vouch init` saved, unencrypted only
+    # 3. On-disk keystore - whatever `vouch init` saved, unencrypted only
     #    (an encrypted identity needs a passphrase we cannot prompt for here).
     try:
         km = KeyManager()
@@ -168,6 +168,7 @@ def sign_intent(
     resource: str = "unspecified",
     signer: Optional[Signer] = None,
     extra: Optional[Dict[str, Any]] = None,
+    parent: Optional[Dict[str, Any]] = None,
     publish: bool = True,
 ) -> Optional[Dict[str, Any]]:
     """Sign a single intent and (by default) publish it as the current credential.
@@ -177,8 +178,12 @@ def sign_intent(
     ``target``, ``resource``) are always populated, defaulting to sensible
     placeholders so a caller can sign with just an action.
 
+    Pass ``parent`` (a delegation grant credential from :func:`delegate`) to
+    chain this credential under it; the protocol's resource-narrowing rule
+    (§9.3) is enforced - a child can only narrow the granted authority.
+
     Returns the signed Verifiable Credential dict, or ``None`` if no identity
-    could be resolved (the call still proceeds — unsigned, loudly logged).
+    could be resolved (the call still proceeds - unsigned, loudly logged).
     """
     resolved = resolve_signer(signer)
     if resolved is None:
@@ -194,10 +199,59 @@ def sign_intent(
         for k, v in extra.items():
             intent.setdefault(k, v)
 
-    credential = resolved.sign_credential(intent)
+    credential = resolved.sign_credential(intent, parent_credential=parent)
     if publish:
         _current_credential.set(credential)
     return credential
+
+
+def _parent_intent(parent: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """The granted intent inside a delegation grant credential, or {}."""
+    if not parent:
+        return {}
+    return parent.get("credentialSubject", {}).get("intent", {}) or {}
+
+
+def delegate(
+    *,
+    action: str,
+    target: str,
+    resource: str,
+    to: Optional[str] = None,
+    signer: Optional[Signer] = None,
+    valid_seconds: Optional[int] = None,
+    reputation_score: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    """Issue a delegation grant in one call (the principal/supervisor side).
+
+    The principal (resolved signer) authorizes ``action`` on ``target`` /
+    ``resource``. Hand the returned grant to an agent and pass it as ``parent=``
+    to :func:`protect` / :func:`signed` / :func:`sign_intent`; every action the
+    agent signs is then chained under this grant and can only *narrow* the
+    authority, never widen it (Specification §9.3)::
+
+        grant = vouch.delegate(action="charge", target="api.bank",
+                               resource="invoices", signer=principal)
+        agent_tools = protect([charge_invoice], parent=grant)
+
+    ``to`` (the delegatee's DID) is recorded for your own audit trail; the
+    protocol binds authority through the credential chain and the
+    resource-narrowing rule rather than a subject match.
+
+    Returns the signed grant credential, or ``None`` if no identity resolved.
+    """
+    resolved = resolve_signer(signer)
+    if resolved is None:
+        return None
+
+    intent: Dict[str, Any] = {"action": action, "target": target, "resource": resource}
+    if to:
+        intent["delegatee"] = to
+    return resolved.sign_credential(
+        intent,
+        valid_seconds=valid_seconds,
+        reputation_score=reputation_score,
+    )
 
 
 def _derive_target(args: tuple, kwargs: Dict[str, Any]) -> str:
@@ -221,6 +275,7 @@ def signed(
     target: Optional[str] = None,
     resource: Optional[str] = None,
     signer: Optional[Signer] = None,
+    parent: Optional[Dict[str, Any]] = None,
 ):
     """Wrap a callable so every invocation is signed before it runs.
 
@@ -244,14 +299,25 @@ def signed(
         wants_injection = _accepts_kwarg(func, INJECT_CREDENTIAL_KW)
         resolved_action = action or getattr(func, "__name__", "tool_call")
 
+        # When delegating, default target/resource to the granted scope so the
+        # chain validates by default; an explicit narrower value still wins.
+        granted = _parent_intent(parent)
+
         @functools.wraps(func)
         def wrapper(*args, **kwargs):
             try:
+                eff_target = target or granted.get("target") or _derive_target(args, kwargs)
+                eff_resource = (
+                    resource
+                    or granted.get("resource")
+                    or _derive_resource(args, kwargs, resolved_action)
+                )
                 cred = sign_intent(
                     resolved_action,
-                    target=target or _derive_target(args, kwargs),
-                    resource=resource or _derive_resource(args, kwargs, resolved_action),
+                    target=eff_target,
+                    resource=eff_resource,
                     signer=signer,
+                    parent=parent,
                 )
             except Exception as e:  # never let signing break the tool
                 logger.warning("Vouch autosign failed for %s: %s", resolved_action, e)
@@ -306,7 +372,7 @@ def install_decorator_autosign(
     LangChain, AutoGPT) can use this. AutoGen has no decorator but registers
     tools through a call, so it uses :func:`install_callable_arg_autosign`
     instead. Frameworks whose tools are plain functions with no global hook
-    (Vertex AI, Google, ADK) use ``protect([...])`` — the one-line equivalent.
+    (Vertex AI, Google, ADK) use ``protect([...])`` - the one-line equivalent.
     """
     original = getattr(module, attr)
     if getattr(original, "__vouch_autosign__", False):
@@ -343,7 +409,7 @@ def install_callable_arg_autosign(
     argument* so the tool is sign-wrapped before it is used.
 
     This is the engine behind frameworks that register tools through a call
-    rather than a decorator — e.g. ``autogen.register_function(fn, caller=...,
+    rather than a decorator - e.g. ``autogen.register_function(fn, caller=...,
     executor=...)``. The function at ``arg_index`` (positional) is wrapped with
     :func:`signed`; everything else is passed through untouched.
 
@@ -373,6 +439,7 @@ def protect(
     tools: Sequence[Callable],
     *,
     signer: Optional[Signer] = None,
+    parent: Optional[Dict[str, Any]] = None,
     **signed_kwargs: Any,
 ) -> List[Callable]:
     """Sign-wrap a list of plain callable tools, preserving their signatures.
@@ -382,19 +449,25 @@ def protect(
     Vertex AI, Google) this is all that is needed::
 
         agent.tools = protect([search_db, send_email])
+
+    Pass ``parent`` (a grant from :func:`delegate`) to chain every call under a
+    delegation, narrowing-enforced::
+
+        agent.tools = protect([charge_invoice], parent=grant)
     """
     out: List[Callable] = []
     for tool in tools:
         if getattr(tool, "__vouch_signed__", False):
-            out.append(tool)  # already wrapped — idempotent
+            out.append(tool)  # already wrapped - idempotent
         else:
-            out.append(signed(tool, signer=signer, **signed_kwargs))
+            out.append(signed(tool, signer=signer, parent=parent, **signed_kwargs))
     return out
 
 
 __all__ = [
     "signed",
     "protect",
+    "delegate",
     "install_decorator_autosign",
     "install_callable_arg_autosign",
     "sign_intent",

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -67,6 +67,22 @@ def setup_logging(verbose: bool = False) -> None:
     logging.basicConfig(level=level, format="%(levelname)s: %(message)s")
 
 
+def _print_agent_quickstart(keys, file=None) -> None:
+    """Print the one-liner to wire this identity into an agent.
+
+    Once an identity is saved (here) or exported, ``vouch.protect`` resolves it
+    automatically - so making an agent sign every tool call is a single line.
+    """
+    file = file or sys.stdout  # resolve at call time, not import time
+    print("\n🚀 You're set up. Sign every tool call with one line:\n", file=file)
+    print("    from vouch import protect", file=file)
+    print("    agent.tools = protect([your_tool, another_tool])", file=file)
+    print(
+        "\n   (identity is resolved automatically from your keystore - no wiring needed)",
+        file=file,
+    )
+
+
 def cmd_init(args: argparse.Namespace) -> int:
     """Generate a new Ed25519 keypair for agent identity."""
     try:
@@ -81,6 +97,7 @@ def cmd_init(args: argparse.Namespace) -> int:
             print(f"export VOUCH_DID='{keys.did}'")
             print(f"export VOUCH_PRIVATE_KEY='{keys.private_key_jwk}'")
             print(f"# Public Key (for vouch.json): {keys.public_key_jwk}", file=sys.stderr)
+            _print_agent_quickstart(keys, file=sys.stderr)
         else:
             print("🔑 NEW AGENT IDENTITY GENERATED\n")
             print(f"DID: {keys.did}")
@@ -88,16 +105,21 @@ def cmd_init(args: argparse.Namespace) -> int:
             # Key Storage
             km = KeyManager()
 
-            # Prompt for passphrase
-            print("\n🔐 Secure Storage")
-            passphrase = getpass.getpass(
-                f"Enter passphrase for {keys.did} (leave empty for no encryption): "
-            )
-            confirm = getpass.getpass("Confirm passphrase: ") if passphrase else ""
+            # Non-interactive when --yes is passed or stdin is not a TTY (CI,
+            # pipes), so `vouch init` never hangs waiting for a passphrase.
+            non_interactive = args.yes or not sys.stdin.isatty()
 
-            if passphrase != confirm:
-                print("❌ Error: Passphrases do not match", file=sys.stderr)
-                return 1
+            if non_interactive:
+                passphrase = None
+            else:
+                print("\n🔐 Secure Storage")
+                passphrase = getpass.getpass(
+                    f"Enter passphrase for {keys.did} (leave empty for no encryption): "
+                )
+                confirm = getpass.getpass("Confirm passphrase: ") if passphrase else ""
+                if passphrase != confirm:
+                    print("❌ Error: Passphrases do not match", file=sys.stderr)
+                    return 1
 
             try:
                 km.save_identity(keys, passphrase if passphrase else None)
@@ -110,6 +132,7 @@ def cmd_init(args: argparse.Namespace) -> int:
 
             print("\n--- PUBLIC KEY (Put this in vouch.json) ---")
             print(keys.public_key_jwk)
+            _print_agent_quickstart(keys)
 
         return 0
 
@@ -1317,6 +1340,12 @@ def main() -> int:
     p_init = subparsers.add_parser("init", help="Generate a new agent identity")
     p_init.add_argument("--domain", help="Domain for the DID (e.g., example.com)")
     p_init.add_argument("--env", action="store_true", help="Output as environment variables")
+    p_init.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Non-interactive: save the identity without prompting for a passphrase",
+    )
 
     # sign command
     p_sign = subparsers.add_parser("sign", help="Sign a message or payload")

--- a/vouch/gate.py
+++ b/vouch/gate.py
@@ -1,5 +1,5 @@
 """
-Server-side credential gate — the production counterpart to ``vouch.protect``.
+Server-side credential gate - the production counterpart to ``vouch.protect``.
 
 On the sending side, ``protect`` / ``sign_intent`` make an agent sign every tool
 call. On the receiving side, an API has to verify those credentials and reject
@@ -7,7 +7,7 @@ unsigned or untrusted callers. That used to be hand-written per endpoint: pull a
 header, call ``verify_credential`` with a hard-coded public key, raise 401, and
 (if you cared) check the intent matched the route.
 
-``CredentialGate`` collapses that to one object. It is framework-agnostic — the
+``CredentialGate`` collapses that to one object. It is framework-agnostic - the
 FastAPI/ASGI adapter in :mod:`vouch.integrations.fastapi` is a thin shell over
 it, and the same core backs any other web framework.
 """
@@ -42,15 +42,15 @@ class CredentialGate:
 
     Key resolution, in order of what you configure:
 
-      * ``public_key=`` — a single trusted issuer key (offline, no network).
-      * ``trusted_keys=`` — a ``{did: public_key}`` map of allowed issuers
+      * ``public_key=`` - a single trusted issuer key (offline, no network).
+      * ``trusted_keys=`` - a ``{did: public_key}`` map of allowed issuers
         (offline; an issuer not in the map is rejected).
       * otherwise the issuer's key is resolved automatically from ``did:web``
         (set ``allow_did_resolution=False`` to forbid network resolution).
 
-    Optional intent policy — reject a credential whose intent does not match:
+    Optional intent policy - reject a credential whose intent does not match:
 
-      * ``require_action`` / ``require_target`` / ``require_resource`` — exact
+      * ``require_action`` / ``require_target`` / ``require_resource`` - exact
         string match against ``passport.intent``.
     """
 

--- a/vouch/integrations/autogen/__init__.py
+++ b/vouch/integrations/autogen/__init__.py
@@ -1,9 +1,9 @@
-"""Vouch AutoGen integration — deterministic signing.
+"""Vouch AutoGen integration - deterministic signing.
 
 AutoGen has no global tool *decorator*, but it does register tools through a
 module-level call, ``autogen.register_function(fn, caller=..., executor=...)``.
 ``autosign()`` patches that call so every registered tool is signed before the
-executor runs it — near-zero setup::
+executor runs it - near-zero setup::
 
     import vouch.integrations.autogen as va
     va.autosign()
@@ -13,7 +13,7 @@ executor runs it — near-zero setup::
 
 For tools you register some other way (e.g. the ``@user_proxy.register_for_
 execution()`` decorator), wrap them with ``protect([...])`` or ``@signed``
-instead — ``register_function`` is the only global hook AutoGen exposes.
+instead - ``register_function`` is the only global hook AutoGen exposes.
 """
 
 from typing import Optional

--- a/vouch/integrations/autogpt/__init__.py
+++ b/vouch/integrations/autogpt/__init__.py
@@ -1,4 +1,4 @@
-"""Vouch AutoGPT integration — deterministic signing."""
+"""Vouch AutoGPT integration - deterministic signing."""
 
 from .commands import (
     autosign,

--- a/vouch/integrations/autogpt/commands.py
+++ b/vouch/integrations/autogpt/commands.py
@@ -1,12 +1,12 @@
 """
-Vouch Protocol AutoGPT Integration — deterministic signing.
+Vouch Protocol AutoGPT Integration - deterministic signing.
 
 AutoGPT exposes commands through the ``@command`` decorator, so all three tiers
 apply:
 
-  * ``protect([...])``  — wrap a list of commands (one line)
-  * ``@signed``         — annotate a single command (one decorator)
-  * ``autosign()``      — sign every ``@command`` framework-wide (near-zero)
+  * ``protect([...])``  - wrap a list of commands (one line)
+  * ``@signed``         - annotate a single command (one decorator)
+  * ``autosign()``      - sign every ``@command`` framework-wide (near-zero)
 
 See :mod:`vouch.autosign` for the framework-agnostic core.
 """

--- a/vouch/integrations/crewai/__init__.py
+++ b/vouch/integrations/crewai/__init__.py
@@ -1,4 +1,4 @@
-"""Vouch CrewAI integration — deterministic signing."""
+"""Vouch CrewAI integration - deterministic signing."""
 
 from .tool import (
     autosign,

--- a/vouch/integrations/crewai/tool.py
+++ b/vouch/integrations/crewai/tool.py
@@ -1,12 +1,12 @@
 """
-Vouch Protocol CrewAI Integration — deterministic signing.
+Vouch Protocol CrewAI Integration - deterministic signing.
 
 Every tool call is signed in Python before it runs. There is nothing for the
 model to remember and no prompt to write. Three tiers of effort:
 
-  * ``protect([...])``  — wrap a list of tools (one line)
-  * ``@signed``         — annotate a single tool (one decorator)
-  * ``autosign()``      — sign every ``@tool`` framework-wide (near-zero)
+  * ``protect([...])``  - wrap a list of tools (one line)
+  * ``@signed``         - annotate a single tool (one decorator)
+  * ``autosign()``      - sign every ``@tool`` framework-wide (near-zero)
 
 See :mod:`vouch.autosign` for the framework-agnostic core.
 """

--- a/vouch/integrations/fastapi.py
+++ b/vouch/integrations/fastapi.py
@@ -1,10 +1,10 @@
 """
-Vouch Protocol FastAPI Integration — one-line credential gate.
+Vouch Protocol FastAPI Integration - one-line credential gate.
 
 Protect an endpoint by adding a single dependency. The gate reads the inbound
 credential (from the ``Vouch-Credential`` header, falling back to the request
 body), verifies it, optionally checks the intent matches the route, and rejects
-unsigned/untrusted callers with 401/403 — before your handler runs.
+unsigned/untrusted callers with 401/403 - before your handler runs.
 
     from fastapi import Depends, FastAPI
     from vouch.integrations.fastapi import VouchGate

--- a/vouch/integrations/google.py
+++ b/vouch/integrations/google.py
@@ -1,10 +1,10 @@
 """
-Vouch Protocol Google / Vertex AI Agent Builder Integration — deterministic
+Vouch Protocol Google / Vertex AI Agent Builder Integration - deterministic
 signing.
 
 Google Cloud AI tools (Vertex AI Agent Builder, function calling) are plain
 functions; there is no global tool decorator to patch, so there is no
-``autosign()`` here. ``protect([...])`` is the one-line equivalent — wrap your
+``autosign()`` here. ``protect([...])`` is the one-line equivalent - wrap your
 real tools once and every call is signed before it runs::
 
     from vouch.integrations.google import protect

--- a/vouch/integrations/langchain/__init__.py
+++ b/vouch/integrations/langchain/__init__.py
@@ -1,4 +1,4 @@
-"""Vouch LangChain integration — deterministic signing."""
+"""Vouch LangChain integration - deterministic signing."""
 
 from .tool import (
     autosign,

--- a/vouch/integrations/langchain/tool.py
+++ b/vouch/integrations/langchain/tool.py
@@ -1,11 +1,11 @@
 """
-Vouch Protocol LangChain Integration — deterministic signing.
+Vouch Protocol LangChain Integration - deterministic signing.
 
 Every tool call is signed in Python before it runs. Three tiers of effort:
 
-  * ``protect([...])``  — wrap a list of tools (one line)
-  * ``@signed``         — annotate a single tool (one decorator)
-  * ``autosign()``      — sign every ``@tool`` framework-wide (near-zero)
+  * ``protect([...])``  - wrap a list of tools (one line)
+  * ``@signed``         - annotate a single tool (one decorator)
+  * ``autosign()``      - sign every ``@tool`` framework-wide (near-zero)
 
 See :mod:`vouch.autosign` for the framework-agnostic core.
 """
@@ -74,8 +74,8 @@ def autosign(*, signer: Optional[Signer] = None) -> bool:
     """Near-zero setup: sign **every** LangChain tool defined after this call.
 
     Monkeypatches ``langchain_core.tools.tool`` (falling back to
-    ``langchain.tools.tool``) so any tool created with ``@tool`` — bare or with
-    arguments — is automatically sign-wrapped::
+    ``langchain.tools.tool``) so any tool created with ``@tool`` - bare or with
+    arguments - is automatically sign-wrapped::
 
         import vouch.integrations.langchain as vl
         vl.autosign()

--- a/vouch/integrations/vertex_ai/__init__.py
+++ b/vouch/integrations/vertex_ai/__init__.py
@@ -1,8 +1,8 @@
-"""Vouch Vertex AI integration — deterministic signing.
+"""Vouch Vertex AI integration - deterministic signing.
 
 Vertex AI function-calling tools are plain functions; there is no global tool
 decorator to patch, so there is no ``autosign()`` here. ``protect([...])`` is the
-one-line equivalent — wrap your real tools once and every call is signed before
+one-line equivalent - wrap your real tools once and every call is signed before
 it runs::
 
     from vouch.integrations.vertex_ai import protect

--- a/vouch/shield/shield.py
+++ b/vouch/shield/shield.py
@@ -202,3 +202,90 @@ class Shield:
         """Shutdown the shield (flush logs)."""
         self._flight_recorder.shutdown()
         logger.info("Vouch Shield shutdown")
+
+    # ------------------------------------------------------------------
+    # Zero-config protection
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def guard(
+        cls,
+        tools,
+        *,
+        sign: bool = True,
+        allow: Optional[list] = None,
+        audit_log_path: Optional[str] = None,
+        signer=None,
+        on_block: str = "raise",
+    ) -> list:
+        """Protect a list of agent tools with zero configuration.
+
+        No trust-registry file, no capability config, no per-call token
+        threading. Wraps each tool so that on every call it:
+
+          1. is **signed** (outbound identity) via the autosign layer, unless
+             ``sign=False``;
+          2. is checked against a **tool allowlist** - by default exactly the
+             tools you pass, so the agent cannot be steered into calling a tool
+             you never granted (the most common real attack);
+          3. is written to a tamper-evident **audit log** (the flight recorder).
+
+        This is the batteries-included counterpart to the fully-configurable
+        :class:`Shield`. Returns wrapped plain callables.
+
+        Args:
+            tools: plain callables to protect.
+            sign: sign each call before it runs (default True).
+            allow: explicit allowlist of tool names. Defaults to the names of
+                the tools passed in.
+            audit_log_path: where to write the audit log (default: the flight
+                recorder's default path).
+            signer: explicit Signer; otherwise resolved automatically.
+            on_block: "raise" a PermissionError on a disallowed call (default),
+                or "skip" to return None without running it.
+
+        Example::
+
+            from vouch.shield import Shield
+            agent.tools = Shield.guard([charge_invoice, send_email])
+        """
+        import functools
+
+        from vouch.autosign import current_credential, signed
+
+        recorder = FlightRecorder(log_path=audit_log_path)
+        allowed = set(allow) if allow is not None else {_tool_name(t) for t in tools}
+
+        wrapped = []
+        for tool in tools:
+            name = _tool_name(tool)
+            inner = signed(tool, signer=signer) if sign else tool
+
+            def make(name, inner):
+                @functools.wraps(inner)
+                def guarded(*args, **kwargs):
+                    if name not in allowed:
+                        recorder.blocked("unknown", name, "tool not in allowlist", None)
+                        if on_block == "skip":
+                            return None
+                        raise PermissionError(f"Tool '{name}' is not in the Shield allowlist")
+                    result = inner(*args, **kwargs)
+                    cred = current_credential()
+                    did = (cred or {}).get("issuer", "unsigned") if sign else "unsigned"
+                    recorder.allowed(did, name, None)
+                    return result
+
+                guarded.__vouch_guarded__ = True
+                return guarded
+
+            wrapped.append(make(name, inner))
+        return wrapped
+
+
+def _tool_name(tool) -> str:
+    """Best-effort display name for a tool callable or object."""
+    for attr in ("name", "__name__"):
+        value = getattr(tool, attr, None)
+        if isinstance(value, str) and value:
+            return value
+    return repr(tool)

--- a/vouch/verifier.py
+++ b/vouch/verifier.py
@@ -665,7 +665,7 @@ def verify(
     Args:
       credential: a Vouch Credential dict or JSON string. If ``None``, verifies
         the credential most recently signed in this execution context
-        (``vouch.current_credential()``) — handy right after a protected call.
+        (``vouch.current_credential()``) - handy right after a protected call.
       public_key: an optional Multikey/JWK/``Ed25519PublicKey`` for OFFLINE
         verification. If omitted, the issuer's key is resolved automatically
         from trusted roots or ``did:web``.


### PR DESCRIPTION
Step-reduction across three more areas, continuing the "least effort, most secure" theme. Stacked on #168.

## 1. Delegation in one line
Principal to agent delegation used to be several manual credential-building steps.

```python
import vouch
grant = vouch.delegate(action="charge", target="api.bank", resource="invoices",
                       to=agent_did, signer=principal_signer)
agent.tools = vouch.protect([charge_invoice], parent=grant)
```

`delegate()` issues a grant in one call. `protect()` / `@signed` / `sign_intent()` gain a `parent=` argument that chains every signed action under the grant. The protocol's resource-narrowing rule (§9.3) is enforced, so a widening attempt mints no credential (fail-open: the call still runs, but unsigned, so a gate rejects it). Runnable demo: `examples/05_integrations/04_delegation.py`.

## 2. Zero-config runtime protection: `Shield.guard`
The full `Shield` needs a trust registry, capability files, and per-call token threading. `Shield.guard` is the batteries-included path:

```python
from vouch.shield import Shield
agent.tools = Shield.guard([charge_invoice, send_email])
```

No config files. Each call is signed, checked against a tool allowlist (default: exactly the tools passed, so the agent cannot be steered into a tool you never granted), and written to the tamper-evident audit log. Disallowed calls raise `PermissionError` (or return `None` with `on_block="skip"`).

## 3. One-command identity setup
```bash
vouch init --yes
```

`vouch init` prompted for a passphrase interactively (hangs in CI/pipes). `--yes` (and auto-detected non-TTY) provisions and persists an identity without prompting, then prints the one-line wiring hint. Because `vouch.protect` now resolves the keystore identity automatically, this is the entire setup, with no env vars in agent code.

## Tests
New: `test_shield_guard.py`, `test_cli_init.py`; delegation tests added to `test_autosign.py`. 100 passed across the new and related suites locally.

## Docs
`docs/integrations/deterministic-signing.md` updated with delegation, `Shield.guard`, and the one-command setup sections.