### PR TITLE
feat(transport): hybrid UDNA + HTTP transport layer

### DIFF
--- a/docs/HYBRID_TRANSPORT.md
+++ b/docs/HYBRID_TRANSPORT.md
@@ -1,0 +1,158 @@
+# Hybrid Transport Architecture (UDNA + HTTP)
+
+Vouch credentials say *what* an agent intends and *who* is accountable. The
+transport layer decides *how* that statement reaches a peer. This document
+describes Vouch's modular, DID-addressed transport layer (`vouch.transport`),
+which lets an agent dispatch a message to a peer's **identity** and remain
+agnostic about whether it travelled over an identity-first overlay (UDNA) or
+standard DNS/IP + HTTP.
+
+## Why
+
+Standard routing resolves an identity *down to a location* — `did:web` → domain
+→ IP — and then trusts whoever answers that IP. Location is the weak link:
+domains get seized, DNS gets poisoned, IPs get hijacked.
+
+**UDNA (Universal DID-Native Addressing)** inverts the stack. The DID itself is
+the routing primitive; delivery rides a Noise-encrypted channel straight to the
+key that owns the DID. There is no location to spoof — the peer you reach is, by
+construction, the peer whose key matches the DID.
+
+UDNA is powerful but not universal: not every peer is on the overlay. So Vouch
+treats it as an **optional, preferred** transport with **graceful fallback** to
+HTTP. Agents get identity-first routing when both ends support it and
+location-first reachability everywhere else, behind a single API.
+
+## Module layout
+
+```
+vouch/transport/
+├── __init__.py          Public API surface
+├── base.py              Transport ABC, PeerAddress, DeliveryResult, errors
+├── envelope.py          VouchEnvelope — payload-preserving message container
+├── did_key.py           did:key generation/parsing (UDNA's native identity)
+├── http_transport.py    HttpTransport — DNS/IP + HTTPS (did:web), the fallback
+├── udna.py              UdnaTransport — Sirraya UDNA SDK adapter (Noise)
+└── manager.py           TransportManager — fallback routing middleware
+```
+
+## Components
+
+### `Transport` (abstract base)
+
+Every transport implements three methods, all keyed on DID, never on location:
+
+| Method | Purpose |
+| --- | --- |
+| `can_route(did) -> bool` | Cheap pre-filter: could this transport plausibly reach this DID? |
+| `resolve(did) -> PeerAddress \| None` | Turn the DID into a concrete address, or `None` to trigger fallback. |
+| `send(envelope, peer) -> dict` | Deliver the payload; return the peer reply. |
+
+A transport signals **"not me, try the next one"** by raising
+`TransportUnavailable` or returning `None` from `resolve`. It signals a
+**corrupted payload** (fatal, never retried) by raising
+`PayloadIntegrityError`. The manager keys its fallback-vs-fail decision on
+exactly that distinction.
+
+### `VouchEnvelope` — payload preservation
+
+The envelope carries three compartments verbatim across any transport boundary:
+
+- `payload` — the signed Vouch credential, complete with its `eddsa-jcs-2022`
+  (or hybrid PQ) Data Integrity `proof`. Stored by reference, never
+  re-serialized lossily.
+- `attestations` — liability attestations (outcome commitments, penalty
+  receipts, delegation links).
+- `provenance` — provenance metadata (content hashes, C2PA pointers, capture
+  context).
+
+Integrity is enforced by `content_digest()`: a SHA-256 over the **JCS
+canonicalization** (RFC 8785) of those three compartments. Because the digest
+is computed over the canonical form rather than the wire bytes, an envelope
+survives a UDNA→HTTP transition, re-indentation, or key reordering with its
+signatures intact. `from_wire()` re-verifies the seal on receipt and raises
+`PayloadIntegrityError` on any mismatch.
+
+### `UdnaTransport` — identity-first
+
+Wraps the core concepts of `sirraya-udna-sdk`:
+
+- **DID generation** — derives a `did:key` from the agent's existing Ed25519
+  identity via `vouch.multikey` (no new key material, no registry).
+- **UDNA address creation** — projects a DID and a *facet* (a named capability
+  lane, default `vouch.message`) into a `udna://<did>/<facet>` address.
+- **Secure messaging** — hands the sealed envelope to the SDK node, which
+  performs the Noise handshake, verifies the peer's DID, and delivers the bytes.
+
+The SDK is an **optional dependency** (`pip install vouch-protocol[udna]`). All
+SDK interaction goes through the minimal `UdnaNode` protocol, so the transport
+is fully testable without the SDK and the rest of Vouch imports it
+unconditionally. When the SDK is absent and no node is injected, the transport
+is **dormant**: it routes nothing and the manager falls back to HTTP. UDNA being
+unavailable is never an error — that is the point of the hybrid design.
+
+### `HttpTransport` — location-first fallback
+
+The universal lowest common denominator. Resolves `did:web` → domain via
+DNS/IP, discovers the peer's inbox (an explicit `VouchInbox` service in the DID
+Document, else the conventional `/.well-known/vouch/inbox`), and POSTs the
+sealed envelope over TLS. Every outbound URL is screened by `vouch.ssrf`
+(https-only, public IPs only, redirects disabled) because the target host is
+derived from a potentially attacker-controlled DID.
+
+### `TransportManager` — fallback middleware
+
+The single entry point for agents. Holds an ordered list of transports
+(UDNA preferred, HTTP behind) and exposes one method, `dispatch(envelope)`,
+that walks them in order:
+
+1. skip if `can_route` is false (cheap pre-filter);
+2. skip if `resolve` returns `None` (peer doesn't support this transport);
+3. attempt `send` if resolution succeeded.
+
+`TransportUnavailable` at any step → move to the next transport.
+`PayloadIntegrityError` → stop immediately (never re-route a corrupt payload).
+All transports exhausted → raise `TransportError` carrying the last failure.
+The **same** envelope instance is handed to whichever transport wins, so the
+credential, proof, attestations, and provenance are never re-signed or stripped.
+
+## Usage
+
+```python
+from vouch import Signer, generate_identity
+from vouch.transport import TransportManager, build_envelope
+
+kp = generate_identity(domain="agent.example.com")
+signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+credential = signer.sign_credential(intent={
+    "action": "settle_invoice",
+    "target": "invoice-42",
+    "resource": "https://api.example.com/invoices/42",
+})
+
+envelope = build_envelope(
+    from_did=kp.did,
+    to_did="did:web:peer.example.com",
+    payload=credential,
+    attestations=[...],   # liability
+    provenance={...},     # provenance
+)
+
+# UDNA preferred, HTTP fallback. UDNA auto-wires if the SDK is installed.
+manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
+result = await manager.dispatch(envelope)
+
+print(result.transport)   # "udna" or "http"
+print(result.attempts)    # e.g. ["udna", "http"] — the fallback path taken
+```
+
+A runnable, network-free demo lives at
+[`examples/hybrid_transport_demo.py`](../examples/hybrid_transport_demo.py).
+
+## Extending
+
+To add a transport (libp2p, Tor, a message bus), subclass `Transport`,
+implement the three methods, and insert it into the manager's preference list.
+Agents and the envelope are unaffected — that is the whole point of the
+abstraction.

--- a/docs/HYBRID_TRANSPORT.md
+++ b/docs/HYBRID_TRANSPORT.md
@@ -75,21 +75,43 @@ signatures intact. `from_wire()` re-verifies the seal on receipt and raises
 
 ### `UdnaTransport` — identity-first
 
-Wraps the core concepts of `sirraya-udna-sdk`:
+Targets the real `sirraya-udna-sdk` (distribution `sirraya-udna-sdk`, **import
+package `udna_sdk`**, v1.0.x). That SDK provides:
 
-- **DID generation** — derives a `did:key` from the agent's existing Ed25519
-  identity via `vouch.multikey` (no new key material, no registry).
-- **UDNA address creation** — projects a DID and a *facet* (a named capability
-  lane, default `vouch.message`) into a `udna://<did>/<facet>` address.
-- **Secure messaging** — hands the sealed envelope to the SDK node, which
-  performs the Noise handshake, verifies the peer's DID, and delivers the bytes.
+- **DID generation** — `UdnaSDK.create_did()` mints a `did:key`. Its encoding
+  (`z` + base58(`0xed01` ‖ pubkey)) is byte-identical to Vouch's own Multikey,
+  so a Vouch identity and a UDNA identity interoperate with no translation —
+  `UdnaTransport.generate_did(public_jwk)` derives the same `did:key` from the
+  agent's existing signing key.
+- **UDNA address creation** — `UdnaSDK.create_address(did, facet_id, flags)`
+  produces a signed base58 address. `facet_id` selects a capability lane
+  (`0x01` Control, `0x02` Messaging, `0x03` Telemetry); Vouch messages ride
+  Messaging.
+- **Address verification** — `UdnaSDK.verify_address(address)` checks the
+  address signature against the DID's key.
+- **Secure messaging** — `udna_sdk.udna.NoiseHandshake` (a DID-authenticated
+  Noise-IK handshake) plus `SecureMessaging` (ChaCha20-Poly1305 over the
+  derived session key).
+
+**What the SDK does not provide is a production wire transport** — byte
+delivery to a remote peer is left to the integrator (the bundled DHT is an
+in-memory demo). The adapter splits the two concerns accordingly:
+
+- **`UdnaNode`** — the session+delivery seam the transport talks to.
+  `SirrayaUdnaNode` implements it by composing the SDK's Noise/SecureMessaging
+  crypto with a delivery channel: a secure send is a real
+  `initiate → respond → finalize` handshake followed by an encrypted payload,
+  each carried as one channel exchange.
+- **`UdnaChannel`** — the pluggable byte-delivery overlay the deployment
+  supplies (a relay, a libp2p/QUIC overlay, a websocket bridge).
 
 The SDK is an **optional dependency** (`pip install vouch-protocol[udna]`). All
-SDK interaction goes through the minimal `UdnaNode` protocol, so the transport
-is fully testable without the SDK and the rest of Vouch imports it
-unconditionally. When the SDK is absent and no node is injected, the transport
-is **dormant**: it routes nothing and the manager falls back to HTTP. UDNA being
-unavailable is never an error — that is the point of the hybrid design.
+SDK interaction goes through the minimal `UdnaNode` seam, so the transport is
+fully testable without the SDK (see `tests/test_transport.py`) and validated
+against it when present (`tests/test_transport_udna_sdk.py`, auto-skipped
+otherwise). When the SDK is absent, or no node/channel is wired, the transport
+is **dormant**: it routes nothing and the manager falls back to HTTP. UDNA
+being unavailable is never an error — that is the point of the hybrid design.
 
 ### `HttpTransport` — location-first fallback
 

--- a/docs/udna-upstream-proposal.md
+++ b/docs/udna-upstream-proposal.md
@@ -1,0 +1,116 @@
+# Upstream improvement proposal: `sirraya-udna-sdk`
+
+Vouch integrates `sirraya-udna-sdk` (import `udna_sdk`) as an optional
+identity-first transport (see `docs/HYBRID_TRANSPORT.md`). While integrating we
+read the v1.0.3 source and found one **security-critical** issue and several
+smaller gaps. This document records them and proposes fixes, so that (a) Vouch's
+adapter documents *why* it currently treats the UDNA channel as non-confidential,
+and (b) the findings can be contributed upstream.
+
+These notes are about the **external** package, not Vouch code. Vouch's own
+guarantees do not depend on them: a Vouch envelope carries a signed credential,
+so payload integrity and authenticity hold end-to-end regardless of transport.
+
+---
+
+## 1. CRITICAL — the handshake provides no confidentiality
+
+`udna_sdk/udna.py :: NoiseHandshake.finalize_handshake` derives the session key
+from **public values only**:
+
+```python
+key_material = (
+    str(session['local_did']).encode() +
+    str(session['remote_did']).encode() +
+    session['ephemeral_private_key'].public_key().public_bytes(Raw, Raw) +  # PUBLIC
+    remote_ephemeral                                                         # PUBLIC
+)
+session_key = hashlib.sha256(key_material).digest()
+```
+
+Both DIDs and both ephemeral **public** keys travel in the clear inside the
+handshake JSON. No private key material and no Diffie-Hellman ever enter the
+KDF. Therefore **any passive observer of the handshake can recompute the exact
+session key** and decrypt every subsequent `SecureMessaging` (ChaCha20-Poly1305)
+frame. The code comments confirm it is a placeholder:
+
+> `# In a full Noise implementation, this would perform DH key exchange`
+> `# For demo, we'll derive a session key from the DIDs and ephemeral keys`
+
+Impact: the "end-to-end encrypted messaging" claim does not hold. Peer
+authenticity *is* present (ephemeral keys are signed by the DID keys), but
+channel secrecy and forward secrecy are absent.
+
+### Proposed fix — real ephemeral ECDH (X25519), keep Ed25519 for auth
+
+Ed25519 identity keys can't do DH, so add an ephemeral **X25519** keypair per
+handshake and sign its public key with the Ed25519 DID key (Noise-IK / X3DH
+shape):
+
+```python
+from cryptography.hazmat.primitives.asymmetric.x25519 import (
+    X25519PrivateKey, X25519PublicKey,
+)
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
+
+# initiate / respond: generate an ephemeral X25519 key, send its public bytes,
+# and authenticate it with the static Ed25519 DID key:
+eph = X25519PrivateKey.generate()
+eph_pub = eph.public_key().public_bytes(Raw, Raw)
+auth_sig = ed25519_did_key.sign(eph_pub + str(remote_did).encode())  # binds eph→identity
+
+# finalize (both sides): verify the peer's auth_sig against their did:key,
+# then derive the key from the DH shared secret + a transcript hash:
+shared = eph.exchange(X25519PublicKey.from_public_bytes(remote_eph_pub))
+session_key = HKDF(
+    algorithm=hashes.SHA256(), length=32,
+    salt=transcript_hash,            # H(init_msg ‖ response_msg)
+    info=b"udna-noise-v2",
+).derive(shared)
+```
+
+This yields confidentiality, forward secrecy, and mutual authentication, and is
+a localized change to the three `NoiseHandshake` methods. The wire format gains
+an `x25519_ephemeral` field alongside the existing signed Ed25519 ephemeral.
+
+---
+
+## 2. No transport / overlay — only an in-memory demo DHT
+
+`DhtNode` is a single-process dict (`store`/`lookup`), so the SDK cannot
+actually deliver bytes between hosts. Vouch works around this with a pluggable
+`UdnaChannel`. Upstream would benefit from a documented `Transport` interface
+(e.g. `async def send(address, frame) -> frame`) with at least one real backend
+(QUIC/libp2p/websocket relay), so integrators don't each reinvent delivery.
+
+## 3. `create_address` only works for SDK-generated DIDs
+
+`create_address` requires the DID to be in `self._active_keys`, i.e. created by
+`UdnaSDK.create_did()`. There is no public way to register an externally-held
+key, so an agent that already owns an Ed25519 identity (the common case for
+Vouch) cannot mint an SDK address for it. Proposed: an
+`import_identity(did, private_key)` / `register_key(did, signer)` entry point,
+or accept a signing callback.
+
+## 4. Minor
+
+- **Version mismatch:** `udna_sdk/__init__.py` sets `__version__ = "1.0.2"`
+  while the distribution is `1.0.3`. Source the version from one place.
+- **Address timestamps are unauthenticated:** `UdnaAddressInfo.created_at` is
+  set from `datetime.now()` at *parse* time, not signed into the address, so it
+  conveys nothing verifiable. Either sign it or drop it from the verified view.
+- **`verify_address` swallows all errors into `is_valid=False`:** useful for
+  callers, but consider distinguishing "malformed" from "signature mismatch" in
+  `VerificationResult.error` for debuggability (it partly does this already).
+
+---
+
+## What Vouch does in the meantime
+
+- The adapter (`vouch/transport/udna.py :: SirrayaUdnaNode`) carries an explicit
+  warning that the v1.0.x channel is authenticated but **not confidential**.
+- Vouch never relies on UDNA channel encryption for security; envelope payloads
+  are signed credentials, so tampering and forgery are caught regardless.
+- For confidential payloads, encrypt at the application layer before sealing, or
+  use a transport with real channel encryption, until item 1 lands upstream.

--- a/examples/hybrid_transport_demo.py
+++ b/examples/hybrid_transport_demo.py
@@ -10,8 +10,13 @@ Demonstrates the modular, DID-addressed transport layer:
      to standard DNS/IP + HTTP when the peer is not on the UDNA overlay.
   4. The signed payload is preserved byte-for-byte across the transition.
 
-The Sirraya UDNA SDK is optional. This demo wires an in-process fake UDNA node
-so you can watch routing and fallback without any network or the real SDK.
+The Sirraya UDNA SDK (``pip install vouch-protocol[udna]``, import ``udna_sdk``)
+is optional. In production it provides DID/address creation and the Noise
+handshake + ChaCha20-Poly1305 crypto, while a pluggable ``UdnaChannel`` moves
+the bytes (the SDK ships no production wire transport). To keep this demo
+network-free and runnable without the SDK, it wires an in-process fake UDNA
+node directly to the same ``UdnaNode`` seam ``SirrayaUdnaNode`` implements — so
+you can watch routing and fallback without the real SDK.
 
 Run:  python examples/hybrid_transport_demo.py
 """

--- a/examples/hybrid_transport_demo.py
+++ b/examples/hybrid_transport_demo.py
@@ -1,0 +1,109 @@
+"""
+Vouch Protocol: Hybrid Transport Demo (UDNA + HTTP fallback)
+
+Demonstrates the modular, DID-addressed transport layer:
+
+  1. An agent signs a Vouch credential (its accountable intent).
+  2. It seals the credential — plus liability attestations and provenance —
+     into a VouchEnvelope addressed to a peer's *DID* (not an IP).
+  3. The TransportManager tries identity-first UDNA routing, then falls back
+     to standard DNS/IP + HTTP when the peer is not on the UDNA overlay.
+  4. The signed payload is preserved byte-for-byte across the transition.
+
+The Sirraya UDNA SDK is optional. This demo wires an in-process fake UDNA node
+so you can watch routing and fallback without any network or the real SDK.
+
+Run:  python examples/hybrid_transport_demo.py
+"""
+
+import asyncio
+import json
+
+from vouch import Signer, generate_identity
+from vouch.transport import TransportManager, UdnaTransport, build_envelope
+
+
+class DemoUdnaNode:
+    """A toy UDNA node. `reachable_dids` decides who is on the overlay."""
+
+    def __init__(self, reachable_dids):
+        self._reachable = set(reachable_dids)
+
+    async def resolve(self, address):
+        # address looks like "udna://<did>/vouch.message"
+        did = address.split("//", 1)[1].rsplit("/", 1)[0]
+        return {"address": address} if did in self._reachable else None
+
+    async def send_secure(self, address, data):
+        print(f"   🔐 UDNA Noise channel → {address} ({len(data)} bytes)")
+        return json.dumps({"status": "delivered", "via": "udna"}).encode()
+
+    async def close(self):
+        pass
+
+
+async def main():
+    print("\n🌐 Vouch Hybrid Transport Demo\n" + "=" * 40)
+
+    # -- Identities ------------------------------------------------------
+    sender = generate_identity(domain="sender.example.com")
+    signer = Signer(private_key=sender.private_key_jwk, did=sender.did)
+
+    udna_native_peer = UdnaTransport.generate_did(generate_identity().public_key_jwk)
+    web_only_peer = "did:web:peer.example.com"
+
+    print(f"Sender:          {sender.did}")
+    print(f"UDNA-native peer: {udna_native_peer[:32]}…")
+    print(f"Web-only peer:    {web_only_peer}")
+
+    # -- Sign an accountable intent --------------------------------------
+    credential = signer.sign_credential(
+        intent={
+            "action": "settle_invoice",
+            "target": "invoice-42",
+            "resource": "https://api.example.com/invoices/42",
+        }
+    )
+
+    # -- Hybrid stack: UDNA preferred, HTTP fallback ---------------------
+    # Only the UDNA-native peer is on the overlay.
+    node = DemoUdnaNode(reachable_dids={udna_native_peer})
+    manager = TransportManager.default(udna_node=node)
+
+    # -- Case 1: peer IS on UDNA → identity-first delivery ---------------
+    print("\n[1] Dispatch to a UDNA-native peer")
+    env1 = build_envelope(
+        from_did=sender.did,
+        to_did=udna_native_peer,
+        payload=credential,
+        attestations=[{"type": "OutcomeCommitment", "id": "urn:commit:1"}],
+        provenance={"contentHash": credential.get("id", "n/a")},
+    )
+    result1 = await manager.dispatch(env1)
+    print(f"   ✅ delivered via '{result1.transport}'  attempts={result1.attempts}")
+
+    # -- Case 2: peer NOT on UDNA → graceful fallback to HTTP ------------
+    print("\n[2] Dispatch to a web-only peer (UDNA resolution fails → fallback)")
+    env2 = build_envelope(from_did=sender.did, to_did=web_only_peer, payload=credential)
+    try:
+        result2 = await manager.dispatch(env2)
+        print(f"   ✅ delivered via '{result2.transport}'  attempts={result2.attempts}")
+    except Exception as exc:
+        # No real HTTPS inbox is running in this demo, so HTTP delivery will
+        # fail at the network step — but note UDNA was tried first and yielded.
+        print("   ↪️  UDNA yielded, HTTP attempted; network step failed as expected:")
+        print(f"      {type(exc).__name__}: {exc}")
+
+    # -- Payload preservation proof --------------------------------------
+    print("\n[3] Payload preservation across the transport boundary")
+    wire = env1.to_wire()
+    assert wire["payload"]["proof"] == credential["proof"], "proof must survive"
+    print("   ✅ Data Integrity proof, attestations, and provenance preserved verbatim")
+    print(f"   🔎 content digest: {env1.content_digest()}")
+
+    await manager.close()
+    print("\nDone.\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,10 @@ azure = ["azure-keyvault-keys>=4.0.0"]
 # wrote that into a Dockerfile or requirements.txt.
 pq = []
 
+# UDNA (Universal DID-Native Addressing) identity-first transport.
+# Optional: when absent, the hybrid transport stack degrades to HTTP fallback.
+udna = ["sirraya-udna-sdk>=0.1.0"]
+
 # OpenTelemetry tracing
 tracing = [
     "opentelemetry-api>=1.20.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,9 @@ azure = ["azure-keyvault-keys>=4.0.0"]
 pq = []
 
 # UDNA (Universal DID-Native Addressing) identity-first transport.
+# Distribution `sirraya-udna-sdk` imports as the `udna_sdk` package.
 # Optional: when absent, the hybrid transport stack degrades to HTTP fallback.
-udna = ["sirraya-udna-sdk>=0.1.0"]
+udna = ["sirraya-udna-sdk>=1.0.3"]
 
 # OpenTelemetry tracing
 tracing = [

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,0 +1,247 @@
+"""
+Tests for the hybrid transport layer (UDNA + HTTP fallback).
+
+The Sirraya UDNA SDK is not a test dependency, so the UDNA transport is
+exercised through the :class:`UdnaNode` protocol with in-memory fakes. This is
+the same seam a real deployment uses, so the routing logic under test is the
+production path, not a mock of it.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.transport import (
+    DeliveryResult,
+    HttpTransport,
+    PayloadIntegrityError,
+    PeerAddress,
+    TransportError,
+    TransportManager,
+    UdnaTransport,
+    VouchEnvelope,
+    build_envelope,
+    ed25519_public_from_did_key,
+    is_did_key,
+    udna_address,
+)
+from vouch.transport.envelope import ENVELOPE_VERSION
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures / helpers
+# --------------------------------------------------------------------------- #
+def _signed_credential(domain: str = "agent.example.com"):
+    kp = generate_identity(domain=domain)
+    signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+    cred = signer.sign_credential(
+        intent={
+            "action": "settle_invoice",
+            "target": "invoice-42",
+            "resource": "https://api.example.com/invoices/42",
+        }
+    )
+    return kp, cred
+
+
+class FakeUdnaNode:
+    """In-memory stand-in for a sirraya-udna-sdk node."""
+
+    def __init__(self, reachable=True, reply=None):
+        self.reachable = reachable
+        self.reply = reply if reply is not None else {"status": "delivered"}
+        self.sent = []
+        self.closed = False
+
+    async def resolve(self, address):
+        if not self.reachable:
+            return None
+        return {"address": address, "hops": 1}
+
+    async def send_secure(self, address, data):
+        self.sent.append((address, data))
+        return json.dumps(self.reply).encode("utf-8")
+
+    async def close(self):
+        self.closed = True
+
+
+# --------------------------------------------------------------------------- #
+# Envelope: payload preservation + integrity
+# --------------------------------------------------------------------------- #
+class TestEnvelope:
+    def test_build_preserves_signed_payload_by_reference(self):
+        _, cred = _signed_credential()
+        env = build_envelope(
+            from_did="did:web:a.example.com",
+            to_did="did:web:b.example.com",
+            payload=cred,
+        )
+        # The credential dict is carried verbatim — proof intact.
+        assert env.payload is cred
+        assert "proof" in env.payload
+
+    def test_wire_roundtrip_preserves_proof_and_attestations(self):
+        _, cred = _signed_credential()
+        env = build_envelope(
+            from_did="did:web:a.example.com",
+            to_did="did:web:b.example.com",
+            payload=cred,
+            attestations=[{"type": "OutcomeCommitment", "id": "urn:c:1"}],
+            provenance={"contentHash": "sha256:abcd"},
+        )
+        wire = env.to_wire()
+        assert wire["vouch_envelope"] == ENVELOPE_VERSION
+        restored = VouchEnvelope.from_wire(wire)
+        assert restored.payload == cred
+        assert restored.payload["proof"] == cred["proof"]
+        assert restored.attestations[0]["id"] == "urn:c:1"
+        assert restored.provenance["contentHash"] == "sha256:abcd"
+
+    def test_digest_is_order_independent(self):
+        env1 = build_envelope(from_did="a", to_did="b", payload={"x": 1, "y": 2})
+        env2 = build_envelope(from_did="a", to_did="b", payload={"y": 2, "x": 1})
+        assert env1.content_digest() == env2.content_digest()
+
+    def test_tampered_cargo_fails_integrity_on_decode(self):
+        _, cred = _signed_credential()
+        env = build_envelope(from_did="a", to_did="b", payload=cred)
+        wire = env.to_wire()
+        # Mutate the payload after the digest was stamped.
+        wire["payload"]["credentialSubject"] = {"action": "tampered"}
+        with pytest.raises(PayloadIntegrityError):
+            VouchEnvelope.from_wire(wire)
+
+    def test_verify_integrity_detects_external_digest_mismatch(self):
+        env = build_envelope(from_did="a", to_did="b", payload={"x": 1})
+        assert env.verify_integrity(env.content_digest()) is True
+        assert env.verify_integrity("sha256:deadbeef") is False
+
+
+# --------------------------------------------------------------------------- #
+# did:key generation (UDNA identity)
+# --------------------------------------------------------------------------- #
+class TestDidKey:
+    def test_generate_did_key_from_identity(self):
+        kp = generate_identity()
+        did = UdnaTransport.generate_did(kp.public_key_jwk)
+        assert is_did_key(did)
+        assert did.startswith("did:key:z6Mk")
+
+    def test_did_key_roundtrips_to_public_key(self):
+        kp = generate_identity()
+        did = UdnaTransport.generate_did(kp.public_key_jwk)
+        raw = ed25519_public_from_did_key(did)
+        assert len(raw) == 32
+
+    def test_udna_address_binds_did_and_facet(self):
+        addr = udna_address("did:key:z6MkABC", facet="vouch.message")
+        assert addr == "udna://did:key:z6MkABC/vouch.message"
+
+
+# --------------------------------------------------------------------------- #
+# UDNA transport
+# --------------------------------------------------------------------------- #
+class TestUdnaTransport:
+    async def test_dormant_without_node_routes_nothing(self):
+        udna = UdnaTransport(node=None)
+        assert udna.is_active is False
+        assert await udna.can_route("did:key:z6MkABC") is False
+        assert await udna.resolve("did:key:z6MkABC") is None
+
+    async def test_resolve_marks_peer_verified(self):
+        udna = UdnaTransport(node=FakeUdnaNode())
+        peer = await udna.resolve("did:key:z6MkABC")
+        assert peer is not None
+        assert peer.verified is True
+        assert peer.transport == "udna"
+        assert peer.locator == "udna://did:key:z6MkABC/vouch.message"
+
+    async def test_resolve_returns_none_when_peer_not_on_overlay(self):
+        udna = UdnaTransport(node=FakeUdnaNode(reachable=False))
+        assert await udna.resolve("did:key:z6MkABC") is None
+
+    async def test_send_delivers_over_secure_channel(self):
+        node = FakeUdnaNode(reply={"status": "ok"})
+        udna = UdnaTransport(node=node)
+        _, cred = _signed_credential()
+        env = build_envelope(from_did="a", to_did="did:key:z6MkABC", payload=cred)
+        peer = await udna.resolve("did:key:z6MkABC")
+        reply = await udna.send(env, peer)
+        assert reply == {"status": "ok"}
+        # The bytes that hit the wire are the canonical envelope, proof intact.
+        sent_address, sent_bytes = node.sent[0]
+        decoded = json.loads(sent_bytes.decode("utf-8"))
+        assert decoded["payload"]["proof"] == cred["proof"]
+
+
+# --------------------------------------------------------------------------- #
+# Fallback routing manager
+# --------------------------------------------------------------------------- #
+class TestTransportManager:
+    async def test_prefers_udna_when_available(self):
+        node = FakeUdnaNode()
+        manager = TransportManager.default(udna_node=node)
+        _, cred = _signed_credential()
+        env = build_envelope(from_did="a", to_did="did:key:z6MkABC", payload=cred)
+        result = await manager.dispatch(env)
+        assert isinstance(result, DeliveryResult)
+        assert result.ok is True
+        assert result.transport == "udna"
+        assert result.attempts == ["udna"]
+
+    async def test_falls_back_to_http_when_udna_dormant(self):
+        # No node and no SDK → UDNA dormant. did:web is HTTP-routable.
+        captured = {}
+
+        class FakeHttp(HttpTransport):
+            async def resolve(self, did):
+                return PeerAddress(did=did, transport="http", locator="https://b.example.com/inbox")
+
+            async def send(self, envelope, peer):
+                captured["wire"] = envelope.to_wire()
+                return {"status": "accepted"}
+
+        manager = TransportManager([UdnaTransport(node=None), FakeHttp()])
+        _, cred = _signed_credential()
+        env = build_envelope(from_did="a", to_did="did:web:b.example.com", payload=cred)
+        result = await manager.dispatch(env)
+        assert result.transport == "http"
+        # UDNA dormant → can_route False → not even attempted.
+        assert result.attempts == ["http"]
+        assert captured["wire"]["payload"]["proof"] == cred["proof"]
+
+    async def test_falls_back_when_udna_peer_not_reachable(self):
+        # UDNA node present but peer not on overlay → fall through to HTTP.
+        node = FakeUdnaNode(reachable=False)
+
+        class FakeHttp(HttpTransport):
+            async def resolve(self, did):
+                return PeerAddress(did=did, transport="http", locator="https://b.example.com/inbox")
+
+            async def send(self, envelope, peer):
+                return {"status": "accepted"}
+
+        manager = TransportManager([UdnaTransport(node=node), FakeHttp()])
+        _, cred = _signed_credential()
+        env = build_envelope(from_did="a", to_did="did:web:b.example.com", payload=cred)
+        result = await manager.dispatch(env)
+        assert result.transport == "http"
+        assert result.attempts == ["udna", "http"]
+
+    async def test_raises_when_no_transport_can_deliver(self):
+        manager = TransportManager([UdnaTransport(node=None), HttpTransport()])
+        _, cred = _signed_credential()
+        # did:key is not HTTP-routable and UDNA is dormant → nothing can deliver.
+        env = build_envelope(from_did="a", to_did="did:key:z6MkABC", payload=cred)
+        with pytest.raises(TransportError):
+            await manager.dispatch(env)
+
+    async def test_close_propagates_to_transports(self):
+        node = FakeUdnaNode()
+        manager = TransportManager.default(udna_node=node)
+        await manager.close()
+        assert node.closed is True

--- a/tests/test_transport_udna_sdk.py
+++ b/tests/test_transport_udna_sdk.py
@@ -1,0 +1,139 @@
+"""
+Integration tests against the *real* ``sirraya-udna-sdk`` (import: ``udna_sdk``).
+
+These are skipped unless the SDK is installed (``pip install
+vouch-protocol[udna]``), so the default test run does not depend on it. When it
+is present, they exercise Vouch's UDNA adapter against the genuine SDK API —
+``UdnaSDK.create_did`` / ``create_address`` / ``verify_address`` and the
+``NoiseHandshake`` + ``SecureMessaging`` crypto — proving the adapter is wired
+to real method names, not guessed ones.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+udna_sdk = pytest.importorskip("udna_sdk")
+
+from vouch import generate_identity  # noqa: E402
+from vouch.transport import (  # noqa: E402
+    SirrayaUdnaNode,
+    UdnaTransport,
+    build_envelope,
+    is_did_key,
+)
+from vouch.transport.udna import FACET_MESSAGING  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# Real SDK: DID + address primitives
+# --------------------------------------------------------------------------- #
+def test_sdk_create_did_returns_did_key():
+    did = UdnaTransport.generate_did_via_sdk()
+    assert is_did_key(did)
+    assert did.startswith("did:key:z6Mk")
+
+
+def test_sdk_address_create_and_verify_roundtrip():
+    from udna_sdk import UdnaSDK
+
+    sdk = UdnaSDK()
+    did = sdk.create_did().did
+    addr = sdk.create_address(did, facet_id=FACET_MESSAGING, flags=["messaging", "routing"])
+    # The adapter's verify helper wraps the real verify_address.
+    assert UdnaTransport.verify_udna_address(addr.address) is True
+
+
+def test_vouch_did_key_matches_sdk_encoding():
+    """Vouch's Multikey did:key must be byte-identical to the SDK's encoding."""
+    from cryptography.hazmat.primitives import serialization
+    from udna_sdk.udna import DidKeyMethod
+
+    sdk_did, priv = DidKeyMethod.generate()
+    raw_pub = priv.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    vouch_did = UdnaTransport.generate_did_from_raw(raw_pub)
+    assert vouch_did == str(sdk_did)
+
+
+# --------------------------------------------------------------------------- #
+# Real SDK: Noise handshake + secure messaging through the adapter
+# --------------------------------------------------------------------------- #
+class PeerChannel:
+    """
+    A delivery channel that plays the *peer* using the real SDK:
+    it answers the Noise handshake with ``respond_to_handshake`` and
+    acknowledges the encrypted payload.
+    """
+
+    def __init__(self):
+        from udna_sdk.udna import DidKeyMethod, NoiseHandshake
+
+        self._noise = NoiseHandshake()
+        self._peer_did, self._peer_priv = DidKeyMethod.generate()
+        self.received_ciphertext = None
+
+    async def reachable(self, address):
+        return True
+
+    async def exchange(self, address, frame):
+        # Distinguish the handshake frame (JSON with a 'type') from ciphertext.
+        try:
+            msg = json.loads(frame.decode("utf-8"))
+            is_handshake = isinstance(msg, dict) and msg.get("type") == "handshake_init"
+        except (ValueError, UnicodeDecodeError):
+            is_handshake = False
+
+        if is_handshake:
+            _session_id, response = self._noise.respond_to_handshake(
+                self._peer_did, self._peer_priv, frame
+            )
+            return response
+        # Encrypted payload: record it and acknowledge with no body.
+        self.received_ciphertext = frame
+        return b""
+
+    async def close(self):
+        pass
+
+
+async def test_secure_send_runs_real_noise_handshake():
+    kp = generate_identity()
+    node = SirrayaUdnaNode(
+        channel=PeerChannel(),
+        local_did=UdnaTransport.generate_did(kp.public_key_jwk),
+        local_private_key=_priv_obj(kp.private_key_jwk),
+    )
+    transport = UdnaTransport(node=node)
+
+    peer_did = UdnaTransport.generate_did_via_sdk()
+    env = build_envelope(from_did=kp.did, to_did=peer_did, payload={"hello": "udna"})
+    peer = await transport.resolve(peer_did)
+    assert peer is not None and peer.verified is True
+
+    # Completes a real initiate→respond→finalize handshake and encrypts the
+    # envelope with ChaCha20-Poly1305 — no exception means the real API matched.
+    reply = await transport.send(env, peer)
+    assert reply == {}  # peer acknowledged without a body
+    assert node._channel.received_ciphertext is not None
+
+
+def test_secure_messaging_encrypt_decrypt_roundtrip():
+    from udna_sdk.udna import SecureMessaging
+
+    sm = SecureMessaging()
+    key = b"\x01" * 32
+    blob = b'{"vouch_envelope":"1.0"}'
+    ct = sm.encrypt_message(key, blob)
+    assert sm.decrypt_message(key, ct) == blob
+
+
+def _priv_obj(private_key_jwk: str):
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from jwcrypto.common import base64url_decode
+
+    seed = base64url_decode(json.loads(private_key_jwk)["d"])
+    return Ed25519PrivateKey.from_private_bytes(seed)

--- a/vouch/transport/__init__.py
+++ b/vouch/transport/__init__.py
@@ -65,7 +65,17 @@ from .envelope import (
 )
 from .http_transport import HttpTransport
 from .manager import TransportManager
-from .udna import DEFAULT_FACET, UdnaNode, UdnaTransport, udna_address
+from .udna import (
+    DEFAULT_FACET,
+    FACET_CONTROL,
+    FACET_MESSAGING,
+    FACET_TELEMETRY,
+    SirrayaUdnaNode,
+    UdnaChannel,
+    UdnaNode,
+    UdnaTransport,
+    udna_address,
+)
 
 __all__ = [
     # Core abstractions
@@ -85,8 +95,13 @@ __all__ = [
     # Transports
     "UdnaTransport",
     "UdnaNode",
+    "UdnaChannel",
+    "SirrayaUdnaNode",
     "udna_address",
     "DEFAULT_FACET",
+    "FACET_CONTROL",
+    "FACET_MESSAGING",
+    "FACET_TELEMETRY",
     "HttpTransport",
     # did:key helpers
     "is_did_key",

--- a/vouch/transport/__init__.py
+++ b/vouch/transport/__init__.py
@@ -1,0 +1,96 @@
+"""
+Vouch hybrid transport layer.
+
+A modular, DID-addressed networking layer that lets a Vouch agent dispatch a
+message to a peer's *identity* and stay agnostic about how it is routed. Two
+transports ship in the box:
+
+  * :class:`UdnaTransport` — identity-first routing via the Sirraya UDNA SDK.
+    The DID is the route; delivery rides a Noise-encrypted channel straight to
+    the key that owns it. Optional; dormant (and harmless) when the SDK is
+    absent.
+  * :class:`HttpTransport` — the location-first fallback. Resolve ``did:web``
+    to a domain over DNS/IP and POST over TLS. Universally reachable.
+
+:class:`TransportManager` ties them together with graceful fallback: prefer
+UDNA, fall back to HTTP when a peer is not on the overlay. The
+:class:`VouchEnvelope` carries the signed credential, liability attestations,
+and provenance metadata across the transport boundary without altering a byte.
+
+Quick start::
+
+    from vouch import Signer, generate_identity
+    from vouch.transport import TransportManager, build_envelope
+
+    kp = generate_identity(domain="agent.example.com")
+    signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+    credential = signer.sign_credential(intent={
+        "action": "settle_invoice",
+        "target": "invoice-42",
+        "resource": "https://api.example.com/invoices/42",
+    })
+
+    envelope = build_envelope(
+        from_did=kp.did,
+        to_did="did:web:peer.example.com",
+        payload=credential,
+    )
+
+    manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
+    result = await manager.dispatch(envelope)
+    print(result.transport, result.attempts)   # e.g. "http" ["udna", "http"]
+"""
+
+from __future__ import annotations
+
+from .base import (
+    DeliveryResult,
+    PayloadIntegrityError,
+    PeerAddress,
+    Transport,
+    TransportError,
+    TransportUnavailable,
+)
+from .did_key import (
+    did_key_from_ed25519_public,
+    did_key_from_public_jwk,
+    ed25519_public_from_did_key,
+    is_did_key,
+)
+from .envelope import (
+    ENVELOPE_CONTENT_TYPE,
+    ENVELOPE_VERSION,
+    VouchEnvelope,
+    build_envelope,
+)
+from .http_transport import HttpTransport
+from .manager import TransportManager
+from .udna import DEFAULT_FACET, UdnaNode, UdnaTransport, udna_address
+
+__all__ = [
+    # Core abstractions
+    "Transport",
+    "TransportManager",
+    "PeerAddress",
+    "DeliveryResult",
+    # Errors
+    "TransportError",
+    "TransportUnavailable",
+    "PayloadIntegrityError",
+    # Envelope
+    "VouchEnvelope",
+    "build_envelope",
+    "ENVELOPE_VERSION",
+    "ENVELOPE_CONTENT_TYPE",
+    # Transports
+    "UdnaTransport",
+    "UdnaNode",
+    "udna_address",
+    "DEFAULT_FACET",
+    "HttpTransport",
+    # did:key helpers
+    "is_did_key",
+    "did_key_from_ed25519_public",
+    "did_key_from_public_jwk",
+    "ed25519_public_from_did_key",
+]

--- a/vouch/transport/base.py
+++ b/vouch/transport/base.py
@@ -1,0 +1,146 @@
+"""
+Transport abstraction for the Vouch Protocol.
+
+Vouch credentials (signed intents, liability attestations, provenance
+metadata) are *what* an agent says; a transport is *how* that statement
+reaches a peer. Historically the only transport was DNS/IP + HTTP(S): you
+resolve a `did:web` to a domain, then POST to it. That couples delivery to
+location — whoever controls the IP controls the route.
+
+This module defines the location-agnostic interface every transport
+implements so that a Vouch agent can dispatch a message addressed only to a
+peer's DID and remain unaware of whether it travelled over UDNA
+(identity-first) or HTTP (location-first). The :class:`Transport` contract is
+deliberately small:
+
+  * ``can_route(did)``  — could this transport plausibly reach this DID?
+  * ``resolve(did)``    — turn the DID into a concrete :class:`PeerAddress`.
+  * ``send(envelope, peer)`` — deliver the payload, returning the peer reply.
+
+A transport signals "not my problem, try the next one" by raising
+:class:`TransportUnavailable` (or returning ``None`` from ``resolve``). It
+signals a corrupted payload — a bug the caller must not paper over by
+silently re-routing — by raising :class:`PayloadIntegrityError`. The
+:class:`~vouch.transport.manager.TransportManager` uses exactly that
+distinction to decide between graceful fallback and hard failure.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+class TransportError(Exception):
+    """Base class for all transport-layer failures."""
+
+
+class TransportUnavailable(TransportError):
+    """
+    Raised when a transport cannot reach a peer — the peer does not advertise
+    this transport, resolution failed, or the underlying channel could not be
+    established. This is the signal the routing manager treats as "fall back to
+    the next transport"; it is never fatal on its own.
+    """
+
+
+class PayloadIntegrityError(TransportError):
+    """
+    Raised when an envelope's content digest does not match its payload. This
+    means the Vouch credential, liability attestations, or provenance metadata
+    were altered after sealing. It is fatal: the manager must NOT fall back and
+    re-send a payload it can no longer vouch for.
+    """
+
+
+@dataclass
+class PeerAddress:
+    """
+    A resolved, transport-specific way to reach a peer DID.
+
+    The ``did`` is the stable, location-independent identity. ``locator`` is
+    the concrete handle the owning transport understands — a UDNA address
+    (``udna://…``) or an HTTPS inbox URL — and is meaningful only to the
+    transport that produced it. ``verified`` records whether the locator was
+    cryptographically bound to the DID during resolution (UDNA verifies the
+    DID owns the route; plain DNS does not).
+    """
+
+    did: str
+    transport: str
+    locator: Optional[str] = None
+    verified: bool = False
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class DeliveryResult:
+    """
+    Outcome of a dispatch. ``attempts`` lists, in order, every transport the
+    manager tried, so callers can observe the fallback path (e.g.
+    ``["udna", "http"]`` means UDNA was attempted first and HTTP delivered).
+    """
+
+    ok: bool
+    transport: str
+    peer: PeerAddress
+    envelope_id: str
+    response: Optional[Dict[str, Any]] = None
+    attempts: List[str] = field(default_factory=list)
+
+
+class Transport(ABC):
+    """
+    Abstract base class for a Vouch message transport.
+
+    Implementations are addressed by DID, never by location. The manager calls
+    ``can_route`` as a cheap pre-filter, then ``resolve`` to obtain a
+    :class:`PeerAddress`, then ``send``. Implementations must not mutate the
+    envelope they are handed — the payload's cryptographic proofs depend on it
+    being byte-for-byte preserved across the transport boundary.
+    """
+
+    #: Stable, lowercase identifier used in preference ordering and
+    #: ``DeliveryResult.attempts`` (e.g. ``"udna"``, ``"http"``).
+    name: str = "transport"
+
+    @abstractmethod
+    async def can_route(self, did: str) -> bool:
+        """
+        Cheap, best-effort check of whether this transport could reach ``did``.
+        Should not perform network I/O when a syntactic check suffices (e.g.
+        HTTP can route any ``did:web``; UDNA can route any DID once a node is
+        attached). Returning ``True`` is not a promise of delivery.
+        """
+
+    @abstractmethod
+    async def resolve(self, did: str) -> Optional[PeerAddress]:
+        """
+        Resolve ``did`` to a concrete :class:`PeerAddress`, or return ``None``
+        if this transport cannot reach the peer (which triggers fallback). May
+        raise :class:`TransportUnavailable` for the same effect when it wants
+        to attach a diagnostic message.
+        """
+
+    @abstractmethod
+    async def send(self, envelope: "VouchEnvelope", peer: PeerAddress) -> Dict[str, Any]:
+        """
+        Deliver ``envelope`` to ``peer`` and return the peer's reply as a dict
+        (empty dict if the peer acknowledges without a body).
+
+        Raises:
+          TransportUnavailable: the channel could not be established or the
+            peer rejected the connection — the manager will fall back.
+          PayloadIntegrityError: the envelope failed its own integrity check.
+        """
+
+    async def close(self) -> None:
+        """Release any held resources (sockets, SDK nodes). Idempotent."""
+        return None
+
+
+# Imported at the bottom to avoid a circular import: ``envelope`` imports
+# nothing from this module, but type checkers and the ``send`` signature above
+# reference :class:`VouchEnvelope`.
+from .envelope import VouchEnvelope  # noqa: E402  (re-exported for typing)

--- a/vouch/transport/did_key.py
+++ b/vouch/transport/did_key.py
@@ -1,0 +1,77 @@
+"""
+``did:key`` helpers for identity-first (UDNA) routing.
+
+Where ``did:web`` anchors trust in a domain, ``did:key`` anchors it in the key
+itself: the DID *is* the public key, multibase-encoded. That makes it the
+natural addressing primitive for UDNA, which routes to a cryptographic identity
+rather than to a location. These helpers are pure functions over the same
+Ed25519 + Multikey machinery the rest of Vouch already uses (see
+:mod:`vouch.multikey`), so a UDNA address can be derived offline, with no
+registry and no network.
+
+Method spec: ``did:key`` for Ed25519 is ``did:key:z6Mk…`` where the suffix is
+the ``Multikey`` encoding of the public key (multicodec ``0xed01`` || raw key,
+base58btc, ``z`` prefix) — identical to the ``publicKeyMultibase`` Vouch
+publishes in DID Documents.
+"""
+
+from __future__ import annotations
+
+import json
+
+from .. import multikey
+
+DID_KEY_PREFIX = "did:key:"
+
+
+def is_did_key(did: str) -> bool:
+    """True if ``did`` is a ``did:key`` identifier."""
+    return did.startswith(DID_KEY_PREFIX)
+
+
+def did_key_from_ed25519_public(raw_public_key: bytes) -> str:
+    """
+    Build a ``did:key`` from a 32-byte raw Ed25519 public key.
+
+    >>> did_key_from_ed25519_public(os.urandom(32)).startswith("did:key:z6Mk")
+    True
+    """
+    return DID_KEY_PREFIX + multikey.encode_ed25519_public(raw_public_key)
+
+
+def did_key_from_public_jwk(public_jwk: str) -> str:
+    """
+    Build a ``did:key`` from an Ed25519 public JWK (the JSON string form
+    produced by :func:`vouch.generate_identity`).
+
+    Raises:
+      ValueError: if the JWK is not an Ed25519 OKP key.
+    """
+    from jwcrypto.common import base64url_decode
+
+    jwk_dict = json.loads(public_jwk)
+    if jwk_dict.get("kty") != "OKP" or jwk_dict.get("crv") != "Ed25519":
+        raise ValueError("did:key generation requires an Ed25519 OKP public JWK")
+    x = jwk_dict.get("x")
+    if not x:
+        raise ValueError("public JWK is missing the 'x' coordinate")
+    return did_key_from_ed25519_public(base64url_decode(x))
+
+
+def ed25519_public_from_did_key(did: str) -> bytes:
+    """
+    Recover the raw 32-byte Ed25519 public key from a ``did:key``.
+
+    This is what lets a UDNA peer verify, with no registry lookup, that the
+    party it established a Noise channel with actually owns the DID it claims —
+    the key is right there in the identifier.
+
+    Raises:
+      ValueError: if ``did`` is not an Ed25519 ``did:key``.
+    """
+    if not is_did_key(did):
+        raise ValueError(f"not a did:key identifier: {did}")
+    alg, raw = multikey.decode(did[len(DID_KEY_PREFIX) :])
+    if alg != "Ed25519":
+        raise ValueError(f"unsupported did:key algorithm: {alg}")
+    return raw

--- a/vouch/transport/envelope.py
+++ b/vouch/transport/envelope.py
@@ -1,0 +1,194 @@
+"""
+The Vouch transport envelope.
+
+A transport moves bytes; Vouch moves *accountable* statements. The envelope is
+the bridge: a thin, transport-neutral container that carries a signed Vouch
+credential together with the liability and provenance context a peer needs to
+hold the sender accountable — without ever touching the signed bytes
+themselves.
+
+Three payload compartments, each preserved verbatim:
+
+  * ``payload``      — the signed Vouch credential (an ``eddsa-jcs-2022`` or
+    hybrid Verifiable Credential, complete with its ``proof`` block). This is
+    opaque to the transport layer and is never re-serialized lossily.
+  * ``attestations`` — zero or more liability attestations (outcome
+    commitments, penalty receipts, delegation links) that bind the sender to
+    consequences.
+  * ``provenance``   — provenance metadata (content hashes, C2PA pointers,
+    capture context) describing where the payload's subject came from.
+
+Integrity across the transport boundary is enforced by ``content_digest()``: a
+SHA-256 over the JCS canonicalization of those three compartments. The manager
+stamps the digest at seal time; the receiver (or a fallback transport
+re-handling the same envelope) recomputes it and rejects any mismatch. Because
+the digest is computed over the canonical form — not the wire bytes — an
+envelope survives a UDNA→HTTP transition, re-indentation, or key reordering
+with its proofs intact.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from .. import jcs
+
+#: Wire-format version. Bump on breaking changes to the envelope shape.
+ENVELOPE_VERSION = "1.0"
+
+#: Media type advertised by transports that carry a sealed envelope.
+ENVELOPE_CONTENT_TYPE = "application/vouch-envelope+json"
+
+
+def _now_iso8601() -> str:
+    """UTC timestamp, second precision, ``Z`` suffix (matches the signer)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class VouchEnvelope:
+    """
+    A payload-preserving message addressed by DID.
+
+    The three payload compartments (``payload``, ``attestations``,
+    ``provenance``) are treated as immutable cargo: transports route the
+    envelope but must not alter them, and the content digest is the proof they
+    didn't. Routing metadata (``to_did``, ``from_did``, ``created``,
+    ``envelope_id``) lives alongside the cargo but outside the digest, so the
+    manager may stamp delivery details without invalidating the seal.
+    """
+
+    to_did: str
+    from_did: str
+    payload: Dict[str, Any]
+    attestations: List[Dict[str, Any]] = field(default_factory=list)
+    provenance: Dict[str, Any] = field(default_factory=dict)
+    created: str = field(default_factory=_now_iso8601)
+    envelope_id: str = field(default_factory=lambda: f"urn:uuid:{uuid.uuid4()}")
+    content_type: str = ENVELOPE_CONTENT_TYPE
+
+    # ------------------------------------------------------------------ #
+    # Integrity
+    # ------------------------------------------------------------------ #
+    def _digest_input(self) -> Dict[str, Any]:
+        """The exact subtree the content digest covers (cargo only)."""
+        return {
+            "payload": self.payload,
+            "attestations": self.attestations,
+            "provenance": self.provenance,
+        }
+
+    def content_digest(self) -> str:
+        """
+        SHA-256 of the JCS-canonical cargo, as a ``sha256:`` hex string.
+
+        Canonicalization (RFC 8785) makes the digest independent of key order
+        and whitespace, so it is stable across serialization round-trips and
+        across transports.
+        """
+        canonical = jcs.canonicalize(self._digest_input())
+        return "sha256:" + hashlib.sha256(canonical).hexdigest()
+
+    def verify_integrity(self, expected_digest: Optional[str] = None) -> bool:
+        """
+        Recompute the content digest and compare. With no argument, compares
+        against the digest carried in this envelope's wire form (a no-op for an
+        in-memory envelope, which is always self-consistent); pass the digest
+        received out-of-band to detect tampering in transit.
+        """
+        actual = self.content_digest()
+        if expected_digest is None:
+            return True
+        return _consttime_eq(actual, expected_digest)
+
+    # ------------------------------------------------------------------ #
+    # Serialization
+    # ------------------------------------------------------------------ #
+    def to_wire(self) -> Dict[str, Any]:
+        """
+        Full wire representation, including the stamped ``content_digest`` so a
+        receiver can verify integrity without re-deriving the seal context.
+        """
+        return {
+            "vouch_envelope": ENVELOPE_VERSION,
+            "envelope_id": self.envelope_id,
+            "to": self.to_did,
+            "from": self.from_did,
+            "created": self.created,
+            "content_type": self.content_type,
+            "content_digest": self.content_digest(),
+            "payload": self.payload,
+            "attestations": self.attestations,
+            "provenance": self.provenance,
+        }
+
+    @classmethod
+    def from_wire(cls, data: Dict[str, Any]) -> "VouchEnvelope":
+        """
+        Reconstruct an envelope from its wire form and verify its seal.
+
+        Raises:
+          PayloadIntegrityError: if the recomputed digest does not match the
+            ``content_digest`` carried on the wire — the cargo was altered.
+          ValueError: if the envelope is structurally malformed.
+        """
+        version = data.get("vouch_envelope")
+        if version != ENVELOPE_VERSION:
+            raise ValueError(f"unsupported envelope version: {version!r}")
+
+        env = cls(
+            to_did=data["to"],
+            from_did=data["from"],
+            payload=data["payload"],
+            attestations=data.get("attestations", []),
+            provenance=data.get("provenance", {}),
+            created=data.get("created", _now_iso8601()),
+            envelope_id=data.get("envelope_id", f"urn:uuid:{uuid.uuid4()}"),
+            content_type=data.get("content_type", ENVELOPE_CONTENT_TYPE),
+        )
+
+        stamped = data.get("content_digest")
+        if stamped is not None and not env.verify_integrity(stamped):
+            # Local import to avoid a circular dependency with base.py.
+            from .base import PayloadIntegrityError
+
+            raise PayloadIntegrityError(
+                "envelope content digest mismatch: payload, attestations, or "
+                "provenance were altered in transit"
+            )
+        return env
+
+
+def _consttime_eq(a: str, b: str) -> bool:
+    """Constant-time-ish string compare for digest equality."""
+    import hmac
+
+    return hmac.compare_digest(a, b)
+
+
+def build_envelope(
+    *,
+    from_did: str,
+    to_did: str,
+    payload: Dict[str, Any],
+    attestations: Optional[List[Dict[str, Any]]] = None,
+    provenance: Optional[Dict[str, Any]] = None,
+) -> VouchEnvelope:
+    """
+    Convenience constructor for a Vouch envelope.
+
+    ``payload`` should be an already-signed Vouch credential — typically the
+    dict returned by ``Signer.sign_credential(...)``. It is stored by reference
+    and never mutated, so its Data Integrity proof remains valid.
+    """
+    return VouchEnvelope(
+        to_did=to_did,
+        from_did=from_did,
+        payload=payload,
+        attestations=list(attestations) if attestations else [],
+        provenance=dict(provenance) if provenance else {},
+    )

--- a/vouch/transport/http_transport.py
+++ b/vouch/transport/http_transport.py
@@ -1,0 +1,160 @@
+"""
+HTTP transport — the location-first fallback.
+
+This is the transport Vouch has always implicitly used: resolve a ``did:web``
+to a domain via DNS/IP, then POST the sealed envelope to that domain's Vouch
+inbox over TLS. It is the universal lowest common denominator — any peer that
+publishes a ``did:web`` document and runs an HTTPS endpoint is reachable — and
+so it serves as the graceful-fallback target when an identity-first transport
+(UDNA) is unavailable or the peer does not support it.
+
+Resolution path for ``did:web:example.com``:
+
+  1. Fetch and parse the DID Document (reusing :func:`resolve_did_web`).
+  2. If the document advertises a ``VouchInbox`` service, use its
+     ``serviceEndpoint``.
+  3. Otherwise fall back to the conventional well-known inbox,
+     ``https://example.com/.well-known/vouch/inbox``.
+
+Every outbound URL is run through :mod:`vouch.ssrf` (https-only, public IPs
+only, redirects disabled) before any request, because the target host is
+derived from a potentially attacker-controlled DID.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+from .. import ssrf
+from ..did_web import did_web_to_url, is_did_web, resolve_did_web
+from .base import PeerAddress, Transport, TransportUnavailable
+from .envelope import VouchEnvelope
+
+#: Service ``type`` a DID Document uses to advertise a Vouch message inbox.
+VOUCH_INBOX_SERVICE = "VouchInbox"
+
+#: Conventional inbox path when the DID Document declares no explicit service.
+WELL_KNOWN_INBOX = "/.well-known/vouch/inbox"
+
+DEFAULT_TIMEOUT = 10.0
+
+
+class HttpTransport(Transport):
+    """
+    DNS/IP + HTTPS transport keyed on ``did:web``.
+
+    Args:
+      timeout: per-request timeout in seconds.
+      verify_ssl: whether to verify TLS certificates (leave on in production).
+      client: an optional pre-built ``httpx.AsyncClient`` (mainly for tests).
+    """
+
+    name = "http"
+
+    def __init__(
+        self,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify_ssl: bool = True,
+        client: Optional[httpx.AsyncClient] = None,
+    ) -> None:
+        self.timeout = timeout
+        self.verify_ssl = verify_ssl
+        self._client = client
+        self._owns_client = client is None
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self.timeout,
+                verify=self.verify_ssl,
+                follow_redirects=False,
+            )
+        return self._client
+
+    async def can_route(self, did: str) -> bool:
+        """HTTP can route any ``did:web`` — that's the only location-bound DID."""
+        return is_did_web(did)
+
+    async def resolve(self, did: str) -> Optional[PeerAddress]:
+        """
+        Resolve ``did:web`` to a Vouch inbox URL.
+
+        Returns ``None`` (→ fallback) for any non-``did:web`` identifier, since
+        HTTP has no way to locate a location-independent DID. Raises
+        :class:`TransportUnavailable` if the DID Document cannot be fetched.
+        """
+        if not is_did_web(did):
+            return None
+
+        inbox = await self._discover_inbox(did)
+        ssrf.validate_url(inbox)  # https-only, public IPs only
+        # DNS does not bind the route to the DID's key, so this peer is reached
+        # but not cryptographically *verified* at the transport layer.
+        return PeerAddress(
+            did=did,
+            transport=self.name,
+            locator=inbox,
+            verified=False,
+            metadata={"resolution": "did:web"},
+        )
+
+    async def _discover_inbox(self, did: str) -> str:
+        """Find the inbox URL: explicit service first, well-known second."""
+        try:
+            doc = await resolve_did_web(did, timeout=self.timeout, verify_ssl=self.verify_ssl)
+        except Exception as exc:
+            raise TransportUnavailable(f"did:web resolution failed for {did}: {exc}") from exc
+
+        # The parsed DIDDocument does not expose `service`, so read the raw
+        # field defensively if a richer document was provided.
+        services = getattr(doc, "service", None) or []
+        for svc in services:
+            if isinstance(svc, dict) and svc.get("type") == VOUCH_INBOX_SERVICE:
+                endpoint = svc.get("serviceEndpoint")
+                if isinstance(endpoint, str) and endpoint:
+                    return endpoint
+
+        # Conventional well-known inbox derived from the DID's domain.
+        doc_url = did_web_to_url(did)
+        parsed = urlparse(doc_url)
+        return f"{parsed.scheme}://{parsed.netloc}{WELL_KNOWN_INBOX}"
+
+    async def send(self, envelope: VouchEnvelope, peer: PeerAddress) -> Dict[str, Any]:
+        """POST the sealed envelope to the peer's inbox over TLS."""
+        if not peer.locator:
+            raise TransportUnavailable("HTTP peer has no inbox locator")
+        ssrf.validate_url(peer.locator)
+
+        client = self._get_client()
+        try:
+            response = await client.post(
+                peer.locator,
+                json=envelope.to_wire(),
+                headers={
+                    "Content-Type": envelope.content_type,
+                    "Accept": "application/json",
+                },
+            )
+        except (httpx.ConnectError, httpx.TimeoutException) as exc:
+            # Network-level failure → let the manager fall back.
+            raise TransportUnavailable(f"HTTP delivery to {peer.locator} failed: {exc}") from exc
+
+        if response.status_code >= 400:
+            raise TransportUnavailable(
+                f"HTTP inbox {peer.locator} rejected envelope: {response.status_code}"
+            )
+
+        if not response.content:
+            return {}
+        try:
+            return response.json()
+        except ValueError:
+            return {"status": "accepted"}
+
+    async def close(self) -> None:
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None

--- a/vouch/transport/manager.py
+++ b/vouch/transport/manager.py
@@ -68,16 +68,19 @@ class TransportManager:
         cls,
         *,
         udna_node: Optional["UdnaNode"] = None,
+        udna_channel: Optional["UdnaChannel"] = None,
         private_key_jwk: Optional[str] = None,
         verify_ssl: bool = True,
     ) -> "TransportManager":
         """
         Build the canonical hybrid stack: UDNA preferred, HTTP fallback.
 
-        UDNA is wired optimistically — if neither an explicit ``udna_node`` nor
-        the ``sirraya-udna-sdk`` is available, the UDNA transport stays dormant
-        and every dispatch falls straight through to HTTP. Nothing to configure,
-        nothing to fail.
+        UDNA is wired optimistically. Pass an explicit ``udna_node`` to use a
+        ready-made node, or ``private_key_jwk`` + ``udna_channel`` to have a
+        :class:`SirrayaUdnaNode` auto-built on the real ``udna_sdk``. If neither
+        the SDK nor the prerequisites are available, the UDNA transport stays
+        dormant and every dispatch falls straight through to HTTP — nothing to
+        configure, nothing to fail.
         """
         from .http_transport import HttpTransport
         from .udna import UdnaTransport
@@ -85,7 +88,7 @@ class TransportManager:
         if udna_node is not None:
             udna = UdnaTransport(node=udna_node)
         else:
-            udna = UdnaTransport.from_sdk(private_key_jwk=private_key_jwk)
+            udna = UdnaTransport.from_sdk(private_key_jwk=private_key_jwk, channel=udna_channel)
 
         return cls([udna, HttpTransport(verify_ssl=verify_ssl)])
 
@@ -181,5 +184,5 @@ class TransportManager:
                 logger.debug("error closing transport %s", transport.name, exc_info=True)
 
 
-# Imported for the type annotation on `default(udna_node=...)` only.
-from .udna import UdnaNode  # noqa: E402
+# Imported for the type annotations on `default(...)` only.
+from .udna import UdnaChannel, UdnaNode  # noqa: E402

--- a/vouch/transport/manager.py
+++ b/vouch/transport/manager.py
@@ -1,0 +1,185 @@
+"""
+Transport manager — the graceful-fallback routing middleware.
+
+This is the piece a Vouch agent actually talks to. It holds an ordered list of
+transports (identity-first UDNA in front, location-first HTTP behind) and a
+single method, :meth:`dispatch`, that hides every routing decision behind one
+call: *"deliver this envelope to this DID."* The agent never learns, nor needs
+to, whether the bytes left over a Noise channel or an HTTPS POST.
+
+Fallback contract — the manager walks its transports in preference order and,
+for each:
+
+  1. skips it if ``can_route`` says no (cheap pre-filter);
+  2. skips it if ``resolve`` returns ``None`` (peer doesn't support it);
+  3. attempts ``send`` if resolution succeeded.
+
+A transport that raises :class:`TransportUnavailable` at any step — peer not on
+the overlay, resolution failed, Noise handshake refused, connection dropped —
+is treated as "not this one, try the next." The manager moves on. Only when
+*every* transport has been exhausted does it raise the last error. The single
+exception is :class:`PayloadIntegrityError`: if an envelope fails its own seal
+check, the payload is corrupt and re-routing it would be dishonest, so the
+manager refuses to fall back and raises immediately.
+
+Payload preservation is structural: the *same* :class:`VouchEnvelope` instance
+is handed to whichever transport wins. The Vouch credential, its Data Integrity
+proof, the liability attestations, and the provenance metadata are never
+re-signed, re-encoded, or stripped during the UDNA→HTTP transition — the
+manager verifies the content digest once up front and then routes the bytes
+untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import List, Optional, Sequence
+
+from .base import (
+    DeliveryResult,
+    PayloadIntegrityError,
+    Transport,
+    TransportError,
+    TransportUnavailable,
+)
+from .envelope import VouchEnvelope
+
+logger = logging.getLogger(__name__)
+
+
+class TransportManager:
+    """
+    Dispatches Vouch envelopes across an ordered set of transports with
+    automatic fallback.
+
+    Args:
+      transports: transports in preference order (first = most preferred).
+        The conventional order is ``[UdnaTransport(...), HttpTransport(...)]``:
+        try identity-first routing, fall back to DNS/IP + HTTP.
+    """
+
+    def __init__(self, transports: Sequence[Transport]) -> None:
+        if not transports:
+            raise ValueError("TransportManager requires at least one transport")
+        self._transports: List[Transport] = list(transports)
+
+    @classmethod
+    def default(
+        cls,
+        *,
+        udna_node: Optional["UdnaNode"] = None,
+        private_key_jwk: Optional[str] = None,
+        verify_ssl: bool = True,
+    ) -> "TransportManager":
+        """
+        Build the canonical hybrid stack: UDNA preferred, HTTP fallback.
+
+        UDNA is wired optimistically — if neither an explicit ``udna_node`` nor
+        the ``sirraya-udna-sdk`` is available, the UDNA transport stays dormant
+        and every dispatch falls straight through to HTTP. Nothing to configure,
+        nothing to fail.
+        """
+        from .http_transport import HttpTransport
+        from .udna import UdnaTransport
+
+        if udna_node is not None:
+            udna = UdnaTransport(node=udna_node)
+        else:
+            udna = UdnaTransport.from_sdk(private_key_jwk=private_key_jwk)
+
+        return cls([udna, HttpTransport(verify_ssl=verify_ssl)])
+
+    @property
+    def transports(self) -> List[Transport]:
+        """The transports in current preference order (read-only copy)."""
+        return list(self._transports)
+
+    async def dispatch(self, envelope: VouchEnvelope) -> DeliveryResult:
+        """
+        Deliver ``envelope`` to ``envelope.to_did`` using the first transport
+        that can reach the peer.
+
+        Returns:
+          A :class:`DeliveryResult` recording which transport delivered and the
+          full ordered list of transports attempted.
+
+        Raises:
+          PayloadIntegrityError: the envelope's cargo does not match its seal —
+            fatal, never retried.
+          TransportError: no transport could reach the peer; carries the last
+            underlying failure.
+        """
+        # Verify the seal once, up front. A corrupt payload must never be
+        # routed — falling back would just spread the corruption.
+        if not envelope.verify_integrity(envelope.content_digest()):  # pragma: no cover
+            raise PayloadIntegrityError("envelope failed its content-digest self-check")
+
+        did = envelope.to_did
+        attempts: List[str] = []
+        last_error: Optional[TransportError] = None
+
+        for transport in self._transports:
+            try:
+                if not await transport.can_route(did):
+                    continue
+
+                attempts.append(transport.name)
+
+                peer = await transport.resolve(did)
+                if peer is None:
+                    # Transport cannot reach this peer → try the next one.
+                    logger.debug(
+                        "transport %s cannot resolve %s; falling back", transport.name, did
+                    )
+                    continue
+
+                response = await transport.send(envelope, peer)
+
+            except PayloadIntegrityError:
+                # Fatal: do not fall back on a corrupted payload.
+                raise
+            except TransportUnavailable as exc:
+                logger.debug("transport %s unavailable for %s: %s", transport.name, did, exc)
+                last_error = exc
+                continue
+            except TransportError as exc:
+                # Unexpected transport-layer error: record and keep falling back
+                # so one misbehaving transport can't sink an otherwise routable
+                # message.
+                logger.warning("transport %s errored for %s: %s", transport.name, did, exc)
+                last_error = exc
+                continue
+
+            logger.info(
+                "delivered envelope %s to %s via %s (attempts: %s)",
+                envelope.envelope_id,
+                did,
+                transport.name,
+                attempts,
+            )
+            return DeliveryResult(
+                ok=True,
+                transport=transport.name,
+                peer=peer,
+                envelope_id=envelope.envelope_id,
+                response=response,
+                attempts=attempts,
+            )
+
+        # Every transport exhausted.
+        detail = f": {last_error}" if last_error else ""
+        raise TransportError(
+            f"no transport could deliver to {did} (tried: {attempts or 'none'}){detail}"
+        )
+
+    async def close(self) -> None:
+        """Close all underlying transports."""
+        for transport in self._transports:
+            try:
+                await transport.close()
+            except Exception:  # pragma: no cover - best-effort cleanup
+                logger.debug("error closing transport %s", transport.name, exc_info=True)
+
+
+# Imported for the type annotation on `default(udna_node=...)` only.
+from .udna import UdnaNode  # noqa: E402

--- a/vouch/transport/udna.py
+++ b/vouch/transport/udna.py
@@ -19,9 +19,11 @@ This adapter targets the real ``sirraya-udna-sdk`` (distribution
     lane (``0x01`` Control, ``0x02`` Messaging, ``0x03`` Telemetry).
   * **Address verification** — ``UdnaSDK.verify_address(address)`` checks the
     address signature against the DID's key.
-  * **Secure messaging** — ``udna_sdk.udna.NoiseHandshake`` (a DID-authenticated
-    Noise-IK handshake) plus ``SecureMessaging`` (ChaCha20-Poly1305 over the
-    derived session key).
+  * **Secure messaging** — ``udna_sdk.udna.NoiseHandshake`` (a handshake that
+    exchanges DID-signed ephemeral keys) plus ``SecureMessaging``
+    (ChaCha20-Poly1305 over the derived session key). NOTE: the v1.0.x handshake
+    authenticates peers but does *not* provide confidentiality — see the
+    security warning on :class:`SirrayaUdnaNode`.
 
 What the SDK deliberately does *not* ship is a production wire transport: byte
 delivery to a remote peer is left to the integrator (the bundled DHT is an
@@ -362,16 +364,34 @@ class SirrayaUdnaNode:
     Responsibilities are split exactly along what the SDK does and doesn't
     provide:
 
-      * **crypto (SDK):** ``udna_sdk.udna.NoiseHandshake`` runs a
-        DID-authenticated Noise-IK handshake bound to ``local_private_key``;
-        ``SecureMessaging`` encrypts the envelope with ChaCha20-Poly1305 over
+      * **crypto (SDK):** ``udna_sdk.udna.NoiseHandshake`` exchanges
+        DID-signed ephemeral keys bound to ``local_private_key``;
+        ``SecureMessaging`` then frames the envelope with ChaCha20-Poly1305 over
         the derived session key.
       * **delivery (channel):** the resulting handshake and ciphertext frames
         are moved to the peer by the injected :class:`UdnaChannel`.
 
-    A secure send is therefore two channel exchanges: the Noise handshake, then
-    the encrypted payload. The peer endpoint is expected to speak the same
+    A secure send is therefore two channel exchanges: the handshake, then the
+    encrypted payload. The peer endpoint is expected to speak the same
     ``udna_sdk`` handshake (``respond_to_handshake``) on the other side.
+
+    .. warning::
+       **The bundled ``udna_sdk`` v1.0.x handshake does NOT provide transport
+       confidentiality.** Its ``finalize_handshake`` derives the session key as
+       ``sha256(local_did ‖ remote_did ‖ both ephemeral *public* keys)`` — every
+       input is sent in the clear, with no Diffie-Hellman, so a passive observer
+       can recompute the key and decrypt the ChaCha20-Poly1305 frames (the SDK's
+       own code comments it as a demo placeholder for "a full Noise
+       implementation"). The handshake messages *are* signed, so peer
+       authenticity holds, but channel secrecy does not.
+
+       Vouch does not depend on this for security: the envelope payload is a
+       signed Vouch credential, so its integrity and authenticity hold
+       end-to-end regardless of transport. But do **not** treat a UDNA channel
+       as private for sensitive payloads until upstream ships a real DH
+       handshake (see ``docs/udna-upstream-proposal.md``). For confidential
+       payloads today, encrypt at the application layer before sealing, or
+       prefer a transport with real channel encryption.
 
     Args:
       channel: the byte-delivery overlay.

--- a/vouch/transport/udna.py
+++ b/vouch/transport/udna.py
@@ -1,0 +1,291 @@
+"""
+UDNA transport — identity-first routing via the Sirraya UDNA SDK.
+
+UDNA (Universal DID-Native Addressing) inverts the usual stack: instead of
+resolving an identity *down to* a location (DID → domain → IP) and trusting
+whoever answers, UDNA treats the DID itself as the routing primitive and
+establishes an end-to-end encrypted channel (Noise protocol) directly to the
+key that owns it. There is no location to spoof and no domain to seize — the
+peer you reach is, by construction, the peer whose key matches the DID.
+
+This adapter wraps the core concepts of ``sirraya-udna-sdk``:
+
+  * **DID generation** — derive a ``did:key`` from an Ed25519 identity
+    (:mod:`vouch.transport.did_key`), the same key Vouch already signs with.
+  * **UDNA address creation** — project a DID (optionally a *facet*, a named
+    capability lane such as ``vouch.message``) into a ``udna://`` address the
+    overlay can route.
+  * **Secure messaging** — hand the sealed envelope to the SDK node, which
+    performs the Noise handshake, verifies the peer's DID, and delivers the
+    bytes.
+
+The SDK is an *optional* dependency. To keep the transport usable and testable
+without it — and to let the rest of Vouch import this module unconditionally —
+all SDK interaction goes through the small :class:`UdnaNode` protocol. A real
+deployment passes a node backed by ``sirraya-udna-sdk`` (auto-constructed by
+:meth:`UdnaTransport.from_sdk`); when the SDK is absent and no node is
+injected, the transport simply reports it ``can_route`` nothing, and the
+routing manager falls back to HTTP. Nothing about UDNA being unavailable is
+fatal — that is the whole point of the hybrid design.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+from .base import PeerAddress, Transport, TransportUnavailable
+from .did_key import did_key_from_ed25519_public, did_key_from_public_jwk
+from .envelope import VouchEnvelope
+
+#: Default facet — the capability lane Vouch messages travel on.
+DEFAULT_FACET = "vouch.message"
+
+#: URI scheme for UDNA addresses.
+UDNA_SCHEME = "udna"
+
+
+def udna_address(did: str, facet: str = DEFAULT_FACET) -> str:
+    """
+    Project a DID into a UDNA address.
+
+    The address binds an identity to a capability lane (*facet*) without
+    binding it to a location:
+
+      ``did:key:z6Mk…``  →  ``udna://did:key:z6Mk…/vouch.message``
+
+    Routing is over the DID; the facet selects which of the peer's advertised
+    capabilities the message is for.
+    """
+    if not did:
+        raise ValueError("udna_address requires a DID")
+    if facet:
+        return f"{UDNA_SCHEME}://{did}/{facet}"
+    return f"{UDNA_SCHEME}://{did}"
+
+
+@runtime_checkable
+class UdnaNode(Protocol):
+    """
+    The slice of ``sirraya-udna-sdk`` this adapter depends on.
+
+    Implemented for real by :class:`_SirrayaUdnaNode` (wrapping the SDK) and by
+    test doubles. Keeping the surface this small is what lets the UDNA transport
+    be exercised end-to-end without the SDK installed.
+    """
+
+    async def resolve(self, address: str) -> Optional[Dict[str, Any]]:
+        """
+        Resolve a ``udna://`` address over the overlay. Return a route
+        descriptor (implementation-defined) if the peer advertises the facet,
+        or ``None`` if it does not (which triggers fallback).
+        """
+        ...
+
+    async def send_secure(self, address: str, data: bytes) -> bytes:
+        """
+        Open (or reuse) a Noise channel to ``address``, verify the peer's DID,
+        send ``data``, and return the peer's reply bytes. Raise on failure to
+        establish the channel.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Tear down channels and overlay sockets."""
+        ...
+
+
+class UdnaTransport(Transport):
+    """
+    Identity-first transport. Routes any DID for which a UDNA node is attached
+    and the peer advertises the configured facet.
+
+    Construct directly with a node (or a test double), or via
+    :meth:`from_sdk` to auto-wire the real ``sirraya-udna-sdk``.
+
+    Args:
+      node: an object satisfying :class:`UdnaNode`, or ``None`` to leave the
+        transport dormant (it will route nothing, forcing fallback).
+      facet: the capability lane Vouch messages use.
+    """
+
+    name = "udna"
+
+    def __init__(self, node: Optional[UdnaNode] = None, facet: str = DEFAULT_FACET) -> None:
+        self._node = node
+        self.facet = facet
+
+    # ------------------------------------------------------------------ #
+    # Construction
+    # ------------------------------------------------------------------ #
+    @classmethod
+    def from_sdk(
+        cls,
+        *,
+        private_key_jwk: Optional[str] = None,
+        facet: str = DEFAULT_FACET,
+        **sdk_kwargs: Any,
+    ) -> "UdnaTransport":
+        """
+        Build a UDNA transport backed by ``sirraya-udna-sdk``.
+
+        If the SDK is not installed, returns a *dormant* transport (no node)
+        rather than raising — so a caller can always wire UDNA in optimistically
+        and rely on graceful fallback. Pass ``private_key_jwk`` to give the
+        node a stable identity (its own ``did:key`` is derived from it).
+        """
+        node = _try_build_sirraya_node(private_key_jwk=private_key_jwk, **sdk_kwargs)
+        return cls(node=node, facet=facet)
+
+    @property
+    def is_active(self) -> bool:
+        """True when a UDNA node is attached and able to route."""
+        return self._node is not None
+
+    # ------------------------------------------------------------------ #
+    # DID / address helpers (pure, usable without a node)
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def generate_did(public_key_jwk: str) -> str:
+        """Derive this transport's native ``did:key`` from an Ed25519 public JWK."""
+        return did_key_from_public_jwk(public_key_jwk)
+
+    @staticmethod
+    def generate_did_from_raw(raw_public_key: bytes) -> str:
+        """Derive a ``did:key`` from a raw 32-byte Ed25519 public key."""
+        return did_key_from_ed25519_public(raw_public_key)
+
+    def address_for(self, did: str) -> str:
+        """The UDNA address this transport would route ``did`` to."""
+        return udna_address(did, self.facet)
+
+    # ------------------------------------------------------------------ #
+    # Transport contract
+    # ------------------------------------------------------------------ #
+    async def can_route(self, did: str) -> bool:
+        """
+        UDNA can route any DID — *if* a node is attached. With no node the
+        transport is dormant and routes nothing, so the manager falls back.
+        """
+        return self._node is not None and bool(did)
+
+    async def resolve(self, did: str) -> Optional[PeerAddress]:
+        """
+        Resolve ``did`` over the UDNA overlay.
+
+        Returns ``None`` (→ fallback) when the transport is dormant or the peer
+        does not advertise the facet. A successful resolution is marked
+        ``verified=True``: UDNA binds the route to the DID's key, so reaching
+        the address means reaching the key's owner.
+        """
+        if self._node is None:
+            return None
+
+        address = self.address_for(did)
+        try:
+            route = await self._node.resolve(address)
+        except Exception as exc:
+            raise TransportUnavailable(f"UDNA resolution failed for {did}: {exc}") from exc
+
+        if route is None:
+            # Peer is not on UDNA / does not advertise this facet → fall back.
+            return None
+
+        return PeerAddress(
+            did=did,
+            transport=self.name,
+            locator=address,
+            verified=True,
+            metadata={"facet": self.facet, "route": route},
+        )
+
+    async def send(self, envelope: VouchEnvelope, peer: PeerAddress) -> Dict[str, Any]:
+        """
+        Deliver the sealed envelope over a Noise channel to the peer's DID.
+
+        The envelope is serialized to its canonical wire form (preserving the
+        Vouch credential, liability attestations, and provenance verbatim),
+        encrypted by the SDK's Noise channel, and sent. The peer's reply is
+        returned as a dict.
+        """
+        if self._node is None:
+            raise TransportUnavailable("UDNA transport is dormant (no node attached)")
+        if not peer.locator:
+            raise TransportUnavailable("UDNA peer has no address locator")
+
+        import json
+
+        wire = json.dumps(envelope.to_wire(), separators=(",", ":")).encode("utf-8")
+        try:
+            reply = await self._node.send_secure(peer.locator, wire)
+        except Exception as exc:
+            # Channel could not be established / peer dropped → fall back.
+            raise TransportUnavailable(
+                f"UDNA secure delivery to {peer.locator} failed: {exc}"
+            ) from exc
+
+        if not reply:
+            return {}
+        try:
+            return json.loads(reply.decode("utf-8"))
+        except (ValueError, UnicodeDecodeError):
+            return {"status": "accepted"}
+
+    async def close(self) -> None:
+        if self._node is not None:
+            await self._node.close()
+            self._node = None
+
+
+def _try_build_sirraya_node(
+    *, private_key_jwk: Optional[str] = None, **sdk_kwargs: Any
+) -> Optional[UdnaNode]:
+    """
+    Attempt to construct a node backed by ``sirraya-udna-sdk``.
+
+    Returns ``None`` if the SDK is not importable, so the caller degrades to
+    HTTP fallback instead of crashing. The exact SDK surface is wrapped in
+    :class:`_SirrayaUdnaNode` so that API drift is contained to one place.
+    """
+    try:
+        import sirraya_udna_sdk  # type: ignore  # noqa: F401
+    except ImportError:
+        return None
+    return _SirrayaUdnaNode(private_key_jwk=private_key_jwk, **sdk_kwargs)
+
+
+class _SirrayaUdnaNode:
+    """
+    Thin wrapper translating the :class:`UdnaNode` protocol onto the
+    ``sirraya-udna-sdk`` runtime.
+
+    The SDK's concrete API is accessed lazily and defensively: we wrap it here
+    so the rest of Vouch depends only on the stable :class:`UdnaNode` shape, and
+    any change in the SDK's method names is absorbed in this single class.
+    """
+
+    def __init__(self, *, private_key_jwk: Optional[str] = None, **sdk_kwargs: Any) -> None:
+        import sirraya_udna_sdk  # type: ignore
+
+        # The SDK exposes a Node/Agent entry point that owns the Noise stack and
+        # the DID-native overlay socket. We pass through the agent's identity so
+        # its own did:key matches the Vouch signing key.
+        node_factory = getattr(sirraya_udna_sdk, "Node", None) or getattr(
+            sirraya_udna_sdk, "UdnaNode", None
+        )
+        if node_factory is None:  # pragma: no cover - depends on SDK version
+            raise TransportUnavailable("sirraya-udna-sdk exposes no Node entry point")
+        self._node = node_factory(private_key_jwk=private_key_jwk, **sdk_kwargs)
+
+    async def resolve(
+        self, address: str
+    ) -> Optional[Dict[str, Any]]:  # pragma: no cover - needs SDK
+        return await self._node.resolve(address)
+
+    async def send_secure(self, address: str, data: bytes) -> bytes:  # pragma: no cover - needs SDK
+        # The SDK performs the Noise handshake + DID verification internally.
+        return await self._node.send(address, data)
+
+    async def close(self) -> None:  # pragma: no cover - needs SDK
+        close = getattr(self._node, "close", None)
+        if close is not None:
+            await close()

--- a/vouch/transport/udna.py
+++ b/vouch/transport/udna.py
@@ -8,40 +8,56 @@ establishes an end-to-end encrypted channel (Noise protocol) directly to the
 key that owns it. There is no location to spoof and no domain to seize — the
 peer you reach is, by construction, the peer whose key matches the DID.
 
-This adapter wraps the core concepts of ``sirraya-udna-sdk``:
+This adapter targets the real ``sirraya-udna-sdk`` (distribution
+``sirraya-udna-sdk``, import package ``udna_sdk``, v1.0.x). That SDK provides:
 
-  * **DID generation** — derive a ``did:key`` from an Ed25519 identity
-    (:mod:`vouch.transport.did_key`), the same key Vouch already signs with.
-  * **UDNA address creation** — project a DID (optionally a *facet*, a named
-    capability lane such as ``vouch.message``) into a ``udna://`` address the
-    overlay can route.
-  * **Secure messaging** — hand the sealed envelope to the SDK node, which
-    performs the Noise handshake, verifies the peer's DID, and delivers the
-    bytes.
+  * **DID generation** — ``UdnaSDK.create_did()`` mints a ``did:key`` whose
+    encoding (``z`` + base58(``0xed01`` ‖ pubkey)) is byte-identical to Vouch's
+    own Multikey, so the two interoperate without translation.
+  * **UDNA address creation** — ``UdnaSDK.create_address(did, facet_id, flags)``
+    produces a signed, base58 UDNA address. ``facet_id`` selects a capability
+    lane (``0x01`` Control, ``0x02`` Messaging, ``0x03`` Telemetry).
+  * **Address verification** — ``UdnaSDK.verify_address(address)`` checks the
+    address signature against the DID's key.
+  * **Secure messaging** — ``udna_sdk.udna.NoiseHandshake`` (a DID-authenticated
+    Noise-IK handshake) plus ``SecureMessaging`` (ChaCha20-Poly1305 over the
+    derived session key).
 
-The SDK is an *optional* dependency. To keep the transport usable and testable
-without it — and to let the rest of Vouch import this module unconditionally —
-all SDK interaction goes through the small :class:`UdnaNode` protocol. A real
-deployment passes a node backed by ``sirraya-udna-sdk`` (auto-constructed by
-:meth:`UdnaTransport.from_sdk`); when the SDK is absent and no node is
-injected, the transport simply reports it ``can_route`` nothing, and the
-routing manager falls back to HTTP. Nothing about UDNA being unavailable is
-fatal — that is the whole point of the hybrid design.
+What the SDK deliberately does *not* ship is a production wire transport: byte
+delivery to a remote peer is left to the integrator (the bundled DHT is an
+in-memory demo). So this adapter splits the two concerns cleanly:
+
+  * a :class:`UdnaNode` (the seam the transport talks to) owns *session +
+    delivery*. :class:`SirrayaUdnaNode` implements it by composing the SDK's
+    Noise/SecureMessaging crypto with a pluggable :class:`UdnaChannel` that
+    actually moves the bytes.
+  * everything is *optional*. When the SDK is absent, or no node/channel is
+    wired, the transport is **dormant** — ``can_route`` returns nothing and the
+    routing manager falls back to HTTP. UDNA being unavailable is never fatal;
+    that is the whole point of the hybrid design.
 """
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, Optional, Protocol, runtime_checkable
 
 from .base import PeerAddress, Transport, TransportUnavailable
 from .did_key import did_key_from_ed25519_public, did_key_from_public_jwk
 from .envelope import VouchEnvelope
 
-#: Default facet — the capability lane Vouch messages travel on.
+#: Default facet — the capability lane Vouch messages travel on. Maps to the
+#: SDK's Messaging facet (``facet_id=0x02``).
 DEFAULT_FACET = "vouch.message"
 
 #: URI scheme for UDNA addresses.
 UDNA_SCHEME = "udna"
+
+#: SDK facet identifiers (``udna_sdk``: 0x01 Control, 0x02 Messaging, 0x03
+#: Telemetry). Vouch messages ride the Messaging facet.
+FACET_CONTROL = 0x01
+FACET_MESSAGING = 0x02
+FACET_TELEMETRY = 0x03
 
 
 def udna_address(did: str, facet: str = DEFAULT_FACET) -> str:
@@ -66,11 +82,12 @@ def udna_address(did: str, facet: str = DEFAULT_FACET) -> str:
 @runtime_checkable
 class UdnaNode(Protocol):
     """
-    The slice of ``sirraya-udna-sdk`` this adapter depends on.
+    The session + delivery seam the transport talks to.
 
-    Implemented for real by :class:`_SirrayaUdnaNode` (wrapping the SDK) and by
-    test doubles. Keeping the surface this small is what lets the UDNA transport
-    be exercised end-to-end without the SDK installed.
+    Implemented for real by :class:`SirrayaUdnaNode` (which composes the SDK's
+    Noise/SecureMessaging crypto with a :class:`UdnaChannel`) and by test
+    doubles. Keeping the surface this small is what lets the UDNA transport be
+    exercised end-to-end without the SDK installed.
     """
 
     async def resolve(self, address: str) -> Optional[Dict[str, Any]]:
@@ -91,6 +108,35 @@ class UdnaNode(Protocol):
 
     async def close(self) -> None:
         """Tear down channels and overlay sockets."""
+        ...
+
+
+@runtime_checkable
+class UdnaChannel(Protocol):
+    """
+    Moves opaque bytes to/from a peer keyed by its UDNA address.
+
+    This is the piece ``sirraya-udna-sdk`` does *not* provide: the SDK supplies
+    DID/address/Noise crypto but no production wire transport (only an in-memory
+    demo DHT). A deployment plugs in its own delivery here — a relay, a
+    libp2p/QUIC overlay, a websocket bridge — and :class:`SirrayaUdnaNode`
+    layers the SDK's Noise handshake and ChaCha20-Poly1305 encryption on top.
+    """
+
+    async def reachable(self, udna_address: str) -> bool:
+        """Whether the peer at ``udna_address`` is currently on the overlay."""
+        ...
+
+    async def exchange(self, udna_address: str, frame: bytes) -> bytes:
+        """
+        Send one frame to ``udna_address`` and return the peer's response frame
+        (empty bytes if the peer acknowledges without a body). Used twice per
+        secure send: once for the Noise handshake, once for the ciphertext.
+        """
+        ...
+
+    async def close(self) -> None:
+        """Release the channel's resources."""
         ...
 
 
@@ -122,18 +168,26 @@ class UdnaTransport(Transport):
         cls,
         *,
         private_key_jwk: Optional[str] = None,
+        channel: Optional["UdnaChannel"] = None,
         facet: str = DEFAULT_FACET,
-        **sdk_kwargs: Any,
     ) -> "UdnaTransport":
         """
         Build a UDNA transport backed by ``sirraya-udna-sdk``.
 
-        If the SDK is not installed, returns a *dormant* transport (no node)
-        rather than raising — so a caller can always wire UDNA in optimistically
-        and rely on graceful fallback. Pass ``private_key_jwk`` to give the
-        node a stable identity (its own ``did:key`` is derived from it).
+        Returns a *dormant* transport (no node) — never raises — when any
+        prerequisite is missing, so a caller can always wire UDNA in
+        optimistically and rely on graceful fallback. The prerequisites are:
+
+          * the ``udna_sdk`` package is importable;
+          * ``private_key_jwk`` is supplied (the node's own ``did:key`` and the
+            Noise handshake are bound to this Ed25519 key — the same key Vouch
+            signs with);
+          * a ``channel`` is supplied (the SDK provides no wire transport, so
+            byte delivery must come from the deployment).
         """
-        node = _try_build_sirraya_node(private_key_jwk=private_key_jwk, **sdk_kwargs)
+        node = _try_build_sirraya_node(
+            private_key_jwk=private_key_jwk, channel=channel, facet=facet
+        )
         return cls(node=node, facet=facet)
 
     @property
@@ -153,6 +207,30 @@ class UdnaTransport(Transport):
     def generate_did_from_raw(raw_public_key: bytes) -> str:
         """Derive a ``did:key`` from a raw 32-byte Ed25519 public key."""
         return did_key_from_ed25519_public(raw_public_key)
+
+    @staticmethod
+    def generate_did_via_sdk() -> str:
+        """
+        Mint a fresh ``did:key`` using the real ``udna_sdk.UdnaSDK.create_did``.
+
+        Unlike :meth:`generate_did`, this generates *new* key material inside the
+        SDK (use it when you want a UDNA-managed identity rather than reusing the
+        Vouch signing key). Raises if the SDK is not installed.
+        """
+        from udna_sdk import UdnaSDK  # type: ignore
+
+        return UdnaSDK().create_did().did
+
+    @staticmethod
+    def verify_udna_address(address: str) -> bool:
+        """
+        Verify a base58 UDNA address with ``udna_sdk.UdnaSDK.verify_address``
+        (checks the address signature against the DID's key). Raises if the SDK
+        is not installed.
+        """
+        from udna_sdk import UdnaSDK  # type: ignore
+
+        return bool(UdnaSDK().verify_address(address).is_valid)
 
     def address_for(self, did: str) -> str:
         """The UDNA address this transport would route ``did`` to."""
@@ -212,8 +290,6 @@ class UdnaTransport(Transport):
         if not peer.locator:
             raise TransportUnavailable("UDNA peer has no address locator")
 
-        import json
-
         wire = json.dumps(envelope.to_wire(), separators=(",", ":")).encode("utf-8")
         try:
             reply = await self._node.send_secure(peer.locator, wire)
@@ -236,56 +312,110 @@ class UdnaTransport(Transport):
             self._node = None
 
 
+def _ed25519_priv_from_jwk(private_key_jwk: str):
+    """Recover an ``Ed25519PrivateKey`` from an Ed25519 private JWK string."""
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+    from jwcrypto.common import base64url_decode
+
+    jwk_dict = json.loads(private_key_jwk)
+    if jwk_dict.get("kty") != "OKP" or jwk_dict.get("crv") != "Ed25519":
+        raise ValueError("UDNA node identity requires an Ed25519 OKP private JWK")
+    seed = base64url_decode(jwk_dict["d"])
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
 def _try_build_sirraya_node(
-    *, private_key_jwk: Optional[str] = None, **sdk_kwargs: Any
+    *,
+    private_key_jwk: Optional[str] = None,
+    channel: Optional["UdnaChannel"] = None,
+    facet: str = DEFAULT_FACET,
 ) -> Optional[UdnaNode]:
     """
-    Attempt to construct a node backed by ``sirraya-udna-sdk``.
+    Build a :class:`SirrayaUdnaNode` if every prerequisite is present, else
+    ``None`` (so the transport stays dormant and the manager falls back).
 
-    Returns ``None`` if the SDK is not importable, so the caller degrades to
-    HTTP fallback instead of crashing. The exact SDK surface is wrapped in
-    :class:`_SirrayaUdnaNode` so that API drift is contained to one place.
+    Prerequisites: the ``udna_sdk`` package importable, an identity key, and a
+    delivery channel (the SDK ships no wire transport — see :class:`UdnaChannel`).
     """
     try:
-        import sirraya_udna_sdk  # type: ignore  # noqa: F401
+        import udna_sdk  # type: ignore  # noqa: F401
     except ImportError:
         return None
-    return _SirrayaUdnaNode(private_key_jwk=private_key_jwk, **sdk_kwargs)
+    if channel is None or private_key_jwk is None:
+        return None
+
+    local_priv = _ed25519_priv_from_jwk(private_key_jwk)
+    from cryptography.hazmat.primitives import serialization
+
+    pub_raw = local_priv.public_key().public_bytes(
+        serialization.Encoding.Raw, serialization.PublicFormat.Raw
+    )
+    local_did = did_key_from_ed25519_public(pub_raw)
+    return SirrayaUdnaNode(channel=channel, local_did=local_did, local_private_key=local_priv)
 
 
-class _SirrayaUdnaNode:
+class SirrayaUdnaNode:
     """
-    Thin wrapper translating the :class:`UdnaNode` protocol onto the
-    ``sirraya-udna-sdk`` runtime.
+    Real :class:`UdnaNode` backed by ``udna_sdk`` + a pluggable
+    :class:`UdnaChannel`.
 
-    The SDK's concrete API is accessed lazily and defensively: we wrap it here
-    so the rest of Vouch depends only on the stable :class:`UdnaNode` shape, and
-    any change in the SDK's method names is absorbed in this single class.
+    Responsibilities are split exactly along what the SDK does and doesn't
+    provide:
+
+      * **crypto (SDK):** ``udna_sdk.udna.NoiseHandshake`` runs a
+        DID-authenticated Noise-IK handshake bound to ``local_private_key``;
+        ``SecureMessaging`` encrypts the envelope with ChaCha20-Poly1305 over
+        the derived session key.
+      * **delivery (channel):** the resulting handshake and ciphertext frames
+        are moved to the peer by the injected :class:`UdnaChannel`.
+
+    A secure send is therefore two channel exchanges: the Noise handshake, then
+    the encrypted payload. The peer endpoint is expected to speak the same
+    ``udna_sdk`` handshake (``respond_to_handshake``) on the other side.
+
+    Args:
+      channel: the byte-delivery overlay.
+      local_did: this node's ``did:key`` (derived from ``local_private_key``).
+      local_private_key: the Ed25519 key the handshake authenticates with.
     """
 
-    def __init__(self, *, private_key_jwk: Optional[str] = None, **sdk_kwargs: Any) -> None:
-        import sirraya_udna_sdk  # type: ignore
+    def __init__(self, *, channel: "UdnaChannel", local_did: str, local_private_key: Any) -> None:
+        from udna_sdk.udna import Did, NoiseHandshake, SecureMessaging  # type: ignore
 
-        # The SDK exposes a Node/Agent entry point that owns the Noise stack and
-        # the DID-native overlay socket. We pass through the agent's identity so
-        # its own did:key matches the Vouch signing key.
-        node_factory = getattr(sirraya_udna_sdk, "Node", None) or getattr(
-            sirraya_udna_sdk, "UdnaNode", None
+        self._channel = channel
+        self._noise = NoiseHandshake()
+        self._secure = SecureMessaging()
+        self._Did = Did
+        self._local_did = Did.parse(local_did)
+        self._local_priv = local_private_key
+
+    @staticmethod
+    def _remote_did_of(address: str) -> str:
+        """Extract the peer DID from a ``udna://<did>/<facet>`` address."""
+        body = address.split("://", 1)[1] if "://" in address else address
+        return body.rsplit("/", 1)[0] if "/" in body else body
+
+    async def resolve(self, address: str) -> Optional[Dict[str, Any]]:
+        if not await self._channel.reachable(address):
+            return None
+        return {"address": address, "transport": "sirraya-udna-sdk"}
+
+    async def send_secure(self, address: str, data: bytes) -> bytes:
+        remote_did = self._Did.parse(self._remote_did_of(address))
+
+        # 1. DID-authenticated Noise handshake over the delivery channel.
+        session_id, init_frame = self._noise.initiate_handshake(
+            self._local_did, self._local_priv, remote_did
         )
-        if node_factory is None:  # pragma: no cover - depends on SDK version
-            raise TransportUnavailable("sirraya-udna-sdk exposes no Node entry point")
-        self._node = node_factory(private_key_jwk=private_key_jwk, **sdk_kwargs)
+        response_frame = await self._channel.exchange(address, init_frame)
+        session_key = self._noise.finalize_handshake(session_id, response_frame)
 
-    async def resolve(
-        self, address: str
-    ) -> Optional[Dict[str, Any]]:  # pragma: no cover - needs SDK
-        return await self._node.resolve(address)
+        # 2. Encrypt the sealed envelope and deliver it on the same channel.
+        ciphertext = self._secure.encrypt_message(session_key, data)
+        reply = await self._channel.exchange(address, ciphertext)
+        if not reply:
+            return b""
+        return self._secure.decrypt_message(session_key, reply)
 
-    async def send_secure(self, address: str, data: bytes) -> bytes:  # pragma: no cover - needs SDK
-        # The SDK performs the Noise handshake + DID verification internally.
-        return await self._node.send(address, data)
-
-    async def close(self) -> None:  # pragma: no cover - needs SDK
-        close = getattr(self._node, "close", None)
-        if close is not None:
-            await close()
+    async def close(self) -> None:
+        await self._channel.close()

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -64,6 +64,12 @@ const FEATURES: Array<{ num: string; title: string; body: string; spec: string; 
     body: 'Reputation as a verifiable aggregate of signed receipts, the relying party attesting an action, a settled outcome, an authority recording a penalty, computed by a public deterministic function and keyed to the agent DID. A consumer recomputes the score from the receipts rather than trusting a server, with multi-dimensional scores, decay, threshold proofs that reveal nothing but the threshold, and disputes that exclude bad receipts.',
     spec: 'Reputation',
   },
+  {
+    num: 'xi.',
+    title: 'Reach AI Agents by Identity',
+    body: 'Agents move across hosts and clouds and rarely hold a stable domain or IP, but they always hold a key. Vouch reaches a peer by its identity, not its location. It prefers identity-first routing over UDNA (Universal DID-Native Addressing) and falls back to standard DNS and HTTPS when a peer is not on the overlay. The signed credential, liability attestations, and provenance cross the switch unchanged, so the trust properties hold whichever path the bytes take. Optional and aligned with the W3C UDNA Community Group.',
+    spec: 'Hybrid Transport',
+  },
 ];
 
 const LANGUAGE_TILES = [
@@ -153,6 +159,7 @@ export default function HomePage() {
             identity and delegation specifications. Built on Verifiable Credentials, Data Integrity
             proofs, and Decentralized Identifiers, with one byte-exact core and SDKs for every major
             platform: web, mobile, JVM, .NET, and native, plus the Python, TypeScript, and Go references.
+            Agents are reached by who they are, not where they are.
           </p>
           <div className="flex flex-wrap gap-3 items-center">
             <Link href="/faq/" className="btn-primary">Read the FAQ</Link>


### PR DESCRIPTION
## Description

Adds a modular, DID-addressed transport layer (`vouch.transport`) so Vouch agents can dispatch messages to a peer's identity and stay agnostic about how the bytes are routed. Identity-first routing via UDNA (the Sirraya `udna_sdk`) is preferred, with automatic fallback to standard DNS/IP + HTTPS when a peer is not on the overlay. Vouch credentials, liability attestations, and provenance metadata are preserved byte for byte across the transport boundary.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Closes #

## Changes Made

- **`Transport` ABC + types** (`base.py`): `PeerAddress`, `DeliveryResult`, and an error split (`TransportUnavailable` triggers fallback, `PayloadIntegrityError` is fatal) that drives the fallback-vs-fail decision.
- **`VouchEnvelope`** (`envelope.py`): payload-preserving container carrying the signed credential, liability attestations, and provenance verbatim, with a JCS-canonical SHA-256 content digest that survives a UDNA to HTTP transition.
- **`UdnaTransport` + `SirrayaUdnaNode`** (`udna.py`): identity-first adapter wired to the real `udna_sdk` API (`UdnaSDK.create_did` / `create_address` / `verify_address`, plus `NoiseHandshake` and `SecureMessaging`). The SDK ships no production wire transport, so delivery is a pluggable `UdnaChannel`. Optional dependency, dormant and harmless when absent.
- **`HttpTransport`** (`http_transport.py`): location-first `did:web` / DNS / HTTPS fallback with SSRF screening on every outbound URL.
- **`TransportManager`** (`manager.py`): graceful-fallback routing middleware that hides all routing behind a single `dispatch()` call and never re-signs or strips the payload.
- **`did:key` helpers** (`did_key.py`): built on the existing Ed25519 + Multikey machinery. The encoding is byte for byte identical to `udna_sdk`'s `did:key`, so identities interoperate with no translation.
- **Docs**: `docs/HYBRID_TRANSPORT.md` (architecture) and `docs/udna-upstream-proposal.md` (findings against `udna_sdk` v1.0.3, including a handshake confidentiality gap and a proposed X25519 + HKDF fix). The adapter carries an explicit warning that the v1.0.x channel is authenticated but not confidential; Vouch's guarantees do not depend on it.
- **Website**: adds "Reach AI Agents by Identity" to the homepage feature list and a one-line hero clause, framed as optional and aligned with the W3C UDNA Community Group.
- **Example**: `examples/hybrid_transport_demo.py`, a network-free demo of routing, fallback, and payload preservation.
- Added a `udna` optional extra in `pyproject.toml`.

## Testing

- [x] Existing tests pass (`pytest tests/`)
- [x] New tests added for new functionality
- [x] Manual testing performed

`tests/test_transport.py` (17 tests, no SDK required) covers envelope integrity, `did:key` round-trips, UDNA routing, and the fallback paths. `tests/test_transport_udna_sdk.py` (5 tests) runs against the genuine `udna_sdk` and is auto-skipped when it is not installed; verified locally with the SDK installed, including a full Noise handshake through the adapter. The demo runs end to end. 22 transport tests pass and the adjacent suites (multikey, data_integrity, delegation_chain) are unaffected. `ruff check` and `ruff format --check` pass.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)

## Notes for reviewers

- The UDNA transport is optional and dormant by default, so this is purely additive: existing agents keep using HTTP with no change.
- Please skim the security note in `docs/udna-upstream-proposal.md`. The `udna_sdk` handshake does not provide channel confidentiality today, and the adapter is written to not rely on it.