### PR TITLE
Update assistant-facing surfaces to the one-line adoption philosophy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,22 +18,21 @@
   dependencies use `Annotated[..., Depends(...)]`, not call-in-default, to
   satisfy bugbear B008.
 
-## Glossary
+## Assistant-facing surfaces (keep in sync)
 
-- **FHKCOG**: the set of assistant-facing surfaces to keep in sync when the API
-  or philosophy changes. It stands for:
-  - **F** = FAQ (`agents-and-skills/FAQ-DRAFT.md`)
-  - **H** = Help Guide (`agents-and-skills/HELP-GUIDE-DRAFT.md`)
-  - **K** = Knowledge Base for the Vouch Assistant
-    (`website-agent/backend/knowledge/`)
-  - **C** = Claude Skill (`claude-skill/skills/vouch-protocol/`)
-  - **O** = OpenAI Custom GPT (`openai-gpt/`)
-  - **G** = Gemini Gem (`gemini-gem/`)
+When the API or philosophy changes, update these surfaces together:
 
-  The four assistant surfaces (Knowledge Base, Claude Skill, OpenAI GPT, Gemini
-  Gem) share the same knowledge files (`quickstart.md`, `integrations.md`,
-  `delegation.md`, etc.). Keep them identical: edit one canonical copy and
-  propagate to all four.
+- FAQ (`agents-and-skills/FAQ-DRAFT.md`)
+- Help Guide (`agents-and-skills/HELP-GUIDE-DRAFT.md`)
+- Knowledge Base for the Vouch Assistant (`website-agent/backend/knowledge/`)
+- Claude Skill (`claude-skill/skills/vouch-protocol/`)
+- OpenAI Custom GPT (`openai-gpt/`)
+- Gemini Gem (`gemini-gem/`)
+
+The four assistant surfaces (Knowledge Base, Claude Skill, OpenAI GPT, Gemini
+Gem) share the same knowledge files (`quickstart.md`, `integrations.md`,
+`delegation.md`, etc.). Keep them identical: edit one canonical copy and
+propagate to all four.
 
 ## Product philosophy
 


### PR DESCRIPTION
Brings the assistant-facing surfaces (Knowledge Base, Claude Skill, OpenAI Custom GPT, Gemini Gem, plus the FAQ and Help Guide drafts) in line with the one-line adoption philosophy from #168 and #169.

Most important: `integrations.md` previously documented the per-framework "minting" tools that were removed (`VouchSignerTool`, `sign_request`, `sign_action`, `sign_with_vouch`, `VertexAISigner`). That guidance was broken for users. It is now rewritten around the real API.

## Changes
- **integrations.md** (all four surfaces, kept identical): rewritten around `protect` / `@signed` / `autosign`, `vouch.verify`, `VouchGate`, `vouch.delegate`, and `Shield.guard`. Removed all references to deleted tools.
- **quickstart.md** (all four): leads with `protect` + `verify` + `vouch init --yes`, keeps the lower-level `sign_credential` path below. Also fixes the previous example, which used a non-existent `build_vouch_credential(...)` wrapper around `sign_credential`.
- **delegation.md** (all four): construction examples fixed to `vouch.delegate(...)` and the real `sign_credential(parent_credential=...)` API (the old examples used non-existent `Signer.from_did` / `sign_credential_with_parent`).
- **instructions.md** (OpenAI GPT, Gemini Gem) and **SKILL.md** (Claude Skill): added a short directive to lead with the one-line path and to stop showing the removed tools.
- **FAQ-DRAFT.md**: added a one-line integration section and removed em-dashes.
- **CLAUDE.md** (new): records project conventions (author identity, no AI attribution, no em-dashes, DCO sign-off, ruff) and the one-line product philosophy so future sessions follow them.

## Notes
- The four assistant knowledge bases share the same files; they are kept byte-identical (edit one, propagate to all four).
- All changed files are free of em-dashes. The commit is signed off and authored correctly.

## Next
Website content update, plus the fuller brainstorm of further one-line wins, are the next steps.