### PR TITLE
Reflect one-line adoption on the website

### DIFF
--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -524,6 +524,20 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
     title: 'Adding Vouch to your code',
     items: [
       {
+        q: 'What is the fastest way to add Vouch to my agent?',
+        a: `One line. Run \`vouch init --yes\` once to provision an identity, then wrap your tools:
+
+\`\`\`python
+from vouch import protect
+
+agent.tools = protect([charge_invoice, send_email])
+\`\`\`
+
+Every tool call is now signed in Python before it runs. There is no prompt to write and nothing for the model to remember, and identity is resolved automatically, so agent code needs no key plumbing. \`protect\` works for plain functions and for CrewAI, LangChain, AutoGen, AutoGPT, Vertex AI, Google, and ADK tools. For decorator frameworks you can also call \`<framework>.autosign()\` to sign every tool framework-wide. Verify on the receiving side with \`vouch.verify(credential)\`, or add the FastAPI \`VouchGate\` dependency to an endpoint.`,
+        helpLinks: [{ label: 'Integrations', href: '/help/#integrations' }],
+        meta: 'Shipped v1.6.x',
+      },
+      {
         q: 'Which languages have Vouch SDKs?',
         a: `One canonical Rust core does the cryptography once, and every language is a thin wrapper over it, so a credential signed on any platform verifies on every other, byte for byte (JCS canonicalization):
 
@@ -544,22 +558,22 @@ Every implementation passes the same cross-language test vectors at [test-vector
       },
       {
         q: 'How do I sign a credential in Python?',
-        a: `Three lines after imports:
+        a: `Build a signer from your identity, then pass the intent directly to \`sign_credential\`:
 
 \`\`\`python
-from vouch import Signer, build_vouch_credential
+from vouch import Signer, generate_identity
 
-signer = Signer.from_did("did:web:agent.example.com")
-credential = build_vouch_credential(
-  subject_did="did:web:agent.example.com",
-  intent={"action": "submit_claim", "target": "claim:HC-001",
-      "resource": "https://insurance.example.com/claims/HC-001"},
-  valid_seconds=300,
-)
-signed = signer.sign_credential(credential)
+keys = generate_identity("agent.example.com")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
+
+signed = signer.sign_credential(intent={
+  "action": "submit_claim",
+  "target": "claim:HC-001",
+  "resource": "https://insurance.example.com/claims/HC-001",
+}, valid_seconds=300)
 \`\`\`
 
-The \`signed\` dict has a \`proof\` object with a \`proofValue\` (z-base58 encoded Ed25519 signature) and verification metadata.`,
+The \`signed\` dict has a \`proof\` object with a \`proofValue\` (z-base58 encoded Ed25519 signature) and verification metadata. To make an agent sign every tool call automatically, use \`protect([...])\` instead (see the question above).`,
         helpLinks: [{ label: 'Full Python quickstart', href: '/help/#quickstart-python' }],
       },
       {

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -277,38 +277,36 @@ export default function HomePage() {
             <h2>A quick taste</h2>
           </div>
           <p className="text-ink-soft max-w-prose mb-8 leading-relaxed">
-            Sign a Vouch Credential and read back its proof. The same credential verifies
-            byte-identically across every SDK, so pick your language.
+            One line makes an agent sign every tool call. The Python reference SDK wraps
+            your tools with <code>protect([...])</code> and verifies with{' '}
+            <code>vouch.verify(...)</code>, and the same credential verifies byte-identically
+            across every SDK, so pick your language.
           </p>
           <LangCodeBlock
             variants={[
               {
                 label: 'Python',
                 language: 'python',
-                code: `from vouch import Signer, build_vouch_credential
+                code: `# One line makes an agent sign every tool call.
+# Run \`vouch init --yes\` once; identity is resolved automatically.
+from vouch import protect, verify, current_credential
 
-signer = Signer.from_did("did:web:agent.example.com")
+def submit_claim(claim_id, amount):
+    return charge_api(claim_id, amount)
 
-credential = build_vouch_credential(
-  subject_did="did:web:agent.example.com",
-  intent={
-    "action": "submit_claim",
-    "target": "claim:HC-001",
-    "resource": "https://insurance.example.com/claims/HC-001",
-  },
-  reputation_score=92,
-  valid_seconds=300,
-)
+# The one line: every call is signed in Python before it runs.
+agent_tools = protect([submit_claim])
+agent_tools[0]("HC-001", 250)
 
-signed = signer.sign_credential(credential)
-print(signed["proof"]["proofValue"])  # z-base58-encoded Ed25519 signature
+# Verify on the receiving side, also one line.
+ok, passport = verify(current_credential())
+print(ok, passport.intent["action"])  # True submit_claim
 `,
               },
               {
                 label: 'TypeScript',
                 language: 'typescript',
-                code: `import { Signer, generateIdentity, buildVouchCredential }
-  from '@vouch-protocol-official/sdk';
+                code: `import { Signer, generateIdentity } from '@vouch-protocol-official/sdk';
 
 const identity = await generateIdentity('agent.example.com');
 const signer = new Signer({
@@ -316,8 +314,8 @@ const signer = new Signer({
   did: identity.did!,
 });
 
-const credential = buildVouchCredential({
-  subjectDid: identity.did!,
+// signCredential takes the intent directly (action, target, resource).
+const signed = await signer.signCredential({
   intent: {
     action: 'submit_claim',
     target: 'claim:HC-001',
@@ -326,7 +324,6 @@ const credential = buildVouchCredential({
   validSeconds: 300,
 });
 
-const signed = await signer.signCredential(credential);
 console.log(signed.proof.proofValue); // z-base58-encoded Ed25519 signature
 `,
               },


### PR DESCRIPTION
Surfaces the one-line adoption path on the website and corrects the documented code samples to the real SDK API.

## Landing page (`src/app/page.tsx`)
- The "quick taste" Python tab now leads with the one-line path: `protect([tools])` to sign every tool call and `vouch.verify(...)` to verify.
- Fixed the TypeScript tab to `signer.signCredential({ intent })`.
- Reframed the section intro around one-line adoption.

## FAQ (`src/app/faq/faq-data.ts`)
- Added "What is the fastest way to add Vouch to my agent?" as the first developer entry (`protect` / `autosign` / `vouch.verify` / `VouchGate`).
- Corrected the basic-signing, hybrid post-quantum, and revocable-credential samples.

## Help (`src/app/help/help-data.ts`)
- Corrected the credential-signing, hybrid, delegation-chain, and status-list samples.

All of the corrected Python samples previously used `Signer.from_did(...)`, `Signer.from_did_with_hybrid(...)`, or `build_vouch_credential(...)`, none of which exist in the SDK. They now use `Signer(private_key=, did=)` with `sign_credential(intent=...)` / `sign_credential_hybrid(intent=...)`, and `parent_credential=` for delegation chains.

## SDK (`vouch/signer.py`)
- Added a `credential_status` pass-through on `Signer.sign_credential`, so a revocable credential can be issued in one call (the status sample relies on it). The proof covers the status entry. Includes a test.