### PR TITLE
feat(transport): identity-first rendezvous resolver and transport follow-ups

### DIFF
--- a/agents-and-skills/FAQ-DRAFT.md
+++ b/agents-and-skills/FAQ-DRAFT.md
@@ -365,6 +365,35 @@ investigate within five business days.
 
 ---
 
+## Reaching agents by identity (transport)
+
+**Q: How does an agent reach another agent that has no domain or IP?**
+A: By its DID. The transport layer (`vouch.transport`) addresses a peer by
+identity, not location. It prefers identity-first routing over UDNA (Universal
+DID-Native Addressing) and falls back to standard DNS and HTTPS when the peer is
+not on the overlay. The agent dispatches to a DID and does not care which path
+the bytes take.
+
+**Q: Do I have to run UDNA to use Vouch?**
+A: No. The transport is optional and experimental, and it is dormant unless you
+opt in with `pip install vouch-protocol[udna]`. Without it, dispatch falls
+through to HTTP, so your code runs unchanged. UDNA is aligned with the W3C UDNA
+Community Group.
+
+**Q: Are my credentials safe if the message switches from UDNA to HTTP?**
+A: Yes. The message is a `VouchEnvelope` that carries the signed credential, its
+liability attestations, and provenance unchanged, with a content digest checked
+on receipt. The signature is what protects integrity and authenticity, so the
+trust properties hold whichever transport delivers the bytes.
+
+**Q: Is the UDNA channel encrypted?**
+A: Not yet in the reference SDK. The `udna_sdk` v1.0.x handshake authenticates
+the peer but does not provide channel confidentiality, so Vouch does not rely on
+it for secrecy. For confidential payloads, encrypt at the application layer
+before sealing. See `docs/udna-upstream-proposal.md`.
+
+---
+
 ## Notes for the user reviewing this draft
 
 - "https://agent.vouch-protocol.org" is the proposed hostname for the

--- a/agents-and-skills/HELP-GUIDE-DRAFT.md
+++ b/agents-and-skills/HELP-GUIDE-DRAFT.md
@@ -475,6 +475,55 @@ release notifications on https://github.com/vouch-protocol/vouch.
 
 ---
 
+# Part 3: Reach agents by identity (transport)
+
+Optional and experimental. Use this when agents need to reach each other by
+identity rather than by a fixed domain or IP. It is aligned with the W3C UDNA
+Community Group and is dormant unless you opt in.
+
+## When to use it
+
+- Agents are ephemeral or move across hosts, so a stable domain or IP is not
+  available, but a DID always is.
+- You want delivery to follow the identity, with a standard HTTP path as the
+  fallback for peers that are not on the overlay.
+
+## How it works
+
+`TransportManager` tries transports in order: UDNA first (identity-first), then
+HTTP (did:web, DNS, HTTPS). A peer that cannot be reached over one transport
+falls through to the next, and `DeliveryResult.attempts` records the path taken.
+The message is a `VouchEnvelope` that carries the signed credential, liability
+attestations, and provenance unchanged, with a content digest checked on
+receipt, so the trust properties hold whichever path delivers it.
+
+## Enable it
+
+```bash
+pip install vouch-protocol[udna]
+```
+
+```python
+from vouch.transport import TransportManager, build_envelope
+
+envelope = build_envelope(from_did=my_did, to_did=peer_did, payload=credential)
+manager = TransportManager.default(private_key_jwk=my_private_key_jwk)
+result = await manager.dispatch(envelope)   # result.transport -> "udna" or "http"
+```
+
+Without the extra installed, the UDNA transport stays dormant and dispatch falls
+through to HTTP, so the same code runs unchanged.
+
+## Security note
+
+The reference UDNA SDK (`udna_sdk` v1.0.x) authenticates the peer but does not
+provide channel confidentiality yet, so do not treat a UDNA channel as private.
+Vouch does not rely on it: envelope payloads are signed credentials, so their
+integrity and authenticity hold end to end. For confidential payloads, encrypt
+at the application layer before sealing.
+
+---
+
 # Notes for the user reviewing this draft
 
 - The `/help/ai-assistants` and `/help/sidecars` routes are proposals;

--- a/claude-skill/skills/vouch-protocol/reference/transport.md
+++ b/claude-skill/skills/vouch-protocol/reference/transport.md
@@ -1,0 +1,95 @@
+# Identity-Native Transport Reference
+
+Vouch addresses a peer by its DID, not its IP or domain. The transport
+layer (`vouch.transport`) prefers identity-first routing over UDNA
+(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
+when a peer is not on the overlay. An agent dispatches a message to a DID
+and stays agnostic about how the bytes are routed.
+
+This is optional and experimental. It is aligned with the W3C UDNA
+Community Group and is dormant unless you opt in.
+
+## Why it exists
+
+Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
+They rarely hold a stable domain or IP, but they always hold a key, so a
+DID is the only stable handle. Identity-first routing matches how agents
+actually run. Vouch already makes a DID accountable (identity, reputation,
+liability); UDNA answers how to reach it.
+
+## How it routes
+
+`TransportManager` holds an ordered list of transports and tries them in
+preference order:
+
+1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
+
+A transport that cannot reach a peer raises `TransportUnavailable`, and the
+manager moves to the next one. `DeliveryResult.attempts` records the path
+taken, for example `["udna", "http"]`.
+
+## What "route by DID" means
+
+The DID Document (the json with the DID and public key) is a key store, not
+a routing target. Its job is to give you the public key so you can verify
+signatures. Location comes from elsewhere. In `did:web`, the location is a
+`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
+a signed route record under its DID, and a resolver maps the DID to the
+agent's current endpoint, so there is no domain to seize and no DNS to
+poison. The key is the constant; the location is dynamic and self-published.
+
+## Payload preservation
+
+The message is a `VouchEnvelope` that carries three things unchanged: the
+signed Vouch credential (with its Data Integrity proof), liability
+attestations, and provenance metadata. A JCS-canonical SHA-256 content
+digest is verified on receipt, so the trust properties hold whichever path
+the bytes take. Switching from UDNA to HTTP never re-signs or strips the
+payload.
+
+## Quick start
+
+```python
+from vouch import Signer, generate_identity
+from vouch.transport import TransportManager, build_envelope
+
+kp = generate_identity(domain="agent.example.com")
+signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+credential = signer.sign_credential(intent={
+    "action": "settle_invoice",
+    "target": "invoice-42",
+    "resource": "https://api.example.com/invoices/42",
+})
+
+envelope = build_envelope(
+    from_did=kp.did,
+    to_did="did:web:peer.example.com",
+    payload=credential,
+)
+
+manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
+result = await manager.dispatch(envelope)
+print(result.transport)   # "udna" or "http"
+```
+
+Install the optional dependency with `pip install vouch-protocol[udna]`.
+Without it, the UDNA transport stays dormant and dispatch falls through to
+HTTP, so the code above runs unchanged.
+
+## Security note
+
+The reference UDNA SDK (`udna_sdk` v1.0.x) authenticates the peer during
+its handshake but does not provide channel confidentiality: its session key
+is derived from public values, so the channel should not be treated as
+private yet. Vouch does not rely on it. Envelope payloads are signed
+credentials, so their integrity and authenticity hold end to end no matter
+which transport carries them. For confidential payloads, encrypt at the
+application layer before sealing, or use a transport with real channel
+encryption.
+
+## See also
+
+- `docs/HYBRID_TRANSPORT.md` for the architecture.
+- `docs/udna-upstream-proposal.md` for the security finding and a proposed
+  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).

--- a/docs/HYBRID_TRANSPORT.md
+++ b/docs/HYBRID_TRANSPORT.md
@@ -9,13 +9,13 @@ standard DNS/IP + HTTP.
 
 ## Why
 
-Standard routing resolves an identity *down to a location* — `did:web` → domain
-→ IP — and then trusts whoever answers that IP. Location is the weak link:
+Standard routing resolves an identity *down to a location*, `did:web` → domain
+→ IP, and then trusts whoever answers that IP. Location is the weak link:
 domains get seized, DNS gets poisoned, IPs get hijacked.
 
 **UDNA (Universal DID-Native Addressing)** inverts the stack. The DID itself is
 the routing primitive; delivery rides a Noise-encrypted channel straight to the
-key that owns the DID. There is no location to spoof — the peer you reach is, by
+key that owns the DID. There is no location to spoof, the peer you reach is, by
 construction, the peer whose key matches the DID.
 
 UDNA is powerful but not universal: not every peer is on the overlay. So Vouch
@@ -29,11 +29,11 @@ location-first reachability everywhere else, behind a single API.
 vouch/transport/
 ├── __init__.py          Public API surface
 ├── base.py              Transport ABC, PeerAddress, DeliveryResult, errors
-├── envelope.py          VouchEnvelope — payload-preserving message container
+├── envelope.py          VouchEnvelope, payload-preserving message container
 ├── did_key.py           did:key generation/parsing (UDNA's native identity)
-├── http_transport.py    HttpTransport — DNS/IP + HTTPS (did:web), the fallback
-├── udna.py              UdnaTransport — Sirraya UDNA SDK adapter (Noise)
-└── manager.py           TransportManager — fallback routing middleware
+├── http_transport.py    HttpTransport, DNS/IP + HTTPS (did:web), the fallback
+├── udna.py              UdnaTransport, Sirraya UDNA SDK adapter (Noise)
+└── manager.py           TransportManager, fallback routing middleware
 ```
 
 ## Components
@@ -54,16 +54,16 @@ A transport signals **"not me, try the next one"** by raising
 `PayloadIntegrityError`. The manager keys its fallback-vs-fail decision on
 exactly that distinction.
 
-### `VouchEnvelope` — payload preservation
+### `VouchEnvelope`, payload preservation
 
 The envelope carries three compartments verbatim across any transport boundary:
 
-- `payload` — the signed Vouch credential, complete with its `eddsa-jcs-2022`
+- `payload`, the signed Vouch credential, complete with its `eddsa-jcs-2022`
   (or hybrid PQ) Data Integrity `proof`. Stored by reference, never
   re-serialized lossily.
-- `attestations` — liability attestations (outcome commitments, penalty
+- `attestations`, liability attestations (outcome commitments, penalty
   receipts, delegation links).
-- `provenance` — provenance metadata (content hashes, C2PA pointers, capture
+- `provenance`, provenance metadata (content hashes, C2PA pointers, capture
   context).
 
 Integrity is enforced by `content_digest()`: a SHA-256 over the **JCS
@@ -73,36 +73,36 @@ survives a UDNA→HTTP transition, re-indentation, or key reordering with its
 signatures intact. `from_wire()` re-verifies the seal on receipt and raises
 `PayloadIntegrityError` on any mismatch.
 
-### `UdnaTransport` — identity-first
+### `UdnaTransport`, identity-first
 
 Targets the real `sirraya-udna-sdk` (distribution `sirraya-udna-sdk`, **import
 package `udna_sdk`**, v1.0.x). That SDK provides:
 
-- **DID generation** — `UdnaSDK.create_did()` mints a `did:key`. Its encoding
+- **DID generation**, `UdnaSDK.create_did()` mints a `did:key`. Its encoding
   (`z` + base58(`0xed01` ‖ pubkey)) is byte-identical to Vouch's own Multikey,
-  so a Vouch identity and a UDNA identity interoperate with no translation —
+  so a Vouch identity and a UDNA identity interoperate with no translation -
   `UdnaTransport.generate_did(public_jwk)` derives the same `did:key` from the
   agent's existing signing key.
-- **UDNA address creation** — `UdnaSDK.create_address(did, facet_id, flags)`
+- **UDNA address creation**, `UdnaSDK.create_address(did, facet_id, flags)`
   produces a signed base58 address. `facet_id` selects a capability lane
   (`0x01` Control, `0x02` Messaging, `0x03` Telemetry); Vouch messages ride
   Messaging.
-- **Address verification** — `UdnaSDK.verify_address(address)` checks the
+- **Address verification**, `UdnaSDK.verify_address(address)` checks the
   address signature against the DID's key.
-- **Secure messaging** — `udna_sdk.udna.NoiseHandshake` (a DID-authenticated
+- **Secure messaging**, `udna_sdk.udna.NoiseHandshake` (a DID-authenticated
   Noise-IK handshake) plus `SecureMessaging` (ChaCha20-Poly1305 over the
   derived session key).
 
-**What the SDK does not provide is a production wire transport** — byte
+**What the SDK does not provide is a production wire transport**, byte
 delivery to a remote peer is left to the integrator (the bundled DHT is an
 in-memory demo). The adapter splits the two concerns accordingly:
 
-- **`UdnaNode`** — the session+delivery seam the transport talks to.
+- **`UdnaNode`**, the session+delivery seam the transport talks to.
   `SirrayaUdnaNode` implements it by composing the SDK's Noise/SecureMessaging
   crypto with a delivery channel: a secure send is a real
   `initiate → respond → finalize` handshake followed by an encrypted payload,
   each carried as one channel exchange.
-- **`UdnaChannel`** — the pluggable byte-delivery overlay the deployment
+- **`UdnaChannel`**, the pluggable byte-delivery overlay the deployment
   supplies (a relay, a libp2p/QUIC overlay, a websocket bridge).
 
 The SDK is an **optional dependency** (`pip install vouch-protocol[udna]`). All
@@ -111,9 +111,9 @@ fully testable without the SDK (see `tests/test_transport.py`) and validated
 against it when present (`tests/test_transport_udna_sdk.py`, auto-skipped
 otherwise). When the SDK is absent, or no node/channel is wired, the transport
 is **dormant**: it routes nothing and the manager falls back to HTTP. UDNA
-being unavailable is never an error — that is the point of the hybrid design.
+being unavailable is never an error, that is the point of the hybrid design.
 
-### `HttpTransport` — location-first fallback
+### `HttpTransport`, location-first fallback
 
 The universal lowest common denominator. Resolves `did:web` → domain via
 DNS/IP, discovers the peer's inbox (an explicit `VouchInbox` service in the DID
@@ -122,7 +122,7 @@ sealed envelope over TLS. Every outbound URL is screened by `vouch.ssrf`
 (https-only, public IPs only, redirects disabled) because the target host is
 derived from a potentially attacker-controlled DID.
 
-### `TransportManager` — fallback middleware
+### `TransportManager`, fallback middleware
 
 The single entry point for agents. Holds an ordered list of transports
 (UDNA preferred, HTTP behind) and exposes one method, `dispatch(envelope)`,
@@ -166,7 +166,7 @@ manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
 result = await manager.dispatch(envelope)
 
 print(result.transport)   # "udna" or "http"
-print(result.attempts)    # e.g. ["udna", "http"] — the fallback path taken
+print(result.attempts)    # e.g. ["udna", "http"], the fallback path taken
 ```
 
 A runnable, network-free demo lives at
@@ -176,5 +176,5 @@ A runnable, network-free demo lives at
 
 To add a transport (libp2p, Tor, a message bus), subclass `Transport`,
 implement the three methods, and insert it into the manager's preference list.
-Agents and the envelope are unaffected — that is the whole point of the
+Agents and the envelope are unaffected, that is the whole point of the
 abstraction.

--- a/docs/udna-upstream-proposal.md
+++ b/docs/udna-upstream-proposal.md
@@ -13,7 +13,7 @@ so payload integrity and authenticity hold end-to-end regardless of transport.
 
 ---
 
-## 1. CRITICAL — the handshake provides no confidentiality
+## 1. CRITICAL, the handshake provides no confidentiality
 
 `udna_sdk/udna.py :: NoiseHandshake.finalize_handshake` derives the session key
 from **public values only**:
@@ -41,7 +41,7 @@ Impact: the "end-to-end encrypted messaging" claim does not hold. Peer
 authenticity *is* present (ephemeral keys are signed by the DID keys), but
 channel secrecy and forward secrecy are absent.
 
-### Proposed fix — real ephemeral ECDH (X25519), keep Ed25519 for auth
+### Proposed fix, real ephemeral ECDH (X25519), keep Ed25519 for auth
 
 Ed25519 identity keys can't do DH, so add an ephemeral **X25519** keypair per
 handshake and sign its public key with the Ed25519 DID key (Noise-IK / X3DH
@@ -76,7 +76,7 @@ an `x25519_ephemeral` field alongside the existing signed Ed25519 ephemeral.
 
 ---
 
-## 2. No transport / overlay — only an in-memory demo DHT
+## 2. No transport / overlay, only an in-memory demo DHT
 
 `DhtNode` is a single-process dict (`store`/`lookup`), so the SDK cannot
 actually deliver bytes between hosts. Vouch works around this with a pluggable

--- a/examples/hybrid_transport_demo.py
+++ b/examples/hybrid_transport_demo.py
@@ -4,7 +4,7 @@ Vouch Protocol: Hybrid Transport Demo (UDNA + HTTP fallback)
 Demonstrates the modular, DID-addressed transport layer:
 
   1. An agent signs a Vouch credential (its accountable intent).
-  2. It seals the credential — plus liability attestations and provenance —
+  2. It seals the credential, plus liability attestations and provenance -
      into a VouchEnvelope addressed to a peer's *DID* (not an IP).
   3. The TransportManager tries identity-first UDNA routing, then falls back
      to standard DNS/IP + HTTP when the peer is not on the UDNA overlay.
@@ -15,7 +15,7 @@ is optional. In production it provides DID/address creation and the Noise
 handshake + ChaCha20-Poly1305 crypto, while a pluggable ``UdnaChannel`` moves
 the bytes (the SDK ships no production wire transport). To keep this demo
 network-free and runnable without the SDK, it wires an in-process fake UDNA
-node directly to the same ``UdnaNode`` seam ``SirrayaUdnaNode`` implements — so
+node directly to the same ``UdnaNode`` seam ``SirrayaUdnaNode`` implements, so
 you can watch routing and fallback without the real SDK.
 
 Run:  python examples/hybrid_transport_demo.py
@@ -95,7 +95,7 @@ async def main():
         print(f"   ✅ delivered via '{result2.transport}'  attempts={result2.attempts}")
     except Exception as exc:
         # No real HTTPS inbox is running in this demo, so HTTP delivery will
-        # fail at the network step — but note UDNA was tried first and yielded.
+        # fail at the network step, but note UDNA was tried first and yielded.
         print("   ↪️  UDNA yielded, HTTP attempted; network step failed as expected:")
         print(f"      {type(exc).__name__}: {exc}")
 

--- a/examples/udna_rendezvous_demo.py
+++ b/examples/udna_rendezvous_demo.py
@@ -1,0 +1,101 @@
+"""
+Vouch Protocol: identity-first routing demo (rendezvous resolver)
+
+Shows the piece UDNA needs and the reference SDK does not have yet: resolving a
+DID to where the agent is right now, with the route signed by the agent, and no
+DNS in the path.
+
+  1. A receiving agent announces a signed route record under its did:key.
+  2. A sender, knowing only the DID, resolves it to the current endpoint.
+  3. The sender delivers a sealed Vouch envelope, and the proof is preserved.
+
+Run:  python examples/udna_rendezvous_demo.py
+"""
+
+import asyncio
+import json
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Signer, generate_identity
+from vouch.transport import (
+    RendezvousChannel,
+    RendezvousRegistry,
+    build_envelope,
+    build_route_record,
+    route_fingerprint,
+    udna_address,
+)
+from vouch.transport.did_key import did_key_from_public_jwk
+
+
+def _priv(private_key_jwk: str) -> Ed25519PrivateKey:
+    seed = base64url_decode(json.loads(private_key_jwk)["d"])
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+async def main():
+    print("\nIdentity-first routing demo (no DNS)\n" + "=" * 40)
+
+    # The receiving agent's identity, as a did:key derived from its Vouch key.
+    agent = generate_identity()
+    agent_did = did_key_from_public_jwk(agent.public_key_jwk)
+    agent_priv = _priv(agent.private_key_jwk)
+    print(f"Agent DID:        {agent_did[:40]}...")
+    print(f"Routing key:      {route_fingerprint(agent_did)[:16]}...  (sha256 of the DID)")
+
+    registry = RendezvousRegistry()
+    channel = RendezvousChannel(registry)
+
+    # 1. The agent registers an inbox and announces its current route, signed.
+    async def inbox(frame: bytes) -> bytes:
+        msg = json.loads(frame)
+        print(f"   inbox received envelope for {msg['to'][:32]}...")
+        return json.dumps({"status": "delivered"}).encode("utf-8")
+
+    channel.register_inbox("inproc://agent-node-7", inbox)
+    record = build_route_record(
+        did=agent_did, endpoint="inproc://agent-node-7", private_key=agent_priv
+    )
+    registry.announce(record)
+    print("\n[1] Agent announced a signed route record")
+    print(f"    endpoint:  {record.endpoint}")
+    print(f"    signature: {record.signature[:20]}...  (Ed25519 over the record)")
+
+    # 2. A sender knows only the DID. Resolve it to the live endpoint.
+    addr = udna_address(agent_did)
+    print("\n[2] Sender resolves the DID, with no DNS")
+    print(f"    udna address: {addr[:48]}...")
+    print(f"    reachable:    {await channel.reachable(addr)}")
+
+    # 3. Deliver a sealed Vouch envelope; the proof must survive.
+    signer = Signer(private_key=agent.private_key_jwk, did="did:web:sender.example.com")
+    credential = signer.sign_credential(
+        intent={
+            "action": "settle_invoice",
+            "target": "invoice-42",
+            "resource": "https://api.example.com/invoices/42",
+        }
+    )
+    envelope = build_envelope(
+        from_did="did:web:sender.example.com", to_did=agent_did, payload=credential
+    )
+    print("\n[3] Sender delivers a sealed envelope over the resolved route")
+    reply = await channel.exchange(addr, json.dumps(envelope.to_wire()).encode("utf-8"))
+    print(f"    reply: {json.loads(reply)}")
+
+    # 4. Tamper check: a forged route cannot be announced.
+    print("\n[4] A forged route record is rejected")
+    record.endpoint = "inproc://attacker"
+    try:
+        registry.announce(record)
+        print("    ERROR: forged record accepted")
+    except ValueError as exc:
+        print(f"    rejected: {exc}")
+
+    print("\nDone.\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/gemini-gem/knowledge/transport.md
+++ b/gemini-gem/knowledge/transport.md
@@ -1,0 +1,95 @@
+# Identity-Native Transport Reference
+
+Vouch addresses a peer by its DID, not its IP or domain. The transport
+layer (`vouch.transport`) prefers identity-first routing over UDNA
+(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
+when a peer is not on the overlay. An agent dispatches a message to a DID
+and stays agnostic about how the bytes are routed.
+
+This is optional and experimental. It is aligned with the W3C UDNA
+Community Group and is dormant unless you opt in.
+
+## Why it exists
+
+Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
+They rarely hold a stable domain or IP, but they always hold a key, so a
+DID is the only stable handle. Identity-first routing matches how agents
+actually run. Vouch already makes a DID accountable (identity, reputation,
+liability); UDNA answers how to reach it.
+
+## How it routes
+
+`TransportManager` holds an ordered list of transports and tries them in
+preference order:
+
+1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
+
+A transport that cannot reach a peer raises `TransportUnavailable`, and the
+manager moves to the next one. `DeliveryResult.attempts` records the path
+taken, for example `["udna", "http"]`.
+
+## What "route by DID" means
+
+The DID Document (the json with the DID and public key) is a key store, not
+a routing target. Its job is to give you the public key so you can verify
+signatures. Location comes from elsewhere. In `did:web`, the location is a
+`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
+a signed route record under its DID, and a resolver maps the DID to the
+agent's current endpoint, so there is no domain to seize and no DNS to
+poison. The key is the constant; the location is dynamic and self-published.
+
+## Payload preservation
+
+The message is a `VouchEnvelope` that carries three things unchanged: the
+signed Vouch credential (with its Data Integrity proof), liability
+attestations, and provenance metadata. A JCS-canonical SHA-256 content
+digest is verified on receipt, so the trust properties hold whichever path
+the bytes take. Switching from UDNA to HTTP never re-signs or strips the
+payload.
+
+## Quick start
+
+```python
+from vouch import Signer, generate_identity
+from vouch.transport import TransportManager, build_envelope
+
+kp = generate_identity(domain="agent.example.com")
+signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+credential = signer.sign_credential(intent={
+    "action": "settle_invoice",
+    "target": "invoice-42",
+    "resource": "https://api.example.com/invoices/42",
+})
+
+envelope = build_envelope(
+    from_did=kp.did,
+    to_did="did:web:peer.example.com",
+    payload=credential,
+)
+
+manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
+result = await manager.dispatch(envelope)
+print(result.transport)   # "udna" or "http"
+```
+
+Install the optional dependency with `pip install vouch-protocol[udna]`.
+Without it, the UDNA transport stays dormant and dispatch falls through to
+HTTP, so the code above runs unchanged.
+
+## Security note
+
+The reference UDNA SDK (`udna_sdk` v1.0.x) authenticates the peer during
+its handshake but does not provide channel confidentiality: its session key
+is derived from public values, so the channel should not be treated as
+private yet. Vouch does not rely on it. Envelope payloads are signed
+credentials, so their integrity and authenticity hold end to end no matter
+which transport carries them. For confidential payloads, encrypt at the
+application layer before sealing, or use a transport with real channel
+encryption.
+
+## See also
+
+- `docs/HYBRID_TRANSPORT.md` for the architecture.
+- `docs/udna-upstream-proposal.md` for the security finding and a proposed
+  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).

--- a/openai-gpt/knowledge/transport.md
+++ b/openai-gpt/knowledge/transport.md
@@ -1,0 +1,95 @@
+# Identity-Native Transport Reference
+
+Vouch addresses a peer by its DID, not its IP or domain. The transport
+layer (`vouch.transport`) prefers identity-first routing over UDNA
+(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
+when a peer is not on the overlay. An agent dispatches a message to a DID
+and stays agnostic about how the bytes are routed.
+
+This is optional and experimental. It is aligned with the W3C UDNA
+Community Group and is dormant unless you opt in.
+
+## Why it exists
+
+Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
+They rarely hold a stable domain or IP, but they always hold a key, so a
+DID is the only stable handle. Identity-first routing matches how agents
+actually run. Vouch already makes a DID accountable (identity, reputation,
+liability); UDNA answers how to reach it.
+
+## How it routes
+
+`TransportManager` holds an ordered list of transports and tries them in
+preference order:
+
+1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
+
+A transport that cannot reach a peer raises `TransportUnavailable`, and the
+manager moves to the next one. `DeliveryResult.attempts` records the path
+taken, for example `["udna", "http"]`.
+
+## What "route by DID" means
+
+The DID Document (the json with the DID and public key) is a key store, not
+a routing target. Its job is to give you the public key so you can verify
+signatures. Location comes from elsewhere. In `did:web`, the location is a
+`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
+a signed route record under its DID, and a resolver maps the DID to the
+agent's current endpoint, so there is no domain to seize and no DNS to
+poison. The key is the constant; the location is dynamic and self-published.
+
+## Payload preservation
+
+The message is a `VouchEnvelope` that carries three things unchanged: the
+signed Vouch credential (with its Data Integrity proof), liability
+attestations, and provenance metadata. A JCS-canonical SHA-256 content
+digest is verified on receipt, so the trust properties hold whichever path
+the bytes take. Switching from UDNA to HTTP never re-signs or strips the
+payload.
+
+## Quick start
+
+```python
+from vouch import Signer, generate_identity
+from vouch.transport import TransportManager, build_envelope
+
+kp = generate_identity(domain="agent.example.com")
+signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+credential = signer.sign_credential(intent={
+    "action": "settle_invoice",
+    "target": "invoice-42",
+    "resource": "https://api.example.com/invoices/42",
+})
+
+envelope = build_envelope(
+    from_did=kp.did,
+    to_did="did:web:peer.example.com",
+    payload=credential,
+)
+
+manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
+result = await manager.dispatch(envelope)
+print(result.transport)   # "udna" or "http"
+```
+
+Install the optional dependency with `pip install vouch-protocol[udna]`.
+Without it, the UDNA transport stays dormant and dispatch falls through to
+HTTP, so the code above runs unchanged.
+
+## Security note
+
+The reference UDNA SDK (`udna_sdk` v1.0.x) authenticates the peer during
+its handshake but does not provide channel confidentiality: its session key
+is derived from public values, so the channel should not be treated as
+private yet. Vouch does not rely on it. Envelope payloads are signed
+credentials, so their integrity and authenticity hold end to end no matter
+which transport carries them. For confidential payloads, encrypt at the
+application layer before sealing, or use a transport with real channel
+encryption.
+
+## See also
+
+- `docs/HYBRID_TRANSPORT.md` for the architecture.
+- `docs/udna-upstream-proposal.md` for the security finding and a proposed
+  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -80,7 +80,7 @@ class TestEnvelope:
             to_did="did:web:b.example.com",
             payload=cred,
         )
-        # The credential dict is carried verbatim — proof intact.
+        # The credential dict is carried verbatim, proof intact.
         assert env.payload is cred
         assert "proof" in env.payload
 

--- a/tests/test_transport_rendezvous.py
+++ b/tests/test_transport_rendezvous.py
@@ -1,0 +1,159 @@
+"""
+Tests for the identity-first rendezvous resolver.
+
+These exercise the announce, resolve, verify, and deliver contract end to end
+with no network and no SDK: an agent publishes a signed route record under its
+DID, a sender resolves the DID to the current endpoint, verifies it, and
+delivers a sealed Vouch envelope whose proof survives the trip.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.transport import (
+    RendezvousChannel,
+    RendezvousRegistry,
+    RouteRecord,
+    build_envelope,
+    build_route_record,
+    route_fingerprint,
+    udna_address,
+)
+from vouch.transport.did_key import did_key_from_public_jwk
+from vouch.transport.rendezvous import _format_iso8601, _now
+from datetime import timedelta
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from jwcrypto.common import base64url_decode
+
+
+def _identity():
+    kp = generate_identity()
+    did = did_key_from_public_jwk(kp.public_key_jwk)
+    seed = base64url_decode(json.loads(kp.private_key_jwk)["d"])
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    return kp, did, priv
+
+
+# --------------------------------------------------------------------------- #
+# Route record: sign, verify, tamper, expiry
+# --------------------------------------------------------------------------- #
+class TestRouteRecord:
+    def test_sign_and_verify_roundtrip(self):
+        _, did, priv = _identity()
+        rec = build_route_record(did=did, endpoint="inproc://a", private_key=priv)
+        assert rec.signature.startswith("z")
+        assert rec.verify() is True
+
+    def test_tampered_endpoint_fails(self):
+        _, did, priv = _identity()
+        rec = build_route_record(did=did, endpoint="inproc://a", private_key=priv)
+        rec.endpoint = "inproc://attacker"
+        assert rec.verify() is False
+
+    def test_wrong_key_fails(self):
+        _, did, _ = _identity()
+        other = Ed25519PrivateKey.generate()
+        rec = build_route_record(did=did, endpoint="inproc://a", private_key=other)
+        # Signed by a key that does not match the DID.
+        assert rec.verify() is False
+
+    def test_expired_record_fails(self):
+        _, did, priv = _identity()
+        rec = build_route_record(did=did, endpoint="inproc://a", private_key=priv, ttl_seconds=1)
+        rec.expires = _format_iso8601(_now() - timedelta(seconds=5))
+        # expires is part of the signed body, so this also breaks the signature,
+        # but is_expired alone must already reject it.
+        assert rec.is_expired() is True
+
+    def test_wire_roundtrip(self):
+        _, did, priv = _identity()
+        rec = build_route_record(did=did, endpoint="inproc://a", private_key=priv)
+        restored = RouteRecord.from_wire(rec.to_wire())
+        assert restored.verify() is True
+        assert restored.endpoint == "inproc://a"
+
+
+# --------------------------------------------------------------------------- #
+# Fingerprint
+# --------------------------------------------------------------------------- #
+def test_fingerprint_is_stable_and_did_keyed():
+    _, did, _ = _identity()
+    fp = route_fingerprint(did)
+    assert fp == route_fingerprint(did)
+    assert len(fp) == 64  # sha256 hex
+    assert did not in fp  # the location-independent key does not leak the DID
+
+
+# --------------------------------------------------------------------------- #
+# Registry: announce / resolve
+# --------------------------------------------------------------------------- #
+class TestRegistry:
+    def test_announce_then_resolve(self):
+        _, did, priv = _identity()
+        reg = RendezvousRegistry()
+        reg.announce(build_route_record(did=did, endpoint="inproc://inbox-1", private_key=priv))
+        assert reg.resolve(did) == "inproc://inbox-1"
+
+    def test_resolve_unknown_returns_none(self):
+        _, did, _ = _identity()
+        assert RendezvousRegistry().resolve(did) is None
+
+    def test_announce_rejects_unverified_record(self):
+        _, did, _ = _identity()
+        bad = RouteRecord(did=did, endpoint="inproc://x", signature="zdeadbeef")
+        with pytest.raises(ValueError):
+            RendezvousRegistry().announce(bad)
+
+    def test_reannounce_updates_endpoint(self):
+        _, did, priv = _identity()
+        reg = RendezvousRegistry()
+        reg.announce(build_route_record(did=did, endpoint="inproc://old", private_key=priv))
+        reg.announce(build_route_record(did=did, endpoint="inproc://new", private_key=priv))
+        assert reg.resolve(did) == "inproc://new"
+
+
+# --------------------------------------------------------------------------- #
+# Channel: resolve a DID and deliver, no DNS
+# --------------------------------------------------------------------------- #
+class TestRendezvousChannel:
+    async def test_resolve_and_deliver_preserves_payload(self):
+        kp, did, priv = _identity()
+        reg = RendezvousRegistry()
+        channel = RendezvousChannel(reg)
+
+        # The receiving agent registers an inbox and announces its route.
+        received = {}
+
+        async def inbox(frame: bytes) -> bytes:
+            received["frame"] = frame
+            return json.dumps({"status": "ok"}).encode("utf-8")
+
+        channel.register_inbox("inproc://inbox-1", inbox)
+        reg.announce(build_route_record(did=did, endpoint="inproc://inbox-1", private_key=priv))
+
+        # The sender knows only the DID. Resolve and deliver a sealed envelope.
+        addr = udna_address(did)
+        assert await channel.reachable(addr) is True
+
+        signer = Signer(private_key=kp.private_key_jwk, did="did:web:sender.example.com")
+        cred = signer.sign_credential(
+            intent={"action": "ping", "target": "t", "resource": "https://x/t"}
+        )
+        env = build_envelope(from_did="did:web:sender.example.com", to_did=did, payload=cred)
+        reply = await channel.exchange(addr, json.dumps(env.to_wire()).encode("utf-8"))
+
+        assert json.loads(reply) == {"status": "ok"}
+        delivered = json.loads(received["frame"])
+        assert delivered["payload"]["proof"] == cred["proof"]
+
+    async def test_unreachable_when_not_announced(self):
+        _, did, _ = _identity()
+        channel = RendezvousChannel(RendezvousRegistry())
+        assert await channel.reachable(udna_address(did)) is False
+        with pytest.raises(KeyError):
+            await channel.exchange(udna_address(did), b"{}")

--- a/tests/test_transport_udna_sdk.py
+++ b/tests/test_transport_udna_sdk.py
@@ -3,9 +3,9 @@ Integration tests against the *real* ``sirraya-udna-sdk`` (import: ``udna_sdk``)
 
 These are skipped unless the SDK is installed (``pip install
 vouch-protocol[udna]``), so the default test run does not depend on it. When it
-is present, they exercise Vouch's UDNA adapter against the genuine SDK API —
+is present, they exercise Vouch's UDNA adapter against the genuine SDK API -
 ``UdnaSDK.create_did`` / ``create_address`` / ``verify_address`` and the
-``NoiseHandshake`` + ``SecureMessaging`` crypto — proving the adapter is wired
+``NoiseHandshake`` + ``SecureMessaging`` crypto, proving the adapter is wired
 to real method names, not guessed ones.
 """
 
@@ -115,7 +115,7 @@ async def test_secure_send_runs_real_noise_handshake():
     assert peer is not None and peer.verified is True
 
     # Completes a real initiate→respond→finalize handshake and encrypts the
-    # envelope with ChaCha20-Poly1305 — no exception means the real API matched.
+    # envelope with ChaCha20-Poly1305, no exception means the real API matched.
     reply = await transport.send(env, peer)
     assert reply == {}  # peer acknowledged without a body
     assert node._channel.received_ciphertext is not None

--- a/vouch/transport/__init__.py
+++ b/vouch/transport/__init__.py
@@ -5,11 +5,11 @@ A modular, DID-addressed networking layer that lets a Vouch agent dispatch a
 message to a peer's *identity* and stay agnostic about how it is routed. Two
 transports ship in the box:
 
-  * :class:`UdnaTransport` — identity-first routing via the Sirraya UDNA SDK.
+  * :class:`UdnaTransport`, identity-first routing via the Sirraya UDNA SDK.
     The DID is the route; delivery rides a Noise-encrypted channel straight to
     the key that owns it. Optional; dormant (and harmless) when the SDK is
     absent.
-  * :class:`HttpTransport` — the location-first fallback. Resolve ``did:web``
+  * :class:`HttpTransport`, the location-first fallback. Resolve ``did:web``
     to a domain over DNS/IP and POST over TLS. Universally reachable.
 
 :class:`TransportManager` ties them together with graceful fallback: prefer
@@ -65,6 +65,14 @@ from .envelope import (
 )
 from .http_transport import HttpTransport
 from .manager import TransportManager
+from .rendezvous import (
+    ROUTE_RECORD_TYPE,
+    RendezvousChannel,
+    RendezvousRegistry,
+    RouteRecord,
+    build_route_record,
+    route_fingerprint,
+)
 from .udna import (
     DEFAULT_FACET,
     FACET_CONTROL,
@@ -103,6 +111,13 @@ __all__ = [
     "FACET_MESSAGING",
     "FACET_TELEMETRY",
     "HttpTransport",
+    # Rendezvous resolver (identity-first routing proof)
+    "RouteRecord",
+    "build_route_record",
+    "route_fingerprint",
+    "RendezvousRegistry",
+    "RendezvousChannel",
+    "ROUTE_RECORD_TYPE",
     # did:key helpers
     "is_did_key",
     "did_key_from_ed25519_public",

--- a/vouch/transport/base.py
+++ b/vouch/transport/base.py
@@ -5,7 +5,7 @@ Vouch credentials (signed intents, liability attestations, provenance
 metadata) are *what* an agent says; a transport is *how* that statement
 reaches a peer. Historically the only transport was DNS/IP + HTTP(S): you
 resolve a `did:web` to a domain, then POST to it. That couples delivery to
-location — whoever controls the IP controls the route.
+location, whoever controls the IP controls the route.
 
 This module defines the location-agnostic interface every transport
 implements so that a Vouch agent can dispatch a message addressed only to a
@@ -13,14 +13,14 @@ peer's DID and remain unaware of whether it travelled over UDNA
 (identity-first) or HTTP (location-first). The :class:`Transport` contract is
 deliberately small:
 
-  * ``can_route(did)``  — could this transport plausibly reach this DID?
-  * ``resolve(did)``    — turn the DID into a concrete :class:`PeerAddress`.
-  * ``send(envelope, peer)`` — deliver the payload, returning the peer reply.
+  * ``can_route(did)``: could this transport plausibly reach this DID?
+  * ``resolve(did)``: turn the DID into a concrete :class:`PeerAddress`.
+  * ``send(envelope, peer)``, deliver the payload, returning the peer reply.
 
 A transport signals "not my problem, try the next one" by raising
 :class:`TransportUnavailable` (or returning ``None`` from ``resolve``). It
-signals a corrupted payload — a bug the caller must not paper over by
-silently re-routing — by raising :class:`PayloadIntegrityError`. The
+signals a corrupted payload, a bug the caller must not paper over by
+silently re-routing, by raising :class:`PayloadIntegrityError`. The
 :class:`~vouch.transport.manager.TransportManager` uses exactly that
 distinction to decide between graceful fallback and hard failure.
 """
@@ -38,7 +38,7 @@ class TransportError(Exception):
 
 class TransportUnavailable(TransportError):
     """
-    Raised when a transport cannot reach a peer — the peer does not advertise
+    Raised when a transport cannot reach a peer, the peer does not advertise
     this transport, resolution failed, or the underlying channel could not be
     established. This is the signal the routing manager treats as "fall back to
     the next transport"; it is never fatal on its own.
@@ -60,8 +60,8 @@ class PeerAddress:
     A resolved, transport-specific way to reach a peer DID.
 
     The ``did`` is the stable, location-independent identity. ``locator`` is
-    the concrete handle the owning transport understands — a UDNA address
-    (``udna://…``) or an HTTPS inbox URL — and is meaningful only to the
+    the concrete handle the owning transport understands, a UDNA address
+    (``udna://…``) or an HTTPS inbox URL, and is meaningful only to the
     transport that produced it. ``verified`` records whether the locator was
     cryptographically bound to the DID during resolution (UDNA verifies the
     DID owns the route; plain DNS does not).
@@ -97,7 +97,7 @@ class Transport(ABC):
     Implementations are addressed by DID, never by location. The manager calls
     ``can_route`` as a cheap pre-filter, then ``resolve`` to obtain a
     :class:`PeerAddress`, then ``send``. Implementations must not mutate the
-    envelope they are handed — the payload's cryptographic proofs depend on it
+    envelope they are handed, the payload's cryptographic proofs depend on it
     being byte-for-byte preserved across the transport boundary.
     """
 
@@ -131,7 +131,7 @@ class Transport(ABC):
 
         Raises:
           TransportUnavailable: the channel could not be established or the
-            peer rejected the connection — the manager will fall back.
+            peer rejected the connection, the manager will fall back.
           PayloadIntegrityError: the envelope failed its own integrity check.
         """
 

--- a/vouch/transport/did_key.py
+++ b/vouch/transport/did_key.py
@@ -11,7 +11,7 @@ registry and no network.
 
 Method spec: ``did:key`` for Ed25519 is ``did:key:z6Mk…`` where the suffix is
 the ``Multikey`` encoding of the public key (multicodec ``0xed01`` || raw key,
-base58btc, ``z`` prefix) — identical to the ``publicKeyMultibase`` Vouch
+base58btc, ``z`` prefix), identical to the ``publicKeyMultibase`` Vouch
 publishes in DID Documents.
 """
 
@@ -63,7 +63,7 @@ def ed25519_public_from_did_key(did: str) -> bytes:
     Recover the raw 32-byte Ed25519 public key from a ``did:key``.
 
     This is what lets a UDNA peer verify, with no registry lookup, that the
-    party it established a Noise channel with actually owns the DID it claims —
+    party it established a Noise channel with actually owns the DID it claims -
     the key is right there in the identifier.
 
     Raises:

--- a/vouch/transport/envelope.py
+++ b/vouch/transport/envelope.py
@@ -4,25 +4,25 @@ The Vouch transport envelope.
 A transport moves bytes; Vouch moves *accountable* statements. The envelope is
 the bridge: a thin, transport-neutral container that carries a signed Vouch
 credential together with the liability and provenance context a peer needs to
-hold the sender accountable — without ever touching the signed bytes
+hold the sender accountable, without ever touching the signed bytes
 themselves.
 
 Three payload compartments, each preserved verbatim:
 
-  * ``payload``      — the signed Vouch credential (an ``eddsa-jcs-2022`` or
+  * ``payload``: the signed Vouch credential (an ``eddsa-jcs-2022`` or
     hybrid Verifiable Credential, complete with its ``proof`` block). This is
     opaque to the transport layer and is never re-serialized lossily.
-  * ``attestations`` — zero or more liability attestations (outcome
+  * ``attestations``, zero or more liability attestations (outcome
     commitments, penalty receipts, delegation links) that bind the sender to
     consequences.
-  * ``provenance``   — provenance metadata (content hashes, C2PA pointers,
+  * ``provenance``: provenance metadata (content hashes, C2PA pointers,
     capture context) describing where the payload's subject came from.
 
 Integrity across the transport boundary is enforced by ``content_digest()``: a
 SHA-256 over the JCS canonicalization of those three compartments. The manager
 stamps the digest at seal time; the receiver (or a fallback transport
 re-handling the same envelope) recomputes it and rejects any mismatch. Because
-the digest is computed over the canonical form — not the wire bytes — an
+the digest is computed over the canonical form, not the wire bytes, an
 envelope survives a UDNA→HTTP transition, re-indentation, or key reordering
 with its proofs intact.
 """
@@ -133,7 +133,7 @@ class VouchEnvelope:
 
         Raises:
           PayloadIntegrityError: if the recomputed digest does not match the
-            ``content_digest`` carried on the wire — the cargo was altered.
+            ``content_digest`` carried on the wire, the cargo was altered.
           ValueError: if the envelope is structurally malformed.
         """
         version = data.get("vouch_envelope")
@@ -181,7 +181,7 @@ def build_envelope(
     """
     Convenience constructor for a Vouch envelope.
 
-    ``payload`` should be an already-signed Vouch credential — typically the
+    ``payload`` should be an already-signed Vouch credential, typically the
     dict returned by ``Signer.sign_credential(...)``. It is stored by reference
     and never mutated, so its Data Integrity proof remains valid.
     """

--- a/vouch/transport/http_transport.py
+++ b/vouch/transport/http_transport.py
@@ -1,10 +1,10 @@
 """
-HTTP transport — the location-first fallback.
+HTTP transport, the location-first fallback.
 
 This is the transport Vouch has always implicitly used: resolve a ``did:web``
 to a domain via DNS/IP, then POST the sealed envelope to that domain's Vouch
-inbox over TLS. It is the universal lowest common denominator — any peer that
-publishes a ``did:web`` document and runs an HTTPS endpoint is reachable — and
+inbox over TLS. It is the universal lowest common denominator, any peer that
+publishes a ``did:web`` document and runs an HTTPS endpoint is reachable, and
 so it serves as the graceful-fallback target when an identity-first transport
 (UDNA) is unavailable or the peer does not support it.
 
@@ -75,7 +75,7 @@ class HttpTransport(Transport):
         return self._client
 
     async def can_route(self, did: str) -> bool:
-        """HTTP can route any ``did:web`` — that's the only location-bound DID."""
+        """HTTP can route any ``did:web``, that's the only location-bound DID."""
         return is_did_web(did)
 
     async def resolve(self, did: str) -> Optional[PeerAddress]:

--- a/vouch/transport/manager.py
+++ b/vouch/transport/manager.py
@@ -1,5 +1,5 @@
 """
-Transport manager — the graceful-fallback routing middleware.
+Transport manager, the graceful-fallback routing middleware.
 
 This is the piece a Vouch agent actually talks to. It holds an ordered list of
 transports (identity-first UDNA in front, location-first HTTP behind) and a
@@ -7,15 +7,15 @@ single method, :meth:`dispatch`, that hides every routing decision behind one
 call: *"deliver this envelope to this DID."* The agent never learns, nor needs
 to, whether the bytes left over a Noise channel or an HTTPS POST.
 
-Fallback contract — the manager walks its transports in preference order and,
+Fallback contract, the manager walks its transports in preference order and,
 for each:
 
   1. skips it if ``can_route`` says no (cheap pre-filter);
   2. skips it if ``resolve`` returns ``None`` (peer doesn't support it);
   3. attempts ``send`` if resolution succeeded.
 
-A transport that raises :class:`TransportUnavailable` at any step — peer not on
-the overlay, resolution failed, Noise handshake refused, connection dropped —
+A transport that raises :class:`TransportUnavailable` at any step, peer not on
+the overlay, resolution failed, Noise handshake refused, connection dropped -
 is treated as "not this one, try the next." The manager moves on. Only when
 *every* transport has been exhausted does it raise the last error. The single
 exception is :class:`PayloadIntegrityError`: if an envelope fails its own seal
@@ -25,7 +25,7 @@ manager refuses to fall back and raises immediately.
 Payload preservation is structural: the *same* :class:`VouchEnvelope` instance
 is handed to whichever transport wins. The Vouch credential, its Data Integrity
 proof, the liability attestations, and the provenance metadata are never
-re-signed, re-encoded, or stripped during the UDNA→HTTP transition — the
+re-signed, re-encoded, or stripped during the UDNA→HTTP transition, the
 manager verifies the content digest once up front and then routes the bytes
 untouched.
 """
@@ -79,7 +79,7 @@ class TransportManager:
         ready-made node, or ``private_key_jwk`` + ``udna_channel`` to have a
         :class:`SirrayaUdnaNode` auto-built on the real ``udna_sdk``. If neither
         the SDK nor the prerequisites are available, the UDNA transport stays
-        dormant and every dispatch falls straight through to HTTP — nothing to
+        dormant and every dispatch falls straight through to HTTP, nothing to
         configure, nothing to fail.
         """
         from .http_transport import HttpTransport
@@ -107,13 +107,13 @@ class TransportManager:
           full ordered list of transports attempted.
 
         Raises:
-          PayloadIntegrityError: the envelope's cargo does not match its seal —
+          PayloadIntegrityError: the envelope's cargo does not match its seal -
             fatal, never retried.
           TransportError: no transport could reach the peer; carries the last
             underlying failure.
         """
         # Verify the seal once, up front. A corrupt payload must never be
-        # routed — falling back would just spread the corruption.
+        # routed, falling back would just spread the corruption.
         if not envelope.verify_integrity(envelope.content_digest()):  # pragma: no cover
             raise PayloadIntegrityError("envelope failed its content-digest self-check")
 

--- a/vouch/transport/rendezvous.py
+++ b/vouch/transport/rendezvous.py
@@ -1,0 +1,259 @@
+"""
+Reference resolver for identity-first routing (proof of concept).
+
+This is the piece UDNA needs and the reference SDK does not yet have: a way to
+resolve a DID to the agent's current network location, with the mapping signed
+by the agent itself. It answers the one question ``did:key`` cannot, "where is
+this agent right now," without DNS and without a domain.
+
+The contract is three steps:
+
+  1. **Announce.** An agent publishes a :class:`RouteRecord`, a small object that
+     binds its DID to a current endpoint and an expiry, signed by the DID's
+     Ed25519 key. Because it is signed, anyone can verify the agent itself
+     asserted this route.
+  2. **Resolve.** A sender looks up a DID, the registry returns the latest valid
+     record, and the sender verifies the signature and the expiry before using
+     the endpoint.
+  3. **Deliver.** The sender sends to the resolved endpoint.
+
+The lookup here is a single in-memory :class:`RendezvousRegistry`, deliberately
+not a distributed hash table. It proves the announce-resolve-verify contract end
+to end so the design can be exercised and tested. Swapping the single rendezvous
+for a real overlay (a Kademlia DHT, or an existing one like libp2p) is a later
+step and does not change this record format or the verification logic, which are
+the parts worth pinning down first.
+
+:class:`RendezvousChannel` adapts this resolver to the :class:`UdnaChannel`
+protocol, so it drops in behind the rest of the transport stack: resolve the
+DID, then deliver the bytes to the registered inbox for that endpoint.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Awaitable, Callable, Dict, Optional, Tuple
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+from cryptography.exceptions import InvalidSignature
+
+from .. import jcs
+from ..multikey import _b58decode, _b58encode
+from .did_key import ed25519_public_from_did_key, is_did_key
+from .udna import DEFAULT_FACET
+
+ROUTE_RECORD_TYPE = "UdnaRouteRecord"
+DEFAULT_TTL_SECONDS = 3600
+
+
+def route_fingerprint(did: str) -> str:
+    """
+    The routing key for a DID: ``sha256(did)`` as hex.
+
+    This is the handle an overlay would index on, matching the fingerprint the
+    UDNA SDK uses for DHT routing. The identity is the key; no location leaks
+    into it.
+    """
+    return hashlib.sha256(did.encode("utf-8")).hexdigest()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _format_iso8601(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso8601(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+
+
+@dataclass
+class RouteRecord:
+    """
+    A signed mapping from a DID to its current endpoint.
+
+    The signature covers everything except itself, so the record is
+    tamper-evident and self-authenticating: the verifier recovers the public key
+    from the DID and checks that the holder of that key produced this route.
+    """
+
+    did: str
+    endpoint: str
+    facet: str = DEFAULT_FACET
+    expires: str = ""
+    nonce: str = ""
+    signature: Optional[str] = None
+
+    def _unsigned(self) -> Dict[str, str]:
+        return {
+            "type": ROUTE_RECORD_TYPE,
+            "did": self.did,
+            "endpoint": self.endpoint,
+            "facet": self.facet,
+            "expires": self.expires,
+            "nonce": self.nonce,
+        }
+
+    def to_wire(self) -> Dict[str, str]:
+        body = self._unsigned()
+        if self.signature is not None:
+            body["signature"] = self.signature
+        return body
+
+    @classmethod
+    def from_wire(cls, data: Dict[str, str]) -> "RouteRecord":
+        return cls(
+            did=data["did"],
+            endpoint=data["endpoint"],
+            facet=data.get("facet", DEFAULT_FACET),
+            expires=data.get("expires", ""),
+            nonce=data.get("nonce", ""),
+            signature=data.get("signature"),
+        )
+
+    def is_expired(self, at: Optional[datetime] = None) -> bool:
+        if not self.expires:
+            return True
+        return (at or _now()) >= _parse_iso8601(self.expires)
+
+    def verify(self) -> bool:
+        """
+        True when the signature is valid, the DID owns the signing key, and the
+        record has not expired. Only ``did:key`` is supported here, since the key
+        is in the identifier and needs no network lookup.
+        """
+        if self.signature is None or not self.signature.startswith("z"):
+            return False
+        if not is_did_key(self.did):
+            return False
+        if self.is_expired():
+            return False
+        try:
+            raw_pub = ed25519_public_from_did_key(self.did)
+        except ValueError:
+            return False
+        try:
+            sig = _b58decode(self.signature[1:])
+            Ed25519PublicKey.from_public_bytes(raw_pub).verify(
+                sig, jcs.canonicalize(self._unsigned())
+            )
+            return True
+        except (InvalidSignature, ValueError):
+            return False
+
+
+def build_route_record(
+    *,
+    did: str,
+    endpoint: str,
+    private_key: Ed25519PrivateKey,
+    facet: str = DEFAULT_FACET,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> RouteRecord:
+    """
+    Build and sign a :class:`RouteRecord`. The agent calls this to announce
+    where it can currently be reached. ``private_key`` must be the Ed25519 key
+    behind ``did`` (a ``did:key``).
+    """
+    record = RouteRecord(
+        did=did,
+        endpoint=endpoint,
+        facet=facet,
+        expires=_format_iso8601(_now() + timedelta(seconds=ttl_seconds)),
+        nonce=os.urandom(12).hex(),
+    )
+    sig = private_key.sign(jcs.canonicalize(record._unsigned()))
+    record.signature = "z" + _b58encode(sig)
+    return record
+
+
+class RendezvousRegistry:
+    """
+    A single in-memory rendezvous point: agents announce signed route records,
+    senders resolve them by DID. This is the simplest thing that proves the
+    contract; a production deployment replaces it with a real overlay while
+    keeping the same record format and verification.
+    """
+
+    def __init__(self) -> None:
+        # (fingerprint, facet) -> RouteRecord
+        self._records: Dict[Tuple[str, str], RouteRecord] = {}
+
+    def announce(self, record: RouteRecord) -> None:
+        """
+        Store a route record after verifying it. A record that fails
+        verification (bad signature, wrong DID, expired) is rejected, so the
+        registry never serves a route the DID holder did not sign.
+        """
+        if not record.verify():
+            raise ValueError("route record failed verification; not announced")
+        self._records[(route_fingerprint(record.did), record.facet)] = record
+
+    def resolve(self, did: str, facet: str = DEFAULT_FACET) -> Optional[str]:
+        """
+        Return the current endpoint for ``did`` on ``facet``, or ``None`` if the
+        DID is unknown or its record has expired. The record is re-verified on
+        read, so an entry that aged out is not served.
+        """
+        record = self._records.get((route_fingerprint(did), facet))
+        if record is None or not record.verify():
+            return None
+        return record.endpoint
+
+
+# An inbox handler takes a request frame and returns a reply frame.
+InboxHandler = Callable[[bytes], Awaitable[bytes]]
+
+
+class RendezvousChannel:
+    """
+    A :class:`UdnaChannel` backed by a :class:`RendezvousRegistry`.
+
+    It proves the full identity-first path with no DNS: resolve a ``udna://``
+    address to the DID's current endpoint, then deliver the frame to the inbox
+    registered for that endpoint. Delivery here is in-process (a registered
+    coroutine), which keeps the proof self-contained; a real channel would carry
+    the same frame to that endpoint over the network.
+    """
+
+    def __init__(self, registry: RendezvousRegistry) -> None:
+        self._registry = registry
+        self._inboxes: Dict[str, InboxHandler] = {}
+
+    def register_inbox(self, endpoint: str, handler: InboxHandler) -> None:
+        """Bind an endpoint string to an in-process handler (the loopback)."""
+        self._inboxes[endpoint] = handler
+
+    @staticmethod
+    def _split(udna_address: str) -> Tuple[str, str]:
+        body = udna_address.split("://", 1)[1] if "://" in udna_address else udna_address
+        if "/" in body:
+            did, facet = body.rsplit("/", 1)
+            return did, facet
+        return body, DEFAULT_FACET
+
+    async def reachable(self, udna_address: str) -> bool:
+        did, facet = self._split(udna_address)
+        endpoint = self._registry.resolve(did, facet)
+        return endpoint is not None and endpoint in self._inboxes
+
+    async def exchange(self, udna_address: str, frame: bytes) -> bytes:
+        did, facet = self._split(udna_address)
+        endpoint = self._registry.resolve(did, facet)
+        if endpoint is None:
+            raise KeyError(f"no route record for {did} on facet {facet}")
+        handler = self._inboxes.get(endpoint)
+        if handler is None:
+            raise KeyError(f"no inbox registered for endpoint {endpoint}")
+        return await handler(frame)
+
+    async def close(self) -> None:
+        self._inboxes.clear()

--- a/vouch/transport/udna.py
+++ b/vouch/transport/udna.py
@@ -1,28 +1,28 @@
 """
-UDNA transport — identity-first routing via the Sirraya UDNA SDK.
+UDNA transport, identity-first routing via the Sirraya UDNA SDK.
 
 UDNA (Universal DID-Native Addressing) inverts the usual stack: instead of
 resolving an identity *down to* a location (DID → domain → IP) and trusting
 whoever answers, UDNA treats the DID itself as the routing primitive and
 establishes an end-to-end encrypted channel (Noise protocol) directly to the
-key that owns it. There is no location to spoof and no domain to seize — the
+key that owns it. There is no location to spoof and no domain to seize, the
 peer you reach is, by construction, the peer whose key matches the DID.
 
 This adapter targets the real ``sirraya-udna-sdk`` (distribution
 ``sirraya-udna-sdk``, import package ``udna_sdk``, v1.0.x). That SDK provides:
 
-  * **DID generation** — ``UdnaSDK.create_did()`` mints a ``did:key`` whose
+  * **DID generation**, ``UdnaSDK.create_did()`` mints a ``did:key`` whose
     encoding (``z`` + base58(``0xed01`` ‖ pubkey)) is byte-identical to Vouch's
     own Multikey, so the two interoperate without translation.
-  * **UDNA address creation** — ``UdnaSDK.create_address(did, facet_id, flags)``
+  * **UDNA address creation**, ``UdnaSDK.create_address(did, facet_id, flags)``
     produces a signed, base58 UDNA address. ``facet_id`` selects a capability
     lane (``0x01`` Control, ``0x02`` Messaging, ``0x03`` Telemetry).
-  * **Address verification** — ``UdnaSDK.verify_address(address)`` checks the
+  * **Address verification**, ``UdnaSDK.verify_address(address)`` checks the
     address signature against the DID's key.
-  * **Secure messaging** — ``udna_sdk.udna.NoiseHandshake`` (a handshake that
+  * **Secure messaging**, ``udna_sdk.udna.NoiseHandshake`` (a handshake that
     exchanges DID-signed ephemeral keys) plus ``SecureMessaging``
     (ChaCha20-Poly1305 over the derived session key). NOTE: the v1.0.x handshake
-    authenticates peers but does *not* provide confidentiality — see the
+    authenticates peers but does *not* provide confidentiality, see the
     security warning on :class:`SirrayaUdnaNode`.
 
 What the SDK deliberately does *not* ship is a production wire transport: byte
@@ -34,7 +34,7 @@ in-memory demo). So this adapter splits the two concerns cleanly:
     Noise/SecureMessaging crypto with a pluggable :class:`UdnaChannel` that
     actually moves the bytes.
   * everything is *optional*. When the SDK is absent, or no node/channel is
-    wired, the transport is **dormant** — ``can_route`` returns nothing and the
+    wired, the transport is **dormant**, ``can_route`` returns nothing and the
     routing manager falls back to HTTP. UDNA being unavailable is never fatal;
     that is the whole point of the hybrid design.
 """
@@ -48,7 +48,7 @@ from .base import PeerAddress, Transport, TransportUnavailable
 from .did_key import did_key_from_ed25519_public, did_key_from_public_jwk
 from .envelope import VouchEnvelope
 
-#: Default facet — the capability lane Vouch messages travel on. Maps to the
+#: Default facet, the capability lane Vouch messages travel on. Maps to the
 #: SDK's Messaging facet (``facet_id=0x02``).
 DEFAULT_FACET = "vouch.message"
 
@@ -120,8 +120,8 @@ class UdnaChannel(Protocol):
 
     This is the piece ``sirraya-udna-sdk`` does *not* provide: the SDK supplies
     DID/address/Noise crypto but no production wire transport (only an in-memory
-    demo DHT). A deployment plugs in its own delivery here — a relay, a
-    libp2p/QUIC overlay, a websocket bridge — and :class:`SirrayaUdnaNode`
+    demo DHT). A deployment plugs in its own delivery here, a relay, a
+    libp2p/QUIC overlay, a websocket bridge, and :class:`SirrayaUdnaNode`
     layers the SDK's Noise handshake and ChaCha20-Poly1305 encryption on top.
     """
 
@@ -176,13 +176,13 @@ class UdnaTransport(Transport):
         """
         Build a UDNA transport backed by ``sirraya-udna-sdk``.
 
-        Returns a *dormant* transport (no node) — never raises — when any
+        Returns a *dormant* transport (no node), never raises, when any
         prerequisite is missing, so a caller can always wire UDNA in
         optimistically and rely on graceful fallback. The prerequisites are:
 
           * the ``udna_sdk`` package is importable;
           * ``private_key_jwk`` is supplied (the node's own ``did:key`` and the
-            Noise handshake are bound to this Ed25519 key — the same key Vouch
+            Noise handshake are bound to this Ed25519 key, the same key Vouch
             signs with);
           * a ``channel`` is supplied (the SDK provides no wire transport, so
             byte delivery must come from the deployment).
@@ -243,7 +243,7 @@ class UdnaTransport(Transport):
     # ------------------------------------------------------------------ #
     async def can_route(self, did: str) -> bool:
         """
-        UDNA can route any DID — *if* a node is attached. With no node the
+        UDNA can route any DID, *if* a node is attached. With no node the
         transport is dormant and routes nothing, so the manager falls back.
         """
         return self._node is not None and bool(did)
@@ -337,7 +337,7 @@ def _try_build_sirraya_node(
     ``None`` (so the transport stays dormant and the manager falls back).
 
     Prerequisites: the ``udna_sdk`` package importable, an identity key, and a
-    delivery channel (the SDK ships no wire transport — see :class:`UdnaChannel`).
+    delivery channel (the SDK ships no wire transport, see :class:`UdnaChannel`).
     """
     try:
         import udna_sdk  # type: ignore  # noqa: F401
@@ -378,7 +378,7 @@ class SirrayaUdnaNode:
     .. warning::
        **The bundled ``udna_sdk`` v1.0.x handshake does NOT provide transport
        confidentiality.** Its ``finalize_handshake`` derives the session key as
-       ``sha256(local_did ‖ remote_did ‖ both ephemeral *public* keys)`` — every
+       ``sha256(local_did ‖ remote_did ‖ both ephemeral *public* keys)``, every
        input is sent in the clear, with no Diffie-Hellman, so a passive observer
        can recompute the key and decrypt the ChaCha20-Poly1305 frames (the SDK's
        own code comments it as a demo placeholder for "a full Noise

--- a/website-agent/backend/knowledge/transport.md
+++ b/website-agent/backend/knowledge/transport.md
@@ -1,0 +1,95 @@
+# Identity-Native Transport Reference
+
+Vouch addresses a peer by its DID, not its IP or domain. The transport
+layer (`vouch.transport`) prefers identity-first routing over UDNA
+(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
+when a peer is not on the overlay. An agent dispatches a message to a DID
+and stays agnostic about how the bytes are routed.
+
+This is optional and experimental. It is aligned with the W3C UDNA
+Community Group and is dormant unless you opt in.
+
+## Why it exists
+
+Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
+They rarely hold a stable domain or IP, but they always hold a key, so a
+DID is the only stable handle. Identity-first routing matches how agents
+actually run. Vouch already makes a DID accountable (identity, reputation,
+liability); UDNA answers how to reach it.
+
+## How it routes
+
+`TransportManager` holds an ordered list of transports and tries them in
+preference order:
+
+1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
+
+A transport that cannot reach a peer raises `TransportUnavailable`, and the
+manager moves to the next one. `DeliveryResult.attempts` records the path
+taken, for example `["udna", "http"]`.
+
+## What "route by DID" means
+
+The DID Document (the json with the DID and public key) is a key store, not
+a routing target. Its job is to give you the public key so you can verify
+signatures. Location comes from elsewhere. In `did:web`, the location is a
+`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
+a signed route record under its DID, and a resolver maps the DID to the
+agent's current endpoint, so there is no domain to seize and no DNS to
+poison. The key is the constant; the location is dynamic and self-published.
+
+## Payload preservation
+
+The message is a `VouchEnvelope` that carries three things unchanged: the
+signed Vouch credential (with its Data Integrity proof), liability
+attestations, and provenance metadata. A JCS-canonical SHA-256 content
+digest is verified on receipt, so the trust properties hold whichever path
+the bytes take. Switching from UDNA to HTTP never re-signs or strips the
+payload.
+
+## Quick start
+
+```python
+from vouch import Signer, generate_identity
+from vouch.transport import TransportManager, build_envelope
+
+kp = generate_identity(domain="agent.example.com")
+signer = Signer(private_key=kp.private_key_jwk, did=kp.did)
+credential = signer.sign_credential(intent={
+    "action": "settle_invoice",
+    "target": "invoice-42",
+    "resource": "https://api.example.com/invoices/42",
+})
+
+envelope = build_envelope(
+    from_did=kp.did,
+    to_did="did:web:peer.example.com",
+    payload=credential,
+)
+
+manager = TransportManager.default(private_key_jwk=kp.private_key_jwk)
+result = await manager.dispatch(envelope)
+print(result.transport)   # "udna" or "http"
+```
+
+Install the optional dependency with `pip install vouch-protocol[udna]`.
+Without it, the UDNA transport stays dormant and dispatch falls through to
+HTTP, so the code above runs unchanged.
+
+## Security note
+
+The reference UDNA SDK (`udna_sdk` v1.0.x) authenticates the peer during
+its handshake but does not provide channel confidentiality: its session key
+is derived from public values, so the channel should not be treated as
+private yet. Vouch does not rely on it. Envelope payloads are signed
+credentials, so their integrity and authenticity hold end to end no matter
+which transport carries them. For confidential payloads, encrypt at the
+application layer before sealing, or use a transport with real channel
+encryption.
+
+## See also
+
+- `docs/HYBRID_TRANSPORT.md` for the architecture.
+- `docs/udna-upstream-proposal.md` for the security finding and a proposed
+  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -159,7 +159,7 @@ export default function HomePage() {
             identity and delegation specifications. Built on Verifiable Credentials, Data Integrity
             proofs, and Decentralized Identifiers, with one byte-exact core and SDKs for every major
             platform: web, mobile, JVM, .NET, and native, plus the Python, TypeScript, and Go references.
-            Agents are reached by who they are, not where they are.
+            Agents can be reached by who they are, not where they are.
           </p>
           <div className="flex flex-wrap gap-3 items-center">
             <Link href="/faq/" className="btn-primary">Read the FAQ</Link>


### PR DESCRIPTION
Continues the work from #175, which closed automatically during a branch update on main. The branch and commits are unchanged and rebased on current main.

## Description

Follow-up to #170. Lands a few transport changes that the #170 squash missed, plus the next piece of the transport story.

What was missing from `main`:
- a writing-style cleanup of the transport code and docs,
- the hero reword on the homepage,
- the assistant-knowledge sync for the transport topic.

What is new:
- an identity-first **rendezvous resolver**, the routing piece UDNA needs that the reference SDK does not yet have: resolve a DID to the agent's current endpoint, with the mapping signed by the agent itself, no DNS in the path.

## Changes Made

- **Writing-style cleanup** of the merged transport code, docs, example, and tests. No behavior change.
- **Website**: reword the hero clause to "Agents can be reached by who they are, not where they are."
- **Assistant knowledge**: add a `transport.md` topic file and propagate the identical copy to all four assistant surfaces (Knowledge Base, Claude Skill, OpenAI GPT, Gemini Gem), plus an FAQ section and a Help Guide part. Measured framing, with the channel-confidentiality caveat stated.
- **Rendezvous resolver** (`vouch/transport/rendezvous.py`):
  - `RouteRecord`: a signed (Ed25519) binding of a DID to an endpoint and expiry, self-authenticating against the `did:key`.
  - `RendezvousRegistry`: announce and resolve by DID, records re-verified on read. A single in-memory rendezvous, deliberately not a DHT. The record format and verification are the parts worth pinning down first; the overlay swaps in later without changing them.
  - `RendezvousChannel`: a `UdnaChannel` that resolves a DID and delivers to the registered inbox, so it drops in behind the transport stack.
  - `tests/test_transport_rendezvous.py` and `examples/udna_rendezvous_demo.py`.

## Testing

29 transport tests pass. `ruff check` and `ruff format --check` pass. Both demos run end to end.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_01D85PkkWmtKp7YRvebxxdRJ)_