### PR TITLE
feat(accountability): third-party timestamp anchor and generic AccountabilityRecord fields

### DIFF
--- a/docs/disclosures/PAD-071-outcome-evidence-commit-before-outcome-credential.md
+++ b/docs/disclosures/PAD-071-outcome-evidence-commit-before-outcome-credential.md
@@ -182,6 +182,24 @@ caller.
 
 ---
 
+## Update (2026-06-27): Third-party timestamp anchoring
+
+The original disclosure relied on the signed `created` time to fix the commitment
+before its outcome. On its own that timestamp is asserted by the committer, so the
+pre-outcome timing is only as trustworthy as the committer's clock. This update
+adds an optional `anchor` to the commitment: one entry or a tier list, each
+carrying a `method` (a third-party timestamping service such as OpenTimestamps,
+an RFC 3161 timestamp authority, a transparency log, or an on-chain method), a
+`reference` to the proof at that service, and a `recomputeCmd` a verifier runs to
+check it. With an anchor, a consumer confirms the commitment existed before the
+outcome without trusting the committer. The anchor is carried inside the signed
+credential, so it is tamper-evident, and the anchor itself is checked out of band
+by the consumer against the named method. The original claims are unchanged; the
+anchor is a disclosed strengthening of the pre-outcome timing property, released
+under Apache 2.0.
+
+---
+
 ## Prior Art Declaration
 
 This document is published as a defensive disclosure to establish prior art as of

--- a/docs/interop/erc-8004-crosswalk.md
+++ b/docs/interop/erc-8004-crosswalk.md
@@ -1,0 +1,57 @@
+# Crosswalk: Vouch accountability records and ERC-8004 / ERC-8299
+
+Status: draft. This maps Vouch's neutral accountability fields onto the Ethereum
+agent-standards vocabulary so a record is portable across a Verifiable Credential
+and an on-chain transport, without either side depending on the other. Vouch
+defines its own fields; this document is the bridge, not a normative reference to
+the ERCs.
+
+Credit: ERC-8004 "Trustless Agents" (Identity, Reputation, Validation registries)
+and ERC-8299 ("What You Read Is What You Execute", JudgmentExecutionAttestation,
+the anchor-tier hierarchy) informed the field set below.
+
+## Why a crosswalk rather than a dependency
+
+Vouch is off-chain and crypto-agnostic (W3C Verifiable Credentials, eddsa-jcs-2022,
+optional hybrid post-quantum). The ERC vocabulary is on-chain and EVM-native
+(ERC-721 identity, schnorr/secp256k1, on-chain settlement). Keeping the Vouch
+fields self-contained lets enterprise and non-EVM deployments use the same record
+shape, while this crosswalk keeps it interoperable with the on-chain world. One
+record, two transports, no translation layer required at the field level.
+
+## OutcomeCommitment
+
+| Vouch field | ERC-8299 / 8004 | Notes |
+|---|---|---|
+| `commitment.digest` | `verdictHash` / `artifactHash` | salted SHA-256 over JCS-canonical claim |
+| `validFrom` | `verdictTimestamp` (committed time) | self-asserted unless anchored |
+| `commitment.anchor[]` `{method, reference, recomputeCmd}` | ERC-8299 Appendix B anchor hierarchy | open `method` string; a consumer takes the strongest surviving tier |
+| `settlement` `{method, locator, resolutionCriteria}` | resolution descriptor | transport-neutral on the Vouch side |
+| `proof` (eddsa-jcs-2022) | on-chain signature | a pointer references on-chain entries; it does not re-verify their crypto |
+
+## OutcomeAttestation
+
+| Vouch field | ERC-8299 / 8004 | Notes |
+|---|---|---|
+| `commitment.credentialId` | `commitmentRef` / `rawProposalHash` link | binds outcome to its commitment |
+| `reveal` `{claim, salt}` | revealed input | lets any party recompute the committed digest |
+| `outcome.matchesCommitment` | settled result | wins and losses, same record |
+| `settlement` `{venue, reference}` | `settlementVenue` / `executedActionHash` | where the issuer cannot edit it |
+
+## AccountabilityRecord (the pointer)
+
+| Vouch field | ERC-8299 / 8004 | Notes |
+|---|---|---|
+| `ledger` / `recordPointer` | reputation-registry feed + entry | resolvable locator |
+| `verifierKey` | published signing key | verify against this, not the presenter |
+| `verifyEndpoint` | recompute service | a convenience, not a trust root |
+| `reputationModel` (`recomputable` \| `asserted-score`) | registry model | recomputable carries derivation inputs |
+| `publishesLosses` | feed integrity flag | a feed that hides losses is not accountability |
+
+## Verification stance
+
+Vouch carries the pointer and the anchor inside a signed credential, so both are
+tamper-evident. Vouch does not re-verify an on-chain or schnorr-signed external
+record's own cryptography; the consumer checks that record at its native venue
+using `verifierKey` and the anchor `recomputeCmd`. The credential answers "who and
+what record"; the linked attestation and its anchor answer "and can I check it".

--- a/tests/test_accountability.py
+++ b/tests/test_accountability.py
@@ -13,6 +13,7 @@ from vouch.accountability import (
     attest_outcome,
     commit_outcome,
     commitment_digest,
+    timestamp_anchor,
     verify_attestation,
     verify_commitment,
 )
@@ -231,3 +232,91 @@ class TestDigest:
         d2 = commitment_digest(CLAIM, None)
         assert d1 == d2
         assert commitment_digest(CLAIM, b"\x00" * 32) != d1
+
+
+class TestAnchor:
+    def test_anchor_embedded_and_signed(self):
+        kp, signer = _identity()
+        anchor = timestamp_anchor("opentimestamps", "ref-abc", "ots verify -d ref-abc")
+        cred, _ = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, anchor=anchor)
+        embedded = cred["credentialSubject"]["commitment"]["anchor"]
+        assert embedded[0]["method"] == "opentimestamps"
+        assert embedded[0]["recomputeCmd"] == "ots verify -d ref-abc"
+        ok, _ = verify_commitment(cred, kp.public_key_jwk)
+        assert ok is True
+
+    def test_anchor_is_tamper_evident(self):
+        kp, signer = _identity()
+        cred, _ = commit_outcome(
+            signer,
+            claim=CLAIM,
+            settlement=SETTLEMENT,
+            anchor=timestamp_anchor("rfc3161-tsa", "ref-1"),
+        )
+        cred["credentialSubject"]["commitment"]["anchor"][0]["reference"] = "forged"
+        ok, _ = verify_commitment(cred, kp.public_key_jwk)
+        assert ok is False  # anchor is inside the signed credential
+
+    def test_anchor_accepts_multiple_tiers(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(
+            signer,
+            claim=CLAIM,
+            settlement=SETTLEMENT,
+            anchor=[
+                timestamp_anchor("opentimestamps", "a"),
+                timestamp_anchor("nostr-relay", "b"),
+            ],
+        )
+        assert len(cred["credentialSubject"]["commitment"]["anchor"]) == 2
+
+    def test_anchor_requires_method_and_reference(self):
+        _, signer = _identity()
+        with pytest.raises(AccountabilityError):
+            commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, anchor={"method": "x"})
+
+    def test_timestamp_anchor_helper(self):
+        a = timestamp_anchor("transparency-log", "leaf-7", "rekor verify leaf-7")
+        assert a == {
+            "method": "transparency-log",
+            "reference": "leaf-7",
+            "recomputeCmd": "rekor verify leaf-7",
+        }
+
+
+class TestSettlementAndPointerFields:
+    def test_attestation_settlement_fields(self):
+        kp, signer = _identity()
+        cred, secret = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT, private=True)
+        att = attest_outcome(
+            signer,
+            commitment=cred,
+            outcome=OUTCOME,
+            secret=secret,
+            settlement_venue="public-onchain-account",
+            settlement_ref="tx-0x123",
+        )
+        s = att["credentialSubject"]["settlement"]
+        assert s["venue"] == "public-onchain-account"
+        assert s["reference"] == "tx-0x123"
+        ok, _ = verify_attestation(att, kp.public_key_jwk)
+        assert ok is True
+
+    def test_pointer_generic_fields(self):
+        p = accountability_pointer(
+            ledger="https://example.com/ledger",
+            verifier_key="z6Mk-published-key",
+            record_pointer="https://example.com/ledger/entry/7",
+            verify_endpoint="https://example.com/verify-proof",
+            reputation_model="recomputable",
+            publishes_losses=True,
+        )
+        assert p["verifierKey"] == "z6Mk-published-key"
+        assert p["recordPointer"] == "https://example.com/ledger/entry/7"
+        assert p["verifyEndpoint"] == "https://example.com/verify-proof"
+        assert p["reputationModel"] == "recomputable"
+        assert p["publishesLosses"] is True
+
+    def test_pointer_rejects_bad_reputation_model(self):
+        with pytest.raises(AccountabilityError):
+            accountability_pointer(ledger="https://x.example", reputation_model="made-up")

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -198,6 +198,7 @@ def __getattr__(name):
         "verify_attestation",
         "accountability_pointer",
         "commitment_digest",
+        "timestamp_anchor",
         "OUTCOME_COMMITMENT_TYPE",
         "OUTCOME_ATTESTATION_TYPE",
     ):
@@ -357,6 +358,7 @@ __all__ = [
     "verify_attestation",
     "accountability_pointer",
     "commitment_digest",
+    "timestamp_anchor",
     "OUTCOME_COMMITMENT_TYPE",
     "OUTCOME_ATTESTATION_TYPE",
     # Reputation receipts and aggregation

--- a/vouch/accountability.py
+++ b/vouch/accountability.py
@@ -121,6 +121,39 @@ def _type_list(credential: Dict[str, Any]) -> list:
 # ---------------------------------------------------------------------------
 
 
+def timestamp_anchor(
+    method: str, reference: str, recompute_cmd: Optional[str] = None
+) -> Dict[str, Any]:
+    """
+    Build a third-party timestamp anchor for a commitment.
+
+    `method` names the external timestamping service (for example
+    ``opentimestamps``, ``rfc3161-tsa``, ``transparency-log``, or an on-chain
+    method), `reference` is the proof or locator at that service, and
+    `recompute_cmd` is the literal command a verifier runs to check it. The anchor
+    lets a consumer confirm a commitment existed before its outcome without
+    trusting the committer's own clock.
+    """
+    if not method or not reference:
+        raise AccountabilityError("an anchor needs a method and a reference")
+    entry: Dict[str, Any] = {"method": method, "reference": reference}
+    if recompute_cmd is not None:
+        entry["recomputeCmd"] = recompute_cmd
+    return entry
+
+
+def _normalize_anchor(anchor: Any) -> Optional[list]:
+    if anchor is None:
+        return None
+    items = anchor if isinstance(anchor, list) else [anchor]
+    out = []
+    for a in items:
+        if not isinstance(a, dict) or not a.get("method") or not a.get("reference"):
+            raise AccountabilityError("each anchor needs a method and a reference")
+        out.append(dict(a))
+    return out
+
+
 def commit_outcome(
     signer: Any,
     *,
@@ -130,6 +163,7 @@ def commit_outcome(
     claim_type: str = "prediction",
     private: bool = False,
     salt: Optional[bytes] = None,
+    anchor: Any = None,
     valid_from: Optional[datetime] = None,
     credential_id: Optional[str] = None,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
@@ -157,6 +191,11 @@ def commit_outcome(
         private: If True, withhold the cleartext claim and publish only the digest.
         salt: Optional explicit salt. A random 32-byte salt is generated when the
             commitment is private and no salt is supplied.
+        anchor: Optional third-party timestamp anchor (one entry or a list of
+            tiers), each ``{"method", "reference", "recomputeCmd"?}``. Built with
+            :func:`timestamp_anchor`. It makes the pre-outcome timing checkable
+            without trusting the committer's own clock; absent it, the timing is
+            self-asserted by the signed ``validFrom``.
         valid_from: Commitment time (defaults to now, UTC).
         credential_id: Optional credential id (defaults to a ``urn:uuid``).
 
@@ -176,18 +215,23 @@ def commit_outcome(
     if salt is None and private:
         salt = secrets.token_bytes(32)
     digest = commitment_digest(claim, salt)
+    normalized_anchor = _normalize_anchor(anchor)
 
     issuer = signer.get_did()
     issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
 
+    commitment_block: Dict[str, Any] = {
+        "algorithm": COMMITMENT_ALGORITHM,
+        "digest": _mb64(digest),
+        "salted": salt is not None,
+    }
+    if normalized_anchor is not None:
+        commitment_block["anchor"] = normalized_anchor
+
     subject_block: Dict[str, Any] = {
         "id": subject or issuer,
         "claimType": claim_type,
-        "commitment": {
-            "algorithm": COMMITMENT_ALGORITHM,
-            "digest": _mb64(digest),
-            "salted": salt is not None,
-        },
+        "commitment": commitment_block,
         "settlement": dict(settlement),
     }
     if not private:
@@ -263,6 +307,8 @@ def attest_outcome(
     claim: Optional[Dict[str, Any]] = None,
     salt: Optional[bytes] = None,
     matches: Optional[bool] = None,
+    settlement_venue: Optional[str] = None,
+    settlement_ref: Optional[str] = None,
     valid_from: Optional[datetime] = None,
     credential_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -287,6 +333,9 @@ def attest_outcome(
         salt: The raw salt bytes, if not supplied via ``secret``.
         matches: Optional explicit verdict on whether the claim proved correct;
             recorded as ``outcome.matchesCommitment``.
+        settlement_venue: Optional name of the venue where the outcome is recorded
+            and the issuer cannot edit it (a chain, a notary, a public feed).
+        settlement_ref: Optional locator of the settlement at that venue.
         valid_from: Settlement time (defaults to now, UTC).
         credential_id: Optional credential id (defaults to a ``urn:uuid``).
 
@@ -340,6 +389,13 @@ def attest_outcome(
         "reveal": reveal,
         "outcome": outcome_block,
     }
+    if settlement_venue is not None or settlement_ref is not None:
+        settlement: Dict[str, Any] = {}
+        if settlement_venue is not None:
+            settlement["venue"] = settlement_venue
+        if settlement_ref is not None:
+            settlement["reference"] = settlement_ref
+        subject_block["settlement"] = settlement
 
     credential: Dict[str, Any] = {
         "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
@@ -429,6 +485,11 @@ def accountability_pointer(
     record: Optional[str] = None,
     subject: Optional[str] = None,
     digest: Optional[str] = None,
+    verifier_key: Optional[str] = None,
+    record_pointer: Optional[str] = None,
+    verify_endpoint: Optional[str] = None,
+    reputation_model: Optional[str] = None,
+    publishes_losses: Optional[bool] = None,
 ) -> Dict[str, Any]:
     """
     Build a vendor-neutral ``AccountabilityRecord`` pointer that another credential
@@ -439,9 +500,23 @@ def accountability_pointer(
         record: Optional anchor or id of the specific record within the ledger.
         subject: Optional DID the record is about.
         digest: Optional commitment digest the pointer references.
+        verifier_key: Optional published key every entry is signed against, so a
+            consumer verifies against it rather than trusting the presenter.
+        record_pointer: Optional resolvable feed plus per-entry path.
+        verify_endpoint: Optional free, no-auth recompute endpoint, a convenience
+            on top of self-recompute, not a trust root.
+        reputation_model: Optional ``recomputable`` (a consumer derives standing
+            from public inputs) or ``asserted-score`` (a stored number to trust).
+        publishes_losses: Optional flag asserting the feed publishes losses, not
+            only wins.
     """
     if not ledger:
         raise AccountabilityError("ledger is required")
+    if reputation_model is not None and reputation_model not in (
+        "recomputable",
+        "asserted-score",
+    ):
+        raise AccountabilityError("reputationModel must be 'recomputable' or 'asserted-score'")
     pointer: Dict[str, Any] = {"type": ACCOUNTABILITY_RECORD_TYPE, "ledger": ledger}
     if record is not None:
         pointer["record"] = record
@@ -449,6 +524,16 @@ def accountability_pointer(
         pointer["subject"] = subject
     if digest is not None:
         pointer["digest"] = digest
+    if verifier_key is not None:
+        pointer["verifierKey"] = verifier_key
+    if record_pointer is not None:
+        pointer["recordPointer"] = record_pointer
+    if verify_endpoint is not None:
+        pointer["verifyEndpoint"] = verify_endpoint
+    if reputation_model is not None:
+        pointer["reputationModel"] = reputation_model
+    if publishes_losses is not None:
+        pointer["publishesLosses"] = bool(publishes_losses)
     return pointer
 
 
@@ -459,6 +544,7 @@ __all__ = [
     "COMMITMENT_ALGORITHM",
     "AccountabilityError",
     "commitment_digest",
+    "timestamp_anchor",
     "commit_outcome",
     "verify_commitment",
     "attest_outcome",


### PR DESCRIPTION
Closes the schema discussion in #53 by turning the field requests into shipped, optional fields.

## What

- **OutcomeCommitment `anchor`**: an optional third-party timestamp (one entry or a tier list), each `{method, reference, recomputeCmd}`, built with `timestamp_anchor()`. `method` is an open string (opentimestamps, rfc3161-tsa, transparency-log, on-chain, etc.). It makes the pre-outcome timing checkable without trusting the committer's clock. The anchor sits inside the signed credential, so it is tamper-evident; the consumer checks it out of band via `recomputeCmd`.
- **Generic `AccountabilityRecord` fields**: `verifierKey`, `recordPointer`, `verifyEndpoint`, `reputationModel` (recomputable or asserted-score), `publishesLosses`.
- **OutcomeAttestation `settlement`**: optional `settlement_venue` and `settlement_ref`.
- **PAD-071** amended with the anchor as a disclosed strengthening of the pre-outcome timing property.
- **Crosswalk doc** (`docs/interop/erc-8004-crosswalk.md`): maps these neutral fields onto ERC-8004 and ERC-8299 so a record is portable across a VC and an on-chain transport, without depending on either.

## Why

The fields stay crypto-agnostic and self-contained; the ERC vocabulary is a crosswalk target, not a dependency. This keeps enterprise and non-EVM deployments on the same record shape while staying interoperable with the on-chain agent-standards world.

## Tests

26 tests in `tests/test_accountability.py` (5 new anchor tests, 3 settlement and pointer tests), all passing; ruff clean.
