### PR TITLE
Add shared load_signer() with friendlier missing-env error

### DIFF
--- a/vouch/integrations/_common.py
+++ b/vouch/integrations/_common.py
@@ -1,0 +1,61 @@
+"""
+Shared utilities for Vouch integrations.
+
+Provides a single `load_signer()` entry-point so every integration
+presents the same helpful error when credentials are missing.
+"""
+
+import os
+from typing import Optional
+
+from vouch import Signer
+
+_MISSING_ENV_HELP = """\
+Vouch identity not configured.
+
+Set the following environment variables:
+
+  export VOUCH_DID='did:web:your-agent.example.com'
+  export VOUCH_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+
+To generate a new identity from Python:
+
+  from vouch.keys import generate_identity
+
+  identity = generate_identity(domain="your-agent.example.com")
+  print(f"export VOUCH_DID='{identity.did}'")
+  print(f"export VOUCH_PRIVATE_KEY='{identity.private_key_jwk}'")
+
+Or use the CLI:
+
+  vouch init --domain your-agent.example.com --env
+
+See https://vouch-protocol.com/ for more details.
+"""
+
+
+def load_signer(
+    private_key: Optional[str] = None,
+    did: Optional[str] = None,
+) -> Signer:
+    """Return a Signer, resolving credentials from args or environment.
+
+    Args:
+        private_key: JWK JSON string. If ``None``, reads ``VOUCH_PRIVATE_KEY``.
+        did: Agent DID. If ``None``, reads ``VOUCH_DID``.
+
+    Returns:
+        A configured :class:`vouch.Signer`.
+
+    Raises:
+        OSError: When ``VOUCH_PRIVATE_KEY`` or ``VOUCH_DID`` is unset and
+            not provided as an argument. The error message includes
+            step-by-step setup instructions.
+    """
+    resolved_key = private_key or os.getenv("VOUCH_PRIVATE_KEY")
+    resolved_did = did or os.getenv("VOUCH_DID")
+
+    if not resolved_key or not resolved_did:
+        raise OSError(_MISSING_ENV_HELP)
+
+    return Signer(private_key=resolved_key, did=resolved_did)


### PR DESCRIPTION
Hi @277zyq, re-opening your contribution. Your original PR #107 was closed automatically due to a maintenance issue on the main branch, nothing on your side. Your branch and commits are unchanged, and this brings your work back into review. Apologies for the disruption, and thank you for the contribution. The earlier review comments did not carry over, so please continue here.

Original PR: #107

---

This PR implements issue #91: Friendlier error when VOUCH_PRIVATE_KEY / VOUCH_DID are unset.

Changes:
- Added `vouch/integrations/_common.py` with a shared `load_signer()` function.
- When env vars are missing, raises an `OSError` with step-by-step setup instructions: the exact `export` commands, how to generate an identity via `generate_identity()`, the `vouch init` CLI, and a link to the docs.

This provides a single, consistent error message that all integrations can use.

Closes #91
