### PR TITLE
Print helpful message when vouch init is run without --domain

### DIFF
--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -71,7 +71,15 @@ def cmd_init(args: argparse.Namespace) -> int:
     """Generate a new Ed25519 keypair for agent identity."""
     try:
         # Build DID
-        domain = args.domain if args.domain else "example.com"
+        if args.domain:
+            domain = args.domain
+        else:
+            domain = "example.com"
+            print(
+                "No domain specified, using 'example.com'."
+                " Pass --domain your.domain to set a real domain.",
+                file=sys.stderr,
+            )
 
         # Generate keys
         keys = generate_identity(domain)


### PR DESCRIPTION
Hi @fahadhewad, re-opening your contribution. Your original PR #132 was closed automatically due to a maintenance issue on the main branch, nothing on your side. Your branch and commits are unchanged. Apologies for the disruption, and thank you. The earlier review comments did not carry over, so please continue here.

Original PR: #132

---

Closes #128.

When `vouch init` is run with no domain argument, the CLI silently falls back to example.com with no explanation. This change prints a short message to stderr telling the user what default was chosen and how to pass their own domain.

Example output with this fix applied:

`vouch init`
`No domain specified, using example.com. Pass --domain your.domain to set a real domain.`
