### PR TITLE
Add WASM core smoke test to SDK CI

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -1,10 +1,11 @@
 name: SDK Tests
 
-# Compiles and tests the Go, Rust, and TypeScript SDKs on every PR. The existing
-# Tests workflow covers Python only; this closes the gap so a change that breaks
-# one of the other language implementations is caught in CI rather than after a
-# merge. Byte-identical interop is exercised by each SDK's robotics vector tests
-# against test-vectors/robotics/vector.json.
+# Compiles and tests the Go, Rust, TypeScript, and WebAssembly SDKs on every PR.
+# The existing Tests workflow covers Python only; this closes the gap so a change
+# that breaks one of the other language implementations is caught in CI rather
+# than after a merge. Byte-identical interop is exercised by each SDK's robotics
+# vector tests against test-vectors/robotics/vector.json, and the WASM smoke test
+# verifies the shared cross-implementation vectors.
 
 on:
   push:
@@ -55,3 +56,22 @@ jobs:
         run: |
           npm install
           npm test
+
+  wasm:
+    name: WASM core
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Build and smoke-test the WASM core
+        working-directory: core/wasm
+        run: |
+          wasm-pack build --target web --release
+          node smoke.mjs


### PR DESCRIPTION
Extends the SDK Tests workflow with a WASM core job: it builds the core-wasm package with wasm-pack and runs core/wasm/smoke.mjs, which verifies the shared cross-implementation test vectors (dual proof, composite credential, status list, delegation window). The published WASM/npm package was previously untested in CI.

Verified locally: wasm-pack build plus node smoke.mjs gives 13 pass, 0 fail.
