### PR TITLE
Index share buttons: brand icons matching the contributor certificate

### DIFF
--- a/website/src/app/agent-trust-index/ShareButtons.tsx
+++ b/website/src/app/agent-trust-index/ShareButtons.tsx
@@ -2,11 +2,60 @@
 
 import { useState } from 'react';
 
+// Icons match the contributor certificate share rail (scripts/render_contributor_cert.py):
+// brand glyphs in currentColor, square buttons that invert on hover.
+function IconShare() {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="18" cy="5" r="3" /><circle cx="6" cy="12" r="3" /><circle cx="18" cy="19" r="3" />
+            <path d="M8.6 13.5l6.8 4M15.4 6.5l-6.8 4" />
+        </svg>
+    );
+}
+function IconWhatsApp() {
+    return (
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413Z" />
+        </svg>
+    );
+}
+function IconX() {
+    return (
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24h-6.66l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+        </svg>
+    );
+}
+function IconBluesky() {
+    return (
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M5.06 3.51C7.6 5.42 10.33 9.28 11.33 11.36c.13.28.4.28.53 0C12.87 9.28 15.6 5.42 18.14 3.51c1.83-1.37 4.8-2.43 4.8.96 0 .68-.39 5.7-.62 6.52-.79 2.83-3.67 3.55-6.24 3.11 4.49.77 5.63 3.3 3.16 5.83-4.69 4.8-6.74-1.2-7.27-2.74-.1-.28-.14-.41-.14-.3 0-.11-.05.02-.14.3-.53 1.54-2.58 7.54-7.27 2.74-2.47-2.53-1.33-5.06 3.16-5.83-2.57.44-5.45-.28-6.24-3.11C.66 10.17.27 5.15.27 4.47.27 1.08 3.23 2.14 5.06 3.51z" />
+        </svg>
+    );
+}
+function IconLinkedIn() {
+    return (
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M20.45 20.45h-3.56v-5.57c0-1.33-.02-3.04-1.85-3.04-1.85 0-2.13 1.45-2.13 2.94v5.67H9.35V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.37-1.85 3.6 0 4.27 2.37 4.27 5.45v6.29zM5.34 7.43a2.06 2.06 0 1 1 0-4.13 2.06 2.06 0 0 1 0 4.13zM7.12 20.45H3.56V9h3.56v11.45zM22.22 0H1.77C.79 0 0 .77 0 1.72v20.56C0 23.23.79 24 1.77 24h20.45c.98 0 1.78-.77 1.78-1.72V1.72C24 .77 23.2 0 22.22 0z" />
+        </svg>
+    );
+}
+function IconLink() {
+    return (
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <path d="M10 13a5 5 0 0 0 7.07 0l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+            <path d="M14 11a5 5 0 0 0-7.07 0l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+        </svg>
+    );
+}
+
 export default function ShareButtons({ text, url }: { text: string; url: string }) {
     const [copied, setCopied] = useState(false);
     const enc = encodeURIComponent;
     const x = `https://x.com/intent/tweet?text=${enc(text)}&url=${enc(url)}`;
     const linkedin = `https://www.linkedin.com/sharing/share-offsite/?url=${enc(url)}`;
+    const whatsapp = `https://wa.me/?text=${enc(`${text} ${url}`)}`;
+    const bluesky = `https://bsky.app/intent/compose?text=${enc(`${text} ${url}`)}`;
 
     async function copy() {
         try {
@@ -14,27 +63,53 @@ export default function ShareButtons({ text, url }: { text: string; url: string 
             setCopied(true);
             setTimeout(() => setCopied(false), 2000);
         } catch {
-            // Clipboard blocked; the share links still work.
+            // Clipboard blocked; the other share links still work.
         }
     }
 
-    const cls =
-        'font-mono uppercase text-[0.7rem] tracking-[0.14em] text-ink-soft border-b border-transparent hover:text-burgundy hover:border-burgundy no-underline transition-colors';
+    async function nativeShare() {
+        if (typeof navigator !== 'undefined' && navigator.share) {
+            try {
+                await navigator.share({ title: 'The Agent Trust Index', text, url });
+                return;
+            } catch {
+                // User dismissed or share failed; fall through to copy.
+            }
+        }
+        copy();
+    }
+
+    const srx =
+        'inline-flex items-center justify-center w-[40px] h-[40px] border border-burgundy bg-parchment text-burgundy hover:bg-burgundy hover:text-parchment transition-colors no-underline [&>svg]:w-[18px] [&>svg]:h-[18px]';
 
     return (
-        <div className="flex flex-wrap items-center gap-5">
-            <span className="font-mono uppercase text-[0.62rem] tracking-[0.14em] text-ink-faint">
+        <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono uppercase text-[0.62rem] tracking-[0.14em] text-ink-faint mr-1">
                 Share this
             </span>
-            <a className={cls} href={x} target="_blank" rel="noopener noreferrer">
-                X
-            </a>
-            <a className={cls} href={linkedin} target="_blank" rel="noopener noreferrer">
-                LinkedIn
-            </a>
-            <button type="button" onClick={copy} className={cls}>
-                {copied ? 'Copied' : 'Copy link'}
+            <button type="button" onClick={nativeShare} className={srx} title="Share" aria-label="Share">
+                <IconShare />
             </button>
+            <a className={srx} href={whatsapp} target="_blank" rel="noopener noreferrer" title="Share on WhatsApp" aria-label="Share on WhatsApp">
+                <IconWhatsApp />
+            </a>
+            <a className={srx} href={x} target="_blank" rel="noopener noreferrer" title="Share on X" aria-label="Share on X">
+                <IconX />
+            </a>
+            <a className={srx} href={bluesky} target="_blank" rel="noopener noreferrer" title="Share on Bluesky" aria-label="Share on Bluesky">
+                <IconBluesky />
+            </a>
+            <a className={srx} href={linkedin} target="_blank" rel="noopener noreferrer" title="Share on LinkedIn" aria-label="Share on LinkedIn">
+                <IconLinkedIn />
+            </a>
+            <button type="button" onClick={copy} className={srx} title={copied ? 'Copied' : 'Copy link'} aria-label="Copy link">
+                <IconLink />
+            </button>
+            {copied && (
+                <span className="font-mono uppercase text-[0.62rem] tracking-[0.14em] text-burgundy ml-1">
+                    Copied
+                </span>
+            )}
         </div>
     );
 }


### PR DESCRIPTION
Replaces the plain-text X / LINKEDIN / COPY LINK with the same SVG icon rail used on the contributor certificate (scripts/render_contributor_cert.py): native Share, WhatsApp, X, Bluesky, LinkedIn, and copy link, as square buttons that invert on hover. Same icons, same interaction style. Component-only; the page already renders it. tsc clean, no em-dashes.