### PR TITLE
Additive developer-experience helpers (Agent, one-liners, tool guards)

### DIFF
--- a/examples/01_quickstart/01_hello_world.py
+++ b/examples/01_quickstart/01_hello_world.py
@@ -9,34 +9,39 @@ it. This is the modern credential path; new code should use it.
 Run: python 01_hello_world.py
 """
 
-from vouch import Signer, Verifier, generate_identity
+import vouch
 
-# 1. Generate a new identity (Ed25519 keypair).
-identity = generate_identity(domain="example.com")
-print(f"🔑 Generated identity with DID: {identity.did}")
+# An Agent bundles a fresh identity with its signer, so there is one object to
+# pass around. The intent binds the action to a concrete resource; every Vouch
+# credential requires action, target, and resource.
+agent = vouch.Agent("example.com")
+print(f"🔑 Generated identity with DID: {agent.did}")
 
-# 2. Create a signer with the identity.
-signer = Signer(private_key=identity.private_key_jwk, did=identity.did)
-
-# 3. Sign an action as a Verifiable Credential. The intent binds the action to a
-#    concrete resource; every Vouch credential requires action, target, and resource.
-signed = signer.sign_credential(
-    intent={
-        "action": "greet",
-        "target": "world",
-        "resource": "https://example.com/greetings",
-    }
+signed = agent.sign(
+    action="greet",
+    target="world",
+    resource="https://example.com/greetings",
 )
 print(f"\n✅ Signed a Verifiable Credential (cryptosuite: {signed['proof']['cryptosuite']})")
 
-# 4. Verify the credential. verify_credential returns (is_valid, passport).
-is_valid, passport = Verifier.verify_credential(signed, public_key=identity.public_key_jwk)
+# The agent knows its own key, so verifying its own credential needs no key
+# argument. verify returns (is_valid, passport).
+is_valid, passport = agent.verify(signed)
 
 print("\n🔍 Verification result:")
 print(f"   Valid: {is_valid}")
 if passport:
-    print(f"   Issuer DID: {passport.iss}")
-    print(f"   Intent: {passport.intent}")
+    print(f"   Issuer DID: {passport.issuer}")
+    print(
+        f"   Action / target / resource: "
+        f"{passport.action} / {passport.target} / {passport.resource}"
+    )
+
+# No-class path: the same flow with module-level one-liners and a plain keypair.
+keys = vouch.generate_identity("example.com")
+signed2 = vouch.sign(keys, action="greet", target="world", resource="https://example.com/greetings")
+ok2, who2 = vouch.verify(signed2, keys.public_key_jwk)
+print(f"\n🔁 One-liner path valid: {ok2} (issuer {who2.issuer})")
 
 print("""
 That's it! You've:

--- a/examples/05_integrations/07_mcp.py
+++ b/examples/05_integrations/07_mcp.py
@@ -125,6 +125,47 @@ if not is_valid:
 is_valid, _ = Verifier.verify(signed_calls[2]["token"], signer.get_public_key_jwk())
 print(f"\n   Legitimate execute_command('pytest') still valid? {is_valid} ✅")
 
+# =============================================================================
+# PART 5: One-line guard (verify every tool call with a single decorator)
+# =============================================================================
+
+print(f"\n{'=' * 60}")
+print("PART 5: One-Line Guard (modern credential path)")
+print("=" * 60)
+
+import vouch
+
+# The agent that is allowed to call your tools. A did:key identity verifies
+# offline; a did:web identity resolves over the network with no extra config.
+trusted_agent = vouch.Agent()
+
+# Guard a tool with one decorator. The credential arrives as `vouch_credential`;
+# an unsigned, forged, or untrusted call is rejected before the body runs.
+
+
+@vouch.require_signed(trusted_dids=[trusted_agent.did])
+def guarded_execute(command):
+    return f"ran: {command}"
+
+
+good = trusted_agent.sign(action="execute", target="shell", resource="pytest tests/ -v")
+print(f"\n   Trusted, signed call -> {guarded_execute('pytest tests/ -v', vouch_credential=good)}")
+
+rogue_agent = vouch.Agent()
+rogue = rogue_agent.sign(action="execute", target="shell", resource="cat ~/.ssh/id_rsa")
+try:
+    guarded_execute("cat ~/.ssh/id_rsa", vouch_credential=rogue)
+except PermissionError as exc:
+    print(f"   Rogue agent rejected -> {exc}")
+
+try:
+    guarded_execute("rm -rf /")  # unsigned
+except PermissionError as exc:
+    print(f"   Unsigned call rejected -> {exc}")
+
+# To guard a whole MCP server in one line:
+#     server = vouch.guard_mcp(server, trusted_dids=[trusted_agent.did])
+
 print("""
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 TAKEAWAY: MCP gives AI models powerful system access (file I/O,

--- a/go-sidecar/signer/credential.go
+++ b/go-sidecar/signer/credential.go
@@ -23,8 +23,16 @@ const maxDelegationDepth = 5
 // SignCredentialOptions configures Signer.SignCredential.
 type SignCredentialOptions struct {
 	// Intent is the action being authorized. Must contain action, target,
-	// resource (Specification §5.4.1).
+	// resource (Specification §5.4.1). The intent can also be supplied via the
+	// Action/Target/Resource fields below; when both are set, the named fields
+	// override the matching keys in Intent.
 	Intent map[string]any
+
+	// Action, Target, Resource are a convenience alternative to building the
+	// Intent map by hand. Any that are non-empty are folded into Intent.
+	Action   string
+	Target   string
+	Resource string
 
 	// ValidSeconds overrides the default validity window (Signer.defaultExpiry).
 	ValidSeconds int
@@ -59,6 +67,7 @@ type SignCredentialOptions struct {
 // proof using the eddsa-jcs-2022 cryptosuite (Specification §5, §7.1).
 // Returns the credential as a map suitable for JSON serialization.
 func (s *Signer) SignCredential(opts SignCredentialOptions) (map[string]any, error) {
+	opts.Intent = mergeIntent(opts.Intent, opts.Action, opts.Target, opts.Resource)
 	chain := opts.DelegationChain
 	if opts.ParentCredential != nil {
 		extended, err := s.extendDelegationChain(opts.ParentCredential, opts.Intent)
@@ -175,6 +184,7 @@ func (s *Signer) AttachProof(credential map[string]any) (map[string]any, error) 
 // eddsa-jcs-2022 default. Implementations using this profile SHOULD
 // transmit credentials in the HTTP request body (§5.6).
 func (s *Signer) SignCredentialHybrid(opts SignCredentialOptions) (map[string]any, error) {
+	opts.Intent = mergeIntent(opts.Intent, opts.Action, opts.Target, opts.Resource)
 	chain := opts.DelegationChain
 	if opts.ParentCredential != nil {
 		extended, err := s.extendDelegationChain(opts.ParentCredential, opts.Intent)
@@ -286,4 +296,24 @@ func isSubResource(child, parent string) bool {
 	}
 	trimmed := strings.TrimRight(parent, "/")
 	return strings.HasPrefix(child, trimmed+"/")
+}
+
+// mergeIntent folds the named action/target/resource into a copy of the intent
+// map. Named values override matching keys; the caller's map is not mutated.
+// Required-field validation is left to BuildVouchCredential.
+func mergeIntent(intent map[string]any, action, target, resource string) map[string]any {
+	merged := make(map[string]any, len(intent)+3)
+	for k, v := range intent {
+		merged[k] = v
+	}
+	if action != "" {
+		merged["action"] = action
+	}
+	if target != "" {
+		merged["target"] = target
+	}
+	if resource != "" {
+		merged["resource"] = resource
+	}
+	return merged
 }

--- a/go-sidecar/signer/named_intent_test.go
+++ b/go-sidecar/signer/named_intent_test.go
@@ -1,0 +1,59 @@
+// Tests for the named-argument intent convenience on SignCredentialOptions
+// (Action/Target/Resource). Mirrors the Python tests in tests/test_dx_sugar.py.
+
+package signer
+
+import "testing"
+
+func TestSignCredentialNamedIntentFields(t *testing.T) {
+	s := newTestSigner(t, "")
+
+	cred, err := s.SignCredential(SignCredentialOptions{
+		Action:   "read",
+		Target:   "users_table",
+		Resource: "https://api.example.com/v1/users",
+	})
+	if err != nil {
+		t.Fatalf("SignCredential with named fields: %v", err)
+	}
+
+	subject, ok := cred["credentialSubject"].(map[string]any)
+	if !ok {
+		t.Fatal("missing credentialSubject")
+	}
+	intent, ok := subject["intent"].(map[string]any)
+	if !ok {
+		t.Fatal("missing intent")
+	}
+	if intent["action"] != "read" || intent["target"] != "users_table" ||
+		intent["resource"] != "https://api.example.com/v1/users" {
+		t.Fatalf("named fields not applied: %#v", intent)
+	}
+}
+
+func TestSignCredentialNamedFieldsOverrideIntentMap(t *testing.T) {
+	s := newTestSigner(t, "")
+
+	cred, err := s.SignCredential(SignCredentialOptions{
+		Intent:   validIntent(),
+		Resource: "https://api.example.com/v1/users/override",
+	})
+	if err != nil {
+		t.Fatalf("SignCredential: %v", err)
+	}
+	intent := cred["credentialSubject"].(map[string]any)["intent"].(map[string]any)
+	if intent["resource"] != "https://api.example.com/v1/users/override" {
+		t.Fatalf("named field did not override: %#v", intent)
+	}
+	if intent["action"] != "read_database" {
+		t.Fatalf("unrelated intent key lost: %#v", intent)
+	}
+}
+
+func TestMergeIntentDoesNotMutateInput(t *testing.T) {
+	original := validIntent()
+	_ = mergeIntent(original, "write", "", "")
+	if original["action"] != "read_database" {
+		t.Fatalf("input intent was mutated: %#v", original)
+	}
+}

--- a/tests/test_dx_sugar.py
+++ b/tests/test_dx_sugar.py
@@ -1,0 +1,485 @@
+"""
+Tests for the additive developer-experience sugar:
+
+  1. vouch.Agent              - one object holding identity + signer
+  2. vouch.sign / vouch.verify - top-level one-liners
+  3. Signer.sign_credential(action=, target=, resource=) named-arg intent
+  4. vouch.verify default DID resolution, including did:key (offline)
+  5. CredentialPassport accessors + vouch.Credential wrapper
+  6. vouch.require_signed / vouch.guard_mcp / vouch.guard_tools
+  7. Signer.from_keypair
+
+Everything here is sugar over the canonical dict credential. The tests assert
+the sugar produces and accepts exactly the same credential as the existing
+Signer/Verifier path.
+"""
+
+import json
+
+import pytest
+
+import vouch
+from vouch import (
+    Agent,
+    Credential,
+    Signer,
+    Verifier,
+    generate_identity,
+    guard_mcp,
+    guard_tools,
+    require_signed,
+    sign,
+    verify,
+)
+
+INTENT = {"action": "read", "target": "did:web:files", "resource": "https://files/x"}
+
+
+# ---------------------------------------------------------------------------
+# Item 7: Signer.from_keypair
+# ---------------------------------------------------------------------------
+
+
+def test_from_keypair_matches_manual_construction(keypair):
+    s1 = Signer.from_keypair(keypair)
+    cred = s1.sign_credential(intent=INTENT)
+    ok, passport = Verifier.verify_credential(cred, public_key=keypair.public_key_jwk)
+    assert ok
+    assert passport.iss == keypair.did
+
+
+def test_from_keypair_requires_did():
+    kp = generate_identity()  # no domain -> did is None
+    with pytest.raises(ValueError):
+        Signer.from_keypair(kp)
+
+
+# ---------------------------------------------------------------------------
+# Item 3: named-argument intent on sign_credential
+# ---------------------------------------------------------------------------
+
+
+def test_named_args_equivalent_to_intent_dict(signer, keypair):
+    by_dict = signer.sign_credential(intent=INTENT)
+    by_named = signer.sign_credential(
+        action="read", target="did:web:files", resource="https://files/x"
+    )
+    assert by_dict["credentialSubject"]["intent"] == by_named["credentialSubject"]["intent"]
+    ok, _ = Verifier.verify_credential(by_named, public_key=keypair.public_key_jwk)
+    assert ok
+
+
+def test_named_args_override_intent_dict(signer):
+    cred = signer.sign_credential(intent=INTENT, resource="https://files/override")
+    intent = cred["credentialSubject"]["intent"]
+    assert intent["resource"] == "https://files/override"
+    assert intent["action"] == "read"
+
+
+def test_missing_required_intent_field_raises(signer):
+    with pytest.raises(ValueError):
+        signer.sign_credential(action="read")  # no target/resource
+
+
+def test_intent_dict_is_not_mutated(signer):
+    original = dict(INTENT)
+    signer.sign_credential(intent=INTENT, action="write")
+    assert INTENT == original  # named arg did not leak back into the caller dict
+
+
+# ---------------------------------------------------------------------------
+# Item 2: top-level sign / verify
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_sign_and_verify(keypair):
+    signed = sign(keypair, action="read", target="did:web:files", resource="https://files/x")
+    ok, who = verify(signed, keypair.public_key_jwk)
+    assert ok
+    assert who.action == "read"
+    assert who.resource == "https://files/x"
+
+
+def test_top_level_sign_matches_signer_output(keypair):
+    via_helper = sign(keypair, intent=INTENT)
+    via_signer = Signer.from_keypair(keypair).sign_credential(intent=INTENT)
+    # Same structure (ids/proofs differ); the intent and issuer must match.
+    assert via_helper["credentialSubject"]["intent"] == via_signer["credentialSubject"]["intent"]
+    assert via_helper["issuer"] == via_signer["issuer"]
+
+
+def test_verify_rejects_wrong_key(keypair):
+    signed = sign(keypair, intent=INTENT)
+    other = generate_identity("other.example")
+    ok, _ = verify(signed, other.public_key_jwk)
+    assert not ok
+
+
+def test_verify_accepts_json_string(keypair):
+    signed = sign(keypair, intent=INTENT)
+    ok, who = verify(json.dumps(signed), keypair.public_key_jwk)
+    assert ok
+    assert who.resource == INTENT["resource"]
+
+
+# ---------------------------------------------------------------------------
+# Item 1: Agent wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_agent_mint_sign_self_verify():
+    agent = Agent("agent.example")
+    assert agent.did == "did:web:agent.example"
+    signed = agent.sign(action="read", target="did:web:files", resource="https://files/x")
+    ok, who = agent.verify(signed)  # knows its own key, no network
+    assert ok
+    assert who.issuer == agent.did
+    assert who.action == "read"
+
+
+def test_agent_did_key_when_no_domain():
+    agent = Agent()
+    assert agent.did.startswith("did:key:")
+    signed = agent.sign(action="write", target="t", resource="r")
+    # did:key resolves offline through the default verify path.
+    ok, who = verify(signed)
+    assert ok
+    assert who.issuer == agent.did
+
+
+def test_agent_load_roundtrip():
+    agent = Agent("agent.example")
+    signed = agent.sign(intent=INTENT)
+    reloaded = Agent.load(agent.private_key_jwk, agent.did)
+    assert reloaded.did == agent.did
+    assert reloaded.public_key_jwk == agent.public_key_jwk
+    ok, _ = reloaded.verify(signed)
+    assert ok
+
+
+def test_agent_from_keypair(keypair):
+    agent = Agent.from_keypair(keypair)
+    signed = agent.sign(intent=INTENT)
+    ok, _ = Verifier.verify_credential(signed, public_key=keypair.public_key_jwk)
+    assert ok
+
+
+def test_agent_verify_other_issuer_offline_key():
+    a = Agent("a.example")
+    b = Agent("b.example")
+    signed_by_b = b.sign(intent=INTENT)
+    # a does not know b's key and b is did:web (no network here); an explicit
+    # key still verifies offline.
+    ok, who = a.verify(signed_by_b, public_key=b.public_key_jwk)
+    assert ok
+    assert who.issuer == b.did
+
+
+def test_agent_delegate_and_chain():
+    principal = Agent("principal.example")
+    grant = principal.delegate(
+        action="charge", target="api.bank", resource="https://api.bank/invoices"
+    )
+    worker = Agent("worker.example")
+    child = worker.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    chain = child["credentialSubject"]["delegationChain"]
+    assert len(chain) == 1
+    assert chain[0]["issuer"] == principal.did
+
+
+# ---------------------------------------------------------------------------
+# Item 4: did:key resolution in the default verify path
+# ---------------------------------------------------------------------------
+
+
+def test_did_key_resolves_without_network():
+    agent = Agent()  # did:key
+    signed = agent.sign(intent=INTENT)
+    ok, who = verify(signed)  # no key, no trusted root -> resolved from did:key
+    assert ok
+    assert who.issuer == agent.did
+
+
+def test_did_key_resolution_allowed_even_offline_flag():
+    agent = Agent()
+    signed = agent.sign(intent=INTENT)
+    # did:key needs no network, so it works with resolution disabled too.
+    ok, _ = verify(signed, allow_did_resolution=False)
+    assert ok
+
+
+def test_did_key_tampered_credential_fails():
+    agent = Agent()
+    signed = agent.sign(intent=INTENT)
+    signed["credentialSubject"]["intent"]["resource"] = "https://files/evil"
+    ok, _ = verify(signed)
+    assert not ok
+
+
+# ---------------------------------------------------------------------------
+# Item 5: result accessors + Credential wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_passport_accessors(keypair):
+    signed = sign(keypair, intent=INTENT)
+    ok, p = verify(signed, keypair.public_key_jwk)
+    assert ok
+    assert p.action == "read"
+    assert p.target == "did:web:files"
+    assert p.resource == "https://files/x"
+    assert p.issuer == p.iss == keypair.did
+    assert p.is_expired is False
+
+
+def test_passport_is_expired_true(keypair):
+    expired = Signer(
+        private_key=keypair.private_key_jwk, did=keypair.did, default_expiry_seconds=-60
+    ).sign_credential(intent=INTENT)
+    # Structural verification with skew large enough to still parse a passport.
+    ok, p = Verifier.verify_credential(
+        expired, public_key=keypair.public_key_jwk, clock_skew_seconds=3600
+    )
+    assert ok
+    assert p.is_expired is True
+
+
+def test_credential_wrapper_accessors(keypair):
+    signed = sign(keypair, intent=INTENT)
+    c = Credential(signed)
+    assert c.action == "read"
+    assert c.target == "did:web:files"
+    assert c.resource == "https://files/x"
+    assert c.issuer == keypair.did
+    assert c.intent == INTENT
+    assert c.is_expired is False
+
+
+def test_credential_wrapper_verify_and_json(keypair):
+    signed = sign(keypair, intent=INTENT)
+    c = Credential(signed)
+    ok, p = c.verify(keypair.public_key_jwk)
+    assert ok
+    assert p.action == "read"
+    # to_json round-trips to the same dict
+    assert json.loads(c.to_json()) == signed
+    assert c.to_dict() is signed
+
+
+def test_credential_wrapper_from_json_string(keypair):
+    signed = sign(keypair, intent=INTENT)
+    c = Credential(json.dumps(signed))
+    assert c.resource == "https://files/x"
+    assert "proof" in c
+
+
+def test_credential_wrapper_rejects_bad_input():
+    with pytest.raises(TypeError):
+        Credential(12345)  # not a dict or JSON string
+
+
+# ---------------------------------------------------------------------------
+# Item 6: require_signed / guard_mcp / guard_tools
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def did_key_agent():
+    """A did:key agent whose credentials verify offline (no network)."""
+    return Agent()
+
+
+def test_require_signed_allows_trusted(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    @require_signed(trusted_dids=[did_key_agent.did])
+    def write_file(path):
+        return f"wrote {path}"
+
+    assert write_file("/x", vouch_credential=signed) == "wrote /x"
+
+
+def test_require_signed_rejects_unsigned(did_key_agent):
+    @require_signed(trusted_dids=[did_key_agent.did])
+    def write_file(path):
+        return "ran"
+
+    with pytest.raises(PermissionError):
+        write_file("/x")
+
+
+def test_require_signed_rejects_untrusted_issuer(did_key_agent):
+    other = Agent()
+    signed = other.sign(intent=INTENT)
+
+    @require_signed(trusted_dids=[did_key_agent.did])
+    def write_file(path):
+        return "ran"
+
+    with pytest.raises(PermissionError):
+        write_file("/x", vouch_credential=signed)
+
+
+def test_require_signed_keeps_credential_when_declared(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    @require_signed(trusted_dids=[did_key_agent.did])
+    def needs_cred(path, *, vouch_credential):
+        return vouch_credential["issuer"]
+
+    assert needs_cred("/x", vouch_credential=signed) == did_key_agent.did
+
+
+def test_require_signed_injects_passport(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    @require_signed(trusted_dids=[did_key_agent.did], inject_passport=True)
+    def handler(path, *, vouch_passport):
+        return vouch_passport.action
+
+    assert handler("/x", vouch_credential=signed) == "read"
+
+
+def test_require_signed_intent_policy(did_key_agent):
+    @require_signed(trusted_dids=[did_key_agent.did], require_action="read")
+    def handler(path):
+        return "ok"
+
+    good = did_key_agent.sign(intent=INTENT)
+    assert handler("/x", vouch_credential=good) == "ok"
+
+    bad = did_key_agent.sign(action="delete", target="t", resource="r")
+    with pytest.raises(PermissionError):
+        handler("/x", vouch_credential=bad)
+
+
+def test_require_signed_on_reject_none(did_key_agent):
+    @require_signed(trusted_dids=[did_key_agent.did], on_reject="none")
+    def handler(path):
+        return "ran"
+
+    assert handler("/x") is None
+
+
+def test_require_signed_bare_decorator(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    @require_signed
+    def handler(path):
+        return "ok"
+
+    assert handler("/x", vouch_credential=signed) == "ok"
+    with pytest.raises(PermissionError):
+        handler("/x")
+
+
+def test_require_signed_with_trusted_keys_offline():
+    kp = generate_identity("w.example")
+    signed = sign(kp, intent=INTENT)
+
+    @require_signed(trusted_dids=[kp.did], trusted_keys={kp.did: kp.public_key_jwk})
+    def handler(path):
+        return "ok"
+
+    assert handler("/x", vouch_credential=signed) == "ok"
+
+
+def test_guard_tools(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    def t1(x):
+        return x
+
+    guarded = guard_tools([t1], trusted_dids=[did_key_agent.did])
+    assert guarded[0]("hi", vouch_credential=signed) == "hi"
+    with pytest.raises(PermissionError):
+        guarded[0]("hi")
+
+
+def test_guard_tools_idempotent(did_key_agent):
+    def t1(x):
+        return x
+
+    once = guard_tools([t1], trusted_dids=[did_key_agent.did])
+    twice = guard_tools(once, trusted_dids=[did_key_agent.did])
+    assert twice[0] is once[0]
+
+
+def test_guard_mcp_decorator_server(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    class FakeServer:
+        def __init__(self):
+            self.registered = {}
+
+        def tool(self, *a, **k):
+            def deco(fn):
+                self.registered[fn.__name__] = fn
+                return fn
+
+            return deco
+
+    server = guard_mcp(FakeServer(), trusted_dids=[did_key_agent.did])
+
+    @server.tool()
+    def do_thing(x):
+        return f"did {x}"
+
+    assert server.registered["do_thing"]("y", vouch_credential=signed) == "did y"
+    with pytest.raises(PermissionError):
+        server.registered["do_thing"]("y")
+
+
+def test_guard_mcp_add_tool_server(did_key_agent):
+    signed = did_key_agent.sign(intent=INTENT)
+
+    class FakeServer:
+        def __init__(self):
+            self.tools = []
+
+        def add_tool(self, fn, name=None):
+            self.tools.append(fn)
+            return fn
+
+    server = guard_mcp(FakeServer(), trusted_dids=[did_key_agent.did])
+
+    def do_thing(x):
+        return f"did {x}"
+
+    server.add_tool(do_thing)
+    assert server.tools[0]("y", vouch_credential=signed) == "did y"
+    with pytest.raises(PermissionError):
+        server.tools[0]("y")
+
+
+def test_guard_mcp_raises_without_hook():
+    class Bare:
+        pass
+
+    with pytest.raises(TypeError):
+        guard_mcp(Bare(), trusted_dids=["did:web:x"])
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+def test_new_symbols_exported():
+    for name in (
+        "Agent",
+        "Credential",
+        "sign",
+        "verify",
+        "require_signed",
+        "guard_mcp",
+        "guard_tools",
+        "CredentialGate",
+    ):
+        assert hasattr(vouch, name), name
+        assert name in vouch.__all__, name

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -8,9 +8,14 @@ enabling verifiable proof of intent and non-repudiation.
 __version__ = "1.6.0"
 
 # Core signing/verification
-from .signer import Signer
+from .signer import Signer, sign
 from .verifier import Verifier, Passport, VerificationError, DelegationLink, verify
 from .auditor import Auditor
+
+# One-object identity and the read-friendly credential wrapper (ergonomic sugar
+# over Signer/Verifier; the credential dict stays the canonical wire form).
+from .agent import Agent
+from .credential import Credential
 
 # Key management
 from .keys import generate_identity, KeyPair
@@ -22,12 +27,18 @@ from .kms import RotatingKeyProvider, KeyConfig
 # adapters under vouch.integrations.*.
 from .autosign import (
     current_credential,
+    current_token_header,
     delegate,
     protect,
     resolve_signer,
     sign_intent,
     signed,
 )
+
+# Receiving-side verification guards: a server-side gate and one-line tool
+# guards (the counterpart to protect/sign on the sending side).
+from .gate import CredentialGate, GateResult
+from .mcp_guard import guard_mcp, guard_tools, require_signed
 
 # Audio signing
 from .audio import AudioSigner, SignedAudioResult
@@ -283,8 +294,11 @@ __all__ = [
     "__version__",
     # Core
     "Signer",
+    "sign",
     "Verifier",
     "verify",
+    "Agent",
+    "Credential",
     "Passport",
     "VerificationError",
     "DelegationLink",
@@ -300,7 +314,14 @@ __all__ = [
     "delegate",
     "sign_intent",
     "current_credential",
+    "current_token_header",
     "resolve_signer",
+    # Receiving-side verification guards
+    "CredentialGate",
+    "GateResult",
+    "require_signed",
+    "guard_mcp",
+    "guard_tools",
     # Audio
     "AudioSigner",
     "SignedAudioResult",

--- a/vouch/agent.py
+++ b/vouch/agent.py
@@ -23,11 +23,14 @@ format changes.
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Dict, Optional, Tuple
 
 from vouch.keys import KeyManager, KeyPair, generate_identity
 from vouch.signer import Signer
 from vouch.verifier import CredentialPassport, Verifier, verify
+
+logger = logging.getLogger(__name__)
 
 
 class Agent:
@@ -37,12 +40,34 @@ class Agent:
     :meth:`from_keypair` to rehydrate an existing one. With a ``domain`` the
     identity is ``did:web:<domain>``; without one it is a self-certifying
     ``did:key`` (verifiable offline, no DID document to host).
+
+    Storage: a freshly minted DID, private key, and public key live in memory
+    only (on this Agent and its Signer). Nothing is written to disk until you
+    call :meth:`save`, which stores the identity under ``~/.vouch/keys`` (pass a
+    ``password`` to encrypt the private key at rest).
     """
 
     def __init__(self, domain: Optional[str] = None, *, default_expiry_seconds: int = 300) -> None:
         keypair = generate_identity(domain=domain)
         if not keypair.did:
             keypair.did = _did_key_from_pub_jwk(keypair.public_key_jwk)
+            # No domain was given, so the identity is a self-certifying did:key:
+            # the key IS the identifier, with nothing to host and no authority to
+            # resolve. Say so once, because a caller expecting a did:web anchor
+            # would otherwise not notice. Like every freshly minted identity it
+            # lives in memory only; call agent.save(password=...) to persist it.
+            logger.info(
+                "vouch.Agent minted a self-certifying did:key identity (%s). It "
+                "is held in memory only and is not persisted; pass a domain for a "
+                "did:web identity, or call agent.save(password=...) to keep it.",
+                keypair.did,
+            )
+        else:
+            logger.info(
+                "vouch.Agent minted identity %s (in memory only; call "
+                "agent.save(password=...) to persist it).",
+                keypair.did,
+            )
         self._keypair = keypair
         self._signer = Signer.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
 

--- a/vouch/agent.py
+++ b/vouch/agent.py
@@ -1,0 +1,228 @@
+"""
+The ``Agent`` wrapper: one object that holds an identity and signs/verifies.
+
+The minimal flow mints keys, builds a Signer from two unpacked fields, then
+carries the public key around separately to verify. ``Agent`` collapses that
+into a single object you pass around::
+
+    agent = vouch.Agent("agent.example")          # mints identity, holds signer
+    signed = agent.sign(action="read", target="did:web:files",
+                        resource="https://files/x")
+    ok, who = agent.verify(signed)                 # knows its own key
+    agent.did, agent.public_key_jwk               # plain attributes
+
+    # rehydrate from stored keys / env, no new identity minted:
+    agent2 = vouch.Agent.load(private_key_jwk, did)
+
+``Agent`` is sugar over the existing :class:`~vouch.signer.Signer`,
+:class:`~vouch.verifier.Verifier`, and :func:`~vouch.keys.generate_identity`.
+The credential it signs is the same dict those produce; nothing about the wire
+format changes.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional, Tuple
+
+from vouch.keys import KeyManager, KeyPair, generate_identity
+from vouch.signer import Signer
+from vouch.verifier import CredentialPassport, Verifier, verify
+
+
+class Agent:
+    """An agent identity bundled with its signer.
+
+    Construct it to mint a fresh identity, or use :meth:`load` /
+    :meth:`from_keypair` to rehydrate an existing one. With a ``domain`` the
+    identity is ``did:web:<domain>``; without one it is a self-certifying
+    ``did:key`` (verifiable offline, no DID document to host).
+    """
+
+    def __init__(self, domain: Optional[str] = None, *, default_expiry_seconds: int = 300) -> None:
+        keypair = generate_identity(domain=domain)
+        if not keypair.did:
+            keypair.did = _did_key_from_pub_jwk(keypair.public_key_jwk)
+        self._keypair = keypair
+        self._signer = Signer.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
+
+    # -- constructors ---------------------------------------------------------
+
+    @classmethod
+    def load(
+        cls,
+        private_key_jwk: str,
+        did: str,
+        *,
+        public_key_jwk: Optional[str] = None,
+        default_expiry_seconds: int = 300,
+    ) -> "Agent":
+        """Rehydrate an Agent from stored keys (no new identity is minted).
+
+        The public key is derived from the private key when not supplied.
+        """
+        if public_key_jwk is None:
+            public_key_jwk = _public_jwk_from_private(private_key_jwk)
+        keypair = KeyPair(
+            private_key_jwk=private_key_jwk,
+            public_key_jwk=public_key_jwk,
+            did=did,
+        )
+        return cls.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
+
+    @classmethod
+    def from_keypair(cls, keypair: KeyPair, *, default_expiry_seconds: int = 300) -> "Agent":
+        """Build an Agent from an existing :class:`~vouch.keys.KeyPair`."""
+        if not keypair.did:
+            raise ValueError("Agent.from_keypair requires a keypair with a DID")
+        agent = cls.__new__(cls)
+        agent._keypair = keypair
+        agent._signer = Signer.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
+        return agent
+
+    # -- identity -------------------------------------------------------------
+
+    @property
+    def did(self) -> str:
+        return self._keypair.did or ""
+
+    @property
+    def public_key_jwk(self) -> str:
+        return self._keypair.public_key_jwk
+
+    @property
+    def private_key_jwk(self) -> str:
+        return self._keypair.private_key_jwk
+
+    @property
+    def keypair(self) -> KeyPair:
+        return self._keypair
+
+    @property
+    def signer(self) -> Signer:
+        return self._signer
+
+    # -- signing --------------------------------------------------------------
+
+    def sign(
+        self,
+        intent: Optional[Dict[str, Any]] = None,
+        *,
+        action: Optional[str] = None,
+        target: Optional[str] = None,
+        resource: Optional[str] = None,
+        valid_seconds: Optional[int] = None,
+        reputation_score: Optional[int] = None,
+        parent_credential: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Sign an intent as a Vouch Credential. Same return as
+        :meth:`Signer.sign_credential`.
+        """
+        return self._signer.sign_credential(
+            intent,
+            action=action,
+            target=target,
+            resource=resource,
+            valid_seconds=valid_seconds,
+            reputation_score=reputation_score,
+            parent_credential=parent_credential,
+        )
+
+    def delegate(
+        self,
+        *,
+        action: str,
+        target: str,
+        resource: str,
+        to: Optional[str] = None,
+        valid_seconds: Optional[int] = None,
+        reputation_score: Optional[int] = None,
+    ) -> Dict[str, Any]:
+        """Issue a delegation grant from this agent (the principal side).
+
+        Hand the returned grant to a delegatee and pass it as
+        ``parent_credential=`` to its :meth:`sign` calls; the resource-narrowing
+        rule (Specification §9.3) then constrains what it can sign.
+        """
+        intent: Dict[str, Any] = {"action": action, "target": target, "resource": resource}
+        if to:
+            intent["delegatee"] = to
+        return self._signer.sign_credential(
+            intent,
+            valid_seconds=valid_seconds,
+            reputation_score=reputation_score,
+        )
+
+    # -- verification ---------------------------------------------------------
+
+    def verify(
+        self,
+        credential: Any,
+        *,
+        public_key: Optional[Any] = None,
+        allow_did_resolution: bool = True,
+    ) -> Tuple[bool, Optional[CredentialPassport]]:
+        """Verify a credential.
+
+        If it was issued by this agent (issuer matches :attr:`did`), it is
+        verified offline against this agent's own public key. Otherwise the
+        issuer key is resolved by DID (``did:web`` / ``did:key`` / trusted
+        roots), exactly like :func:`vouch.verify`. An explicit ``public_key``
+        always overrides and forces offline verification.
+        """
+        if public_key is None and _issuer_of(credential) == self.did:
+            return Verifier.verify_credential(credential, public_key=self.public_key_jwk)
+        return verify(
+            credential,
+            public_key=public_key,
+            allow_did_resolution=allow_did_resolution,
+        )
+
+    # -- persistence ----------------------------------------------------------
+
+    def save(self, *, password: Optional[str] = None, key_dir: Optional[str] = None) -> None:
+        """Persist this identity to the on-disk keystore (``~/.vouch/keys``).
+
+        Pass a ``password`` to encrypt the private key (strongly recommended).
+        """
+        km = KeyManager(key_dir) if key_dir else KeyManager()
+        km.save_identity(self._keypair, password=password)
+
+    def __repr__(self) -> str:
+        return f"Agent(did={self.did!r})"
+
+
+def _issuer_of(credential: Any) -> Optional[str]:
+    """Best-effort extraction of the issuer DID from a credential dict/JSON."""
+    try:
+        cred = json.loads(credential) if isinstance(credential, str) else credential
+        if not isinstance(cred, dict):
+            return None
+        issuer = cred.get("issuer")
+        if isinstance(issuer, list):
+            return issuer[0] if issuer else None
+        return issuer
+    except (ValueError, TypeError):
+        return None
+
+
+def _did_key_from_pub_jwk(jwk_json: str) -> str:
+    """Derive a did:key from an Ed25519 public-key JWK."""
+    from jwcrypto.common import base64url_decode
+
+    from vouch import multikey
+
+    data = json.loads(jwk_json)
+    raw = base64url_decode(data["x"])
+    return "did:key:" + multikey.encode_ed25519_public(raw)
+
+
+def _public_jwk_from_private(private_key_jwk: str) -> str:
+    """Derive the public JWK string from a private JWK string."""
+    from jwcrypto import jwk
+
+    key = jwk.JWK.from_json(private_key_jwk)
+    return key.export_public()
+
+
+__all__ = ["Agent"]

--- a/vouch/credential.py
+++ b/vouch/credential.py
@@ -1,0 +1,181 @@
+"""
+A thin, read-friendly wrapper over a Vouch Credential dict.
+
+The dict produced by :meth:`Signer.sign_credential` (and :func:`vouch.sign`) is
+the canonical, on-the-wire form. This wrapper does not replace it; it sits on
+top so you can read back what a credential authorizes without digging through
+``credentialSubject.intent`` by hand, and verify it in one call::
+
+    c = vouch.Credential(signed)
+    c.action, c.target, c.resource      # what it authorizes
+    c.issuer                            # who signed it
+    ok, passport = c.verify()           # resolve issuer key and verify
+    c.to_json()                         # back to the wire form
+
+``Credential`` is sugar only. ``c.to_dict()`` returns the exact same dict you
+passed in (not a copy), so nothing about the wire format changes.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+from vouch.verifier import (
+    CredentialDelegationLink,
+    CredentialPassport,
+    _parse_iso8601,
+    verify,
+)
+
+
+class Credential:
+    """Ergonomic accessor over a Vouch Credential dict.
+
+    Accepts a credential dict or its JSON string. All accessors are read-only;
+    the underlying dict is never mutated.
+    """
+
+    def __init__(self, credential: Union[Dict[str, Any], str]) -> None:
+        if isinstance(credential, Credential):
+            credential = credential._cred
+        if isinstance(credential, str):
+            credential = json.loads(credential)
+        if not isinstance(credential, dict):
+            raise TypeError("Credential expects a dict or JSON string")
+        self._cred: Dict[str, Any] = credential
+
+    # -- intent ---------------------------------------------------------------
+
+    @property
+    def intent(self) -> Dict[str, Any]:
+        """The full intent payload (action, target, resource, and any extras)."""
+        subject = self._cred.get("credentialSubject") or {}
+        return subject.get("intent") or {}
+
+    @property
+    def action(self) -> Optional[str]:
+        return self.intent.get("action")
+
+    @property
+    def target(self) -> Optional[str]:
+        return self.intent.get("target")
+
+    @property
+    def resource(self) -> Optional[str]:
+        return self.intent.get("resource")
+
+    # -- issuer / identity ----------------------------------------------------
+
+    @property
+    def issuer(self) -> str:
+        """The issuer DID (the ``issuer`` field, first entry if it is a list)."""
+        issuer = self._cred.get("issuer")
+        if isinstance(issuer, list):
+            return issuer[0] if issuer else ""
+        return issuer or ""
+
+    @property
+    def subject(self) -> str:
+        """The credentialSubject id (the agent's DID)."""
+        return (self._cred.get("credentialSubject") or {}).get("id", "")
+
+    @property
+    def credential_id(self) -> str:
+        return self._cred.get("id", "")
+
+    # -- validity -------------------------------------------------------------
+
+    @property
+    def valid_from(self) -> str:
+        return self._cred.get("validFrom", "")
+
+    @property
+    def valid_until(self) -> str:
+        return self._cred.get("validUntil", "")
+
+    @property
+    def is_expired(self) -> bool:
+        """True if the credential's validity window has passed (no skew)."""
+        expires = _parse_iso8601(self.valid_until)
+        if expires is None:
+            return False
+        return datetime.now(timezone.utc) > expires
+
+    # -- extras ---------------------------------------------------------------
+
+    @property
+    def reputation_score(self) -> Optional[int]:
+        score = (self._cred.get("credentialSubject") or {}).get("reputationScore")
+        if score is None:
+            return None
+        try:
+            return int(score)
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def delegation_chain(self) -> List[CredentialDelegationLink]:
+        chain: List[CredentialDelegationLink] = []
+        raw = (self._cred.get("credentialSubject") or {}).get("delegationChain") or []
+        for link in raw:
+            chain.append(
+                CredentialDelegationLink(
+                    issuer=link.get("issuer", ""),
+                    subject=link.get("subject", ""),
+                    intent=link.get("intent", {}) or {},
+                    valid_from=link.get("validFrom"),
+                    valid_until=link.get("validUntil"),
+                    parent_proof_value=link.get("parentProofValue"),
+                )
+            )
+        return chain
+
+    @property
+    def proof(self) -> Dict[str, Any]:
+        proof = self._cred.get("proof")
+        return proof if isinstance(proof, dict) else {}
+
+    # -- verification ---------------------------------------------------------
+
+    def verify(
+        self,
+        public_key: Optional[Any] = None,
+        *,
+        allow_did_resolution: bool = True,
+    ) -> Tuple[bool, Optional[CredentialPassport]]:
+        """Verify this credential.
+
+        With ``public_key`` it verifies offline against that key. Without it,
+        the issuer key is resolved from trusted roots, ``did:web``, or
+        ``did:key`` (set ``allow_did_resolution=False`` to forbid the network).
+        Returns ``(is_valid, CredentialPassport | None)``.
+        """
+        return verify(
+            self._cred,
+            public_key=public_key,
+            allow_did_resolution=allow_did_resolution,
+        )
+
+    # -- serialization --------------------------------------------------------
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return the underlying credential dict (the canonical wire form)."""
+        return self._cred
+
+    def to_json(self) -> str:
+        """Return the credential as a compact JSON string for transport."""
+        return json.dumps(self._cred, separators=(",", ":"))
+
+    def __getitem__(self, key: str) -> Any:
+        return self._cred[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self._cred
+
+    def __repr__(self) -> str:
+        return f"Credential(issuer={self.issuer!r}, action={self.action!r}, resource={self.resource!r})"
+
+
+__all__ = ["Credential"]

--- a/vouch/mcp_guard.py
+++ b/vouch/mcp_guard.py
@@ -1,0 +1,265 @@
+"""
+One-line verification guards for tool servers (MCP and other frameworks).
+
+On the sending side, ``vouch.protect`` / ``@vouch.signed`` make an agent sign
+every tool call. On the receiving side, a tool server has to verify those
+credentials before it runs anything. ``CredentialGate`` / ``VouchGate`` cover
+HTTP endpoints; this module covers in-process tool functions:
+
+    @vouch.require_signed(trusted_dids=["did:web:agent.example"])
+    def write_file(path, content, *, vouch_credential): ...
+
+    server = vouch.guard_mcp(server, trusted_dids=["did:web:agent.example"])
+
+Both verify the credential's Data Integrity proof, enforce an issuer allowlist
+(``trusted_dids``), and optionally match the intent (``require_action`` /
+``require_target`` / ``require_resource``) before the tool body runs. A call
+that is unsigned, forged, from an untrusted issuer, or intent-mismatched is
+rejected with ``PermissionError`` (configurable).
+
+Security boundary: the guard authenticates the *caller* (a valid signature from
+a trusted issuer) and, when configured, that the declared intent matches the
+route. It does NOT by itself bind the credential to the specific argument values
+of this call, and it does NOT provide replay protection; pair it with intent
+policy and the nonce tracker (``vouch.MemoryNonceTracker``) when those matter.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from typing import Any, Callable, Dict, List, Optional, Sequence
+
+from vouch.gate import CredentialGate
+
+# Default keyword the guard reads the inbound credential from. A signed caller
+# (or the transport shim) passes the credential under this name.
+DEFAULT_CREDENTIAL_ARG = "vouch_credential"
+PASSPORT_INJECT_ARG = "vouch_passport"
+
+
+def require_signed(
+    trusted_dids: Optional[Any] = None,
+    *,
+    public_key: Optional[Any] = None,
+    trusted_keys: Optional[Dict[str, str]] = None,
+    allow_did_resolution: bool = True,
+    require_action: Optional[str] = None,
+    require_target: Optional[str] = None,
+    require_resource: Optional[str] = None,
+    credential_arg: str = DEFAULT_CREDENTIAL_ARG,
+    pass_credential: bool = False,
+    inject_passport: bool = False,
+    on_reject: str = "raise",
+):
+    """Decorator: require a valid Vouch credential before a tool runs.
+
+    Usable as a factory (the normal form)::
+
+        @require_signed(trusted_dids=["did:web:agent.example"])
+        def write_file(path, content, *, vouch_credential): ...
+
+    or bare (no issuer allowlist, signature still required)::
+
+        @require_signed
+        def read_file(path, *, vouch_credential): ...
+
+    The credential is read from the ``credential_arg`` keyword (default
+    ``vouch_credential``). On success the keyword is removed before the tool is
+    called, unless ``pass_credential=True``; with ``inject_passport=True`` the
+    verified passport is passed as ``vouch_passport``.
+
+    Args:
+      trusted_dids: allowed issuer DIDs. None allows any issuer whose key
+        verifies (signature still required).
+      public_key / trusted_keys / allow_did_resolution: key-resolution options,
+        forwarded to :class:`~vouch.gate.CredentialGate`.
+      require_action / require_target / require_resource: exact intent policy.
+      credential_arg: keyword the credential arrives under.
+      pass_credential: keep the credential keyword when calling the tool.
+      inject_passport: pass the verified passport as ``vouch_passport``.
+      on_reject: ``"raise"`` (default) raises ``PermissionError``; ``"none"``
+        returns None without running the tool.
+    """
+    gate = CredentialGate(
+        public_key=public_key,
+        trusted_keys=trusted_keys,
+        allow_did_resolution=allow_did_resolution,
+        require_action=require_action,
+        require_target=require_target,
+        require_resource=require_resource,
+    )
+
+    # Bare-decorator support: @require_signed with no parentheses passes the
+    # decorated function in as `trusted_dids`.
+    bare_func: Optional[Callable] = None
+    allow: Optional[set] = None
+    if callable(trusted_dids):
+        bare_func = trusted_dids
+    elif trusted_dids is not None:
+        allow = set(trusted_dids)
+
+    def decorate(func: Callable) -> Callable:
+        # Keep the credential keyword only if the tool actually wants it; strip
+        # it otherwise so a plain tool signature is not broken by the extra arg.
+        keep_credential = pass_credential or _accepts_kwarg(func, credential_arg)
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            credential = kwargs.get(credential_arg)
+            result = gate.check(credential)
+
+            reason: Optional[str] = None
+            if not result.ok or result.passport is None:
+                reason = result.reason or "unsigned or invalid credential"
+            elif allow is not None and result.passport.issuer not in allow:
+                reason = f"issuer {result.passport.issuer!r} is not in trusted_dids"
+
+            if reason is not None:
+                if on_reject == "none":
+                    return None
+                raise PermissionError(f"Vouch guard rejected call to {_name(func)}: {reason}")
+
+            if not keep_credential:
+                kwargs.pop(credential_arg, None)
+            if inject_passport:
+                kwargs[PASSPORT_INJECT_ARG] = result.passport
+            return func(*args, **kwargs)
+
+        wrapper.__vouch_guarded__ = True  # type: ignore[attr-defined]
+        return wrapper
+
+    if bare_func is not None:
+        return decorate(bare_func)
+    return decorate
+
+
+def guard_mcp(server: Any, trusted_dids: Optional[Any] = None, **guard_kwargs: Any) -> Any:
+    """Wrap an MCP-style tool server so every registered tool is verified.
+
+    Patches the server's tool-registration entry point so each tool it registers
+    is wrapped with :func:`require_signed`. Returns the same server for
+    chaining::
+
+        server = vouch.guard_mcp(server, trusted_dids=["did:web:agent.example"])
+
+    Recognized registration hooks, in order: a ``tool`` decorator (FastMCP
+    style), ``add_tool``, or ``register_tool`` (each taking the tool function as
+    its first positional argument). Tools registered after this call are
+    guarded; the credential must reach each tool under the ``vouch_credential``
+    argument (see :func:`require_signed`).
+
+    Raises:
+      TypeError: if the server exposes none of the recognized hooks. Use the
+        per-tool :func:`require_signed` decorator in that case.
+    """
+    if trusted_dids is not None:
+        guard_kwargs.setdefault("trusted_dids", trusted_dids)
+
+    for attr, kind in (
+        ("tool", "decorator"),
+        ("add_tool", "callable"),
+        ("register_tool", "callable"),
+    ):
+        hook = getattr(server, attr, None)
+        if callable(hook):
+            if kind == "decorator":
+                _patch_decorator_hook(server, attr, guard_kwargs)
+            else:
+                _patch_callable_hook(server, attr, guard_kwargs)
+            return server
+
+    raise TypeError(
+        "guard_mcp could not find a tool-registration hook (tool/add_tool/"
+        "register_tool) on the server. Use the @vouch.require_signed decorator "
+        "on each tool instead."
+    )
+
+
+def guard_tools(
+    tools: Sequence[Callable], trusted_dids: Optional[Any] = None, **guard_kwargs: Any
+) -> List[Callable]:
+    """Wrap a list of plain tool callables with :func:`require_signed`.
+
+    The framework-agnostic counterpart to :func:`guard_mcp` for servers whose
+    tools are just a list of functions::
+
+        guarded = vouch.guard_tools([read_file, write_file],
+                                    trusted_dids=["did:web:agent.example"])
+    """
+    decorator = require_signed(trusted_dids, **guard_kwargs)
+    out: List[Callable] = []
+    for tool in tools:
+        if getattr(tool, "__vouch_guarded__", False):
+            out.append(tool)
+        else:
+            out.append(decorator(tool))
+    return out
+
+
+def _patch_decorator_hook(server: Any, attr: str, guard_kwargs: Dict[str, Any]) -> None:
+    original = getattr(server, attr)
+    if getattr(original, "__vouch_guard_patched__", False):
+        return
+
+    @functools.wraps(original)
+    def patched(*args: Any, **kwargs: Any) -> Any:
+        # Bare use: decorator applied straight to the tool function.
+        if len(args) == 1 and not kwargs and callable(args[0]):
+            return original(_apply_guard(args[0], guard_kwargs))
+
+        # Factory use: original(...) returns the real decorator; wrap its target.
+        decorator = original(*args, **kwargs)
+
+        def wrapping(func: Callable) -> Any:
+            return decorator(_apply_guard(func, guard_kwargs))
+
+        return wrapping
+
+    patched.__vouch_guard_patched__ = True  # type: ignore[attr-defined]
+    setattr(server, attr, patched)
+
+
+def _patch_callable_hook(server: Any, attr: str, guard_kwargs: Dict[str, Any]) -> None:
+    original = getattr(server, attr)
+    if getattr(original, "__vouch_guard_patched__", False):
+        return
+
+    @functools.wraps(original)
+    def patched(*args: Any, **kwargs: Any) -> Any:
+        args_list = list(args)
+        if args_list and callable(args_list[0]):
+            args_list[0] = _apply_guard(args_list[0], guard_kwargs)
+        return original(*args_list, **kwargs)
+
+    patched.__vouch_guard_patched__ = True  # type: ignore[attr-defined]
+    setattr(server, attr, patched)
+
+
+def _apply_guard(func: Callable, guard_kwargs: Dict[str, Any]) -> Callable:
+    if getattr(func, "__vouch_guarded__", False):
+        return func
+    trusted_dids = guard_kwargs.get("trusted_dids")
+    kwargs = {k: v for k, v in guard_kwargs.items() if k != "trusted_dids"}
+    return require_signed(trusted_dids, **kwargs)(func)
+
+
+def _accepts_kwarg(func: Callable, name: str) -> bool:
+    """True if `func` declares `name` as a parameter or accepts ``**kwargs``."""
+    try:
+        sig = inspect.signature(func)
+    except (TypeError, ValueError):
+        return False
+    for p in sig.parameters.values():
+        if p.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+        if p.name == name:
+            return True
+    return False
+
+
+def _name(func: Callable) -> str:
+    return getattr(func, "__name__", repr(func))
+
+
+__all__ = ["require_signed", "guard_mcp", "guard_tools"]

--- a/vouch/signer.py
+++ b/vouch/signer.py
@@ -97,6 +97,35 @@ class Signer:
         except Exception:  # pragma: no cover - defensive
             self._raw_priv = None
 
+    @classmethod
+    def from_keypair(cls, keypair: Any, default_expiry_seconds: int = 300) -> "Signer":
+        """Construct a Signer directly from a :class:`~vouch.keys.KeyPair`.
+
+        Saves unpacking ``keypair.private_key_jwk`` and ``keypair.did`` by hand::
+
+            keys = generate_identity("agent.example")
+            signer = Signer.from_keypair(keys)
+
+        Args:
+          keypair: a KeyPair (or any object exposing ``private_key_jwk`` and
+            ``did`` attributes).
+          default_expiry_seconds: token validity period (default 5 minutes).
+
+        Raises:
+          ValueError: if the keypair has no DID.
+        """
+        did = getattr(keypair, "did", None)
+        if not did:
+            raise ValueError(
+                "Signer.from_keypair requires a keypair with a DID; "
+                "generate it with a domain, e.g. generate_identity('agent.example')"
+            )
+        return cls(
+            private_key=keypair.private_key_jwk,
+            did=did,
+            default_expiry_seconds=default_expiry_seconds,
+        )
+
     # ------------------------------------------------------------------
     # Legacy JWS path (v0.x). Preserved verbatim for backward compatibility.
     # ------------------------------------------------------------------
@@ -188,8 +217,11 @@ class Signer:
 
     def sign_credential(
         self,
-        intent: Dict[str, Any],
+        intent: Optional[Dict[str, Any]] = None,
         *,
+        action: Optional[str] = None,
+        target: Optional[str] = None,
+        resource: Optional[str] = None,
         valid_seconds: Optional[int] = None,
         reputation_score: Optional[int] = None,
         delegation_chain: Optional[List[Dict[str, Any]]] = None,
@@ -204,8 +236,23 @@ class Signer:
         returned credential is a dict that can be JSON-serialized and
         transmitted in an HTTP body or header.
 
+        The intent can be passed either as a dict (the original form) or as the
+        named keyword arguments `action`, `target`, and `resource`. The two
+        styles are equivalent and may be combined; named arguments override the
+        matching keys in the `intent` dict::
+
+            signer.sign_credential(action="read", target="inbox",
+                                   resource="https://mail/api/inbox")
+            signer.sign_credential(intent={"action": "read", "target": "inbox",
+                                           "resource": "https://mail/api/inbox"})
+
         Args:
-          intent: Intent payload. MUST contain `action`, `target`, `resource`.
+          intent: Intent payload dict. MUST contain `action`, `target`,
+            `resource` once merged with any named arguments.
+          action: Optional intent action (alternative to `intent["action"]`).
+          target: Optional intent target (alternative to `intent["target"]`).
+          resource: Optional intent resource (alternative to
+            `intent["resource"]`).
           valid_seconds: Optional validity window override.
           reputation_score: Optional self-reported score in [0, 100].
           delegation_chain: Pre-built delegation chain to attach (advanced).
@@ -220,7 +267,7 @@ class Signer:
           with a `proof` object (eddsa-jcs-2022).
 
         Raises:
-          ValueError: If `intent` is missing required fields, the chain
+          ValueError: If the merged intent is missing required fields, the chain
             exceeds max depth, or the private key bytes are unavailable.
         """
         if self._raw_priv is None:
@@ -228,6 +275,8 @@ class Signer:
                 "Cannot issue Data Integrity credentials: private key bytes "
                 "could not be derived from the JWK"
             )
+
+        intent = _merge_intent(intent, action=action, target=target, resource=resource)
 
         chain = delegation_chain or []
         if parent_credential is not None:
@@ -253,8 +302,11 @@ class Signer:
 
     def sign_credential_hybrid(
         self,
-        intent: Dict[str, Any],
+        intent: Optional[Dict[str, Any]] = None,
         *,
+        action: Optional[str] = None,
+        target: Optional[str] = None,
+        resource: Optional[str] = None,
         valid_seconds: Optional[int] = None,
         reputation_score: Optional[int] = None,
         delegation_chain: Optional[List[Dict[str, Any]]] = None,
@@ -270,6 +322,9 @@ class Signer:
         over the same canonical form. Verification REQUIRES both signatures
         to validate, providing safety against compromise of either algorithm.
 
+        Accepts the intent either as a dict or as the named `action`/`target`/
+        `resource` arguments, exactly like :meth:`sign_credential`.
+
         Note: this profile produces credentials roughly 2.5 KB larger than
         the eddsa-jcs-2022 default. Implementations using this profile
         SHOULD transmit credentials in the HTTP request body (§5.6).
@@ -282,6 +337,8 @@ class Signer:
                 "Cannot issue Data Integrity credentials: private key bytes "
                 "could not be derived from the JWK"
             )
+
+        intent = _merge_intent(intent, action=action, target=target, resource=resource)
 
         chain = delegation_chain or []
         if parent_credential is not None:
@@ -422,3 +479,76 @@ def _is_sub_resource(child: str, parent: str) -> bool:
     if child.startswith(parent.rstrip("/") + "/"):
         return True
     return False
+
+
+def _merge_intent(
+    intent: Optional[Dict[str, Any]],
+    *,
+    action: Optional[str] = None,
+    target: Optional[str] = None,
+    resource: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Combine a dict intent with the named action/target/resource arguments.
+
+    Named arguments override the matching keys in `intent`. The original dict is
+    never mutated. Required-field validation is left to `vc.build_vouch_credential`
+    so the error message stays in one place.
+    """
+    merged: Dict[str, Any] = dict(intent) if intent else {}
+    if action is not None:
+        merged["action"] = action
+    if target is not None:
+        merged["target"] = target
+    if resource is not None:
+        merged["resource"] = resource
+    return merged
+
+
+# ---------------------------------------------------------------------------
+# One-line signing (the sending-side counterpart to vouch.verify)
+# ---------------------------------------------------------------------------
+
+
+def sign(
+    keypair: Any,
+    intent: Optional[Dict[str, Any]] = None,
+    *,
+    action: Optional[str] = None,
+    target: Optional[str] = None,
+    resource: Optional[str] = None,
+    valid_seconds: Optional[int] = None,
+    reputation_score: Optional[int] = None,
+    parent_credential: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Sign an intent as a Vouch Credential in one line, no Signer to construct.
+
+    The no-class counterpart to :func:`vouch.verify`::
+
+        keys = vouch.generate_identity("agent.example")
+        signed = vouch.sign(keys, action="read", target="did:web:files",
+                            resource="https://files/x")
+        ok, who = vouch.verify(signed, keys.public_key_jwk)
+
+    Args:
+      keypair: a :class:`~vouch.keys.KeyPair` (must carry a DID).
+      intent: optional intent dict; alternatively pass `action`/`target`/
+        `resource` as named arguments. The two styles may be combined.
+      action / target / resource: named intent fields.
+      valid_seconds: optional validity window override.
+      reputation_score: optional self-reported score in [0, 100].
+      parent_credential: optional parent grant to chain this credential under.
+
+    Returns:
+      A signed Vouch Credential dict, identical to what
+      ``Signer.from_keypair(keypair).sign_credential(...)`` returns.
+    """
+    signer = Signer.from_keypair(keypair)
+    return signer.sign_credential(
+        intent,
+        action=action,
+        target=target,
+        resource=resource,
+        valid_seconds=valid_seconds,
+        reputation_score=reputation_score,
+        parent_credential=parent_credential,
+    )

--- a/vouch/verifier.py
+++ b/vouch/verifier.py
@@ -139,6 +139,41 @@ class CredentialPassport:
     reputation_score: Optional[int] = None
     delegation_chain: List[CredentialDelegationLink] = field(default_factory=list)
 
+    # Convenience accessors so callers can read what was authorized without
+    # reaching into `intent` or `raw_credential` by hand.
+
+    @property
+    def action(self) -> Optional[str]:
+        """The intent action that was signed, if present."""
+        return (self.intent or {}).get("action")
+
+    @property
+    def target(self) -> Optional[str]:
+        """The intent target that was signed, if present."""
+        return (self.intent or {}).get("target")
+
+    @property
+    def resource(self) -> Optional[str]:
+        """The intent resource that was signed, if present."""
+        return (self.intent or {}).get("resource")
+
+    @property
+    def issuer(self) -> str:
+        """The issuer DID. Alias for :attr:`iss`."""
+        return self.iss
+
+    @property
+    def is_expired(self) -> bool:
+        """True if the credential's validity window has passed.
+
+        Independent of the clock skew applied during verification: this is a
+        plain "is it past validUntil now" check for display and policy logic.
+        """
+        expires = _parse_iso8601(self.valid_until)
+        if expires is None:
+            return False
+        return datetime.now(timezone.utc) > expires
+
 
 class Verifier:
     """
@@ -630,6 +665,12 @@ class Verifier:
             except Exception:  # pragma: no cover
                 pass
 
+        # did:key is self-certifying: the public key is encoded in the DID
+        # itself, so it resolves offline with no network and is allowed even
+        # when allow_did_resolution is False.
+        if did.startswith("did:key:"):
+            return _resolve_did_key(did)
+
         if not (self._allow_resolution and did.startswith("did:web:")):
             return None
 
@@ -652,8 +693,8 @@ _DEFAULT_VERIFIER: Optional["Verifier"] = None
 
 def verify(
     credential: Optional[Union[Dict[str, Any], str]] = None,
-    *,
     public_key: Optional[Union[Ed25519PublicKey, str]] = None,
+    *,
     allow_did_resolution: bool = True,
 ) -> Tuple[bool, Optional[CredentialPassport]]:
     """Verify a Vouch Credential in one line.
@@ -697,6 +738,23 @@ def verify(
 # ---------------------------------------------------------------------------
 # Module-private helpers
 # ---------------------------------------------------------------------------
+
+
+def _resolve_did_key(did: str) -> Optional[Ed25519PublicKey]:
+    """Decode the Ed25519 public key embedded in a ``did:key`` identifier.
+
+    ``did:key:z6Mk...`` carries the multicodec-tagged public key in the DID
+    string, so there is no network resolution. Returns None for non-Ed25519
+    did:key values or malformed input.
+    """
+    try:
+        mk = did.split("did:key:", 1)[1]
+        alg, raw = multikey.decode(mk)
+        if alg == "Ed25519":
+            return Ed25519PublicKey.from_public_bytes(raw)
+    except (IndexError, ValueError):
+        return None
+    return None
 
 
 def _coerce_ed25519_public_key(


### PR DESCRIPTION
# Additive developer-experience helpers (Agent, one-liners, tool guards)

Seven additive sugar helpers over the existing Signer/Verifier. Nothing changes
the credential wire format; the dict credential stays canonical and every new
API returns or accepts that same dict. The existing Signer, Verifier,
sign_credential, and verify_credential are untouched.

## What changed

1. Agent wrapper. `vouch.Agent("agent.example")` mints an identity and holds the
   signer. `agent.sign(action=, target=, resource=)` issues a credential,
   `agent.verify(signed)` checks it (own key for own credentials, DID resolution
   for others), `agent.did` / `agent.public_key_jwk` are plain attributes, and
   `Agent.load(private_key_jwk, did)` / `Agent.from_keypair(keys)` rehydrate.
   With a domain the identity is did:web, without one it is a self-certifying
   did:key.
2. Top-level one-liners. `vouch.sign(keys, action=, target=, resource=)` issues a
   credential from a keypair with no Signer to construct. `vouch.verify(signed,
   public_key)` already existed and now takes the key positionally too.
3. Named-argument intent. `signer.sign_credential(action=, target=, resource=)`
   in addition to `intent={...}`. The dict form still works; named arguments
   override matching keys. Also on `sign_credential_hybrid`.
4. Verify defaults to DID resolution, now including did:key. `vouch.verify(signed)`
   with no key resolves the issuer from did:web or did:key (did:key is offline,
   so it works even with resolution disabled). Pass a key to override.
5. Result accessors. `passport.action/target/resource/issuer/is_expired`, plus a
   `vouch.Credential(signed)` wrapper exposing `.intent/.action/.target/.resource/
   .issuer/.is_expired`, `.verify(public_key)`, and `.to_json()/.to_dict()`.
6. One-line tool guards. `@vouch.require_signed(trusted_dids=[...])` verifies an
   inbound credential, enforces an issuer allowlist and optional intent policy,
   and rejects unsigned/forged/untrusted calls before the tool runs.
   `vouch.guard_mcp(server, trusted_dids=[...])` patches a tool server's
   registration so every tool is guarded; `vouch.guard_tools([...])` does the
   same for a plain list of callables.
7. `Signer.from_keypair(keys)` convenience constructor.

## Security boundary of each new helper

- `Signer.from_keypair`, `vouch.sign`, named-arg intent: pure construction sugar.
  Identical credential and proof to the existing path; no trust decision is made.
  Named arguments are merged into a copy of the intent (caller dict is never
  mutated). Required-field validation still happens in build_vouch_credential.
- `Agent`: holds the private key in memory exactly as a Signer does. `agent.verify`
  uses the agent's own public key only when the credential's issuer equals the
  agent's own DID; otherwise it delegates to `vouch.verify` (DID resolution). An
  explicit `public_key` always forces offline verification. Minting with no
  domain produces a did:key, which is self-certifying (the key is the identifier),
  not a network-resolvable authority.
- did:key resolution: decodes the Ed25519 key embedded in the DID. It binds the
  proof to whatever key the issuer names in its own DID, so it authenticates
  message integrity and self-consistency, not real-world identity. Treat did:key
  as a self-asserted identifier unless you pin it via trusted_dids or a registry.
  did:web resolution and the existing issuer/verificationMethod binding checks are
  unchanged.
- Result accessors / `Credential`: read-only views over the dict. `Credential.verify`
  is the only place that makes a trust decision and it just calls `vouch.verify`.
  `is_expired` is a plain "past validUntil now" check with no skew, for display
  and policy, and is independent of the skew applied during signature verification.
- `require_signed` / `guard_mcp` / `guard_tools`: verify the Data Integrity proof
  (via CredentialGate), enforce the issuer allowlist (trusted_dids), and optionally
  match action/target/resource, before the tool body runs. They authenticate the
  caller and, when configured, the declared intent. They do NOT by themselves bind
  the credential to the concrete argument values of the call, and they do NOT
  provide replay protection; pair them with intent policy and a nonce tracker when
  those matter. The credential is read from the `vouch_credential` keyword; it is
  stripped before calling a tool that does not declare it, so a plain tool
  signature is not broken. A rejected call raises PermissionError (or returns None
  with `on_reject="none"`).

## Cross-language parity

| # | Helper | Python | Go | TypeScript |
|---|--------|--------|----|-----------|
| 1 | Agent | done | n/a here | follow-up |
| 2 | top-level sign / verify | done | n/a here | follow-up |
| 3 | named-arg intent | done | done | follow-up |
| 4 | verify did:key default | done | n/a here | follow-up |
| 5 | accessors + Credential | done | follow-up | follow-up |
| 6 | require_signed / guard_mcp | done | follow-up | follow-up |
| 7 | Signer.from_keypair | done | n/a here | follow-up |

Python is the reference and is complete. Go gained the named-argument intent
(item 3); the other items need key generation and a verifier, which do not live in
the signer-only `go-sidecar` package yet, so they are a follow-up. TypeScript is a
follow-up: the build environment for this change has no Node toolchain, so the
published package was not edited without a compile check. The intended TS and Go
signatures are written up for the follow-up pass.

## Tests and verification

- New tests in `tests/test_dx_sugar.py` (40 cases), runnable on Python 3.9 to 3.12.
- New Go tests in `go-sidecar/signer/named_intent_test.go`.
- Full Python suite: 877 passed, 2 skipped. The only failures are 3 pre-existing
  ones in `test_git_workflow.py` that shell out to a `python` executable and a
  normal (non-worktree) checkout; they pass in CI.
- Go: `go build`, `go vet`, and `go test ./signer/` all pass.
- Cross-language interop vectors (jcs, hybrid) pass.
- `ruff format --check` and `ruff check` clean.
- Examples updated: `examples/01_quickstart/01_hello_world.py` and
  `examples/05_integrations/07_mcp.py` now use the one-liners.
