### PR TITLE
feat(accountability): anchor precedence affordance (existence vs pre-outcome ordering)

### DIFF
--- a/docs/disclosures/PAD-071-outcome-evidence-commit-before-outcome-credential.md
+++ b/docs/disclosures/PAD-071-outcome-evidence-commit-before-outcome-credential.md
@@ -191,12 +191,22 @@ adds an optional `anchor` to the commitment: one entry or a tier list, each
 carrying a `method` (a third-party timestamping service such as OpenTimestamps,
 an RFC 3161 timestamp authority, a transparency log, or an on-chain method), a
 `reference` to the proof at that service, and a `recomputeCmd` a verifier runs to
-check it. With an anchor, a consumer confirms the commitment existed before the
-outcome without trusting the committer. The anchor is carried inside the signed
-credential, so it is tamper-evident, and the anchor itself is checked out of band
-by the consumer against the named method. The original claims are unchanged; the
-anchor is a disclosed strengthening of the pre-outcome timing property, released
-under Apache 2.0.
+check it. The anchor is carried inside the signed credential, so it is
+tamper-evident, and the anchor itself is checked out of band by the consumer
+against the named method.
+
+A precision the first update glossed: an anchor proves the commitment existed by
+the stamped time, which is existence, not ordering. It does not by itself prove
+that time is before the outcome, because an anchor can be a post-hoc existence
+backfill, stamped after the outcome was known. So each anchor entry carries an
+`establishes` affordance: `existence-only` (the default, asserting only existence
+by the stamped time) or `pre-outcome-ordering` (asserting a forward commitment
+made before the outcome). A consumer concludes commit-before-outcome only when an
+anchor establishes `pre-outcome-ordering` and the consumer independently confirms,
+via the `recomputeCmd`, that the stamped time precedes the settlement time. This
+is the difference between anchored and anchored before the outcome. The original
+claims are unchanged; the anchor with its precedence affordance is a disclosed
+strengthening of the pre-outcome timing property, released under Apache 2.0.
 
 ---
 

--- a/docs/interop/erc-8004-crosswalk.md
+++ b/docs/interop/erc-8004-crosswalk.md
@@ -25,7 +25,7 @@ record, two transports, no translation layer required at the field level.
 |---|---|---|
 | `commitment.digest` | `verdictHash` / `artifactHash` | salted SHA-256 over JCS-canonical claim |
 | `validFrom` | `verdictTimestamp` (committed time) | self-asserted unless anchored |
-| `commitment.anchor[]` `{method, reference, recomputeCmd}` | ERC-8299 Appendix B anchor hierarchy | open `method` string; a consumer takes the strongest surviving tier |
+| `commitment.anchor[]` `{method, reference, recomputeCmd, establishes}` | ERC-8299 Appendix B anchor hierarchy | open `method` string; `establishes` is `pre-outcome-ordering` or `existence-only`; ordering also requires the stamped time to precede settlement |
 | `settlement` `{method, locator, resolutionCriteria}` | resolution descriptor | transport-neutral on the Vouch side |
 | `proof` (eddsa-jcs-2022) | on-chain signature | a pointer references on-chain entries; it does not re-verify their crypto |
 

--- a/tests/test_accountability.py
+++ b/tests/test_accountability.py
@@ -8,9 +8,12 @@ from vouch import Signer, generate_identity
 from vouch.accountability import (
     OUTCOME_ATTESTATION_TYPE,
     OUTCOME_COMMITMENT_TYPE,
+    PRECEDENCE_EXISTENCE,
+    PRECEDENCE_PRE_OUTCOME,
     AccountabilityError,
     accountability_pointer,
     attest_outcome,
+    claims_precedence,
     commit_outcome,
     commitment_digest,
     timestamp_anchor,
@@ -280,8 +283,54 @@ class TestAnchor:
         assert a == {
             "method": "transparency-log",
             "reference": "leaf-7",
+            "establishes": PRECEDENCE_EXISTENCE,
             "recomputeCmd": "rekor verify leaf-7",
         }
+
+    def test_anchor_defaults_to_existence_only(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(
+            signer,
+            claim=CLAIM,
+            settlement=SETTLEMENT,
+            anchor=timestamp_anchor("opentimestamps", "ref"),
+        )
+        anchor = cred["credentialSubject"]["commitment"]["anchor"][0]
+        assert anchor["establishes"] == PRECEDENCE_EXISTENCE
+        assert claims_precedence(cred) is False  # an anchor alone is not ordering
+
+    def test_pre_outcome_ordering_is_claimed(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(
+            signer,
+            claim=CLAIM,
+            settlement=SETTLEMENT,
+            anchor=timestamp_anchor(
+                "opentimestamps", "ref", "ots verify ref", establishes=PRECEDENCE_PRE_OUTCOME
+            ),
+        )
+        assert claims_precedence(cred) is True
+
+    def test_raw_anchor_dict_gets_existence_default(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(
+            signer,
+            claim=CLAIM,
+            settlement=SETTLEMENT,
+            anchor={"method": "rfc3161-tsa", "reference": "r"},
+        )
+        assert cred["credentialSubject"]["commitment"]["anchor"][0]["establishes"] == (
+            PRECEDENCE_EXISTENCE
+        )
+
+    def test_bad_establishes_rejected(self):
+        with pytest.raises(AccountabilityError):
+            timestamp_anchor("opentimestamps", "ref", establishes="whenever")
+
+    def test_no_anchor_does_not_claim_precedence(self):
+        _, signer = _identity()
+        cred, _ = commit_outcome(signer, claim=CLAIM, settlement=SETTLEMENT)
+        assert claims_precedence(cred) is False
 
 
 class TestSettlementAndPointerFields:

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -199,6 +199,9 @@ def __getattr__(name):
         "accountability_pointer",
         "commitment_digest",
         "timestamp_anchor",
+        "claims_precedence",
+        "PRECEDENCE_PRE_OUTCOME",
+        "PRECEDENCE_EXISTENCE",
         "OUTCOME_COMMITMENT_TYPE",
         "OUTCOME_ATTESTATION_TYPE",
     ):
@@ -359,6 +362,9 @@ __all__ = [
     "accountability_pointer",
     "commitment_digest",
     "timestamp_anchor",
+    "claims_precedence",
+    "PRECEDENCE_PRE_OUTCOME",
+    "PRECEDENCE_EXISTENCE",
     "OUTCOME_COMMITMENT_TYPE",
     "OUTCOME_ATTESTATION_TYPE",
     # Reputation receipts and aggregation

--- a/vouch/accountability.py
+++ b/vouch/accountability.py
@@ -121,8 +121,16 @@ def _type_list(credential: Dict[str, Any]) -> list:
 # ---------------------------------------------------------------------------
 
 
+PRECEDENCE_PRE_OUTCOME = "pre-outcome-ordering"
+PRECEDENCE_EXISTENCE = "existence-only"
+_PRECEDENCE_VALUES = (PRECEDENCE_PRE_OUTCOME, PRECEDENCE_EXISTENCE)
+
+
 def timestamp_anchor(
-    method: str, reference: str, recompute_cmd: Optional[str] = None
+    method: str,
+    reference: str,
+    recompute_cmd: Optional[str] = None,
+    establishes: str = PRECEDENCE_EXISTENCE,
 ) -> Dict[str, Any]:
     """
     Build a third-party timestamp anchor for a commitment.
@@ -130,13 +138,21 @@ def timestamp_anchor(
     `method` names the external timestamping service (for example
     ``opentimestamps``, ``rfc3161-tsa``, ``transparency-log``, or an on-chain
     method), `reference` is the proof or locator at that service, and
-    `recompute_cmd` is the literal command a verifier runs to check it. The anchor
-    lets a consumer confirm a commitment existed before its outcome without
-    trusting the committer's own clock.
+    `recompute_cmd` is the literal command a verifier runs to check it.
+
+    `establishes` states what the stamp proves. An anchor proves the commitment
+    existed by the stamped time; it does not by itself prove that time is before
+    the outcome. ``existence-only`` (the default) asserts only existence by the
+    stamped time; ``pre-outcome-ordering`` asserts the stamp was a forward
+    commitment made before the outcome. A consumer concludes commit-before-outcome
+    only when an anchor is ``pre-outcome-ordering`` and it independently confirms,
+    via ``recomputeCmd``, that the stamped time precedes the settlement time.
     """
     if not method or not reference:
         raise AccountabilityError("an anchor needs a method and a reference")
-    entry: Dict[str, Any] = {"method": method, "reference": reference}
+    if establishes not in _PRECEDENCE_VALUES:
+        raise AccountabilityError("establishes must be 'pre-outcome-ordering' or 'existence-only'")
+    entry: Dict[str, Any] = {"method": method, "reference": reference, "establishes": establishes}
     if recompute_cmd is not None:
         entry["recomputeCmd"] = recompute_cmd
     return entry
@@ -150,8 +166,28 @@ def _normalize_anchor(anchor: Any) -> Optional[list]:
     for a in items:
         if not isinstance(a, dict) or not a.get("method") or not a.get("reference"):
             raise AccountabilityError("each anchor needs a method and a reference")
-        out.append(dict(a))
+        entry = dict(a)
+        entry.setdefault("establishes", PRECEDENCE_EXISTENCE)
+        if entry["establishes"] not in _PRECEDENCE_VALUES:
+            raise AccountabilityError(
+                "anchor establishes must be 'pre-outcome-ordering' or 'existence-only'"
+            )
+        out.append(entry)
     return out
+
+
+def claims_precedence(commitment: Dict[str, Any]) -> bool:
+    """
+    Whether a commitment carries an anchor that claims pre-outcome ordering.
+
+    True only signals the claim; a consumer still confirms, out of band via the
+    anchor's ``recomputeCmd``, that the stamped time precedes the settlement time
+    before concluding the commitment was made before the outcome.
+    """
+    anchors = ((commitment.get("credentialSubject") or {}).get("commitment") or {}).get("anchor")
+    if not isinstance(anchors, list):
+        return False
+    return any(a.get("establishes") == PRECEDENCE_PRE_OUTCOME for a in anchors)
 
 
 def commit_outcome(
@@ -542,9 +578,12 @@ __all__ = [
     "OUTCOME_ATTESTATION_TYPE",
     "ACCOUNTABILITY_RECORD_TYPE",
     "COMMITMENT_ALGORITHM",
+    "PRECEDENCE_PRE_OUTCOME",
+    "PRECEDENCE_EXISTENCE",
     "AccountabilityError",
     "commitment_digest",
     "timestamp_anchor",
+    "claims_precedence",
     "commit_outcome",
     "verify_commitment",
     "attest_outcome",


### PR DESCRIPTION
Refines the `anchor` (from #180) after a real-world catch from the first reference integrator (invinoveritas) on discussion #53.

## The gap

An `anchor` proves a commitment existed by the stamped time. That is **existence**, not **ordering**. It does not by itself prove the stamped time is before the outcome, because an anchor can be a post-hoc existence backfill, stamped after the result was known. So "take the strongest surviving tier" does not let a consumer conclude back-dating is ruled out.

## The fix

Each anchor entry now carries an `establishes` affordance:

- `existence-only` (the default): asserts only that the commitment existed by the stamped time.
- `pre-outcome-ordering`: asserts a forward commitment, made before the outcome.

A consumer concludes commit-before-outcome only when an anchor establishes `pre-outcome-ordering` and it independently confirms, via the `recomputeCmd`, that the stamped time precedes the settlement time. `claims_precedence(commitment)` reports whether the claim is present; the time comparison stays out of band, as it must.

`timestamp_anchor()` gains an `establishes` parameter (default `existence-only`, the honest default). PAD-071 and the ERC-8004 crosswalk are updated to draw the existence-versus-ordering distinction.

## Tests

31 tests in `tests/test_accountability.py` (6 new precedence tests), all passing; ruff clean.
