### PR TITLE
Correct remaining website code samples to the real SDK API

### DIFF
--- a/tests/test_signer.py
+++ b/tests/test_signer.py
@@ -140,3 +140,25 @@ class TestKeyGeneration:
         keys1 = generate_identity(domain="test.com")
         keys2 = generate_identity(domain="test.com")
         assert keys1.private_key_jwk != keys2.private_key_jwk
+
+
+class TestSignCredentialStatus:
+    """sign_credential accepts a credentialStatus entry covered by the proof."""
+
+    def test_credential_status_is_attached_and_signed(self, keypair):
+        from vouch import Signer, Verifier
+        from vouch.status_list import build_status_list_entry
+
+        signer = Signer(private_key=keypair.private_key_jwk, did=keypair.did)
+        entry = build_status_list_entry(
+            status_list_credential="https://issuer.example/status/1",
+            status_list_index=0,
+        )
+        signed = signer.sign_credential(
+            intent={"action": "a", "target": "t", "resource": "r"},
+            credential_status=entry,
+        )
+        assert signed["credentialStatus"] == entry
+        # The proof covers the status entry, so verification still passes.
+        ok, _ = Verifier.verify_credential(signed, keypair.public_key_jwk)
+        assert ok

--- a/vouch/signer.py
+++ b/vouch/signer.py
@@ -196,6 +196,7 @@ class Signer:
         parent_credential: Optional[Dict[str, Any]] = None,
         valid_from: Optional[datetime] = None,
         credential_id: Optional[str] = None,
+        credential_status: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """
         Issue a Verifiable Credential with a Data Integrity proof.
@@ -214,6 +215,10 @@ class Signer:
             a new link from the parent's subject to this Signer's DID.
           valid_from: Optional override for the credential's `validFrom`.
           credential_id: Optional credential ID. Defaults to a fresh UUID URN.
+          credential_status: Optional W3C `credentialStatus` entry (typically
+            from `vouch.status_list.build_status_list_entry`) so a credential
+            can be revoked later. The proof covers it, so it must be set at
+            signing time.
 
         Returns:
           A signed Vouch Credential dict conforming to VC Data Model 2.0
@@ -241,6 +246,7 @@ class Signer:
             delegation_chain=chain or None,
             credential_id=credential_id,
             valid_from=valid_from,
+            credential_status=credential_status,
         )
 
         proof = data_integrity.build_proof(

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -640,10 +640,16 @@ pip install vouch-protocol
 Then:
 
 \`\`\`python
-from vouch import Signer, build_vouch_credential
+from vouch import Signer, generate_identity
 
-signer = Signer.from_did_with_hybrid("did:web:agent.example.com")
-signed = signer.sign_credential_hybrid(credential)
+keys = generate_identity("agent.example.com")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
+
+signed = signer.sign_credential_hybrid(intent={
+  "action": "submit_claim",
+  "target": "claim:HC-001",
+  "resource": "https://insurance.example.com/claims/HC-001",
+})
 \`\`\`
 
 The resulting credential's \`proof\` field is an **array** of two Data Integrity proofs: one with \`cryptosuite: "eddsa-jcs-2022"\` (the classical Ed25519 proof) and one with \`cryptosuite: "mldsa44-jcs-2026"\` (the post-quantum ML-DSA-44 proof). Both proofs cover the same JCS-canonicalized credential bytes. Verifiers iterate the array and apply their local policy (validate either, validate both).
@@ -688,31 +694,28 @@ The verifier walks every link, validates signatures, and confirms resource subse
       },
       {
         q: 'How do I make a credential revocable later?',
-        a: `Attach a status entry when you issue it. That way, if you ever need to revoke it, you just flip a bit on a published list. Two steps: allocate an index from your status list, then pass a status entry to \`build_vouch_credential\`:
+        a: `Attach a status entry when you issue it. That way, if you ever need to revoke it, you just flip a bit on a published list. Allocate an index from your status list, then pass the entry as \`credential_status\` to \`sign_credential\` so the proof covers it:
 
 \`\`\`python
-from vouch import (
-  StatusList, build_status_list_entry, build_vouch_credential, Signer,
-)
+from vouch import Signer, StatusList, build_status_list_entry, generate_identity
 
 # Issuer maintains a single StatusList per status purpose (revocation or suspension).
 status_list = StatusList(status_list_id="https://issuer.example/status/1")
 index = status_list.allocate_index()
 
-# Attach the status entry at issuance time.
 status_entry = build_status_list_entry(
   status_list_credential="https://issuer.example/status/1",
   status_list_index=index,
 )
 
-credential = build_vouch_credential(
-  issuer_did="did:web:issuer.example",
+keys = generate_identity("issuer.example")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
+
+signed = signer.sign_credential(
   intent={"action": "submit_claim", "target": "claim:HC-001",
       "resource": "https://insurance.example/claims/HC-001"},
   credential_status=status_entry,
 )
-
-signed = Signer.from_did("did:web:issuer.example").sign_credential(credential)
 \`\`\`
 
 The TypeScript and Go SDKs expose the same API (\`buildStatusListEntry\` / \`BuildStatusListEntry\`) and accept \`credentialStatus\` / \`CredentialStatus\` on their credential builders.`,
@@ -1198,8 +1201,14 @@ You can issue dual-proof credentials right now and they remain valid whether you
         a: `Just call the hybrid signer. The \`pqcrypto\` library is bundled with \`vouch-protocol\` by default (since v1.6.0), so a plain \`pip install vouch-protocol\` gives you everything needed:
 
 \`\`\`python
-signer = Signer.from_did_with_hybrid("did:web:agent.example.com")
-signed = signer.sign_credential_hybrid(credential)
+from vouch import Signer, generate_identity
+
+keys = generate_identity("agent.example.com")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
+signed = signer.sign_credential_hybrid(intent={
+  "action": "submit_claim", "target": "claim:HC-001",
+  "resource": "https://insurance.example/claims/HC-001",
+})
 \`\`\`
 
 TypeScript and Go work the same way. There is a full how-to in the [Guides](/help/#hybrid-pq) with code in all three languages.

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -89,10 +89,8 @@ That round-trip is the entire credential layer: keypair, signed action, verified
 The legacy JWS form above stays for backward compatibility. New code should prefer the W3C Verifiable Credential form with a Data Integrity proof (\`eddsa-jcs-2022\`):
 
 \`\`\`python
-from vouch import build_vouch_credential
-
-credential = build_vouch_credential(
-    subject_did=identity.did,
+# sign_credential takes the intent directly (action, target, resource required).
+signed = signer.sign_credential(
     intent={
         "action": "submit_claim",
         "target": "claim:HC-001",
@@ -100,8 +98,6 @@ credential = build_vouch_credential(
     },
     valid_seconds=300,
 )
-
-signed = signer.sign_credential(credential)
 print(signed["proof"]["proofValue"])
 \`\`\`
 
@@ -173,7 +169,6 @@ import {
   Signer,
   Verifier,
   generateIdentity,
-  buildVouchCredential,
 } from '@vouch-protocol-official/sdk';
 
 async function main() {
@@ -186,8 +181,8 @@ async function main() {
     did: identity.did!,
   });
 
-  const credential = buildVouchCredential({
-    subjectDid: identity.did!,
+  // signCredential takes the intent directly (action, target, resource).
+  const signed = await signer.signCredential({
     intent: {
       action: 'submit_claim',
       target: 'claim:HC-001',
@@ -195,8 +190,6 @@ async function main() {
     },
     validSeconds: 300,
   });
-
-  const signed = await signer.signCredential(credential);
   console.log('signed proof value:', signed.proof.proofValue);
 
   // trustedRoots is the local-dev escape hatch: in production the verifier
@@ -603,10 +596,14 @@ The Cloudflare circl dependency is already transitive in the sidecar.
 Python:
 
 \`\`\`python
-from vouch import Signer
+from vouch import Signer, generate_identity
 
-signer = Signer.from_did_with_hybrid("did:web:agent.example.com")
-signed = signer.sign_credential_hybrid(credential)
+keys = generate_identity("agent.example.com")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
+signed = signer.sign_credential_hybrid(intent={
+    "action": "submit_claim", "target": "claim:HC-001",
+    "resource": "https://insurance.example.com/claims/HC-001",
+})
 \`\`\`
 
 TypeScript:
@@ -704,36 +701,37 @@ When a human principal delegates to an agent that delegates to a sub-agent, you 
 
 ## Build a chain in Python
 
+Each credential chains under its parent with \`parent_credential=\`, which appends a delegation link and enforces resource narrowing automatically:
+
 \`\`\`python
-from vouch import Signer, build_vouch_credential
+from vouch import Signer
 
-principal = Signer.from_did("did:web:principal.example.com")
-agent = Signer.from_did("did:web:agent.example.com")
-sub_agent = Signer.from_did("did:web:sub-agent.example.com")
+principal = Signer(private_key=principal_priv_jwk, did="did:web:principal.example.com")
+agent = Signer(private_key=agent_priv_jwk, did="did:web:agent.example.com")
+sub_agent = Signer(private_key=sub_agent_priv_jwk, did="did:web:sub-agent.example.com")
 
-# Principal delegates to agent
-principal_link = principal.sign_credential(build_vouch_credential(
-  subject_did=agent.did,
-  intent={"action": "*", "target": "*", "resource": "https://insurance.example.com/claims/*"},
+# Principal delegates broad authority to the agent.
+principal_link = principal.sign_credential(
+  intent={"action": "*", "target": "*", "resource": "claims"},
   valid_seconds=3600,
-))
+)
 
-# Agent narrows and delegates to sub-agent
-agent_link = agent.sign_credential(build_vouch_credential(
-  subject_did=sub_agent.did,
-  intent={"action": "read", "target": "claim:HC-001", "resource": "https://insurance.example.com/claims/HC-001"},
+# Agent narrows and re-delegates to the sub-agent.
+agent_link = agent.sign_credential(
+  intent={"action": "read", "target": "claim:HC-001", "resource": "claims/HC-001"},
   valid_seconds=300,
-  delegated_from=[principal_link],
-))
+  parent_credential=principal_link,
+)
 
-# Sub-agent signs its actual action
-action = sub_agent.sign_credential(build_vouch_credential(
-  subject_did=sub_agent.did,
-  intent={"action": "read", "target": "claim:HC-001", "resource": "https://insurance.example.com/claims/HC-001"},
+# Sub-agent signs its actual action under the chain.
+action = sub_agent.sign_credential(
+  intent={"action": "read", "target": "claim:HC-001", "resource": "claims/HC-001"},
   valid_seconds=60,
-  delegated_from=[principal_link, agent_link],
-))
+  parent_credential=agent_link,
+)
 \`\`\`
+
+For the one-line path, the principal can issue the grant with \`vouch.delegate(...)\` and the agent's tools can be wrapped with \`vouch.protect([...], parent=grant)\`.
 
 ## Verify
 
@@ -1061,7 +1059,7 @@ The issuer maintains one or more \`StatusList\` instances (one per status purpos
 from vouch import (
   Signer, StatusList, FilesystemStatusListStore,
   build_status_list_credential, build_status_list_entry,
-  build_vouch_credential,
+  generate_identity,
 )
 
 # Load or create the status list. Persisted state survives restarts.
@@ -1071,14 +1069,15 @@ try:
 except FileNotFoundError:
   status_list = StatusList(status_list_id="https://issuer.example/status/1")
 
-signer = Signer.from_did("did:web:issuer.example")
+keys = generate_identity("issuer.example")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
 
 # ---- Issue a credential with a credentialStatus entry ----
 index = status_list.allocate_index()
 store.save(status_list) # persist the new cursor
 
-credential = build_vouch_credential(
-  issuer_did="did:web:issuer.example",
+# Pass the status entry to sign_credential so the proof covers it.
+signed_credential = signer.sign_credential(
   intent={"action": "submit_claim", "target": "claim:HC-001",
       "resource": "https://insurance.example/claims/HC-001"},
   credential_status=build_status_list_entry(
@@ -1086,7 +1085,6 @@ credential = build_vouch_credential(
     status_list_index=index,
   ),
 )
-signed_credential = signer.sign_credential(credential)
 
 # ---- Later, revoke that credential ----
 status_list.revoke(index)


### PR DESCRIPTION
Follow-up to #173, which merged the landing-page and first FAQ changes. This corrects the remaining FAQ and Help samples that still used SDK functions which do not exist.

Reopens #177, which was closed automatically when its branch lost its common history with `main`. Same change, rebased on current `main`.

## FAQ (`src/app/faq/faq-data.ts`) and Help (`src/app/help/help-data.ts`)
- Replaced `Signer.from_did(...)` and `Signer.from_did_with_hybrid(...)` with `Signer(private_key=, did=)`.
- Replaced the Python `build_vouch_credential(...)` double-wrap with `sign_credential(intent=...)` / `sign_credential_hybrid(intent=...)`.
- Rewrote the delegation-chain sample to the real `parent_credential=` chaining.
- Rewrote the revocable-credential samples to issue in one call via `sign_credential(credential_status=...)`.

## SDK (`vouch/signer.py`)
- Added a `credential_status` pass-through on `Signer.sign_credential`, so a revocable credential can be issued in one call (the status sample relies on it). The proof covers the status entry. Includes a test.
