### PR TITLE
Add JVM SDK job to SDK CI

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -107,3 +107,22 @@ jobs:
       - name: Test
         working-directory: sdks/dotnet
         run: dotnet test --nologo
+
+  jvm:
+    name: JVM SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build the native core and refresh the binding
+        working-directory: sdks/jvm
+        run: bash build-native.sh
+      - name: Test
+        working-directory: sdks/jvm
+        run: |
+          chmod +x gradlew
+          ./gradlew test --no-daemon


### PR DESCRIPTION
Adds the JVM SDK job to the SDK Tests workflow, completing CI coverage for every language (Python, Go, Rust, TypeScript, WASM, C, .NET, and now JVM).

The job builds the native core via the SDK's own build-native.sh, which also refreshes the UniFFI Kotlin binding so the binding and library stay consistent, then runs the JNA-backed JUnit suite (canonicalize, sign, and verify over the native core).

Verified locally: build-native.sh plus gradle test passes.
