### PR TITLE
TypeScript SDK: developer-experience helpers and secure key custody

### DIFF
--- a/packages/sdk-ts/src/agent.ts
+++ b/packages/sdk-ts/src/agent.ts
@@ -1,0 +1,245 @@
+/**
+ * The `Agent` wrapper: one object that holds an identity and signs/verifies.
+ *
+ * ```typescript
+ * const agent = await Agent.create('agent.example');
+ * const signed = await agent.sign({
+ *   action: 'read', target: 'did:web:files', resource: 'https://files/x',
+ * });
+ * const { isValid, passport } = await agent.verify(signed);
+ * agent.did; agent.publicKeyJwk;
+ * ```
+ *
+ * Construction is via the async `Agent.create` factory (key generation and
+ * persistence are async). With a `domain` the identity is `did:web:<domain>`;
+ * without one it is a self-certifying `did:key`.
+ *
+ * Storage is secure by default: a minted identity is persisted to the best
+ * available store (or the caller is warned that it is memory-only). The raw
+ * private key is not handed back unless `allowKeyExport: true` is set; signing
+ * always works through the Agent.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  EncryptedFileKeyStore,
+  KeyStore,
+  resolveDefaultStore,
+  StoredIdentity,
+} from './keystore';
+import { Signer, generateIdentity } from './signer';
+import type { CredentialVerificationResult, SignCredentialOptions } from './types';
+import type { VouchCredential } from './vc';
+import { Verifier, verify } from './verifier';
+
+export interface AgentCreateOptions {
+  defaultExpirySeconds?: number;
+  /** Explicit key store. Omit to auto-resolve; pass null to disable persistence. */
+  store?: KeyStore | null;
+  /** Persist the minted identity (default true). */
+  persist?: boolean;
+  /** Password for the default encrypted file store. */
+  password?: string;
+  /** Allow reading the raw private key back (default false). */
+  allowKeyExport?: boolean;
+}
+
+export interface AgentVerifyOptions {
+  publicKey?: crypto.KeyObject | string | Record<string, unknown>;
+  clockSkewSeconds?: number;
+}
+
+export class Agent {
+  private readonly identity: StoredIdentity;
+  private readonly signerInstance: Signer;
+  private readonly allowKeyExport: boolean;
+  private store?: KeyStore;
+  /** Where the identity was persisted, if it was. */
+  storedAt?: string;
+
+  private constructor(
+    identity: StoredIdentity,
+    signer: Signer,
+    allowKeyExport: boolean
+  ) {
+    this.identity = identity;
+    this.signerInstance = signer;
+    this.allowKeyExport = allowKeyExport;
+  }
+
+  /** Mint a fresh identity and (by default) persist it securely. */
+  static async create(domain?: string, opts?: AgentCreateOptions): Promise<Agent> {
+    const gen = await generateIdentity(domain);
+    const did = gen.did ?? `did:key:${gen.publicKeyMultikey}`;
+    const identity: StoredIdentity = {
+      privateKeyJwk: gen.privateKeyJwk,
+      publicKeyJwk: gen.publicKeyJwk,
+      did,
+    };
+    const signer = Signer.fromKeypair(
+      { privateKeyJwk: identity.privateKeyJwk, did },
+      { defaultExpirySeconds: opts?.defaultExpirySeconds }
+    );
+    const agent = new Agent(identity, signer, opts?.allowKeyExport ?? false);
+
+    const persist = opts?.persist ?? true;
+    const resolved =
+      opts?.store !== undefined ? opts.store : persist ? resolveDefaultStore(opts?.password) : null;
+    if (persist && resolved) {
+      agent.storedAt = await resolved.save(identity);
+      agent.store = resolved;
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `vouch: Agent minted identity ${did} (in memory only, not persisted). ` +
+        'It is lost when this process exits; pass a store/password to keep it.'
+      );
+    }
+    return agent;
+  }
+
+  /** Rehydrate an Agent from stored keys (no new identity is minted). */
+  static load(
+    privateKeyJwk: string,
+    did: string,
+    opts?: {
+      publicKeyJwk?: string;
+      defaultExpirySeconds?: number;
+      allowKeyExport?: boolean;
+    }
+  ): Agent {
+    const publicKeyJwk = opts?.publicKeyJwk ?? publicJwkFromPrivate(privateKeyJwk);
+    const identity: StoredIdentity = { privateKeyJwk, publicKeyJwk, did };
+    const signer = Signer.fromKeypair(
+      { privateKeyJwk, did },
+      { defaultExpirySeconds: opts?.defaultExpirySeconds }
+    );
+    return new Agent(identity, signer, opts?.allowKeyExport ?? true);
+  }
+
+  /** Load a previously persisted identity from a store (key stays gated). */
+  static async fromStore(
+    did: string,
+    store: KeyStore,
+    opts?: { defaultExpirySeconds?: number; allowKeyExport?: boolean }
+  ): Promise<Agent> {
+    const identity = await store.load(did);
+    const signer = Signer.fromKeypair(
+      { privateKeyJwk: identity.privateKeyJwk, did: identity.did },
+      { defaultExpirySeconds: opts?.defaultExpirySeconds }
+    );
+    const agent = new Agent(identity, signer, opts?.allowKeyExport ?? false);
+    agent.store = store;
+    return agent;
+  }
+
+  get did(): string {
+    return this.identity.did;
+  }
+
+  get publicKeyJwk(): string {
+    return this.identity.publicKeyJwk;
+  }
+
+  get signer(): Signer {
+    return this.signerInstance;
+  }
+
+  /** The raw private key. Gated: requires `allowKeyExport: true`. */
+  privateKeyJwk(): string {
+    this.requireExport('privateKeyJwk');
+    return this.identity.privateKeyJwk;
+  }
+
+  private requireExport(what: string): void {
+    if (!this.allowKeyExport) {
+      throw new Error(
+        `Access to ${what} is disabled for this Agent. The private key is meant ` +
+        'to stay inside the Agent and sign on your behalf. If you really need the ' +
+        'raw key, create the Agent with allowKeyExport: true.'
+      );
+    }
+  }
+
+  /** Sign an intent as a Vouch Credential. */
+  async sign(opts: SignCredentialOptions): Promise<VouchCredential> {
+    return this.signerInstance.signCredential(opts);
+  }
+
+  /** Issue a delegation grant from this agent (the principal side). */
+  async delegate(opts: {
+    action: string;
+    target: string;
+    resource: string;
+    to?: string;
+    validSeconds?: number;
+    reputationScore?: number;
+  }): Promise<VouchCredential> {
+    const intent: Record<string, unknown> = {
+      action: opts.action,
+      target: opts.target,
+      resource: opts.resource,
+    };
+    if (opts.to) intent.delegatee = opts.to;
+    return this.signerInstance.signCredential({
+      intent: intent as never,
+      validSeconds: opts.validSeconds,
+      reputationScore: opts.reputationScore,
+    });
+  }
+
+  /**
+   * Verify a credential. Uses this agent's own key for its own credentials,
+   * otherwise resolves by DID (did:key) or uses an explicit key.
+   */
+  async verify(
+    credential: VouchCredential | Record<string, unknown> | string,
+    opts?: AgentVerifyOptions
+  ): Promise<CredentialVerificationResult> {
+    const skew = opts?.clockSkewSeconds ?? 30;
+    if (opts?.publicKey === undefined && issuerOf(credential) === this.did) {
+      return Verifier.verifyCredential(credential, this.identity.publicKeyJwk, skew);
+    }
+    return verify(credential, opts?.publicKey, { clockSkewSeconds: skew });
+  }
+
+  /** Persist this identity and return where it was saved. */
+  async save(
+    store?: KeyStore,
+    opts?: { password?: string; keyDir?: string }
+  ): Promise<string> {
+    const target =
+      store ?? new EncryptedFileKeyStore({ password: opts?.password, keyDir: opts?.keyDir });
+    const location = await target.save(this.identity);
+    this.store = target;
+    this.storedAt = location;
+    return location;
+  }
+}
+
+function issuerOf(
+  credential: VouchCredential | Record<string, unknown> | string
+): string | null {
+  try {
+    const cred =
+      typeof credential === 'string'
+        ? (JSON.parse(credential) as Record<string, unknown>)
+        : (credential as Record<string, unknown>);
+    const issuer = cred.issuer;
+    if (Array.isArray(issuer)) return (issuer[0] as string) ?? null;
+    return (issuer as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function publicJwkFromPrivate(privateKeyJwk: string): string {
+  const priv = crypto.createPrivateKey({
+    key: JSON.parse(privateKeyJwk) as crypto.JsonWebKey,
+    format: 'jwk',
+  });
+  const pub = crypto.createPublicKey(priv);
+  const jwk = pub.export({ format: 'jwk' });
+  return JSON.stringify(jwk);
+}

--- a/packages/sdk-ts/src/credential.ts
+++ b/packages/sdk-ts/src/credential.ts
@@ -1,0 +1,112 @@
+/**
+ * A thin, read-friendly wrapper over a Vouch Credential object.
+ *
+ * The object produced by `signCredential` (and `sign`) is the canonical, on-the
+ * -wire form. This wrapper sits on top so you can read back what a credential
+ * authorizes without digging through `credentialSubject.intent` by hand, and
+ * verify it in one call. It is sugar only: `toObject()` returns the same object
+ * you passed in, so nothing about the wire format changes.
+ */
+
+import * as crypto from 'crypto';
+
+import type { CredentialVerificationResult } from './types';
+import type { DelegationLink, Intent, VouchCredential } from './vc';
+import { verify } from './verifier';
+
+export class Credential {
+  private readonly cred: Record<string, unknown>;
+
+  constructor(credential: VouchCredential | Record<string, unknown> | string) {
+    let value: unknown = credential;
+    if (value instanceof Credential) {
+      value = value.cred;
+    }
+    if (typeof value === 'string') {
+      value = JSON.parse(value);
+    }
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      throw new TypeError('Credential expects an object or JSON string');
+    }
+    this.cred = value as Record<string, unknown>;
+  }
+
+  private get subject(): Record<string, unknown> {
+    return (this.cred.credentialSubject as Record<string, unknown>) ?? {};
+  }
+
+  get intent(): Intent {
+    return (this.subject.intent as Intent) ?? ({} as Intent);
+  }
+
+  get action(): string | undefined {
+    return this.intent.action;
+  }
+
+  get target(): string | undefined {
+    return this.intent.target;
+  }
+
+  get resource(): string | undefined {
+    return this.intent.resource;
+  }
+
+  get issuer(): string {
+    const issuer = this.cred.issuer;
+    if (Array.isArray(issuer)) return (issuer[0] as string) || '';
+    return (issuer as string) || '';
+  }
+
+  get subjectId(): string {
+    return (this.subject.id as string) || '';
+  }
+
+  get credentialId(): string {
+    return (this.cred.id as string) || '';
+  }
+
+  get validFrom(): string {
+    return (this.cred.validFrom as string) || '';
+  }
+
+  get validUntil(): string {
+    return (this.cred.validUntil as string) || '';
+  }
+
+  get isExpired(): boolean {
+    const t = Date.parse(this.validUntil);
+    if (Number.isNaN(t)) return false;
+    return t < Date.now();
+  }
+
+  get reputationScore(): number | undefined {
+    const score = this.subject.reputationScore;
+    return typeof score === 'number' && Number.isFinite(score) ? score : undefined;
+  }
+
+  get delegationChain(): DelegationLink[] {
+    const chain = this.subject.delegationChain;
+    return Array.isArray(chain) ? (chain as DelegationLink[]) : [];
+  }
+
+  /**
+   * Verify this credential. With a `publicKey`, verifies offline; without one,
+   * resolves a `did:key` issuer (offline). Returns the verification result.
+   */
+  async verify(
+    publicKey?: crypto.KeyObject | string | Record<string, unknown>,
+    opts?: { clockSkewSeconds?: number }
+  ): Promise<CredentialVerificationResult> {
+    return verify(this.cred, publicKey, opts);
+  }
+
+  /** Return the underlying credential object (the canonical wire form). */
+  toObject(): VouchCredential {
+    return this.cred as unknown as VouchCredential;
+  }
+
+  /** Return the credential as a compact JSON string for transport. */
+  toJsonString(): string {
+    return JSON.stringify(this.cred);
+  }
+}

--- a/packages/sdk-ts/src/data-integrity.ts
+++ b/packages/sdk-ts/src/data-integrity.ts
@@ -34,16 +34,28 @@ export interface DataIntegrityProof {
 }
 
 export interface BuildProofOptions {
-  privateKey: crypto.KeyObject;
+  /**
+   * The Ed25519 private key (signs in process), OR provide `sign` instead to
+   * keep the key outside this process. One of the two is required.
+   */
+  privateKey?: crypto.KeyObject;
+  /**
+   * A callback that signs the 32-byte digest and returns the 64-byte Ed25519
+   * signature, without exposing the key to this process (an OS secure element,
+   * a sidecar, a cloud KMS/HSM, or an MPC quorum). If both are set, `sign` wins.
+   */
+  sign?: (digest: Uint8Array) => Uint8Array;
   verificationMethod: string;
   proofPurpose?: string;
   created?: Date;
 }
 
 /**
- * Generate a Data Integrity proof object for `credential` using the given
- * Ed25519 private key. Returns the proof dict (caller attaches it to the
- * credential).
+ * Generate a Data Integrity proof object for `credential`.
+ *
+ * Sign either with `opts.privateKey` (in process) or `opts.sign` (a callback
+ * that signs the digest without exposing the key). Returns the proof dict
+ * (caller attaches it to the credential).
  *
  * Conforms to eddsa-jcs-2022 §3.1.
  */
@@ -64,10 +76,17 @@ export function buildProof(
   const canonical = canonicalize(withUnsignedProof);
   const digest = crypto.createHash('sha256').update(canonical).digest();
 
-  // Ed25519 signing in Node.js: algorithm parameter is null, the key type
-  // alone determines the algorithm.
-  const signature = crypto.sign(null, digest, opts.privateKey);
-  proof.proofValue = 'z' + b58encode(new Uint8Array(signature));
+  let signature: Uint8Array;
+  if (opts.sign) {
+    signature = opts.sign(new Uint8Array(digest));
+  } else if (opts.privateKey) {
+    // Ed25519 signing in Node.js: algorithm parameter is null, the key type
+    // alone determines the algorithm.
+    signature = new Uint8Array(crypto.sign(null, digest, opts.privateKey));
+  } else {
+    throw new Error('buildProof needs a privateKey or a sign callback');
+  }
+  proof.proofValue = 'z' + b58encode(signature);
   return proof;
 }
 

--- a/packages/sdk-ts/src/guard.ts
+++ b/packages/sdk-ts/src/guard.ts
@@ -1,0 +1,209 @@
+/**
+ * One-line verification guards for tool servers (MCP and other frameworks).
+ *
+ * On the sending side, `sign` / the Agent make an agent sign every tool call.
+ * On the receiving side, a tool server has to verify those credentials before
+ * it runs anything. This module covers in-process tool handlers:
+ *
+ * ```typescript
+ * const writeFile = requireSigned(
+ *   async (args) => `wrote ${args.path}`,
+ *   { trustedDids: ['did:key:z6Mk...'] }
+ * );
+ * await writeFile({ path: '/x', vouchCredential: signed });
+ *
+ * const server = guardMcp(server, { trustedDids: ['did:web:agent.example'] });
+ * ```
+ *
+ * Handlers take a single args object; the credential arrives on it under the
+ * `vouchCredential` field (configurable). The guard verifies the Data Integrity
+ * proof, enforces the issuer allowlist (`trustedDids`), and optionally matches
+ * the intent, before the handler runs.
+ *
+ * Security boundary: the guard authenticates the caller and, when configured,
+ * the declared intent. It does NOT by itself bind the credential to the other
+ * argument values, and it does NOT provide replay protection; pair it with
+ * intent policy and a nonce check when those matter.
+ */
+
+import * as crypto from 'crypto';
+
+import type { CredentialVerificationResult } from './types';
+import type { VouchCredential } from './vc';
+import { Verifier, verify } from './verifier';
+
+export const DEFAULT_CREDENTIAL_ARG = 'vouchCredential';
+
+export interface RequireSignedOptions {
+  /** Allowed issuer DIDs. Omit to allow any issuer whose key verifies. */
+  trustedDids?: string[];
+  /** Verify offline against this key. */
+  publicKey?: crypto.KeyObject | string | Record<string, unknown>;
+  /** Offline allowlist of issuer DID to public key. */
+  trustedKeys?: Record<string, string>;
+  /** Exact intent policy. */
+  requireAction?: string;
+  requireTarget?: string;
+  requireResource?: string;
+  /** Field the credential arrives under (default "vouchCredential"). */
+  credentialArg?: string;
+  /** Keep the credential field when calling the handler (default false). */
+  passCredential?: boolean;
+  /** "throw" (default) raises on reject; "null" returns null. */
+  onReject?: 'throw' | 'null';
+}
+
+type ArgsObject = Record<string, unknown>;
+
+/**
+ * Wrap a tool handler so a valid Vouch credential is required before it runs.
+ * The handler takes a single args object; the credential is read from
+ * `options.credentialArg` (default "vouchCredential").
+ */
+export function requireSigned<A extends ArgsObject, R>(
+  handler: (args: A) => R | Promise<R>,
+  options: RequireSignedOptions = {}
+): (args: A) => Promise<R | null> {
+  const allow = options.trustedDids ? new Set(options.trustedDids) : null;
+  const credentialArg = options.credentialArg ?? DEFAULT_CREDENTIAL_ARG;
+
+  const wrapped = async (args: A): Promise<R | null> => {
+    const credential = (args ?? {})[credentialArg] as
+      | VouchCredential
+      | Record<string, unknown>
+      | string
+      | undefined;
+    const result = await checkCredential(credential, options);
+
+    let reason: string | null = null;
+    if (!result.isValid || !result.passport) {
+      reason = result.error ?? 'unsigned or invalid credential';
+    } else if (allow && !allow.has(result.passport.issuer)) {
+      reason = `issuer ${result.passport.issuer} is not in trustedDids`;
+    }
+
+    if (reason) {
+      if (options.onReject === 'null') return null;
+      throw new Error(`Vouch guard rejected the call: ${reason}`);
+    }
+
+    let forwarded: A = args;
+    if (!options.passCredential && args && credentialArg in args) {
+      const copy = { ...(args as ArgsObject) };
+      delete copy[credentialArg];
+      forwarded = copy as A;
+    }
+    return handler(forwarded);
+  };
+  (wrapped as { __vouchGuarded?: boolean }).__vouchGuarded = true;
+  return wrapped;
+}
+
+/** Wrap a list of tool handlers with {@link requireSigned}. */
+export function guardTools<A extends ArgsObject, R>(
+  handlers: Array<(args: A) => R | Promise<R>>,
+  options: RequireSignedOptions = {}
+): Array<(args: A) => Promise<R | null>> {
+  return handlers.map((h) =>
+    (h as { __vouchGuarded?: boolean }).__vouchGuarded
+      ? (h as unknown as (args: A) => Promise<R | null>)
+      : requireSigned(h, options)
+  );
+}
+
+/**
+ * Wrap an MCP-style tool server so every tool registered after this call is
+ * verified. Patches the server's tool-registration entry point (`tool`,
+ * `addTool`, or `registerTool`, each taking the handler as its last function
+ * argument). Returns the same server. The credential must reach each handler
+ * under the `vouchCredential` field of its args object.
+ */
+export function guardMcp<S extends object>(server: S, options: RequireSignedOptions = {}): S {
+  for (const attr of ['tool', 'addTool', 'registerTool'] as const) {
+    const original = (server as Record<string, unknown>)[attr];
+    if (typeof original === 'function') {
+      if ((original as { __vouchGuardPatched?: boolean }).__vouchGuardPatched) {
+        return server;
+      }
+      const patched = function (this: unknown, ...args: unknown[]): unknown {
+        const idx = lastFunctionIndex(args);
+        if (idx >= 0) {
+          args[idx] = requireSigned(args[idx] as (a: ArgsObject) => unknown, options);
+        }
+        return (original as (...a: unknown[]) => unknown).apply(this ?? server, args);
+      };
+      (patched as { __vouchGuardPatched?: boolean }).__vouchGuardPatched = true;
+      (server as Record<string, unknown>)[attr] = patched;
+      return server;
+    }
+  }
+  throw new TypeError(
+    'guardMcp could not find a tool-registration hook (tool/addTool/registerTool) ' +
+    'on the server. Use the requireSigned wrapper on each handler instead.'
+  );
+}
+
+async function checkCredential(
+  credential: VouchCredential | Record<string, unknown> | string | undefined,
+  options: RequireSignedOptions
+): Promise<CredentialVerificationResult> {
+  if (!credential) {
+    return { isValid: false, passport: null, error: 'missing credential' };
+  }
+
+  let result: CredentialVerificationResult;
+  if (options.publicKey !== undefined) {
+    result = await verify(credential, options.publicKey);
+  } else if (options.trustedKeys) {
+    const issuer = issuerOf(credential);
+    const key = issuer ? options.trustedKeys[issuer] : undefined;
+    if (!key) {
+      return { isValid: false, passport: null, error: 'issuer not in trustedKeys' };
+    }
+    result = await Verifier.verifyCredential(credential, key);
+  } else {
+    result = await verify(credential);
+  }
+
+  if (!result.isValid || !result.passport) return result;
+
+  const intent = result.passport.intent ?? {};
+  const checks: Array<[string, string | undefined, unknown]> = [
+    ['action', options.requireAction, intent.action],
+    ['target', options.requireTarget, intent.target],
+    ['resource', options.requireResource, intent.resource],
+  ];
+  for (const [field, expected, actual] of checks) {
+    if (expected !== undefined && actual !== expected) {
+      return {
+        isValid: false,
+        passport: null,
+        error: `intent.${field} does not match ${expected}`,
+      };
+    }
+  }
+  return result;
+}
+
+function issuerOf(
+  credential: VouchCredential | Record<string, unknown> | string
+): string | null {
+  try {
+    const cred =
+      typeof credential === 'string'
+        ? (JSON.parse(credential) as Record<string, unknown>)
+        : (credential as Record<string, unknown>);
+    const issuer = cred.issuer;
+    if (Array.isArray(issuer)) return (issuer[0] as string) ?? null;
+    return (issuer as string) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function lastFunctionIndex(args: unknown[]): number {
+  for (let i = args.length - 1; i >= 0; i--) {
+    if (typeof args[i] === 'function') return i;
+  }
+  return -1;
+}

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -28,8 +28,24 @@
 // Cryptographic SDK (v1.0+)
 // ---------------------------------------------------------------------------
 
-export { Signer, generateIdentity } from './signer';
-export { Verifier } from './verifier';
+export { Signer, generateIdentity, sign } from './signer';
+export { Verifier, verify } from './verifier';
+export { Agent } from './agent';
+export type { AgentCreateOptions, AgentVerifyOptions } from './agent';
+export { Credential } from './credential';
+export {
+  requireSigned,
+  guardMcp,
+  guardTools,
+  DEFAULT_CREDENTIAL_ARG,
+} from './guard';
+export type { RequireSignedOptions } from './guard';
+export {
+  MemoryKeyStore,
+  EncryptedFileKeyStore,
+  resolveDefaultStore,
+} from './keystore';
+export type { KeyStore, StoredIdentity } from './keystore';
 
 export type {
   Passport,

--- a/packages/sdk-ts/src/keystore.ts
+++ b/packages/sdk-ts/src/keystore.ts
@@ -1,0 +1,242 @@
+/**
+ * Where a minted identity is saved, so it is not lost when the process exits.
+ *
+ * A freshly generated identity (DID, private key, public key) lives only in
+ * memory until something persists it. This module gives a small, uniform
+ * `KeyStore` interface and two backends:
+ *
+ *   - `MemoryKeyStore`        in-process only (explicitly ephemeral)
+ *   - `EncryptedFileKeyStore` encrypted file on disk (~/.vouch/keys), with the
+ *                             private key sealed under a password (scrypt +
+ *                             ChaCha20-Poly1305)
+ *
+ * `resolveDefaultStore()` picks the best available backend. The store keeps the
+ * private key sealed; it is only returned to a caller on an explicit `load`.
+ *
+ * (An OS-keyring backend, like the Python KeyringKeyStore, is a follow-up: it
+ * needs an optional native dependency.)
+ */
+
+import * as crypto from 'crypto';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** A stored agent identity. */
+export interface StoredIdentity {
+  privateKeyJwk: string;
+  publicKeyJwk: string;
+  did: string;
+}
+
+/** A place identities can be saved to and loaded from. */
+export interface KeyStore {
+  readonly name: string;
+  /** Persist an identity. Resolves to a human-readable location string. */
+  save(identity: StoredIdentity): Promise<string>;
+  /** Load a previously saved identity by DID. */
+  load(did: string): Promise<StoredIdentity>;
+  /** List the DIDs this store holds. */
+  list(): Promise<string[]>;
+  /** Remove a stored identity. */
+  delete(did: string): Promise<void>;
+}
+
+/** In-process store. Explicitly ephemeral: nothing survives the process. */
+export class MemoryKeyStore implements KeyStore {
+  readonly name = 'memory';
+  private items = new Map<string, StoredIdentity>();
+
+  async save(identity: StoredIdentity): Promise<string> {
+    if (!identity.did) throw new Error('Cannot store an identity without a DID');
+    this.items.set(identity.did, identity);
+    return 'memory (not persisted)';
+  }
+
+  async load(did: string): Promise<StoredIdentity> {
+    const found = this.items.get(did);
+    if (!found) throw new Error(`Identity ${did} not in memory store`);
+    return found;
+  }
+
+  async list(): Promise<string[]> {
+    return [...this.items.keys()];
+  }
+
+  async delete(did: string): Promise<void> {
+    this.items.delete(did);
+  }
+}
+
+interface SealedFile {
+  v: 1;
+  did: string;
+  publicKeyJwk: string;
+  encrypted: boolean;
+  privateKeyJwk?: string;
+  kdf?: { salt: string; n: number; r: number; p: number };
+  cipher?: { algo: string; nonce: string; ciphertext: string; tag: string };
+}
+
+/**
+ * Encrypted-at-rest file store under ~/.vouch/keys.
+ *
+ * With a `password`, the private key is sealed with scrypt + ChaCha20-Poly1305.
+ * With no password the private key is written in plaintext and a warning is
+ * logged; pass a password.
+ */
+export class EncryptedFileKeyStore implements KeyStore {
+  readonly name = 'encrypted-file';
+  private readonly keyDir: string;
+  private readonly password?: string;
+
+  constructor(opts?: { keyDir?: string; password?: string }) {
+    this.keyDir = opts?.keyDir ?? path.join(os.homedir(), '.vouch', 'keys');
+    this.password = opts?.password;
+  }
+
+  private filename(did: string): string {
+    const safe = did.replace(/[^A-Za-z0-9._-]/g, '-').replace(/^\.+|\.+$/g, '');
+    if (!safe) throw new Error(`DID does not yield a safe filename: ${did}`);
+    const file = path.join(this.keyDir, `${safe}.json`);
+    const resolved = path.resolve(file);
+    if (path.dirname(resolved) !== path.resolve(this.keyDir)) {
+      throw new Error(`unsafe key path for DID ${did}`);
+    }
+    return file;
+  }
+
+  async save(identity: StoredIdentity): Promise<string> {
+    if (!identity.did) throw new Error('Cannot store an identity without a DID');
+    fs.mkdirSync(this.keyDir, { recursive: true, mode: 0o700 });
+    const file = this.filename(identity.did);
+
+    let data: SealedFile;
+    if (this.password) {
+      const salt = crypto.randomBytes(16);
+      const n = 16384;
+      const r = 8;
+      const p = 1;
+      const key = crypto.scryptSync(this.password, salt, 32, { N: n, r, p });
+      const nonce = crypto.randomBytes(12);
+      const cipher = crypto.createCipheriv('chacha20-poly1305', key, nonce, {
+        authTagLength: 16,
+      });
+      const ciphertext = Buffer.concat([
+        cipher.update(Buffer.from(identity.privateKeyJwk, 'utf8')),
+        cipher.final(),
+      ]);
+      const tag = cipher.getAuthTag();
+      data = {
+        v: 1,
+        did: identity.did,
+        publicKeyJwk: identity.publicKeyJwk,
+        encrypted: true,
+        kdf: { salt: salt.toString('base64'), n, r, p },
+        cipher: {
+          algo: 'chacha20-poly1305',
+          nonce: nonce.toString('base64'),
+          ciphertext: ciphertext.toString('base64'),
+          tag: tag.toString('base64'),
+        },
+      };
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `vouch: saving identity ${identity.did} WITHOUT a password; the private ` +
+        'key is stored in plaintext. Pass a password to encrypt it.'
+      );
+      data = {
+        v: 1,
+        did: identity.did,
+        publicKeyJwk: identity.publicKeyJwk,
+        encrypted: false,
+        privateKeyJwk: identity.privateKeyJwk,
+      };
+    }
+
+    fs.writeFileSync(file, JSON.stringify(data, null, 2), { mode: 0o600 });
+    fs.chmodSync(file, 0o600);
+    return `${this.keyDir} (${this.password ? 'encrypted' : 'plaintext'})`;
+  }
+
+  async load(did: string): Promise<StoredIdentity> {
+    const file = this.filename(did);
+    if (!fs.existsSync(file)) throw new Error(`Identity ${did} not found`);
+    const data = JSON.parse(fs.readFileSync(file, 'utf8')) as SealedFile;
+
+    let privateKeyJwk: string;
+    if (data.encrypted) {
+      if (!this.password) throw new Error('Password required to decrypt identity');
+      try {
+        const kdf = data.kdf!;
+        const c = data.cipher!;
+        const key = crypto.scryptSync(this.password, Buffer.from(kdf.salt, 'base64'), 32, {
+          N: kdf.n,
+          r: kdf.r,
+          p: kdf.p,
+        });
+        const decipher = crypto.createDecipheriv(
+          'chacha20-poly1305',
+          key,
+          Buffer.from(c.nonce, 'base64'),
+          { authTagLength: 16 }
+        );
+        decipher.setAuthTag(Buffer.from(c.tag, 'base64'));
+        privateKeyJwk = Buffer.concat([
+          decipher.update(Buffer.from(c.ciphertext, 'base64')),
+          decipher.final(),
+        ]).toString('utf8');
+      } catch (e) {
+        throw new Error('Decryption failed. Invalid password or corrupted file.');
+      }
+    } else {
+      privateKeyJwk = data.privateKeyJwk as string;
+    }
+
+    return { privateKeyJwk, publicKeyJwk: data.publicKeyJwk, did: data.did };
+  }
+
+  async list(): Promise<string[]> {
+    if (!fs.existsSync(this.keyDir)) return [];
+    const dids: string[] = [];
+    for (const f of fs.readdirSync(this.keyDir)) {
+      if (!f.endsWith('.json')) continue;
+      try {
+        const data = JSON.parse(
+          fs.readFileSync(path.join(this.keyDir, f), 'utf8')
+        ) as SealedFile;
+        if (data.did) dids.push(data.did);
+      } catch {
+        // skip unreadable files
+      }
+    }
+    return dids;
+  }
+
+  async delete(did: string): Promise<void> {
+    const file = this.filename(did);
+    if (fs.existsSync(file)) fs.rmSync(file);
+  }
+}
+
+/**
+ * Pick the best available store for secure-by-default persistence.
+ *
+ * Order:
+ *   1. `VOUCH_KEYSTORE` = `memory` | `file` (explicit).
+ *   2. The encrypted file store, if a password is available (argument or
+ *      `VOUCH_KEY_PASSWORD`).
+ *   3. `null` (no secure persistence available; the caller should keep the
+ *      identity in memory and tell the user).
+ */
+export function resolveDefaultStore(password?: string): KeyStore | null {
+  const choice = (process.env.VOUCH_KEYSTORE ?? '').trim().toLowerCase();
+  const pw = password ?? process.env.VOUCH_KEY_PASSWORD;
+
+  if (choice === 'memory') return new MemoryKeyStore();
+  if (choice === 'file') return new EncryptedFileKeyStore({ password: pw });
+
+  if (pw) return new EncryptedFileKeyStore({ password: pw });
+  return null;
+}

--- a/packages/sdk-ts/src/signer.ts
+++ b/packages/sdk-ts/src/signer.ts
@@ -24,7 +24,11 @@ import {
   buildHybridProof,
   generateMLDSA44KeyPair,
 } from './data-integrity-hybrid';
-import { encodeEd25519Public, encodeMLDSA44Public } from './multikey';
+import {
+  decode as decodeMultikey,
+  encodeEd25519Public,
+  encodeMLDSA44Public,
+} from './multikey';
 import type {
   SignCredentialOptions,
   SignerConfig,
@@ -62,9 +66,15 @@ const MAX_CHAIN_DEPTH = 5;
 export class Signer {
   private did: string;
   private defaultExpiry: number;
-  private keyPromise: Promise<jose.KeyLike | Uint8Array>;
-  private rawPrivateKeyPromise: Promise<crypto.KeyObject>;
-  private rawPublicKeyBytesPromise: Promise<Uint8Array>;
+  private keyPromise!: Promise<jose.KeyLike | Uint8Array>;
+  private rawPrivateKeyPromise!: Promise<crypto.KeyObject>;
+  private rawPublicKeyBytesPromise!: Promise<Uint8Array>;
+
+  // Set for a backend Signer (fromBackend): the private key lives outside this
+  // process and this callback produces the signature over the digest.
+  private signFunc?: (digest: Uint8Array) => Uint8Array;
+  private backendPublicKeyJwk?: string;
+  private backendPublicMultikey?: string;
 
   // Lazily-generated ML-DSA-44 keypair for the hybrid post-quantum profile
   // (Specification §13.2). Independent of any other PQ key the caller may
@@ -121,6 +131,73 @@ export class Signer {
   }
 
   /**
+   * Build a Signer from a generated identity (the result of generateIdentity),
+   * so you do not have to unpack privateKeyJwk and did by hand.
+   */
+  static fromKeypair(
+    keypair: { privateKeyJwk: string; did: string | null },
+    opts?: { defaultExpirySeconds?: number }
+  ): Signer {
+    if (!keypair.did) {
+      throw new Error(
+        'Signer.fromKeypair requires a keypair with a DID; generate it with a ' +
+        "domain, e.g. generateIdentity('agent.example')"
+      );
+    }
+    return new Signer({
+      privateKey: keypair.privateKeyJwk,
+      did: keypair.did,
+      defaultExpirySeconds: opts?.defaultExpirySeconds,
+    });
+  }
+
+  /**
+   * Build a Signer whose Ed25519 private key lives outside this process.
+   *
+   * Instead of a private JWK you supply the agent's public key and a callback
+   * `sign(digest) -> signature` that produces the Ed25519 signature over the
+   * digest. The raw key never enters this process, so it can live in an OS
+   * secure element, a sidecar, a cloud KMS/HSM, or an MPC quorum. This Signer
+   * issues Data Integrity credentials; the legacy JWS sign() and the hybrid
+   * profile, which need the raw key, are not available.
+   *
+   * @param did The agent's DID.
+   * @param publicKey The agent's public key as a JWK JSON string or a Multikey
+   *          (z-prefixed) string.
+   * @param sign Callback that signs the 32-byte digest, returns the 64-byte
+   *        Ed25519 signature.
+   */
+  static fromBackend(
+    did: string,
+    publicKey: string,
+    sign: (digest: Uint8Array) => Uint8Array,
+    opts?: { defaultExpirySeconds?: number }
+  ): Signer {
+    if (!did) throw new Error('Signer.fromBackend requires a did');
+    if (!publicKey) throw new Error('Signer.fromBackend requires the public key');
+    if (typeof sign !== 'function') {
+      throw new Error('Signer.fromBackend requires a sign callback');
+    }
+    const s: Signer = Object.create(Signer.prototype);
+    s.initBackend(did, publicKey, sign, opts?.defaultExpirySeconds ?? 300);
+    return s;
+  }
+
+  private initBackend(
+    did: string,
+    publicKey: string,
+    sign: (digest: Uint8Array) => Uint8Array,
+    defaultExpiry: number
+  ): void {
+    this.did = did;
+    this.defaultExpiry = defaultExpiry;
+    this.signFunc = sign;
+    const { jwk, multikey } = normalizePublicKey(publicKey);
+    this.backendPublicKeyJwk = jwk;
+    this.backendPublicMultikey = multikey;
+  }
+
+  /**
    * Get the DID associated with this signer.
    */
   getDid(): string {
@@ -140,6 +217,7 @@ export class Signer {
    * Specification §4.3.
    */
   async getPublicKeyMultikey(): Promise<string> {
+    if (this.backendPublicMultikey) return this.backendPublicMultikey;
     const raw = await this.rawPublicKeyBytesPromise;
     return encodeEd25519Public(raw);
   }
@@ -176,6 +254,12 @@ export class Signer {
     payload: Record<string, unknown>,
     expirySeconds?: number
   ): Promise<string> {
+    if (this.signFunc) {
+      throw new Error(
+        'The legacy JWS sign() needs the private key in this process and is not ' +
+        'available for a backend Signer (fromBackend); use signCredential'
+      );
+    }
     const key = await this.keyPromise;
     const now = Math.floor(Date.now() / 1000);
     const exp = now + (expirySeconds ?? this.defaultExpiry);
@@ -201,6 +285,7 @@ export class Signer {
    * Get the public key in JWK format (legacy DID Documents).
    */
   async getPublicKeyJwk(): Promise<string> {
+    if (this.backendPublicKeyJwk) return this.backendPublicKeyJwk;
     const key = await this.keyPromise;
     const publicJwk = await jose.exportJWK(key);
     delete (publicJwk as { d?: string }).d;
@@ -219,17 +304,15 @@ export class Signer {
    * in an HTTP body or header.
    */
   async signCredential(opts: SignCredentialOptions): Promise<VouchCredential> {
+    const intent = mergeIntent(opts);
     let chain: DelegationLink[] | undefined = opts.delegationChain;
     if (opts.parentCredential) {
-      chain = this.extendDelegationChainFromParent(
-        opts.parentCredential,
-        opts.intent
-      );
+      chain = this.extendDelegationChainFromParent(opts.parentCredential, intent);
     }
 
     const credential = buildVouchCredential({
       issuerDid: this.did,
-      intent: opts.intent,
+      intent,
       validSeconds: opts.validSeconds ?? this.defaultExpiry,
       reputationScore: opts.reputationScore,
       delegationChain: chain,
@@ -237,16 +320,28 @@ export class Signer {
       validFrom: opts.validFrom,
     });
 
-    const privateKey = await this.rawPrivateKeyPromise;
     const proof = buildProof(
       credential as unknown as Record<string, unknown>,
-      {
-        privateKey,
-        verificationMethod: this.verificationMethodId(),
-      }
+      await this.proofSignOptions()
     );
     credential.proof = proof;
     return credential;
+  }
+
+  /**
+   * Build the signing options for buildProof: the raw key if this Signer holds
+   * it, otherwise the backend sign callback.
+   */
+  private async proofSignOptions(): Promise<{
+    privateKey?: crypto.KeyObject;
+    sign?: (digest: Uint8Array) => Uint8Array;
+    verificationMethod: string;
+  }> {
+    if (this.signFunc) {
+      return { sign: this.signFunc, verificationMethod: this.verificationMethodId() };
+    }
+    const privateKey = await this.rawPrivateKeyPromise;
+    return { privateKey, verificationMethod: this.verificationMethodId() };
   }
 
   /**
@@ -269,17 +364,21 @@ export class Signer {
    * transmit credentials in the HTTP request body.
    */
   async signCredentialHybrid(opts: SignCredentialOptions): Promise<VouchCredential> {
+    if (this.signFunc) {
+      throw new Error(
+        'signCredentialHybrid is not supported for a backend Signer (fromBackend); ' +
+        'use the eddsa-jcs-2022 path or hold the key locally'
+      );
+    }
+    const intent = mergeIntent(opts);
     let chain: DelegationLink[] | undefined = opts.delegationChain;
     if (opts.parentCredential) {
-      chain = this.extendDelegationChainFromParent(
-        opts.parentCredential,
-        opts.intent
-      );
+      chain = this.extendDelegationChainFromParent(opts.parentCredential, intent);
     }
 
     const credential = buildVouchCredential({
       issuerDid: this.did,
-      intent: opts.intent,
+      intent,
       validSeconds: opts.validSeconds ?? this.defaultExpiry,
       reputationScore: opts.reputationScore,
       delegationChain: chain,
@@ -403,9 +502,58 @@ export async function generateIdentity(domain?: string): Promise<{
   };
 }
 
+/**
+ * Sign an intent as a Vouch Credential in one line, no Signer to construct.
+ *
+ * The sending-side counterpart to {@link verify}:
+ * ```typescript
+ * const keys = await generateIdentity('agent.example');
+ * const signed = await sign(keys, {
+ *   action: 'read', target: 'did:web:files', resource: 'https://files/x',
+ * });
+ * ```
+ */
+export async function sign(
+  keypair: { privateKeyJwk: string; did: string | null },
+  opts: SignCredentialOptions
+): Promise<VouchCredential> {
+  return Signer.fromKeypair(keypair).signCredential(opts);
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+/** Combine a dict intent with the named action/target/resource shortcuts. */
+function mergeIntent(opts: SignCredentialOptions): Intent {
+  const merged: Record<string, unknown> = { ...(opts.intent ?? {}) };
+  if (opts.action !== undefined) merged.action = opts.action;
+  if (opts.target !== undefined) merged.target = opts.target;
+  if (opts.resource !== undefined) merged.resource = opts.resource;
+  return merged as Intent;
+}
+
+/** Accept a JWK JSON string or a Multikey (z...) string, return both forms. */
+function normalizePublicKey(publicKey: string): { jwk: string; multikey: string } {
+  if (publicKey.startsWith('z')) {
+    const { algorithm, rawKey } = decodeMultikey(publicKey);
+    if (algorithm !== 'Ed25519') {
+      throw new Error(`Expected an Ed25519 public key, got ${algorithm}`);
+    }
+    const jwk = JSON.stringify({
+      kty: 'OKP',
+      crv: 'Ed25519',
+      x: base64UrlEncode(rawKey),
+    });
+    return { jwk, multikey: publicKey };
+  }
+  const parsed = JSON.parse(publicKey) as JWKKey;
+  if (parsed.kty !== 'OKP' || parsed.crv !== 'Ed25519' || !parsed.x) {
+    throw new Error('Public key JWK must be an Ed25519 key (OKP, crv Ed25519)');
+  }
+  const raw = base64UrlDecode(parsed.x);
+  return { jwk: publicKey, multikey: encodeEd25519Public(raw) };
+}
 
 function base64UrlDecode(s: string): Uint8Array {
   const padded = s
@@ -413,6 +561,14 @@ function base64UrlDecode(s: string): Uint8Array {
     .replace(/_/g, '/')
     .padEnd(s.length + ((4 - (s.length % 4)) % 4), '=');
   return new Uint8Array(Buffer.from(padded, 'base64'));
+}
+
+function base64UrlEncode(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
 }
 
 function isSubResource(child: string, parent: string): boolean {

--- a/packages/sdk-ts/src/types.ts
+++ b/packages/sdk-ts/src/types.ts
@@ -55,6 +55,16 @@ export interface CredentialPassport {
   credentialId: string;
   /** Intent payload (action, target, resource) */
   intent: Intent;
+  /** Convenience accessor: intent.action. */
+  action?: string;
+  /** Convenience accessor: intent.target. */
+  target?: string;
+  /** Convenience accessor: intent.resource. */
+  resource?: string;
+  /** Issuer DID. Alias for `iss`. */
+  issuer: string;
+  /** True if the credential's validity window has passed (no skew). */
+  isExpired: boolean;
   /** Optional self-reported reputation score in [0, 100] */
   reputationScore?: number;
   /** Ordered delegation chain from root to current */
@@ -109,8 +119,18 @@ export interface JWKKey {
  * Options for issuing a Vouch Credential (modern path).
  */
 export interface SignCredentialOptions {
-  /** Intent payload. MUST contain action, target, resource. */
-  intent: Intent;
+  /**
+   * Intent payload. MUST contain action, target, resource once merged with the
+   * named fields below. Pass the whole intent here, or use the
+   * action/target/resource shortcuts, or combine them (named fields win).
+   */
+  intent?: Intent;
+  /** Intent action (alternative to intent.action). */
+  action?: string;
+  /** Intent target (alternative to intent.target). */
+  target?: string;
+  /** Intent resource (alternative to intent.resource). */
+  resource?: string;
   /** Override the default validity window in seconds. */
   validSeconds?: number;
   /** Optional self-reported reputation score in [0, 100]. */

--- a/packages/sdk-ts/src/verifier.ts
+++ b/packages/sdk-ts/src/verifier.ts
@@ -324,10 +324,15 @@ export class Verifier {
     const passport: CredentialPassport = {
       sub: (subject.id as string) || '',
       iss: issuer,
+      issuer: issuer,
       validFrom: cred.validFrom as string,
       validUntil: cred.validUntil as string,
       credentialId: (cred.id as string) || '',
       intent: intent,
+      action: intent.action,
+      target: intent.target,
+      resource: intent.resource,
+      isExpired: validUntil.getTime() < Date.now(),
       reputationScore: repScore,
       delegationChain: chain,
       rawCredential: cred as unknown as VouchCredential,
@@ -391,6 +396,57 @@ export class Verifier {
       };
     }
   }
+}
+
+/**
+ * Verify a Vouch Credential in one line (the receiving-side counterpart to
+ * {@link sign}).
+ *
+ * With a `publicKey`, verifies offline against that key. Without one, the issuer
+ * key is resolved from a `did:key` issuer (self-certifying, offline). For
+ * `did:web` issuers, pass the public key or use a Verifier with trusted roots.
+ */
+export async function verify(
+  credential: VouchCredential | Record<string, unknown> | string,
+  publicKey?: crypto.KeyObject | string | Record<string, unknown>,
+  opts?: { clockSkewSeconds?: number }
+): Promise<CredentialVerificationResult> {
+  const skew = opts?.clockSkewSeconds ?? 30;
+  if (publicKey !== undefined) {
+    return Verifier.verifyCredential(credential, publicKey, skew);
+  }
+
+  let cred: Record<string, unknown>;
+  try {
+    cred =
+      typeof credential === 'string'
+        ? (JSON.parse(credential) as Record<string, unknown>)
+        : (credential as Record<string, unknown>);
+  } catch {
+    return { isValid: false, passport: null, error: 'Invalid credential JSON' };
+  }
+
+  const issuerField = cred.issuer;
+  const issuer =
+    typeof issuerField === 'string'
+      ? issuerField
+      : Array.isArray(issuerField)
+       ? (issuerField[0] as string) || ''
+       : '';
+
+  if (issuer.startsWith('did:key:')) {
+    // did:key is self-certifying: the multikey after the prefix is the key.
+    const multikey = issuer.slice('did:key:'.length);
+    return Verifier.verifyCredential(cred, multikey, skew);
+  }
+
+  return {
+    isValid: false,
+    passport: null,
+    error:
+      `Cannot resolve the issuer key for ${issuer || 'this credential'}; ` +
+      'pass a publicKey, or use a Verifier configured with trusted roots',
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/sdk-ts/tests/dx-parity.test.ts
+++ b/packages/sdk-ts/tests/dx-parity.test.ts
@@ -1,0 +1,366 @@
+/**
+ * Tests for the developer-experience and secure key-custody surface ported from
+ * the Python SDK: Agent, top-level sign/verify, named-argument intent,
+ * Signer.fromKeypair / fromBackend, the sign callback, did:key resolution, the
+ * Credential wrapper, key stores, and the requireSigned / guardMcp guards.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Agent,
+  Credential,
+  EncryptedFileKeyStore,
+  MemoryKeyStore,
+  Signer,
+  Verifier,
+  buildProof,
+  buildVouchCredential,
+  generateIdentity,
+  guardMcp,
+  guardTools,
+  requireSigned,
+  sign,
+  verify,
+} from '../src';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const INTENT = {
+  action: 'read',
+  target: 'did:web:files',
+  resource: 'https://files/x',
+};
+
+function rawPrivate(privateKeyJwk: string): crypto.KeyObject {
+  return crypto.createPrivateKey({
+    key: JSON.parse(privateKeyJwk) as crypto.JsonWebKey,
+    format: 'jwk',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Named-argument intent + Signer.fromKeypair
+// ---------------------------------------------------------------------------
+
+describe('named-argument intent and fromKeypair', () => {
+  test('named args equal the intent object and verify', async () => {
+    const keys = await generateIdentity('agent.example');
+    const signer = Signer.fromKeypair(keys);
+    const byObject = await signer.signCredential({ intent: INTENT });
+    const byNamed = await signer.signCredential({
+      action: 'read',
+      target: 'did:web:files',
+      resource: 'https://files/x',
+    });
+    expect(byNamed.credentialSubject.intent).toEqual(byObject.credentialSubject.intent);
+    const { isValid } = await Verifier.verifyCredential(byNamed, keys.publicKeyJwk);
+    expect(isValid).toBe(true);
+  });
+
+  test('named fields override the intent object', async () => {
+    const keys = await generateIdentity('agent.example');
+    const signer = Signer.fromKeypair(keys);
+    const cred = await signer.signCredential({
+      intent: INTENT,
+      resource: 'https://files/override',
+    });
+    expect(cred.credentialSubject.intent.resource).toBe('https://files/override');
+    expect(cred.credentialSubject.intent.action).toBe('read');
+  });
+
+  test('fromKeypair without a DID throws', async () => {
+    const keys = await generateIdentity();
+    expect(() => Signer.fromKeypair(keys)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Top-level sign / verify
+// ---------------------------------------------------------------------------
+
+describe('top-level sign and verify', () => {
+  test('sign then verify with an explicit key', async () => {
+    const keys = await generateIdentity('agent.example');
+    const signed = await sign(keys, INTENT);
+    const { isValid, passport } = await verify(signed, keys.publicKeyJwk);
+    expect(isValid).toBe(true);
+    expect(passport?.action).toBe('read');
+    expect(passport?.resource).toBe('https://files/x');
+  });
+
+  test('verify rejects the wrong key', async () => {
+    const keys = await generateIdentity('agent.example');
+    const other = await generateIdentity('other.example');
+    const signed = await sign(keys, INTENT);
+    const { isValid } = await verify(signed, other.publicKeyJwk);
+    expect(isValid).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Agent
+// ---------------------------------------------------------------------------
+
+describe('Agent', () => {
+  test('mint did:web, sign, self-verify', async () => {
+    const agent = await Agent.create('agent.example', { persist: false });
+    expect(agent.did).toBe('did:web:agent.example');
+    const signed = await agent.sign(INTENT);
+    const { isValid, passport } = await agent.verify(signed);
+    expect(isValid).toBe(true);
+    expect(passport?.issuer).toBe(agent.did);
+  });
+
+  test('mint did:key and verify offline through verify()', async () => {
+    const agent = await Agent.create(undefined, { persist: false });
+    expect(agent.did.startsWith('did:key:')).toBe(true);
+    const signed = await agent.sign(INTENT);
+    const { isValid, passport } = await verify(signed);
+    expect(isValid).toBe(true);
+    expect(passport?.issuer).toBe(agent.did);
+  });
+
+  test('load roundtrip', async () => {
+    const agent = await Agent.create('agent.example', {
+      persist: false,
+      allowKeyExport: true,
+    });
+    const signed = await agent.sign(INTENT);
+    const reloaded = Agent.load(agent.privateKeyJwk(), agent.did);
+    expect(reloaded.did).toBe(agent.did);
+    const { isValid } = await reloaded.verify(signed);
+    expect(isValid).toBe(true);
+  });
+
+  test('private key is gated by default and signing still works', async () => {
+    const agent = await Agent.create('agent.example', { persist: false });
+    expect(() => agent.privateKeyJwk()).toThrow();
+    const signed = await agent.sign(INTENT);
+    const { isValid } = await agent.verify(signed);
+    expect(isValid).toBe(true);
+  });
+
+  test('private key with explicit consent', async () => {
+    const agent = await Agent.create('agent.example', {
+      persist: false,
+      allowKeyExport: true,
+    });
+    expect(agent.privateKeyJwk()).toBeTruthy();
+  });
+
+  test('persists to a given store and reloads', async () => {
+    const store = new MemoryKeyStore();
+    const agent = await Agent.create('agent.example', { store });
+    expect(await store.list()).toEqual([agent.did]);
+    const reloaded = await Agent.fromStore(agent.did, store);
+    const signed = await reloaded.sign(INTENT);
+    const { isValid } = await reloaded.verify(signed);
+    expect(isValid).toBe(true);
+    expect(() => reloaded.privateKeyJwk()).toThrow();
+  });
+
+  test('delegate and chain', async () => {
+    const principal = await Agent.create('principal.example', { persist: false });
+    const grant = await principal.delegate({
+      action: 'charge',
+      target: 'api.bank',
+      resource: 'https://api.bank/invoices',
+    });
+    const worker = await Agent.create('worker.example', { persist: false });
+    const child = await worker.sign({
+      action: 'charge',
+      target: 'api.bank',
+      resource: 'https://api.bank/invoices/42',
+      parentCredential: grant,
+    });
+    expect(child.credentialSubject.delegationChain?.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Backend signing (key never in the Signer)
+// ---------------------------------------------------------------------------
+
+describe('backend signing', () => {
+  test('buildProof accepts a sign callback', async () => {
+    const keys = await generateIdentity('agent.example');
+    const raw = rawPrivate(keys.privateKeyJwk);
+    let calls = 0;
+    const cred = buildVouchCredential({ issuerDid: keys.did!, intent: INTENT });
+    const proof = buildProof(cred as unknown as Record<string, unknown>, {
+      sign: (digest) => {
+        calls++;
+        return new Uint8Array(crypto.sign(null, Buffer.from(digest), raw));
+      },
+      verificationMethod: `${keys.did}#key-1`,
+    });
+    (cred as Record<string, unknown>).proof = proof;
+    expect(calls).toBe(1);
+    const { isValid } = await Verifier.verifyCredential(cred, keys.publicKeyJwk);
+    expect(isValid).toBe(true);
+  });
+
+  test('Signer.fromBackend signs without holding the key', async () => {
+    const keys = await generateIdentity('agent.example');
+    const raw = rawPrivate(keys.privateKeyJwk);
+    const signer = Signer.fromBackend(keys.did!, keys.publicKeyJwk, (digest) =>
+      new Uint8Array(crypto.sign(null, Buffer.from(digest), raw))
+    );
+    const cred = await signer.signCredential({ intent: INTENT });
+    const { isValid, passport } = await Verifier.verifyCredential(cred, keys.publicKeyJwk);
+    expect(isValid).toBe(true);
+    expect(passport?.issuer).toBe(keys.did);
+  });
+
+  test('backend signer blocks legacy JWS and hybrid', async () => {
+    const keys = await generateIdentity('agent.example');
+    const raw = rawPrivate(keys.privateKeyJwk);
+    const signer = Signer.fromBackend(keys.did!, keys.publicKeyJwk, (digest) =>
+      new Uint8Array(crypto.sign(null, Buffer.from(digest), raw))
+    );
+    await expect(signer.sign({ action: 'x' })).rejects.toThrow();
+    await expect(
+      signer.signCredentialHybrid({ action: 'a', target: 'b', resource: 'c' })
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Credential wrapper
+// ---------------------------------------------------------------------------
+
+describe('Credential wrapper', () => {
+  test('accessors and verify and JSON', async () => {
+    const keys = await generateIdentity('agent.example');
+    const signed = await sign(keys, INTENT);
+    const c = new Credential(signed);
+    expect(c.action).toBe('read');
+    expect(c.target).toBe('did:web:files');
+    expect(c.resource).toBe('https://files/x');
+    expect(c.issuer).toBe(keys.did);
+    expect(c.isExpired).toBe(false);
+    const { isValid } = await c.verify(keys.publicKeyJwk);
+    expect(isValid).toBe(true);
+    expect(JSON.parse(c.toJsonString())).toEqual(signed);
+  });
+
+  test('rejects bad input', () => {
+    expect(() => new Credential(12345 as never)).toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Key stores
+// ---------------------------------------------------------------------------
+
+describe('key stores', () => {
+  test('memory store roundtrip', async () => {
+    const keys = await generateIdentity('agent.example');
+    const store = new MemoryKeyStore();
+    await store.save({
+      privateKeyJwk: keys.privateKeyJwk,
+      publicKeyJwk: keys.publicKeyJwk,
+      did: keys.did!,
+    });
+    expect(await store.list()).toEqual([keys.did]);
+    const loaded = await store.load(keys.did!);
+    expect(loaded.privateKeyJwk).toBe(keys.privateKeyJwk);
+  });
+
+  test('encrypted file store roundtrip and wrong password', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vouch-ks-'));
+    const keys = await generateIdentity('agent.example');
+    const identity = {
+      privateKeyJwk: keys.privateKeyJwk,
+      publicKeyJwk: keys.publicKeyJwk,
+      did: keys.did!,
+    };
+    const loc = await new EncryptedFileKeyStore({ keyDir: dir, password: 'right' }).save(identity);
+    expect(loc).toContain('encrypted');
+    const loaded = await new EncryptedFileKeyStore({ keyDir: dir, password: 'right' }).load(
+      keys.did!
+    );
+    expect(loaded.privateKeyJwk).toBe(keys.privateKeyJwk);
+    await expect(
+      new EncryptedFileKeyStore({ keyDir: dir, password: 'wrong' }).load(keys.did!)
+    ).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guards
+// ---------------------------------------------------------------------------
+
+describe('requireSigned and guardMcp', () => {
+  test('allows a trusted signed call and rejects others', async () => {
+    const agent = await Agent.create(undefined, { persist: false }); // did:key
+    const signed = await agent.sign(INTENT);
+    const other = await Agent.create(undefined, { persist: false });
+    const fromOther = await other.sign(INTENT);
+
+    const writeFile = requireSigned(
+      async (args: { path: string }) => `wrote ${args.path}`,
+      { trustedDids: [agent.did] }
+    );
+
+    expect(await writeFile({ path: '/x', vouchCredential: signed } as never)).toBe('wrote /x');
+    await expect(writeFile({ path: '/x' } as never)).rejects.toThrow();
+    await expect(
+      writeFile({ path: '/x', vouchCredential: fromOther } as never)
+    ).rejects.toThrow();
+  });
+
+  test('intent policy', async () => {
+    const agent = await Agent.create(undefined, { persist: false });
+    const good = await agent.sign(INTENT);
+    const bad = await agent.sign({ action: 'delete', target: 't', resource: 'r' });
+    const handler = requireSigned(async () => 'ok', {
+      trustedDids: [agent.did],
+      requireAction: 'read',
+    });
+    expect(await handler({ vouchCredential: good } as never)).toBe('ok');
+    await expect(handler({ vouchCredential: bad } as never)).rejects.toThrow();
+  });
+
+  test('onReject null returns null', async () => {
+    const agent = await Agent.create(undefined, { persist: false });
+    const handler = requireSigned(async () => 'ran', {
+      trustedDids: [agent.did],
+      onReject: 'null',
+    });
+    expect(await handler({} as never)).toBeNull();
+  });
+
+  test('guardTools wraps a list', async () => {
+    const agent = await Agent.create(undefined, { persist: false });
+    const signed = await agent.sign(INTENT);
+    const [t1] = guardTools([async (args: { x: string }) => args.x], {
+      trustedDids: [agent.did],
+    });
+    expect(await t1({ x: 'hi', vouchCredential: signed } as never)).toBe('hi');
+    await expect(t1({ x: 'hi' } as never)).rejects.toThrow();
+  });
+
+  test('guardMcp patches a tool-registration hook', async () => {
+    const agent = await Agent.create(undefined, { persist: false });
+    const signed = await agent.sign(INTENT);
+
+    const registered: Record<string, (args: never) => unknown> = {};
+    const server = {
+      tool(name: string, handler: (args: never) => unknown) {
+        registered[name] = handler;
+      },
+    };
+    guardMcp(server, { trustedDids: [agent.did] });
+    server.tool('do_thing', async (args: { x: string }) => `did ${args.x}`);
+
+    expect(await registered.do_thing({ x: 'y', vouchCredential: signed } as never)).toBe('did y');
+    await expect(registered.do_thing({ x: 'y' } as never)).rejects.toThrow();
+  });
+
+  test('guardMcp throws without a hook', () => {
+    expect(() => guardMcp({} as never, { trustedDids: ['did:web:x'] })).toThrow();
+  });
+});


### PR DESCRIPTION
# TypeScript SDK: developer-experience helpers and secure key custody

Brings the TypeScript SDK to parity with the recent Python additions (the
developer-experience helpers and the secure key-custody follow-up). Everything is
additive over the existing `Signer` and `Verifier`; the credential wire format is
unchanged, and a TypeScript-signed credential verifies the same as a Python or Go
one.

## What it adds

- Named-argument intent on `signCredential` (`action` / `target` / `resource`)
  alongside the `intent` object, plus a top-level `sign(keys, opts)` and
  `verify(credential, publicKey?)`, `Signer.fromKeypair`, and `did:key`
  resolution in `verify()`.
- An `Agent` wrapper (`Agent.create(domain?)`, `load`, `fromStore`) that mints or
  loads an identity and signs and verifies; a `Credential` wrapper for reading
  back what a credential authorizes; and convenience accessors on the passport
  (`action` / `target` / `resource` / `issuer` / `isExpired`).
- `requireSigned`, `guardMcp`, and `guardTools` for verifying inbound tool calls.
- Backend signing: `buildProof` accepts a `sign(digest)` callback, and
  `Signer.fromBackend(did, publicKey, sign)` issues credentials while the private
  key lives outside the process. A `vouch.keystore` with in-memory and
  encrypted-file backends, and an `Agent` that persists by default and keeps the
  raw key in unless `allowKeyExport: true`.

## Notes on TypeScript shape

- `Agent.create` is async because key generation and persistence are async; the
  rest mirrors the Python surface.
- Guarded handlers take a single args object and read the credential from its
  `vouchCredential` field, which matches the MCP tool-call shape.
- The encrypted file store seals the private key with scrypt and
  ChaCha20-Poly1305. An OS-keyring backend (the Python `KeyringKeyStore`) is a
  follow-up, since it needs an optional native dependency.

## Security boundary of each piece

- `buildProof` callback and `Signer.fromBackend`: the callback signs the same
  SHA-256 digest of the JCS-canonical credential as the in-process path, so the
  proof is byte-identical and verifies with the ordinary public key. `fromBackend`
  holds only the public key and the callback, so it cannot reveal a key it does
  not have; the legacy JWS `sign` and the hybrid profile are not part of the
  backend surface and report that clearly.
- `Agent` consent gate: signing happens through the Agent; the raw key is not
  returned unless `allowKeyExport: true`. Persistence is on by default so an
  identity is durable rather than discarded at exit.
- `requireSigned` / `guardMcp`: verify the Data Integrity proof, enforce the
  issuer allowlist (`trustedDids`), and optionally match the intent before a
  handler runs. They authenticate the caller and, when configured, the declared
  intent. They do not bind the credential to the other argument values and do not
  provide replay protection; pair with intent policy and a nonce check when those
  matter.
- `did:key` resolution: decodes the key embedded in the DID, so it authenticates
  self-consistency, not real-world identity. Pin issuers via `trustedDids` for
  authorization decisions.
