### PR TITLE
Fix the TypeScript amnesia integration so the SDK typechecks

### DIFF
--- a/packages/sdk-ts/src/integrations/amnesia.ts
+++ b/packages/sdk-ts/src/integrations/amnesia.ts
@@ -18,8 +18,6 @@
  *  // vc is a VC ready to POST, store, or pass to a verifier.
  */
 
-import { signVcDataIntegrity } from '../data-integrity.js';
-import { signVcHybrid } from '../data-integrity-hybrid.js';
 import type { Signer } from '../signer.js';
 
 /**
@@ -78,7 +76,7 @@ export async function attestDecision(
   validateDecision(decision);
 
   const cryptosuite = options.cryptosuite ?? 'eddsa-jcs-2022';
-  const issuer = options.issuer ?? signer.did;
+  const issuer = options.issuer ?? signer.getDid();
   const matched = decision.rule_decisions.filter((r) => r.matched);
 
   const contexts = [...DEFAULT_CONTEXTS];
@@ -104,9 +102,9 @@ export async function attestDecision(
 
   let credential: Record<string, unknown>;
   if (cryptosuite === 'eddsa-jcs-2022') {
-    credential = await signVcDataIntegrity(vc, signer);
+    credential = await signer.attachProof(vc);
   } else if (cryptosuite === 'hybrid-eddsa-mldsa44-jcs-2026') {
-    credential = await signVcHybrid(vc, signer);
+    credential = await signer.attachProofHybrid(vc);
   } else {
     throw new Error(`unsupported cryptosuite: ${String(cryptosuite)}`);
   }

--- a/packages/sdk-ts/src/signer.ts
+++ b/packages/sdk-ts/src/signer.ts
@@ -162,6 +162,24 @@ export class Signer {
     return { ...credential, proof };
   }
 
+  /**
+   * Attach a hybrid-eddsa-mldsa44-jcs-2026 Data Integrity proof to a pre-built
+   * credential. The hybrid counterpart to `attachProof`, for custom credential
+   * types the caller assembles by hand. Lazily generates the ML-DSA-44 keypair.
+   */
+  async attachProofHybrid(
+    credential: Record<string, unknown>
+  ): Promise<Record<string, unknown>> {
+    this.ensureMldsa44KeyPair();
+    const ed25519PrivateKey = await this.rawPrivateKeyPromise;
+    const proof = buildHybridProof(credential, {
+      ed25519PrivateKey,
+      mldsa44SecretKey: this.mldsa44SecretKey!,
+      verificationMethod: this.verificationMethodId(),
+    });
+    return { ...credential, proof };
+  }
+
   // ------------------------------------------------------------------
   // Legacy JWS path. Behavior preserved verbatim.
   // ------------------------------------------------------------------


### PR DESCRIPTION
The amnesia integration imported two helpers that do not exist (signVcDataIntegrity, signVcHybrid) and read the private did field, so tsc --noEmit failed on the SDK. This uses the public Signer.attachProof for the classical proof, adds a Signer.attachProofHybrid for the hybrid counterpart, and reads the DID via getDid(). After this, tsc --noEmit is clean and the full vitest suite passes.