### PR TITLE
Restyle the trust-gap page as an infographic landing

### DIFF
--- a/website/src/app/the-trust-gap/page.tsx
+++ b/website/src/app/the-trust-gap/page.tsx
@@ -1,21 +1,21 @@
 import Link from 'next/link';
-import Image from 'next/image';
 import type { Metadata } from 'next';
 import { ATI_SUMMARY } from '../agent-trust-index/ati-data';
 import ShareButtons from '../agent-trust-index/ShareButtons';
 
 const TOTAL = ATI_SUMMARY.total.toLocaleString('en-US');
+const VERIFIABLE = ATI_SUMMARY.verifiable.toLocaleString('en-US');
 const PAGE_URL = 'https://vouch-protocol.com/the-trust-gap/';
-const SHARE_TEXT = `AI agents now act on our behalf, yet ${ATI_SUMMARY.pctCannot}% of them cannot prove who they are or who authorized them. As they start touching money and real data, this is the AI trust gap to watch:`;
+const SHARE_TEXT = `"Trust me, I'm an AI agent." ${ATI_SUMMARY.pctCannot}% of public AI agents can't back that up: they can't prove who they are or who authorized them. As agents start touching money and real data, this is the AI trust gap to watch:`;
 
 export const metadata: Metadata = {
     title: 'The AI trust gap - Vouch Protocol',
-    description: `AI agents are starting to act for us, book, buy, email, write code. ${ATI_SUMMARY.pctCannot}% of them cannot prove who they are or who put them in charge. Here is why that matters, in plain English.`,
+    description: `"Trust me, I'm an AI agent." ${ATI_SUMMARY.pctCannot}% can't back that up. They act for us, yet cannot prove who they are or who put them in charge. The AI trust gap, in plain English.`,
     alternates: { canonical: PAGE_URL },
     openGraph: {
-        title: `${ATI_SUMMARY.pctCannot}% of AI agents cannot prove who they are`,
+        title: `"Trust me, I'm an AI agent." ${ATI_SUMMARY.pctCannot}% can't prove it.`,
         description:
-            'AI agents are starting to act for us. Almost none can prove who they are or who authorized them. Here is why that matters, in plain English.',
+            'AI agents now act for us. Almost none can prove who they are or who authorized them. The AI trust gap, in plain English.',
         url: PAGE_URL,
         type: 'article',
         images: [{ url: '/assets/ati-card.png', width: 1200, height: 630 }],
@@ -27,73 +27,104 @@ export const metadata: Metadata = {
     },
 };
 
-const POINTS = [
-    {
-        h: 'What is changing',
-        p: 'AI agents have started to do things, not only chat. They book travel, move money, send email, file tickets, and change code, acting for a person or a company.',
-    },
-    {
-        h: 'The problem',
-        p: 'When an agent acts, can you prove which agent it was, who allowed it, and that the instruction was not tampered with on the way? Today, almost never. So when one makes a costly mistake or gets hijacked, no one can say who was responsible.',
-    },
-    {
-        h: 'What Vouch does',
-        p: 'Vouch gives every AI agent a verifiable identity and a signed permission slip, like a passport and an authorization anyone can check. The web got the padlock so you can trust a website. Agents need the same, and Vouch is the open standard for it.',
-    },
+const STEPS = [
+    { n: '01', h: 'They act', s: 'buy · email · code' },
+    { n: '02', h: "Can't prove it", s: 'no id · no permission' },
+    { n: '03', h: 'Vouch proves it', s: 'verified · signed', win: true },
 ];
 
 export default function TrustGapPage() {
     return (
         <main className="min-h-screen bg-parchment text-ink">
-            <div className="container-wide py-20 md:py-28">
-                <p className="eyebrow text-burgundy mb-3">The AI trust gap</p>
-                <h1 className="font-serif font-semibold text-[clamp(2.2rem,5vw,3.6rem)] leading-[1.05] tracking-tight mb-6 max-w-[900px]">
-                    Your AI is starting to act for you. Can it prove it is allowed to?
+            {/* HERO */}
+            <section className="container-wide pt-20 md:pt-28 pb-14">
+                <p className="eyebrow text-burgundy mb-5">The Agent Trust Index</p>
+                <h1 className="font-serif font-semibold text-[clamp(2.6rem,7vw,5rem)] leading-[1.02] tracking-tight mb-6">
+                    &ldquo;Trust me,
+                    <br />
+                    I&rsquo;m an AI agent.&rdquo;
                 </h1>
-                <p className="drop-cap text-[1.2rem] leading-snug text-ink-soft max-w-prose mb-10">
-                    We checked every public AI agent we could find. <strong>{ATI_SUMMARY.pctCannot}%</strong> of
-                    them cannot prove who they are or who put them in charge. Only {ATI_SUMMARY.verifiable} of{' '}
-                    {TOTAL} can.
+                <p className="text-[clamp(1.3rem,3vw,1.9rem)] text-ink-soft mb-9">
+                    <strong className="text-burgundy font-semibold">{ATI_SUMMARY.pctCannot}%</strong> can&rsquo;t
+                    back that up.
                 </p>
-
-                <div className="max-w-3xl mb-12 border border-rule">
-                    <Image
-                        src="/assets/ati-card.png"
-                        alt={`${ATI_SUMMARY.pctCannot}% of AI agents cannot prove who they are`}
-                        width={1200}
-                        height={630}
-                        className="w-full h-auto"
-                        priority
-                    />
+                <div className="flex flex-wrap gap-3">
+                    <Link href="/agent-trust-index/" className="btn-primary">
+                        See the proof
+                    </Link>
+                    <Link href="/" className="btn-secondary">
+                        Meet the standard
+                    </Link>
                 </div>
+            </section>
 
-                <div className="grid md:grid-cols-3 gap-8 max-w-4xl mb-16">
-                    {POINTS.map((c) => (
-                        <div key={c.h} className="border-t-2 border-burgundy pt-3">
-                            <h2 className="font-serif font-semibold text-[1.2rem] tracking-tight mb-2">{c.h}</h2>
-                            <p className="text-ink-soft text-[0.98rem] leading-relaxed">{c.p}</p>
+            {/* THREE-STEP INFOGRAPHIC */}
+            <section className="border-y border-rule">
+                <div className="container-wide grid grid-cols-1 md:grid-cols-3">
+                    {STEPS.map((st, i) => (
+                        <div
+                            key={st.n}
+                            className={`py-10 md:py-14 md:px-8 ${
+                                i < STEPS.length - 1 ? 'border-b md:border-b-0 md:border-r border-rule' : ''
+                            } ${st.win ? 'bg-parchment-warm' : ''}`}
+                        >
+                            <div className="font-mono text-sm text-ink-faint mb-3">{st.n}</div>
+                            <h2
+                                className={`font-serif font-semibold text-[1.6rem] tracking-tight mb-2 ${
+                                    st.win ? 'text-burgundy' : ''
+                                }`}
+                            >
+                                {st.h}
+                            </h2>
+                            <div className="font-mono uppercase text-[0.72rem] tracking-[0.08em] text-ink-soft">
+                                {st.s}
+                            </div>
                         </div>
                     ))}
                 </div>
+            </section>
 
-                <div className="border border-burgundy bg-parchment-warm p-8 md:p-10 max-w-3xl mb-12">
-                    <h2 className="font-serif font-semibold text-[1.6rem] tracking-tight mb-3">
-                        Want to see for yourself?
-                    </h2>
-                    <p className="text-ink-soft leading-relaxed max-w-prose mb-6">
-                        The Agent Trust Index is the live scoreboard: how many agents can prove who they are,
-                        updated every week. You can also grade any agent, or your own, in about ten seconds.
-                    </p>
-                    <div className="flex flex-wrap gap-3">
-                        <Link href="/agent-trust-index/" className="btn-primary">See the live numbers</Link>
-                        <Link href="/" className="btn-secondary">How Vouch works</Link>
+            {/* THE NUMBER */}
+            <section className="container-wide py-16 md:py-24">
+                <div className="flex flex-col md:flex-row md:items-baseline gap-5 md:gap-12">
+                    <div className="font-serif font-semibold text-[clamp(4.5rem,13vw,9rem)] leading-none tracking-tight">
+                        {ATI_SUMMARY.pctCannot}%
                     </div>
+                    <p className="text-[1.3rem] leading-snug text-ink-soft max-w-[22ch]">
+                        of AI agents <strong className="text-ink font-semibold">cannot prove who they are.</strong>{' '}
+                        Only {VERIFIABLE} of {TOTAL} can.
+                    </p>
                 </div>
+            </section>
 
-                <div className="max-w-3xl">
-                    <ShareButtons text={SHARE_TEXT} url={PAGE_URL} image="/assets/ati-card.png" />
+            {/* ONE-LINER */}
+            <section className="border-t border-rule">
+                <div className="container-wide py-14 md:py-16">
+                    <p className="font-serif italic text-[clamp(1.5rem,4vw,2.5rem)] tracking-tight">
+                        The web got a padlock. Agents get Vouch.
+                    </p>
                 </div>
-            </div>
+            </section>
+
+            {/* CTA BAND */}
+            <section className="bg-ink text-parchment">
+                <div className="container-wide py-14 md:py-16 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+                    <p className="font-serif font-semibold text-[clamp(1.6rem,4vw,2.4rem)] tracking-tight">
+                        Can your agent prove it?
+                    </p>
+                    <Link
+                        href="/agent-trust-index/"
+                        className="inline-flex items-center gap-2 font-mono uppercase text-[0.75rem] tracking-[0.16em] px-6 py-[0.85rem] bg-burgundy text-parchment border border-burgundy no-underline transition-colors hover:bg-[#5f222c] hover:border-[#5f222c]"
+                    >
+                        Grade it in 10 seconds
+                    </Link>
+                </div>
+            </section>
+
+            {/* SHARE */}
+            <section className="container-wide py-12">
+                <ShareButtons text={SHARE_TEXT} url={PAGE_URL} image="/assets/ati-card.png" />
+            </section>
         </main>
     );
 }


### PR DESCRIPTION
Reworks /the-trust-gap into a low-text, infographic-style landing page.

- A short, punchy hero: "Trust me, I'm an AI agent." with the headline stat that most agents cannot back that up.
- A three-step strip: they act, they cannot prove it, Vouch proves it.
- The headline number shown large, with the live count of agents that can prove who they are.
- A one-line takeaway and a clear call to action into the live Index.
- The Grade-it call to action reads as a solid button on the dark band.

All copy reads off the live Index data, so the weekly rescan keeps it current.

Signed-off-by: Ramprasad Gaddam <groups.rampy1@gmail.com>