### PR TITLE
Adopters page and signed integration certificates

### DIFF
--- a/.github/workflows/bootstrap-adopter-authority.yml
+++ b/.github/workflows/bootstrap-adopter-authority.yml
@@ -1,0 +1,107 @@
+name: Bootstrap adopter authority (one-time)
+
+# Create the delegated Adopter Authority key entirely in CI, using the root key
+# that is already a repository secret. Mirrors the Conformance Authority setup.
+# This:
+#   1. Generates a fresh Ed25519 key for did:web:vouch-protocol.com:adopters.
+#   2. Signs a root -> adopter delegation with the VOUCH_PRIVATE_KEY secret.
+#   3. Commits the public DID document and the delegation to main.
+#   4. Stores VOUCH_ADOPTER_PRIVATE_KEY and VOUCH_ADOPTER_DID as repository
+#      secrets (needs GH_ADMIN_TOKEN), or uploads the key as a short-lived
+#      private artifact for one-time manual entry if that token is not set.
+#
+# The root private key is read from the secret and never leaves the runner.
+# Run this once. It refuses to overwrite an existing adopter authority.
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: "Type 'bootstrap' to confirm creating the adopter authority key"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  bootstrap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm intent
+        run: |
+          if [ "${{ inputs.confirm }}" != "bootstrap" ]; then
+            echo "::error::Type 'bootstrap' in the confirm box to proceed."
+            exit 1
+          fi
+
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install vouch
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Generate the adopter key and sign the delegation with the root key
+        env:
+          VOUCH_ROOT_PRIVATE_KEY: ${{ secrets.VOUCH_PRIVATE_KEY }}
+          VOUCH_ROOT_DID: ${{ secrets.VOUCH_DID }}
+        run: |
+          if [ -z "$VOUCH_ROOT_PRIVATE_KEY" ]; then
+            echo "::error::Root key not configured (VOUCH_PRIVATE_KEY)."
+            exit 1
+          fi
+          python scripts/bootstrap_adopter_authority.py
+
+      - name: Commit the public DID document and delegation
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add website/public/adopters/did.json adopters/delegation.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(adopters): publish adopter authority DID and delegation"
+            for i in 1 2 3; do
+              git pull --rebase origin main && git push origin HEAD:main && break
+              sleep $((2 ** i))
+            done
+          fi
+
+      - name: Store the adopter signing key as a secret
+        id: store
+        env:
+          GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
+          ADOPTER_DID_VALUE: did:web:vouch-protocol.com:adopters
+        run: |
+          if [ -n "$GH_ADMIN_TOKEN" ]; then
+            GH_TOKEN="$GH_ADMIN_TOKEN" gh secret set VOUCH_ADOPTER_PRIVATE_KEY \
+              --body "$(cat adopter-authority-key.json)"
+            GH_TOKEN="$GH_ADMIN_TOKEN" gh secret set VOUCH_ADOPTER_DID \
+              --body "$ADOPTER_DID_VALUE"
+            rm -f adopter-authority-key.json
+            echo "stored=true" >> "$GITHUB_OUTPUT"
+            echo "Stored VOUCH_ADOPTER_PRIVATE_KEY and VOUCH_ADOPTER_DID as repository secrets." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "stored=false" >> "$GITHUB_OUTPUT"
+            {
+              echo "### Adopter authority bootstrapped"
+              echo ""
+              echo "No GH_ADMIN_TOKEN was set, so the signing key could not be stored automatically."
+              echo "Download the \`adopter-authority-key\` artifact below and set two repository secrets:"
+              echo ""
+              echo "- \`VOUCH_ADOPTER_DID\` = \`did:web:vouch-protocol.com:adopters\`"
+              echo "- \`VOUCH_ADOPTER_PRIVATE_KEY\` = the artifact contents"
+              echo ""
+              echo "Then delete the artifact."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload the signing key for one-time manual entry
+        if: steps.store.outputs.stored == 'false'
+        uses: actions/upload-artifact@v4
+        with:
+          name: adopter-authority-key
+          path: adopter-authority-key.json
+          retention-days: 1

--- a/.github/workflows/issue-adopter-cert.yml
+++ b/.github/workflows/issue-adopter-cert.yml
@@ -1,0 +1,149 @@
+name: Issue adopter certificate (manual)
+
+# Issue a Vouch Verified Integration certificate for a system that integrates
+# Vouch Protocol against the published schema. Renders the certificate page at
+# /i/<slug>/, lists the adopter on /adopters, and redeploys the site. The
+# certificate is a Verifiable Credential signed by the Adopter Authority (a
+# delegated key, see scripts/bootstrap_adopter_authority.py) and chained to the
+# root authority through adopters/delegation.json.
+
+on:
+  workflow_dispatch:
+    inputs:
+      slug:
+        description: "URL slug for the certificate at /i/<slug>/"
+        required: true
+      name:
+        description: "Display name of the integration"
+        required: true
+      by:
+        description: "Author handle or organization (optional)"
+        required: false
+      focus:
+        description: "What part of Vouch it integrates"
+        required: true
+      badge:
+        description: "Short badge label (e.g. First reference integration)"
+        required: true
+      summary:
+        description: "One-paragraph summary for the adopters page"
+        required: true
+      live_surface:
+        description: "URL a verifier can check (optional)"
+        required: false
+      discussion:
+        description: "Discussion or PR URL (optional)"
+        required: false
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: Install vouch
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Mint credential
+        env:
+          ADOPTER_PRIVATE_KEY: ${{ secrets.ADOPTER_PRIVATE_KEY }}
+          ADOPTER_DID: ${{ secrets.ADOPTER_DID }}
+          SLUG: ${{ inputs.slug }}
+          NAME: ${{ inputs.name }}
+          BY: ${{ inputs.by }}
+          FOCUS: ${{ inputs.focus }}
+          LIVE_SURFACE: ${{ inputs.live_surface }}
+          DISCUSSION: ${{ inputs.discussion }}
+        run: |
+          if [ -z "$ADOPTER_PRIVATE_KEY" ] || [ -z "$ADOPTER_DID" ]; then
+            echo "::error::Adopter issuer key not configured (ADOPTER_PRIVATE_KEY / ADOPTER_DID)."
+            echo "::error::Run scripts/bootstrap_adopter_authority.py first, then add the secrets."
+            exit 1
+          fi
+          PARENT=""
+          if [ -f adopters/delegation.json ]; then
+            PARENT="--parent adopters/delegation.json"
+          fi
+          python scripts/mint_adopter_credential.py \
+            --slug "$SLUG" \
+            --name "$NAME" \
+            --by "$BY" \
+            --focus "$FOCUS" \
+            --live-surface "$LIVE_SURFACE" \
+            --discussion "$DISCUSSION" \
+            $PARENT \
+            --out credential.json
+
+      - name: Verify the certificate against the published DID document
+        run: |
+          python - <<'PY'
+          import json, sys
+          from vouch import Verifier
+          cred = open("credential.json").read()
+          doc = json.load(open("website/public/adopters/did.json"))
+          pub = json.dumps(doc["verificationMethod"][0]["publicKeyJwk"])
+          ok, _ = Verifier.verify_credential(cred, public_key=pub)
+          print("Certificate self-verify against published DID:", ok)
+          if not ok:
+              print("::error::Minted certificate does not verify against the published adopter DID."
+                    " Check that ADOPTER_PRIVATE_KEY and ADOPTER_DID hold the adopter issuer key.")
+              sys.exit(1)
+          PY
+
+      - name: Publish the certificate and list the adopter
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SLUG: ${{ inputs.slug }}
+          NAME: ${{ inputs.name }}
+          BY: ${{ inputs.by }}
+          FOCUS: ${{ inputs.focus }}
+          BADGE: ${{ inputs.badge }}
+          SUMMARY: ${{ inputs.summary }}
+          LIVE_SURFACE: ${{ inputs.live_surface }}
+          DISCUSSION: ${{ inputs.discussion }}
+        run: |
+          python scripts/render_adopter_cert.py \
+            --credential credential.json \
+            --slug "$SLUG" \
+            --out "website/public/i/${SLUG}/index.html"
+          python - <<'PY'
+          import json, os
+          path = "website/src/data/adopters.json"
+          entry = {
+              "slug": os.environ["SLUG"],
+              "name": os.environ["NAME"],
+              "by": os.environ.get("BY", ""),
+              "focus": os.environ["FOCUS"],
+              "badge": os.environ["BADGE"],
+              "summary": os.environ["SUMMARY"],
+              "liveSurface": os.environ.get("LIVE_SURFACE", ""),
+              "discussion": os.environ.get("DISCUSSION", ""),
+          }
+          data = json.load(open(path)) if os.path.exists(path) else []
+          data = [a for a in data if a.get("slug") != entry["slug"]]
+          data.append(entry)
+          with open(path, "w") as f:
+              json.dump(data, f, indent=4)
+              f.write("\n")
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "website/public/i/${SLUG}/index.html" website/src/data/adopters.json
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(adopters): certificate for ${SLUG}"
+            for i in 1 2 3; do
+              git pull --rebase origin main && git push origin HEAD:main && break
+              sleep $((2 ** i))
+            done
+            gh workflow run deploy-website.yml --ref main
+          fi

--- a/.github/workflows/issue-adopter-cert.yml
+++ b/.github/workflows/issue-adopter-cert.yml
@@ -56,8 +56,8 @@ jobs:
 
       - name: Mint credential
         env:
-          ADOPTER_PRIVATE_KEY: ${{ secrets.ADOPTER_PRIVATE_KEY }}
-          ADOPTER_DID: ${{ secrets.ADOPTER_DID }}
+          VOUCH_ADOPTER_PRIVATE_KEY: ${{ secrets.VOUCH_ADOPTER_PRIVATE_KEY }}
+          VOUCH_ADOPTER_DID: ${{ secrets.VOUCH_ADOPTER_DID }}
           SLUG: ${{ inputs.slug }}
           NAME: ${{ inputs.name }}
           BY: ${{ inputs.by }}
@@ -65,9 +65,9 @@ jobs:
           LIVE_SURFACE: ${{ inputs.live_surface }}
           DISCUSSION: ${{ inputs.discussion }}
         run: |
-          if [ -z "$ADOPTER_PRIVATE_KEY" ] || [ -z "$ADOPTER_DID" ]; then
-            echo "::error::Adopter issuer key not configured (ADOPTER_PRIVATE_KEY / ADOPTER_DID)."
-            echo "::error::Run scripts/bootstrap_adopter_authority.py first, then add the secrets."
+          if [ -z "$VOUCH_ADOPTER_PRIVATE_KEY" ] || [ -z "$VOUCH_ADOPTER_DID" ]; then
+            echo "::error::Adopter issuer key not configured (VOUCH_ADOPTER_PRIVATE_KEY / VOUCH_ADOPTER_DID)."
+            echo "::error::Run the 'Bootstrap adopter authority' workflow first."
             exit 1
           fi
           PARENT=""

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,8 @@ tests/test_pro.py
 *.key
 *.pem
 vouch/media/certs/
+# Delegated authority signing key, written by bootstrap, load into a secret then delete
+adopter-authority-key.json
 
 # Node modules
 node_modules/

--- a/scripts/bootstrap_adopter_authority.py
+++ b/scripts/bootstrap_adopter_authority.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Bootstrap the Vouch Adopter Authority: a delegated signing key for adopters.
+
+This mirrors the Contributor Authority. It creates a delegated key whose only
+job is to sign "Vouch Verified Integration" certificates for systems that
+build on the protocol, so the root key is never used for routine issuance.
+
+Run this ONCE, on the machine that holds the root private key. It:
+  1. Generates a fresh Ed25519 keypair for did:web:vouch-protocol.com:adopters.
+  2. Writes the public DID document to website/public/adopters/did.json.
+  3. Signs a root -> adopter-authority delegation to adopters/delegation.json,
+     using the root key supplied in the environment.
+  4. Writes the adopter authority PRIVATE key to adopter-authority-key.json
+     (gitignored) for you to load into the ADOPTER_PRIVATE_KEY GitHub secret.
+
+The root key is read from the environment and never written anywhere:
+  VOUCH_ROOT_PRIVATE_KEY  Ed25519 private key JWK (JSON string) for the root DID
+  VOUCH_ROOT_DID          Root issuer DID (default did:web:vouch-protocol.com)
+
+Example:
+  export VOUCH_ROOT_DID='did:web:vouch-protocol.com'
+  export VOUCH_ROOT_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+  python scripts/bootstrap_adopter_authority.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+from vouch import Signer, Verifier, generate_identity
+
+ADOPTER_DID = "did:web:vouch-protocol.com:adopters"
+ADOPTER_DOMAIN = "vouch-protocol.com:adopters"
+# The namespace the adopter authority may attest under. Every integration
+# certificate binds its resource beneath this URI, so the delegation never
+# widens to broader authority than issuing adopter records.
+ADOPTER_RESOURCE = "https://vouch-protocol.com/adopters"
+DELEGATION_VALID_DAYS = 365 * 10
+
+DID_DOC_PATH = "website/public/adopters/did.json"
+DELEGATION_PATH = "adopters/delegation.json"
+PRIVATE_KEY_PATH = "adopter-authority-key.json"
+
+
+def build_did_document(public_key_jwk: str) -> dict:
+    pub = json.loads(public_key_jwk)
+    return {
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/suites/jws-2020/v1",
+        ],
+        "id": ADOPTER_DID,
+        "verificationMethod": [
+            {
+                "id": f"{ADOPTER_DID}#key-1",
+                "type": "JsonWebKey2020",
+                "controller": ADOPTER_DID,
+                "publicKeyJwk": {
+                    "kty": pub["kty"],
+                    "crv": pub["crv"],
+                    "x": pub["x"],
+                },
+            }
+        ],
+        "authentication": [f"{ADOPTER_DID}#key-1"],
+        "assertionMethod": [f"{ADOPTER_DID}#key-1"],
+    }
+
+
+def sign_delegation(root_private_key: str, root_did: str) -> dict:
+    """Return a root -> adopter-authority delegation credential."""
+    signer = Signer(private_key=root_private_key, did=root_did)
+    intent = {
+        "action": "delegate",
+        "target": ADOPTER_DID,
+        "resource": ADOPTER_RESOURCE,
+        "role": "verified-adopter-issuer",
+    }
+    valid_from = datetime.now(timezone.utc).replace(microsecond=0)
+    return signer.sign_credential(
+        intent=intent,
+        valid_seconds=DELEGATION_VALID_DAYS * 86400,
+        valid_from=valid_from,
+    )
+
+
+def main() -> int:
+    root_private_key = os.getenv("VOUCH_ROOT_PRIVATE_KEY")
+    root_did = os.getenv("VOUCH_ROOT_DID", "did:web:vouch-protocol.com")
+    if not root_private_key:
+        print(
+            "VOUCH_ROOT_PRIVATE_KEY (and optionally VOUCH_ROOT_DID) must be set "
+            "to sign the adopter delegation with the root key.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if os.path.exists(DID_DOC_PATH) or os.path.exists(DELEGATION_PATH):
+        print(
+            "Adopter authority files already exist. Remove "
+            f"{DID_DOC_PATH} and {DELEGATION_PATH} first if you intend to rotate "
+            "the key. Refusing to overwrite an existing authority.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 1 + 4: generate the delegated keypair.
+    identity = generate_identity(domain=ADOPTER_DOMAIN)
+
+    # 2: publish the public DID document.
+    did_doc = build_did_document(identity.public_key_jwk)
+    os.makedirs(os.path.dirname(DID_DOC_PATH), exist_ok=True)
+    with open(DID_DOC_PATH, "w", encoding="utf-8") as handle:
+        json.dump(did_doc, handle, indent=2)
+        handle.write("\n")
+
+    # 3: sign the root -> adopter delegation.
+    delegation = sign_delegation(root_private_key, root_did)
+    os.makedirs(os.path.dirname(DELEGATION_PATH), exist_ok=True)
+    with open(DELEGATION_PATH, "w", encoding="utf-8") as handle:
+        json.dump(delegation, handle, indent=2)
+        handle.write("\n")
+
+    # Self-check: the delegation must verify against the root DID's public key.
+    root_pub = Signer(private_key=root_private_key, did=root_did).get_public_key_jwk()
+    ok, _ = Verifier.verify_credential(json.dumps(delegation), public_key=root_pub)
+    if not ok:
+        print(
+            "::error:: delegation did not verify against the root key. "
+            "Check VOUCH_ROOT_PRIVATE_KEY and VOUCH_ROOT_DID.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 4: write the adopter authority private key for the operator to store.
+    with open(PRIVATE_KEY_PATH, "w", encoding="utf-8") as handle:
+        handle.write(identity.private_key_jwk)
+        handle.write("\n")
+
+    print("Adopter authority bootstrapped.")
+    print(f"  Wrote public DID document : {DID_DOC_PATH}")
+    print(f"  Wrote root delegation     : {DELEGATION_PATH}")
+    print(f"  Wrote PRIVATE signing key : {PRIVATE_KEY_PATH}  (gitignored)")
+    print()
+    print("Next steps:")
+    print(f"  1. Commit {DID_DOC_PATH} and {DELEGATION_PATH}.")
+    print("  2. Add two GitHub Actions secrets:")
+    print(f"       ADOPTER_DID          = {ADOPTER_DID}")
+    print(f"       ADOPTER_PRIVATE_KEY  = contents of {PRIVATE_KEY_PATH}")
+    print(f"  3. Delete {PRIVATE_KEY_PATH} once the secret is stored.")
+    print("  4. Run the 'Issue adopter certificate' workflow for each adopter.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bootstrap_adopter_authority.py
+++ b/scripts/bootstrap_adopter_authority.py
@@ -1,26 +1,24 @@
 #!/usr/bin/env python3
 """Bootstrap the Vouch Adopter Authority: a delegated signing key for adopters.
 
-This mirrors the Contributor Authority. It creates a delegated key whose only
-job is to sign "Vouch Verified Integration" certificates for systems that
-build on the protocol, so the root key is never used for routine issuance.
+This mirrors the Conformance and Contributor authorities. It creates a delegated
+key whose only job is to sign "Vouch Verified Integration" certificates for
+systems that build on the protocol, so the root key is never used for routine
+issuance.
 
-Run this ONCE, on the machine that holds the root private key. It:
+It is run once by the bootstrap-adopter-authority workflow, which supplies the
+root key from the VOUCH_PRIVATE_KEY repository secret, so the root key never
+leaves CI. It can also be run locally if you prefer. It:
   1. Generates a fresh Ed25519 keypair for did:web:vouch-protocol.com:adopters.
   2. Writes the public DID document to website/public/adopters/did.json.
   3. Signs a root -> adopter-authority delegation to adopters/delegation.json,
      using the root key supplied in the environment.
   4. Writes the adopter authority PRIVATE key to adopter-authority-key.json
-     (gitignored) for you to load into the ADOPTER_PRIVATE_KEY GitHub secret.
+     (gitignored) for storage in the VOUCH_ADOPTER_PRIVATE_KEY secret.
 
 The root key is read from the environment and never written anywhere:
   VOUCH_ROOT_PRIVATE_KEY  Ed25519 private key JWK (JSON string) for the root DID
   VOUCH_ROOT_DID          Root issuer DID (default did:web:vouch-protocol.com)
-
-Example:
-  export VOUCH_ROOT_DID='did:web:vouch-protocol.com'
-  export VOUCH_ROOT_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
-  python scripts/bootstrap_adopter_authority.py
 """
 
 from __future__ import annotations
@@ -89,7 +87,7 @@ def sign_delegation(root_private_key: str, root_did: str) -> dict:
 
 def main() -> int:
     root_private_key = os.getenv("VOUCH_ROOT_PRIVATE_KEY")
-    root_did = os.getenv("VOUCH_ROOT_DID", "did:web:vouch-protocol.com")
+    root_did = os.getenv("VOUCH_ROOT_DID") or "did:web:vouch-protocol.com"
     if not root_private_key:
         print(
             "VOUCH_ROOT_PRIVATE_KEY (and optionally VOUCH_ROOT_DID) must be set "
@@ -147,9 +145,9 @@ def main() -> int:
     print()
     print("Next steps:")
     print(f"  1. Commit {DID_DOC_PATH} and {DELEGATION_PATH}.")
-    print("  2. Add two GitHub Actions secrets:")
-    print(f"       ADOPTER_DID          = {ADOPTER_DID}")
-    print(f"       ADOPTER_PRIVATE_KEY  = contents of {PRIVATE_KEY_PATH}")
+    print("  2. Store two repository secrets:")
+    print(f"       VOUCH_ADOPTER_DID          = {ADOPTER_DID}")
+    print(f"       VOUCH_ADOPTER_PRIVATE_KEY  = contents of {PRIVATE_KEY_PATH}")
     print(f"  3. Delete {PRIVATE_KEY_PATH} once the secret is stored.")
     print("  4. Run the 'Issue adopter certificate' workflow for each adopter.")
     return 0

--- a/scripts/mint_adopter_credential.py
+++ b/scripts/mint_adopter_credential.py
@@ -7,12 +7,12 @@ a part of Vouch Protocol against the published schema. The credential traces
 back to the root authority through the attached delegation.
 
 The issuer key is read from the environment:
-  ADOPTER_PRIVATE_KEY  Ed25519 private key JWK (JSON string)
-  ADOPTER_DID          Issuer DID, e.g. did:web:vouch-protocol.com:adopters
+  VOUCH_ADOPTER_PRIVATE_KEY  Ed25519 private key JWK (JSON string)
+  VOUCH_ADOPTER_DID          Issuer DID, e.g. did:web:vouch-protocol.com:adopters
 
 Example:
-  export ADOPTER_DID='did:web:vouch-protocol.com:adopters'
-  export ADOPTER_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+  export VOUCH_ADOPTER_DID='did:web:vouch-protocol.com:adopters'
+  export VOUCH_ADOPTER_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
   python scripts/mint_adopter_credential.py \\
       --slug invinoveritas --name invinoveritas --by babyblueviper1 \\
       --focus "Outcome Evidence and the AccountabilityRecord" \\
@@ -88,11 +88,11 @@ def main(argv: list[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
 
-    private_key = os.getenv("ADOPTER_PRIVATE_KEY")
-    did = os.getenv("ADOPTER_DID")
+    private_key = os.getenv("VOUCH_ADOPTER_PRIVATE_KEY")
+    did = os.getenv("VOUCH_ADOPTER_DID")
     if not private_key or not did:
         print(
-            "ADOPTER_PRIVATE_KEY and ADOPTER_DID must be set to mint a credential.",
+            "VOUCH_ADOPTER_PRIVATE_KEY and VOUCH_ADOPTER_DID must be set to mint a credential.",
             file=sys.stderr,
         )
         return 1

--- a/scripts/mint_adopter_credential.py
+++ b/scripts/mint_adopter_credential.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Mint a "Vouch Verified Integration" credential for an adopter.
+
+The Adopter Authority (a delegated key, see bootstrap_adopter_authority.py)
+signs a Verifiable Credential attesting that an independent system integrates
+a part of Vouch Protocol against the published schema. The credential traces
+back to the root authority through the attached delegation.
+
+The issuer key is read from the environment:
+  ADOPTER_PRIVATE_KEY  Ed25519 private key JWK (JSON string)
+  ADOPTER_DID          Issuer DID, e.g. did:web:vouch-protocol.com:adopters
+
+Example:
+  export ADOPTER_DID='did:web:vouch-protocol.com:adopters'
+  export ADOPTER_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+  python scripts/mint_adopter_credential.py \\
+      --slug invinoveritas --name invinoveritas --by babyblueviper1 \\
+      --focus "Outcome Evidence and the AccountabilityRecord" \\
+      --live-surface https://api.babyblueviper.com/.well-known/agent-handshake \\
+      --parent adopters/delegation.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+
+from vouch import Signer
+
+# An integration record attests a fact at a point in time. Like the contributor
+# badge it does not meaningfully expire; revocation, not expiry, retires it.
+DEFAULT_VALID_DAYS = 365 * 100
+ADOPTER_RESOURCE = "https://vouch-protocol.com/adopters"
+
+
+def mint_credential(
+    slug: str,
+    name: str,
+    by: str,
+    focus: str,
+    live_surface: str,
+    discussion: str,
+    private_key: str,
+    did: str,
+    valid_days: int = DEFAULT_VALID_DAYS,
+    parent_credential: dict | None = None,
+) -> dict:
+    """Return a signed Vouch Credential attesting a reference integration."""
+    signer = Signer(private_key=private_key, did=did)
+    intent = {
+        "action": "attest",
+        "target": f"adopter:{slug}",
+        # resource binds the record beneath the adopter namespace so the
+        # delegation's non-expansion rule holds.
+        "resource": f"{ADOPTER_RESOURCE}/{slug}",
+        "role": "reference-integration",
+        "name": name,
+        "integrates": focus,
+    }
+    if by:
+        intent["by"] = by
+    if live_surface:
+        intent["liveSurface"] = live_surface
+    if discussion:
+        intent["discussion"] = discussion
+    return signer.sign_credential(
+        intent=intent,
+        valid_seconds=valid_days * 86400,
+        parent_credential=parent_credential,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Mint a Vouch Verified Integration credential")
+    parser.add_argument("--slug", required=True, help="URL slug under /i/<slug>/")
+    parser.add_argument("--name", required=True, help="Display name of the integration")
+    parser.add_argument("--by", default="", help="Author handle or organization")
+    parser.add_argument("--focus", required=True, help="What part of Vouch it integrates")
+    parser.add_argument("--live-surface", default="", help="URL a verifier can check")
+    parser.add_argument("--discussion", default="", help="Discussion or PR URL")
+    parser.add_argument("--out", default="-", help="Output file, or - for stdout")
+    parser.add_argument(
+        "--parent",
+        default="",
+        help="Path to the root delegation credential (adopters/delegation.json).",
+    )
+    args = parser.parse_args(argv)
+
+    private_key = os.getenv("ADOPTER_PRIVATE_KEY")
+    did = os.getenv("ADOPTER_DID")
+    if not private_key or not did:
+        print(
+            "ADOPTER_PRIVATE_KEY and ADOPTER_DID must be set to mint a credential.",
+            file=sys.stderr,
+        )
+        return 1
+
+    parent_credential = None
+    if args.parent and os.path.exists(args.parent):
+        with open(args.parent, encoding="utf-8") as handle:
+            parent_credential = json.load(handle)
+
+    credential = mint_credential(
+        slug=args.slug,
+        name=args.name,
+        by=args.by,
+        focus=args.focus,
+        live_surface=args.live_surface,
+        discussion=args.discussion,
+        private_key=private_key,
+        did=did,
+        parent_credential=parent_credential,
+    )
+
+    text = json.dumps(credential, indent=2)
+    if args.out == "-":
+        print(text)
+    else:
+        with open(args.out, "w", encoding="utf-8") as handle:
+            handle.write(text)
+        print(f"Wrote credential for {args.name} to {args.out}", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/render_adopter_cert.py
+++ b/scripts/render_adopter_cert.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Render a static Vouch Verified Integration certificate page from a credential.
+
+Matches the contributor certificate design (parchment theme, Vouch Verified wax
+seal, ruled sections), but recognizes a reference integration rather than a
+merged pull request. The certificate is backed by a signed Verifiable
+Credential issued by the Adopter Authority and is verifiable by anyone against
+the published DID document. Intended for /i/<slug>/.
+"""
+
+import argparse
+import html
+import json
+import os
+from datetime import datetime
+
+ADOPTER_DID_URL = "https://vouch-protocol.com/adopters/did.json"
+
+
+def fmt_date(iso: str) -> str:
+    try:
+        return datetime.fromisoformat(iso.replace("Z", "+00:00")).strftime("%-d %b %Y")
+    except Exception:
+        return iso or ""
+
+
+def esc(s: object) -> str:
+    return html.escape(str(s)) if s is not None else ""
+
+
+def section(eyebrow: str, body: str, cls: str = "") -> str:
+    return f"""  <div class="section{(" " + cls) if cls else ""}">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">{esc(eyebrow)}</span><div class="rule-line"></div></div>
+    <div class="section-body">
+{body}
+    </div>
+  </div>"""
+
+
+def render(cred: dict, slug: str) -> str:
+    subject = cred.get("credentialSubject", {})
+    intent = subject.get("intent", {})
+    chain = subject.get("delegationChain") or []
+    root = chain[0].get("issuer", "") if chain else ""
+    issuer = cred.get("issuer", "")
+    proof = cred.get("proof", {})
+    proof_value = proof.get("proofValue", "")
+    cryptosuite = proof.get("cryptosuite", "eddsa-jcs-2022")
+    issued = fmt_date(cred.get("validFrom", ""))
+
+    name = intent.get("name", slug)
+    focus = intent.get("integrates", "")
+    by = intent.get("by", "")
+    live_surface = intent.get("liveSurface", "")
+    discussion = intent.get("discussion", "")
+    cert_url = f"https://vouch-protocol.com/i/{slug}/"
+
+    by_html = ""
+    if by:
+        by_html = (
+            f' &middot; by <a href="https://github.com/{esc(by)}" target="_blank" '
+            f'rel="noopener noreferrer">@{esc(by)}</a>'
+        )
+
+    sections = [
+        section(
+            "Integration",
+            f'      <div class="mono-text">{esc(focus)}</div>\n'
+            '      <div class="signer-caption">The first system to integrate this layer of Vouch Protocol</div>',
+        ),
+        section(
+            "Issued by",
+            f'      <div class="mono-text">{esc(issuer)}</div>\n'
+            '      <div class="signer-caption">Vouch Adopter Authority</div>',
+        ),
+    ]
+    if root:
+        sections.append(
+            section("Chained to root", f'      <div class="mono-text dim">{esc(root)}</div>')
+        )
+    sections.append(
+        section(
+            "Cryptosuite",
+            f'      <div class="mono-text dim">{esc(cryptosuite)} &middot; Ed25519 over RFC 8785 JCS</div>',
+        )
+    )
+    sections.append(
+        section("Signature", f'      <div class="mono-text dim">{esc(proof_value)}</div>')
+    )
+    if live_surface:
+        sections.append(
+            section(
+                "Live surface",
+                f'      <a class="mono-text" href="{esc(live_surface)}" target="_blank" '
+                f'rel="noopener noreferrer">{esc(live_surface.replace("https://", ""))}</a>',
+            )
+        )
+    terminal = (
+        '      <div class="terminal"><span class="comment"># Fetch the issuer DID document</span>\n'
+        f'<span class="prompt">$</span> curl {ADOPTER_DID_URL}\n\n'
+        '<span class="comment"># Verify the credential proof against it</span>\n'
+        '<span class="prompt">&gt;&gt;&gt;</span> Verifier.verify_credential(cred, public_key)  # True</div>'
+    )
+    sections.append(section("Verify locally", terminal, cls="no-print"))
+    sections_html = "\n  \n".join(sections)
+
+    discussion_html = ""
+    if discussion:
+        discussion_html = (
+            f"    <p>See the integration record on "
+            f'<a href="{esc(discussion)}" target="_blank" rel="noopener noreferrer">GitHub</a>.</p>\n'
+        )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Vouch Verified Integration &middot; {esc(name)}</title>
+<meta property="og:title" content="Vouch Verified Integration &middot; {esc(name)}">
+<meta property="og:description" content="A cryptographically signed certificate for a reference integration of Vouch Protocol, the open standard for AI agent identity and accountability.">
+<meta property="og:image" content="https://vouch-protocol.com/android-chrome-512x512.png">
+<meta property="og:url" content="{esc(cert_url)}">
+<meta name="twitter:card" content="summary">
+<link rel="icon" type="image/png" sizes="32x32" href="https://vouch-protocol.com/favicon-32x32.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono&display=swap" rel="stylesheet">
+<style>
+:root {{ --parchment:#FAF7EE; --parchment-warm:#F2EBD9; --ink:#0F172A; --ink-soft:#334155; --ink-faint:#64748B; --burgundy:#7C2D3A; --burgundy-dark:#5C1F2C; --rule:#D9CFB6; --rule-light:#E8DFC9; --code-bg:#0F172A; --code-fg:#FAF7EE; }}
+* {{ box-sizing: border-box; }}
+html, body {{ margin: 0; padding: 0; }}
+body {{ background: var(--parchment); color: var(--ink); font-family: "Source Serif 4", Georgia, serif; font-size: 17px; line-height: 1.6; padding: 64px 24px; min-height: 100vh; }}
+.frame {{ max-width: 720px; margin: 0 auto; }}
+.eyebrow {{ font-family: "JetBrains Mono", monospace; font-size: 0.7rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-faint); }}
+.seal-wrap {{ display: flex; justify-content: center; margin-bottom: 16px; }}
+.seal-img {{ width: 200px; height: 200px; object-fit: contain; }}
+.issued-line {{ text-align: center; font-family: "JetBrains Mono", monospace; font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-faint); margin: 0 0 40px; }}
+h1.title {{ text-align: center; font-weight: 600; font-size: 1.5rem; line-height: 1.3; margin: 0 0 12px; letter-spacing: -0.01em; }}
+.byline {{ text-align: center; color: var(--ink-soft); margin: 0 0 48px; font-style: italic; }}
+.byline a {{ color: var(--burgundy); text-decoration: none; }}
+.byline a:hover {{ color: var(--burgundy-dark); text-decoration: underline; }}
+.section {{ margin: 36px 0; }}
+.section-head {{ display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }}
+.section-head .rule-line {{ flex: 1; height: 1px; background: var(--rule); }}
+.section-body {{ text-align: center; }}
+.mono-text {{ font-family: "JetBrains Mono", monospace; font-size: 0.9rem; word-break: break-word; color: var(--ink); }}
+.mono-text.dim {{ color: var(--ink-soft); font-size: 0.85rem; }}
+.signer-caption {{ color: var(--ink-faint); font-style: italic; font-size: 0.9rem; margin-top: 6px; }}
+.section-body a {{ color: var(--burgundy); text-decoration: none; border-bottom: 1px solid var(--burgundy); }}
+.section-body a:hover {{ color: var(--burgundy-dark); border-bottom-color: var(--burgundy-dark); }}
+.terminal {{ font-family: "JetBrains Mono", monospace; font-size: 0.85rem; background: var(--code-bg); color: var(--code-fg); padding: 16px 18px; margin: 12px auto; text-align: left; overflow-x: auto; max-width: 560px; white-space: pre-wrap; }}
+.terminal .prompt {{ color: #80c08a; user-select: none; }}
+.terminal .comment {{ color: #91a4b8; font-style: italic; }}
+.about {{ margin-top: 56px; padding-top: 28px; border-top: 1px solid var(--rule-light); text-align: center; }}
+.about p {{ color: var(--ink-soft); margin: 14px auto; max-width: 600px; }}
+.about a {{ color: var(--burgundy); text-decoration: none; border-bottom: 1px solid var(--burgundy); }}
+.about .cta {{ font-family: "JetBrains Mono", monospace; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.12em; margin-top: 22px; }}
+.actions {{ text-align: center; margin-top: 28px; }}
+.actions button {{ font-family: "JetBrains Mono", monospace; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.12em; border: 1px solid var(--burgundy); background: var(--parchment); color: var(--burgundy); padding: 9px 16px; cursor: pointer; }}
+.actions button:hover {{ background: var(--burgundy); color: var(--parchment); }}
+.pagefoot {{ margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--rule-light); text-align: center; color: var(--ink-faint); font-size: 0.85rem; }}
+.pagefoot a {{ color: var(--ink-faint); text-decoration: none; border-bottom: 1px dotted var(--rule); }}
+@media print {{
+  .about, .actions, .no-print {{ display: none !important; }}
+  @page {{ margin: 0.8cm; }}
+  body {{ padding: 0; font-size: 12.5px; min-height: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }}
+  .frame {{ max-width: none; margin: 0; padding: 30px 56px 22px; border: 2px double var(--burgundy); }}
+  .seal-img {{ width: 150px; height: 150px; }}
+  .section {{ margin: 18px 0; }}
+}}
+</style>
+</head>
+<body>
+<div class="frame">
+<section>
+  <div class="seal-wrap">
+    <img class="seal-img" src="https://vouch-protocol.com/seal-verified.png" alt="Vouch Protocol Verified" />
+  </div>
+  <p class="issued-line">{esc(issued)} &middot; First Reference Integration</p>
+  <h1 class="title">Vouch Verified Integration</h1>
+  <p class="byline">{esc(name)}{by_html}</p>
+
+{sections_html}
+
+  <div class="about">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">An Open Standard</span><div class="rule-line"></div></div>
+    <p>Vouch gives AI agents a cryptographic identity, verifiable accountability, and a heartbeat
+    protocol for continuous trust, so anyone can prove who acted, under whose authority, and that the
+    agent is still trustworthy. The accountability layer adds commit-before-outcome evidence and an
+    AccountabilityRecord a counterparty can recompute rather than trust.</p>
+{discussion_html}    <p>See everyone building on the protocol on the <a href="https://vouch-protocol.com/adopters/" target="_blank" rel="noopener noreferrer">Vouch adopters</a> page.</p>
+    <p class="cta"><a href="https://vouch-protocol.com" target="_blank" rel="noopener noreferrer">Build on Vouch</a></p>
+  </div>
+
+  <div class="actions no-print">
+    <button type="button" onclick="window.print()">Download</button>
+  </div>
+</section>
+<div class="pagefoot"><a href="https://vouch-protocol.com/" target="_blank" rel="noopener noreferrer">vouch-protocol.com</a></div>
+</div>
+</body>
+</html>
+"""
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Render an adopter integration certificate page")
+    ap.add_argument("--credential", required=True, help="Path to the adopter credential JSON")
+    ap.add_argument("--slug", required=True, help="URL slug under /i/<slug>/")
+    ap.add_argument("--out", required=True, help="Output HTML path")
+    args = ap.parse_args()
+
+    with open(args.credential, encoding="utf-8") as handle:
+        cred = json.load(handle)
+    os.makedirs(os.path.dirname(args.out), exist_ok=True)
+    with open(args.out, "w", encoding="utf-8") as handle:
+        handle.write(render(cred, args.slug))
+    print(f"Wrote certificate for {args.slug} to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/website/public/i/invinoveritas/index.html
+++ b/website/public/i/invinoveritas/index.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Vouch Verified Integration - invinoveritas</title>
+<meta property="og:title" content="Vouch Verified Integration - invinoveritas">
+<meta property="og:description" content="First reference integration of Vouch Protocol Outcome Evidence and the AccountabilityRecord, verifiable on a live handshake surface.">
+<meta property="og:image" content="https://vouch-protocol.com/android-chrome-512x512.png">
+<meta property="og:url" content="https://vouch-protocol.com/i/invinoveritas/">
+<meta name="twitter:card" content="summary">
+<link rel="icon" type="image/png" sizes="32x32" href="https://vouch-protocol.com/favicon-32x32.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Source+Serif+4:ital,wght@0,400;0,600;1,400&family=JetBrains+Mono&display=swap" rel="stylesheet">
+<style>
+:root { --parchment:#FAF7EE; --parchment-warm:#F2EBD9; --ink:#0F172A; --ink-soft:#334155; --ink-faint:#64748B; --burgundy:#7C2D3A; --burgundy-dark:#5C1F2C; --rule:#D9CFB6; --rule-light:#E8DFC9; --code-bg:#0F172A; --code-fg:#FAF7EE; }
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+body { background: var(--parchment); color: var(--ink); font-family: "Source Serif 4", Georgia, serif; font-size: 17px; line-height: 1.6; padding: 64px 24px; min-height: 100vh; }
+.frame { max-width: 720px; margin: 0 auto; }
+.eyebrow { font-family: "JetBrains Mono", monospace; font-size: 0.7rem; letter-spacing: 0.18em; text-transform: uppercase; color: var(--ink-faint); }
+.seal-wrap { display: flex; justify-content: center; margin-bottom: 16px; }
+.seal-img { width: 200px; height: 200px; object-fit: contain; }
+.issued-line { text-align: center; font-family: "JetBrains Mono", monospace; font-size: 0.72rem; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ink-faint); margin: 0 0 40px; }
+h1.title { text-align: center; font-weight: 600; font-size: 1.5rem; line-height: 1.3; margin: 0 0 12px; letter-spacing: -0.01em; }
+.byline { text-align: center; color: var(--ink-soft); margin: 0 0 48px; font-style: italic; }
+.byline a { color: var(--burgundy); text-decoration: none; }
+.byline a:hover { color: var(--burgundy-dark); text-decoration: underline; }
+.section { margin: 36px 0; }
+.section-head { display: flex; align-items: center; gap: 12px; margin-bottom: 14px; }
+.section-head .rule-line { flex: 1; height: 1px; background: var(--rule); }
+.section-body { text-align: center; }
+.mono-text { font-family: "JetBrains Mono", monospace; font-size: 0.9rem; word-break: break-word; color: var(--ink); }
+.mono-text.dim { color: var(--ink-soft); font-size: 0.85rem; }
+.signer-caption { color: var(--ink-faint); font-style: italic; font-size: 0.9rem; margin-top: 6px; }
+.section-body a { color: var(--burgundy); text-decoration: none; border-bottom: 1px solid var(--burgundy); }
+.section-body a:hover { color: var(--burgundy-dark); border-bottom-color: var(--burgundy-dark); }
+.terminal { font-family: "JetBrains Mono", monospace; font-size: 0.85rem; background: var(--code-bg); color: var(--code-fg); padding: 16px 18px; margin: 12px auto; text-align: left; overflow-x: auto; max-width: 560px; white-space: pre-wrap; }
+.terminal .prompt { color: #80c08a; user-select: none; }
+.terminal .comment { color: #91a4b8; font-style: italic; }
+.about { margin-top: 56px; padding-top: 28px; border-top: 1px solid var(--rule-light); text-align: center; }
+.about p { color: var(--ink-soft); margin: 14px auto; max-width: 600px; }
+.about a { color: var(--burgundy); text-decoration: none; border-bottom: 1px solid var(--burgundy); }
+.about .cta { font-family: "JetBrains Mono", monospace; font-size: 0.8rem; text-transform: uppercase; letter-spacing: 0.12em; margin-top: 22px; }
+.actions { text-align: center; margin-top: 28px; }
+.actions button { font-family: "JetBrains Mono", monospace; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.12em; border: 1px solid var(--burgundy); background: var(--parchment); color: var(--burgundy); padding: 9px 16px; cursor: pointer; }
+.actions button:hover { background: var(--burgundy); color: var(--parchment); }
+.pagefoot { margin-top: 40px; padding-top: 24px; border-top: 1px solid var(--rule-light); text-align: center; color: var(--ink-faint); font-size: 0.85rem; }
+.pagefoot a { color: var(--ink-faint); text-decoration: none; border-bottom: 1px dotted var(--rule); }
+@media print {
+  .about, .actions, .no-print { display: none !important; }
+  @page { margin: 0.8cm; }
+  body { padding: 0; font-size: 12.5px; min-height: 0; -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+  .frame { max-width: none; margin: 0; padding: 30px 56px 22px; border: 2px double var(--burgundy); }
+  .seal-img { width: 150px; height: 150px; }
+  .section { margin: 18px 0; }
+}
+</style>
+</head>
+<body>
+<div class="frame">
+<section>
+  <div class="seal-wrap">
+    <img class="seal-img" src="https://vouch-protocol.com/seal-verified.png" alt="Vouch Protocol Verified" />
+  </div>
+  <p class="issued-line">28 Jun 2026 &middot; First Reference Integration</p>
+  <h1 class="title">Vouch Verified Integration</h1>
+  <p class="byline">invinoveritas &middot; by <a href="https://github.com/babyblueviper1" target="_blank" rel="noopener noreferrer">@babyblueviper1</a></p>
+
+  <div class="section">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">Integration</span><div class="rule-line"></div></div>
+    <div class="section-body">
+      <div class="mono-text">Outcome Evidence and the AccountabilityRecord</div>
+      <div class="signer-caption">The first system to integrate this layer of Vouch Protocol</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">Conformance</span><div class="rule-line"></div></div>
+    <div class="section-body">
+      <div class="mono-text dim">Emits a Vouch AccountabilityRecord conforming to the published field set: verifierKey, recordPointer, verifyEndpoint, reputationModel (recomputable), publishesLosses.</div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">Live surface</span><div class="rule-line"></div></div>
+    <div class="section-body">
+      <a class="mono-text" href="https://api.babyblueviper.com/.well-known/agent-handshake" target="_blank" rel="noopener noreferrer">api.babyblueviper.com/.well-known/agent-handshake</a>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">Recognized by</span><div class="rule-line"></div></div>
+    <div class="section-body">
+      <div class="mono-text">Vouch Protocol</div>
+      <div class="signer-caption">Open standard for AI agent identity and accountability</div>
+    </div>
+  </div>
+
+  <div class="section no-print">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">Verify</span><div class="rule-line"></div></div>
+    <div class="section-body">
+      <div class="terminal"><span class="comment"># Fetch the live handshake and read the record</span>
+<span class="prompt">$</span> curl https://api.babyblueviper.com/.well-known/agent-handshake
+
+<span class="comment"># The accountabilityRecord conforms to the Vouch field set.</span>
+<span class="comment"># The public record: discussion #53 and merged PRs #85, #180, #191.</span></div>
+    </div>
+  </div>
+
+  <div class="about">
+    <div class="section-head"><div class="rule-line"></div><span class="eyebrow">An Open Standard</span><div class="rule-line"></div></div>
+    <p>Vouch gives AI agents a cryptographic identity, verifiable accountability, and a heartbeat
+    protocol for continuous trust, so anyone can prove who acted, under whose authority, and that the
+    agent is still trustworthy. The accountability layer adds commit-before-outcome evidence and an
+    AccountabilityRecord a counterparty can recompute rather than trust.</p>
+    <p>See everyone building on the protocol on the <a href="https://vouch-protocol.com/adopters/" target="_blank" rel="noopener noreferrer">Vouch adopters</a> page.</p>
+    <p class="cta"><a href="https://vouch-protocol.com" target="_blank" rel="noopener noreferrer">Build on Vouch</a></p>
+  </div>
+
+  <div class="actions no-print">
+    <button type="button" onclick="window.print()">Download</button>
+  </div>
+</section>
+<div class="pagefoot"><a href="https://vouch-protocol.com/" target="_blank" rel="noopener noreferrer">vouch-protocol.com</a></div>
+</div>
+</body>
+</html>

--- a/website/src/app/adopters/page.tsx
+++ b/website/src/app/adopters/page.tsx
@@ -1,0 +1,115 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+    title: 'Adopters - Vouch Protocol',
+    description:
+        'Independent systems that build on or integrate Vouch Protocol, starting with invinoveritas, the first reference integration of Outcome Evidence and the AccountabilityRecord.',
+};
+
+type LinkItem = { label: string; href: string };
+
+type Adopter = {
+    name: string;
+    by: string;
+    focus: string;
+    badge: string;
+    summary: string;
+    links: LinkItem[];
+};
+
+const ADOPTERS: Adopter[] = [
+    {
+        name: 'invinoveritas',
+        by: 'babyblueviper1',
+        focus: 'Outcome Evidence and the AccountabilityRecord',
+        badge: 'First reference integration',
+        summary:
+            'A live outcome-verified reputation service. invinoveritas emits a Vouch AccountabilityRecord on its handshake surface, conforming to the shipped field set (verifierKey, recordPointer, verifyEndpoint, reputationModel: recomputable, publishesLosses). Its review of the commit-before-outcome primitive also produced the third-party timestamp anchor and the existence-versus-ordering precedence affordance now in the protocol.',
+        links: [
+            {
+                label: 'Live handshake',
+                href: 'https://api.babyblueviper.com/.well-known/agent-handshake',
+            },
+            {
+                label: 'Discussion #53',
+                href: 'https://github.com/vouch-protocol/vouch/discussions/53',
+            },
+            { label: 'Certificate', href: '/i/invinoveritas/' },
+        ],
+    },
+];
+
+export default function AdoptersPage() {
+    return (
+        <main className="min-h-screen bg-parchment text-ink">
+            <div className="container-wide py-16 md:py-24">
+                <header className="mb-12">
+                    <p className="eyebrow text-burgundy mb-3">Built on Vouch</p>
+                    <h1 className="font-serif text-[2.2rem] md:text-[2.8rem] leading-tight tracking-tight mb-4">
+                        Adopters
+                    </h1>
+                    <p className="font-serif italic text-ink-soft text-[1.1rem] max-w-prose leading-relaxed">
+                        Independent systems that build on or integrate Vouch Protocol. A reference
+                        integration produces or consumes Vouch credentials against the published
+                        schema, so anyone can verify it. This is a living list.
+                    </p>
+                </header>
+
+                <section className="space-y-12">
+                    {ADOPTERS.map((a) => (
+                        <article key={a.name} className="bg-parchment-warm border border-rule p-8 md:p-10">
+                            <header className="flex flex-wrap items-baseline gap-x-4 gap-y-2 mb-3 border-b border-rule-light pb-4">
+                                <h2 className="font-serif text-[1.6rem] md:text-[1.8rem] font-semibold tracking-tight">
+                                    {a.name}
+                                </h2>
+                                <span className="font-mono uppercase tracking-[0.16em] text-burgundy text-[0.72rem]">
+                                    {a.badge}
+                                </span>
+                                <span className="font-serif italic text-ink-faint text-[0.95rem]">
+                                    by {a.by}
+                                </span>
+                            </header>
+
+                            <h3 className="eyebrow mb-2">Integrates</h3>
+                            <p className="mb-6 text-ink leading-relaxed">{a.focus}</p>
+
+                            <p className="text-ink leading-relaxed mb-6 max-w-prose">{a.summary}</p>
+
+                            <div className="flex flex-wrap gap-x-6 gap-y-2">
+                                {a.links.map((l) => (
+                                    <a
+                                        key={l.label}
+                                        href={l.href}
+                                        target={l.href.startsWith('http') ? '_blank' : undefined}
+                                        rel={l.href.startsWith('http') ? 'noopener noreferrer' : undefined}
+                                        className="font-mono uppercase tracking-[0.14em] text-[0.72rem] text-burgundy border-b border-burgundy pb-0.5 no-underline hover:text-burgundy-dark hover:border-burgundy-dark"
+                                    >
+                                        {l.label}
+                                    </a>
+                                ))}
+                            </div>
+                        </article>
+                    ))}
+                </section>
+
+                <section className="mt-16 border-t border-rule-light pt-10">
+                    <h2 className="font-serif text-[1.4rem] font-semibold mb-3">Build a reference integration</h2>
+                    <p className="text-ink-soft leading-relaxed max-w-prose mb-4">
+                        If your system produces or consumes Vouch credentials, identity, delegation,
+                        outcome evidence, or an AccountabilityRecord, against the published schema, we
+                        are glad to list it here. Open a discussion and show the live surface a
+                        verifier can check.
+                    </p>
+                    <a
+                        href="https://github.com/vouch-protocol/vouch/discussions"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-mono uppercase tracking-[0.14em] text-[0.72rem] text-burgundy border-b border-burgundy pb-0.5 no-underline hover:text-burgundy-dark hover:border-burgundy-dark"
+                    >
+                        Start a discussion
+                    </a>
+                </section>
+            </div>
+        </main>
+    );
+}

--- a/website/src/app/adopters/page.tsx
+++ b/website/src/app/adopters/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import adoptersData from '@/data/adopters.json';
 
 export const metadata: Metadata = {
     title: 'Adopters - Vouch Protocol',
@@ -9,35 +10,25 @@ export const metadata: Metadata = {
 type LinkItem = { label: string; href: string };
 
 type Adopter = {
+    slug: string;
     name: string;
     by: string;
     focus: string;
     badge: string;
     summary: string;
-    links: LinkItem[];
+    liveSurface?: string;
+    discussion?: string;
 };
 
-const ADOPTERS: Adopter[] = [
-    {
-        name: 'invinoveritas',
-        by: 'babyblueviper1',
-        focus: 'Outcome Evidence and the AccountabilityRecord',
-        badge: 'First reference integration',
-        summary:
-            'A live outcome-verified reputation service. invinoveritas emits a Vouch AccountabilityRecord on its handshake surface, conforming to the shipped field set (verifierKey, recordPointer, verifyEndpoint, reputationModel: recomputable, publishesLosses). Its review of the commit-before-outcome primitive also produced the third-party timestamp anchor and the existence-versus-ordering precedence affordance now in the protocol.',
-        links: [
-            {
-                label: 'Live handshake',
-                href: 'https://api.babyblueviper.com/.well-known/agent-handshake',
-            },
-            {
-                label: 'Discussion #53',
-                href: 'https://github.com/vouch-protocol/vouch/discussions/53',
-            },
-            { label: 'Certificate', href: '/i/invinoveritas/' },
-        ],
-    },
-];
+const ADOPTERS = adoptersData as Adopter[];
+
+function adopterLinks(a: Adopter): LinkItem[] {
+    const links: LinkItem[] = [];
+    if (a.liveSurface) links.push({ label: 'Live handshake', href: a.liveSurface });
+    if (a.discussion) links.push({ label: 'Discussion', href: a.discussion });
+    links.push({ label: 'Certificate', href: `/i/${a.slug}/` });
+    return links;
+}
 
 export default function AdoptersPage() {
     return (
@@ -57,7 +48,7 @@ export default function AdoptersPage() {
 
                 <section className="space-y-12">
                     {ADOPTERS.map((a) => (
-                        <article key={a.name} className="bg-parchment-warm border border-rule p-8 md:p-10">
+                        <article key={a.slug} className="bg-parchment-warm border border-rule p-8 md:p-10">
                             <header className="flex flex-wrap items-baseline gap-x-4 gap-y-2 mb-3 border-b border-rule-light pb-4">
                                 <h2 className="font-serif text-[1.6rem] md:text-[1.8rem] font-semibold tracking-tight">
                                     {a.name}
@@ -76,7 +67,7 @@ export default function AdoptersPage() {
                             <p className="text-ink leading-relaxed mb-6 max-w-prose">{a.summary}</p>
 
                             <div className="flex flex-wrap gap-x-6 gap-y-2">
-                                {a.links.map((l) => (
+                                {adopterLinks(a).map((l) => (
                                     <a
                                         key={l.label}
                                         href={l.href}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -40,6 +40,7 @@ const FOOTER_GROUPS = [
     title: 'Community',
     links: [
       { label: 'Contributors', href: '/contributors/' },
+      { label: 'Adopters', href: '/adopters/' },
       { label: 'Discord', href: 'https://discord.gg/mMqx5cG9Y', external: true },
       { label: 'GitHub issues', href: 'https://github.com/vouch-protocol/vouch/issues', external: true },
       { label: 'X / Twitter', href: 'https://x.com/Vouch_Protocol', external: true },

--- a/website/src/data/adopters.json
+++ b/website/src/data/adopters.json
@@ -1,0 +1,12 @@
+[
+    {
+        "slug": "invinoveritas",
+        "name": "invinoveritas",
+        "by": "babyblueviper1",
+        "focus": "Outcome Evidence and the AccountabilityRecord",
+        "badge": "First reference integration",
+        "summary": "A live outcome-verified reputation service. invinoveritas emits a Vouch AccountabilityRecord on its handshake surface, conforming to the shipped field set (verifierKey, recordPointer, verifyEndpoint, reputationModel: recomputable, publishesLosses). Its review of the commit-before-outcome primitive also produced the third-party timestamp anchor and the existence-versus-ordering precedence affordance now in the protocol.",
+        "liveSurface": "https://api.babyblueviper.com/.well-known/agent-handshake",
+        "discussion": "https://github.com/vouch-protocol/vouch/discussions/53"
+    }
+]


### PR DESCRIPTION
Adds an Adopters page listing independent systems that build on Vouch Protocol, starting with invinoveritas as the first reference integration of the Outcome Evidence and AccountabilityRecord layer.

Adds a delegated Adopter Authority that issues Vouch Verified Integration certificates, modeled on the existing Contributor and Conformance authorities:

- A bootstrap workflow generates the adopter signing key and signs a root-to-adopter delegation in CI, using the root key already held as a repository secret, then publishes the public DID document at `/adopters/did.json`.
- An issue-adopter-certificate workflow mints a signed Verifiable Credential for each adopter, verifies it against the published DID document, and renders the certificate at `/i/<slug>/`.
- Each certificate is a credential anyone can verify, chained back to the root authority.

The adopters list is data-driven (`website/src/data/adopters.json`), so the issue workflow appends new entries and the page renders them.
