### PR TITLE
JVM SDK: ergonomic agent layer (Agent, named-arg intent, did:key)

### DIFF
--- a/sdks/jvm/src/main/java/com/vouchprotocol/core/Multibase.java
+++ b/sdks/jvm/src/main/java/com/vouchprotocol/core/Multibase.java
@@ -1,0 +1,70 @@
+package com.vouchprotocol.core;
+
+import java.math.BigInteger;
+
+/**
+ * Minimal base58btc / Multikey decoding for did:key issuers.
+ *
+ * A did:key encodes the public key in the identifier itself:
+ * {@code did:key:z<base58btc(0xed 0x01 || ed25519_public_key)>}. This decoder
+ * recovers the 32-byte Ed25519 public key so a did:key issuer can be verified
+ * offline. Encoding stays in the Rust core; this is only the small read path the
+ * JVM needs to resolve a did:key.
+ */
+final class Multibase {
+
+    private static final String ALPHABET =
+            "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    private static final BigInteger BASE = BigInteger.valueOf(58);
+
+    // Multicodec prefix for an Ed25519 public key (varint 0xed 0x01).
+    private static final int MULTICODEC_ED25519_0 = 0xed;
+    private static final int MULTICODEC_ED25519_1 = 0x01;
+    private static final int ED25519_PUBLIC_KEY_LEN = 32;
+
+    private Multibase() {}
+
+    /** Decode the Ed25519 public key bytes embedded in a did:key. */
+    static byte[] decodeEd25519DidKey(String didKey) {
+        if (didKey == null || !didKey.startsWith("did:key:")) {
+            throw new VouchAgent.VouchAgentException("not a did:key: " + didKey);
+        }
+        String multikey = didKey.substring("did:key:".length());
+        if (multikey.isEmpty() || multikey.charAt(0) != 'z') {
+            throw new VouchAgent.VouchAgentException("did:key must use base58btc (z) multibase");
+        }
+        byte[] decoded = base58Decode(multikey.substring(1));
+        if (decoded.length != 2 + ED25519_PUBLIC_KEY_LEN
+                || (decoded[0] & 0xff) != MULTICODEC_ED25519_0
+                || (decoded[1] & 0xff) != MULTICODEC_ED25519_1) {
+            throw new VouchAgent.VouchAgentException("did:key is not an Ed25519 key");
+        }
+        byte[] pub = new byte[ED25519_PUBLIC_KEY_LEN];
+        System.arraycopy(decoded, 2, pub, 0, ED25519_PUBLIC_KEY_LEN);
+        return pub;
+    }
+
+    private static byte[] base58Decode(String s) {
+        BigInteger num = BigInteger.ZERO;
+        for (int i = 0; i < s.length(); i++) {
+            int digit = ALPHABET.indexOf(s.charAt(i));
+            if (digit < 0) {
+                throw new VouchAgent.VouchAgentException("invalid base58 character: " + s.charAt(i));
+            }
+            num = num.multiply(BASE).add(BigInteger.valueOf(digit));
+        }
+        byte[] bytes = num.toByteArray();
+        // BigInteger may prepend a sign byte; drop a leading 0x00.
+        int offset = (bytes.length > 1 && bytes[0] == 0) ? 1 : 0;
+
+        // Restore leading zero bytes, one per leading '1' in the input.
+        int leadingZeros = 0;
+        while (leadingZeros < s.length() && s.charAt(leadingZeros) == '1') {
+            leadingZeros++;
+        }
+
+        byte[] out = new byte[leadingZeros + (bytes.length - offset)];
+        System.arraycopy(bytes, offset, out, leadingZeros, bytes.length - offset);
+        return out;
+    }
+}

--- a/sdks/jvm/src/main/java/com/vouchprotocol/core/VouchAgent.java
+++ b/sdks/jvm/src/main/java/com/vouchprotocol/core/VouchAgent.java
@@ -1,0 +1,149 @@
+package com.vouchprotocol.core;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Base64;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Ergonomic developer-experience layer over {@link Vouch}.
+ *
+ * Mirrors the Agent helper in the Python and TypeScript SDKs: one object that
+ * holds an identity and signs and verifies, so callers do not build credential
+ * JSON or pass seeds and public keys around by hand. The credential it produces
+ * is the same wire format every Vouch SDK uses; this class only adds ergonomics
+ * over the existing core calls in {@link Vouch}.
+ *
+ * <pre>
+ *   VouchAgent agent = VouchAgent.create("agent.example");
+ *   String signed = agent.sign("read", "did:web:files", "https://files/x");
+ *   boolean ok = agent.verify(signed);
+ *   agent.did();
+ * </pre>
+ *
+ * With a domain the identity is {@code did:web:<domain>}; without one it is a
+ * self-certifying {@code did:key}. The credential body is built in-language, the
+ * same way the Python, TypeScript, and Go SDKs build it, and signed through the
+ * core.
+ */
+public final class VouchAgent {
+
+    private static final int DEFAULT_EXPIRY_SECONDS = 300;
+
+    private final String did;
+    private final String seedB64;
+    private final String publicB64;
+    private final int defaultExpirySeconds;
+
+    private VouchAgent(String did, String seedB64, String publicB64, int defaultExpirySeconds) {
+        this.did = did;
+        this.seedB64 = seedB64;
+        this.publicB64 = publicB64;
+        this.defaultExpirySeconds = defaultExpirySeconds;
+    }
+
+    /** Mint a fresh identity. With a domain it is did:web, without one did:key. */
+    public static VouchAgent create(String domain) {
+        return create(domain, DEFAULT_EXPIRY_SECONDS);
+    }
+
+    public static VouchAgent create(String domain, int defaultExpirySeconds) {
+        String kp = Vouch.generateEd25519();
+        String seed = jsonString(kp, "seed_b64");
+        String pub = jsonString(kp, "public_b64");
+        String did = (domain != null && !domain.isEmpty())
+                ? "did:web:" + domain
+                : jsonString(kp, "did_key");
+        return new VouchAgent(did, seed, pub, defaultExpirySeconds);
+    }
+
+    /** Rehydrate an agent from stored key material (no new identity is minted). */
+    public static VouchAgent load(String did, String seedB64, String publicB64) {
+        return new VouchAgent(did, seedB64, publicB64, DEFAULT_EXPIRY_SECONDS);
+    }
+
+    public String did() {
+        return did;
+    }
+
+    public String publicKeyB64() {
+        return publicB64;
+    }
+
+    /** Sign an intent as a Vouch Credential, returning the signed credential JSON. */
+    public String sign(String action, String target, String resource) {
+        return sign(action, target, resource, defaultExpirySeconds);
+    }
+
+    public String sign(String action, String target, String resource, int validSeconds) {
+        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        String validFrom = iso(now);
+        String validUntil = iso(now.plusSeconds(validSeconds));
+        String credentialId = "urn:uuid:" + UUID.randomUUID();
+        String unsigned = VouchCredentials.build(
+                did, action, target, resource, validFrom, validUntil, credentialId);
+        return Vouch.signCredential(unsigned, seedB64, did + "#key-1", validFrom);
+    }
+
+    /**
+     * Verify a credential. If it was issued by this agent, it is checked against
+     * this agent's own key; otherwise the issuer key is resolved from a did:key
+     * issuer. Returns true only when the proof and the validity window are valid.
+     */
+    public boolean verify(String credentialJson) {
+        String issuer = jsonString(credentialJson, "issuer");
+        String pub = did.equals(issuer) ? publicB64 : publicKeyForIssuer(issuer);
+        if (pub == null) {
+            return false;
+        }
+        return verifyWith(credentialJson, pub);
+    }
+
+    /** Verify a credential against an explicit public key (base64). */
+    public static boolean verifyWith(String credentialJson, String publicB64) {
+        String result = Vouch.verifyCredential(
+                credentialJson, publicB64, iso(Instant.now()), 30);
+        return result.contains("\"valid\":true");
+    }
+
+    /**
+     * Resolve the Ed25519 public key (base64) for a did:key issuer. Returns null
+     * for non-did:key issuers, which need an explicit key or DID-document lookup.
+     */
+    public static String publicKeyForIssuer(String issuer) {
+        if (issuer == null || !issuer.startsWith("did:key:")) {
+            return null;
+        }
+        try {
+            byte[] pub = Multibase.decodeEd25519DidKey(issuer);
+            return Base64.getEncoder().encodeToString(pub);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    // -- internal helpers -----------------------------------------------------
+
+    static String iso(Instant instant) {
+        return instant.truncatedTo(ChronoUnit.SECONDS).toString().replace("Z", "") + "Z";
+    }
+
+    /** Read a top-level-ish string field from a JSON document. */
+    static String jsonString(String json, String key) {
+        Matcher m = Pattern.compile("\"" + Pattern.quote(key) + "\"\\s*:\\s*\"([^\"]*)\"")
+                .matcher(json);
+        if (!m.find()) {
+            throw new VouchAgentException("field not found: " + key);
+        }
+        return m.group(1);
+    }
+
+    /** Thrown when the ergonomic layer cannot parse or build a value. */
+    public static final class VouchAgentException extends RuntimeException {
+        public VouchAgentException(String message) {
+            super(message);
+        }
+    }
+}

--- a/sdks/jvm/src/main/java/com/vouchprotocol/core/VouchCredentials.java
+++ b/sdks/jvm/src/main/java/com/vouchprotocol/core/VouchCredentials.java
@@ -1,0 +1,147 @@
+package com.vouchprotocol.core;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Builds the unsigned Vouch Credential body in-language and reads it back.
+ *
+ * The JSON shape and field order match the canonical {@code build_vouch_credential}
+ * in the Rust core and the Python/TypeScript/Go SDKs, so the credential signs and
+ * verifies identically across implementations. Only the crypto (signing,
+ * verifying) goes through {@link Vouch}; the body is assembled here, the same way
+ * the other SDKs assemble it.
+ */
+public final class VouchCredentials {
+
+    public static final String VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2";
+    public static final String VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1";
+    public static final String PROTOCOL_VERSION = "1.0";
+
+    private VouchCredentials() {}
+
+    /**
+     * Construct the unsigned credential JSON. The intent fields are required and
+     * must be non-empty (Specification 5.4.1).
+     */
+    public static String build(
+            String issuerDid,
+            String action,
+            String target,
+            String resource,
+            String validFrom,
+            String validUntil,
+            String credentialId) {
+        requireNonEmpty("action", action);
+        requireNonEmpty("target", target);
+        requireNonEmpty("resource", resource);
+
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("{\"@context\":[")
+                .append(str(VC_CONTEXT_V2)).append(',').append(str(VOUCH_CONTEXT_V1))
+                .append("],\"id\":").append(str(credentialId))
+                .append(",\"type\":[\"VerifiableCredential\",\"VouchCredential\"]")
+                .append(",\"issuer\":").append(str(issuerDid))
+                .append(",\"validFrom\":").append(str(validFrom))
+                .append(",\"validUntil\":").append(str(validUntil))
+                .append(",\"credentialSubject\":{\"id\":").append(str(issuerDid))
+                .append(",\"vouchVersion\":").append(str(PROTOCOL_VERSION))
+                .append(",\"intent\":{\"action\":").append(str(action))
+                .append(",\"target\":").append(str(target))
+                .append(",\"resource\":").append(str(resource))
+                .append("}}}");
+        return sb.toString();
+    }
+
+    private static void requireNonEmpty(String name, String value) {
+        if (value == null || value.isEmpty()) {
+            throw new VouchAgent.VouchAgentException(
+                    "intent." + name + " is required and must be a non-empty string");
+        }
+    }
+
+    /** Minimal JSON string encoder for the controlled values used in a credential. */
+    static String str(String value) {
+        StringBuilder sb = new StringBuilder(value.length() + 2);
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    /**
+     * A read-friendly view over a credential JSON: the intent fields, issuer, and
+     * expiry, without re-parsing by hand at the call site.
+     */
+    public static final class Credential {
+        private final String json;
+
+        public Credential(String credentialJson) {
+            if (credentialJson == null || credentialJson.isEmpty()) {
+                throw new VouchAgent.VouchAgentException("credential JSON is empty");
+            }
+            this.json = credentialJson;
+        }
+
+        public String action() {
+            return intentField("action");
+        }
+
+        public String target() {
+            return intentField("target");
+        }
+
+        public String resource() {
+            return intentField("resource");
+        }
+
+        public String issuer() {
+            return optional("issuer");
+        }
+
+        public String validUntil() {
+            return optional("validUntil");
+        }
+
+        public String toJson() {
+            return json;
+        }
+
+        private String intentField(String key) {
+            int idx = json.indexOf("\"intent\"");
+            String scope = idx >= 0 ? json.substring(idx) : json;
+            Matcher m = Pattern.compile("\"" + key + "\"\\s*:\\s*\"([^\"]*)\"").matcher(scope);
+            return m.find() ? m.group(1) : null;
+        }
+
+        private String optional(String key) {
+            Matcher m = Pattern.compile("\"" + key + "\"\\s*:\\s*\"([^\"]*)\"").matcher(json);
+            return m.find() ? m.group(1) : null;
+        }
+    }
+}

--- a/sdks/jvm/src/test/java/com/vouchprotocol/core/VouchAgentTest.java
+++ b/sdks/jvm/src/test/java/com/vouchprotocol/core/VouchAgentTest.java
@@ -1,0 +1,74 @@
+package com.vouchprotocol.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/** Tests for the ergonomic DX layer (VouchAgent, VouchCredentials). */
+class VouchAgentTest {
+
+    @Test
+    void didWebMintSignVerify() {
+        VouchAgent agent = VouchAgent.create("agent.example");
+        assertEquals("did:web:agent.example", agent.did());
+        String signed = agent.sign("read", "did:web:files", "https://files/x");
+        assertTrue(agent.verify(signed), "agent should verify its own credential");
+
+        VouchCredentials.Credential c = new VouchCredentials.Credential(signed);
+        assertEquals("read", c.action());
+        assertEquals("did:web:files", c.target());
+        assertEquals("https://files/x", c.resource());
+        assertEquals("did:web:agent.example", c.issuer());
+    }
+
+    @Test
+    void didKeyWhenNoDomain() {
+        VouchAgent agent = VouchAgent.create(null);
+        assertTrue(agent.did().startsWith("did:key:"), "no domain should yield a did:key");
+        String signed = agent.sign("write", "t", "r");
+        assertTrue(agent.verify(signed));
+    }
+
+    @Test
+    void didKeyResolutionAcrossIssuers() {
+        VouchAgent a = VouchAgent.create(null); // did:key
+        VouchAgent b = VouchAgent.create(null); // did:key
+        String signedByB = b.sign("read", "t", "https://x/y");
+        // a does not know b; it resolves b's key from b's did:key issuer.
+        assertTrue(a.verify(signedByB), "did:key issuer should resolve offline");
+    }
+
+    @Test
+    void wrongKeyFails() {
+        VouchAgent a = VouchAgent.create("a.example");
+        VouchAgent b = VouchAgent.create("b.example");
+        String signed = a.sign("read", "t", "https://x/y");
+        // b is did:web (no resolution here); verifying a's credential with b's key fails.
+        assertFalse(VouchAgent.verifyWith(signed, b.publicKeyB64()));
+    }
+
+    @Test
+    void loadRoundTrip() {
+        VouchAgent agent = VouchAgent.create("agent.example");
+        String signed = agent.sign("read", "t", "https://x/y");
+        // Verifying with the agent's own public key (offline) still works.
+        assertTrue(VouchAgent.verifyWith(signed, agent.publicKeyB64()));
+    }
+
+    @Test
+    void missingIntentFieldThrows() {
+        assertThrows(
+                VouchAgent.VouchAgentException.class,
+                () -> VouchCredentials.build(
+                        "did:web:a", "", "t", "https://x/y", "2026-01-01T00:00:00Z",
+                        "2026-01-01T00:05:00Z", "urn:uuid:1"));
+    }
+
+    @Test
+    void publicKeyForIssuerNullForNonDidKey() {
+        assertEquals(null, VouchAgent.publicKeyForIssuer("did:web:agent.example"));
+    }
+}


### PR DESCRIPTION
Brings the JVM SDK toward parity with the Python and TypeScript developer helpers, layered over the existing core calls in Vouch.java. The credential wire format is unchanged; only ergonomics are added.

What it adds:
- VouchAgent: mint or load an identity (did:web with a domain, did:key without) and sign and verify in one call.
- VouchCredentials: build the credential body in-language with the same shape the Rust core and the Python/TypeScript/Go SDKs use, plus a read-friendly Credential view (action/target/resource/issuer).
- Multibase: resolve a did:key issuer offline so its credentials verify without an explicit key.

Security boundary: VouchCredentials builds only the unsigned body; all signing and verification go through the core (Vouch.signCredential / Vouch.verifyCredential), so signatures are byte-identical to the other SDKs. did:key resolution decodes the key embedded in the DID, so it authenticates self-consistency, not real-world identity. A did:web issuer still needs an explicit key or a DID-document lookup.

Verification: the new VouchAgentTest passes (7 tests) alongside the existing suite, run via gradle against the bundled native core, including a cross-issuer did:key resolution test.