### PR TITLE
chore: stop tracking .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,0 @@
-{
-  "includeCoAuthoredBy": false
-}


### PR DESCRIPTION
Removes `.claude/settings.json` from version control. The repository `.gitignore` already excludes `.claude/`, so this untracks a file that had been force-added past the ignore. The file stays locally and ignored.
