### PR TITLE
Sign the adopter delegation with the root authority

### DIFF
--- a/.github/workflows/bootstrap-adopter-authority.yml
+++ b/.github/workflows/bootstrap-adopter-authority.yml
@@ -4,7 +4,10 @@ name: Bootstrap adopter authority (one-time)
 # that is already a repository secret. Mirrors the Conformance Authority setup.
 # This:
 #   1. Generates a fresh Ed25519 key for did:web:vouch-protocol.com:adopters.
-#   2. Signs a root -> adopter delegation with the VOUCH_PRIVATE_KEY secret.
+#   2. Signs a root -> adopter delegation with the VOUCH_ROOT_PRIVATE_KEY secret
+#      (the true root key that signed contributors/delegation.json, held offline,
+#      added as a secret for this one run; not VOUCH_PRIVATE_KEY, which is the
+#      contributor authority key).
 #   3. Commits the public DID document and the delegation to main.
 #   4. Stores VOUCH_ADOPTER_PRIVATE_KEY and VOUCH_ADOPTER_DID as repository
 #      secrets (needs GH_ADMIN_TOKEN), or uploads the key as a short-lived
@@ -19,6 +22,10 @@ on:
       confirm:
         description: "Type 'bootstrap' to confirm creating the adopter authority key"
         required: true
+      delegation_only:
+        description: "Re-sign only the delegation (keep the existing adopter key)"
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -47,14 +54,20 @@ jobs:
 
       - name: Generate the adopter key and sign the delegation with the root key
         env:
-          VOUCH_ROOT_PRIVATE_KEY: ${{ secrets.VOUCH_PRIVATE_KEY }}
-          VOUCH_ROOT_DID: ${{ secrets.VOUCH_DID }}
+          VOUCH_ROOT_PRIVATE_KEY: ${{ secrets.VOUCH_ROOT_PRIVATE_KEY }}
+          VOUCH_ROOT_DID: ${{ secrets.VOUCH_ROOT_DID }}
         run: |
           if [ -z "$VOUCH_ROOT_PRIVATE_KEY" ]; then
-            echo "::error::Root key not configured (VOUCH_PRIVATE_KEY)."
+            echo "::error::Root key not configured. Add VOUCH_ROOT_PRIVATE_KEY"
+            echo "::error::(the true root key that signed contributors/delegation.json),"
+            echo "::error::not VOUCH_PRIVATE_KEY which is the contributor authority key."
             exit 1
           fi
-          python scripts/bootstrap_adopter_authority.py
+          if [ "${{ inputs.delegation_only }}" = "true" ]; then
+            python scripts/bootstrap_adopter_authority.py --delegation-only
+          else
+            python scripts/bootstrap_adopter_authority.py
+          fi
 
       - name: Commit the public DID document and delegation
         run: |
@@ -75,6 +88,11 @@ jobs:
           GH_ADMIN_TOKEN: ${{ secrets.GH_ADMIN_TOKEN }}
           ADOPTER_DID_VALUE: did:web:vouch-protocol.com:adopters
         run: |
+          if [ ! -f adopter-authority-key.json ]; then
+            echo "stored=skip" >> "$GITHUB_OUTPUT"
+            echo "Delegation re-signed; the adopter key and its secrets are unchanged." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
           if [ -n "$GH_ADMIN_TOKEN" ]; then
             GH_TOKEN="$GH_ADMIN_TOKEN" gh secret set VOUCH_ADOPTER_PRIVATE_KEY \
               --body "$(cat adopter-authority-key.json)"

--- a/scripts/bootstrap_adopter_authority.py
+++ b/scripts/bootstrap_adopter_authority.py
@@ -23,6 +23,7 @@ The root key is read from the environment and never written anywhere:
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import sys
@@ -85,7 +86,36 @@ def sign_delegation(root_private_key: str, root_did: str) -> dict:
     )
 
 
+def _write_delegation(root_private_key: str, root_did: str) -> int:
+    """Sign and write the root -> adopter delegation, then self-check it."""
+    delegation = sign_delegation(root_private_key, root_did)
+    os.makedirs(os.path.dirname(DELEGATION_PATH), exist_ok=True)
+    with open(DELEGATION_PATH, "w", encoding="utf-8") as handle:
+        json.dump(delegation, handle, indent=2)
+        handle.write("\n")
+
+    root_pub = Signer(private_key=root_private_key, did=root_did).get_public_key_jwk()
+    ok, _ = Verifier.verify_credential(json.dumps(delegation), public_key=root_pub)
+    if not ok:
+        print(
+            "::error:: delegation did not verify against the root key. "
+            "Check VOUCH_ROOT_PRIVATE_KEY and VOUCH_ROOT_DID.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
 def main() -> int:
+    parser = argparse.ArgumentParser(description="Bootstrap the Vouch Adopter Authority")
+    parser.add_argument(
+        "--delegation-only",
+        action="store_true",
+        help="Re-sign adopters/delegation.json with the root key without "
+        "regenerating the adopter key or DID document.",
+    )
+    args = parser.parse_args()
+
     root_private_key = os.getenv("VOUCH_ROOT_PRIVATE_KEY")
     root_did = os.getenv("VOUCH_ROOT_DID") or "did:web:vouch-protocol.com"
     if not root_private_key:
@@ -95,6 +125,16 @@ def main() -> int:
             file=sys.stderr,
         )
         return 1
+
+    if args.delegation_only:
+        # The adopter key already exists and is stored; only re-issue the
+        # delegation so it is signed by the true root authority.
+        rc = _write_delegation(root_private_key, root_did)
+        if rc != 0:
+            return rc
+        print(f"Re-signed {DELEGATION_PATH} with root {root_did}.")
+        print("Commit it. The adopter key and its secrets are unchanged.")
+        return 0
 
     if os.path.exists(DID_DOC_PATH) or os.path.exists(DELEGATION_PATH):
         print(
@@ -115,23 +155,10 @@ def main() -> int:
         json.dump(did_doc, handle, indent=2)
         handle.write("\n")
 
-    # 3: sign the root -> adopter delegation.
-    delegation = sign_delegation(root_private_key, root_did)
-    os.makedirs(os.path.dirname(DELEGATION_PATH), exist_ok=True)
-    with open(DELEGATION_PATH, "w", encoding="utf-8") as handle:
-        json.dump(delegation, handle, indent=2)
-        handle.write("\n")
-
-    # Self-check: the delegation must verify against the root DID's public key.
-    root_pub = Signer(private_key=root_private_key, did=root_did).get_public_key_jwk()
-    ok, _ = Verifier.verify_credential(json.dumps(delegation), public_key=root_pub)
-    if not ok:
-        print(
-            "::error:: delegation did not verify against the root key. "
-            "Check VOUCH_ROOT_PRIVATE_KEY and VOUCH_ROOT_DID.",
-            file=sys.stderr,
-        )
-        return 1
+    # 3: sign the root -> adopter delegation (self-checked against the root key).
+    rc = _write_delegation(root_private_key, root_did)
+    if rc != 0:
+        return rc
 
     # 4: write the adopter authority private key for the operator to store.
     with open(PRIVATE_KEY_PATH, "w", encoding="utf-8") as handle:


### PR DESCRIPTION
Signs the adopter delegation with the root authority `did:web:vouch-protocol.com`, matching how the contributor and conformance authorities are delegated, so an adopter certificate chains back to the root.

- The bootstrap workflow reads the root key from a dedicated `VOUCH_ROOT_PRIVATE_KEY` secret.
- Adds a `--delegation-only` mode (and a workflow toggle) that re-issues `adopters/delegation.json` without regenerating the adopter key or DID document, so the already-stored adopter signing key stays in place.
