### PR TITLE
Re-land Python and Go secure key custody onto main

### DIFF
--- a/go-sidecar/signer/backend_signer_test.go
+++ b/go-sidecar/signer/backend_signer_test.go
@@ -1,0 +1,103 @@
+// Tests for backend signing: the Ed25519 key lives outside the Signer and a
+// callback produces the signature. Mirrors the Python tests in
+// tests/test_secure_key_custody.py.
+
+package signer
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+)
+
+func TestNewBackendSignsAndVerifies(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+
+	calls := 0
+	sign := func(digest []byte) []byte {
+		calls++
+		return ed25519.Sign(priv, digest)
+	}
+
+	s, err := NewBackend("did:web:agent.example.com", pub, sign, 300)
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+
+	cred, err := s.SignCredential(SignCredentialOptions{
+		Action:   "read",
+		Target:   "t",
+		Resource: "https://api.example.com/v1/users",
+	})
+	if err != nil {
+		t.Fatalf("SignCredential: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected the sign callback to be used once, got %d", calls)
+	}
+
+	ok, err := VerifyDataIntegrityProof(cred, pub)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !ok {
+		t.Fatal("backend-signed credential failed verification")
+	}
+}
+
+func TestNewBackendRejectsBadInput(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	_, _ = rand.Read(seed)
+	pub := ed25519.NewKeyFromSeed(seed).Public().(ed25519.PublicKey)
+	sign := func(d []byte) []byte { return nil }
+
+	if _, err := NewBackend("", pub, sign, 0); err == nil {
+		t.Fatal("expected error for empty DID")
+	}
+	if _, err := NewBackend("did:web:x", []byte{1, 2, 3}, sign, 0); err == nil {
+		t.Fatal("expected error for short public key")
+	}
+	if _, err := NewBackend("did:web:x", pub, nil, 0); err == nil {
+		t.Fatal("expected error for nil sign callback")
+	}
+}
+
+func TestBackendSignerBlocksCompositeAndHybrid(t *testing.T) {
+	seed := make([]byte, ed25519.SeedSize)
+	_, _ = rand.Read(seed)
+	priv := ed25519.NewKeyFromSeed(seed)
+	pub := priv.Public().(ed25519.PublicKey)
+	s, err := NewBackend("did:web:x", pub, func(d []byte) []byte { return ed25519.Sign(priv, d) }, 0)
+	if err != nil {
+		t.Fatalf("NewBackend: %v", err)
+	}
+
+	if _, err := s.Sign(SignRequest{}); err == nil {
+		t.Fatal("expected composite Sign to be blocked for a backend Signer")
+	}
+	if _, err := s.SignCredentialHybrid(SignCredentialOptions{
+		Action: "a", Target: "b", Resource: "c",
+	}); err == nil {
+		t.Fatal("expected hybrid to be blocked for a backend Signer")
+	}
+}
+
+func TestBuildProofRequiresKeyOrCallback(t *testing.T) {
+	cred, err := BuildVouchCredential(BuildVouchCredentialOptions{
+		IssuerDID: "did:web:x",
+		Intent: map[string]any{
+			"action": "a", "target": "b", "resource": "https://x/r",
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildVouchCredential: %v", err)
+	}
+	if _, err := BuildDataIntegrityProof(cred, BuildProofOptions{VerificationMethod: "did:web:x#key-1"}); err == nil {
+		t.Fatal("expected error when neither PrivateKey nor Sign is set")
+	}
+}

--- a/go-sidecar/signer/credential.go
+++ b/go-sidecar/signer/credential.go
@@ -11,6 +11,7 @@ package signer
 import (
 	"crypto/ed25519"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -96,10 +97,13 @@ func (s *Signer) SignCredential(opts SignCredentialOptions) (map[string]any, err
 		return nil, err
 	}
 
-	proof, err := BuildDataIntegrityProof(cred, BuildProofOptions{
-		PrivateKey:         s.ed25519Private,
-		VerificationMethod: s.VerificationMethodID(),
-	})
+	proofOpts := BuildProofOptions{VerificationMethod: s.VerificationMethodID()}
+	if s.signFunc != nil {
+		proofOpts.Sign = s.signFunc
+	} else {
+		proofOpts.PrivateKey = s.ed25519Private
+	}
+	proof, err := BuildDataIntegrityProof(cred, proofOpts)
 	if err != nil {
 		return nil, fmt.Errorf("build proof: %w", err)
 	}
@@ -184,6 +188,12 @@ func (s *Signer) AttachProof(credential map[string]any) (map[string]any, error) 
 // eddsa-jcs-2022 default. Implementations using this profile SHOULD
 // transmit credentials in the HTTP request body (§5.6).
 func (s *Signer) SignCredentialHybrid(opts SignCredentialOptions) (map[string]any, error) {
+	if s.signFunc != nil {
+		// The hybrid profile needs both an Ed25519 and an ML-DSA-44 signature.
+		// A backend Signer only exposes the Ed25519 callback, so this path is
+		// not available there.
+		return nil, errors.New("vouch: SignCredentialHybrid is not supported for a backend Signer")
+	}
 	opts.Intent = mergeIntent(opts.Intent, opts.Action, opts.Target, opts.Resource)
 	chain := opts.DelegationChain
 	if opts.ParentCredential != nil {

--- a/go-sidecar/signer/data_integrity.go
+++ b/go-sidecar/signer/data_integrity.go
@@ -30,25 +30,31 @@ import (
 
 const (
 	CryptosuiteEddsaJcs2022 = "eddsa-jcs-2022"
-	ProofTypeDataIntegrity = "DataIntegrityProof"
+	ProofTypeDataIntegrity  = "DataIntegrityProof"
 )
 
 // DataIntegrityProof represents a Data Integrity proof object.
 type DataIntegrityProof struct {
-	Type        string `json:"type"`
-	Cryptosuite    string `json:"cryptosuite"`
-	Created      string `json:"created"`
+	Type               string `json:"type"`
+	Cryptosuite        string `json:"cryptosuite"`
+	Created            string `json:"created"`
 	VerificationMethod string `json:"verificationMethod"`
-	ProofPurpose    string `json:"proofPurpose"`
-	ProofValue     string `json:"proofValue,omitempty"`
+	ProofPurpose       string `json:"proofPurpose"`
+	ProofValue         string `json:"proofValue,omitempty"`
 }
 
 // BuildProofOptions configures BuildDataIntegrityProof.
+//
+// Provide either PrivateKey (signed in process) or Sign, a callback that takes
+// the 32-byte digest and returns the 64-byte Ed25519 signature. The Sign form
+// lets the key live where this process cannot read it (an OS secure element, a
+// sidecar, a cloud KMS/HSM, or an MPC quorum). If both are set, Sign wins.
 type BuildProofOptions struct {
-	PrivateKey     ed25519.PrivateKey
+	PrivateKey         ed25519.PrivateKey
+	Sign               func(digest []byte) []byte
 	VerificationMethod string
-	ProofPurpose    string // defaults to "assertionMethod"
-	Created      time.Time
+	ProofPurpose       string // defaults to "assertionMethod"
+	Created            time.Time
 }
 
 // BuildDataIntegrityProof generates a Data Integrity proof for the given
@@ -71,11 +77,11 @@ func BuildDataIntegrityProof(
 	}
 
 	proof := DataIntegrityProof{
-		Type:        ProofTypeDataIntegrity,
-		Cryptosuite:    CryptosuiteEddsaJcs2022,
-		Created:      formatISO8601(created),
+		Type:               ProofTypeDataIntegrity,
+		Cryptosuite:        CryptosuiteEddsaJcs2022,
+		Created:            formatISO8601(created),
 		VerificationMethod: opts.VerificationMethod,
-		ProofPurpose:    purpose,
+		ProofPurpose:       purpose,
 	}
 
 	// Build proof representation as a plain map matching the JSON shape
@@ -92,7 +98,15 @@ func BuildDataIntegrityProof(
 	}
 	digest := sha256.Sum256(canonical)
 
-	signature := ed25519.Sign(opts.PrivateKey, digest[:])
+	var signature []byte
+	switch {
+	case opts.Sign != nil:
+		signature = opts.Sign(digest[:])
+	case opts.PrivateKey != nil:
+		signature = ed25519.Sign(opts.PrivateKey, digest[:])
+	default:
+		return DataIntegrityProof{}, errors.New("BuildProofOptions needs a PrivateKey or a Sign callback")
+	}
 	proof.ProofValue = "z" + b58Encode(signature)
 	return proof, nil
 }
@@ -148,11 +162,11 @@ func VerifyDataIntegrityProof(
 
 func proofToMap(p DataIntegrityProof) map[string]any {
 	m := map[string]any{
-		"type":        p.Type,
-		"cryptosuite":    p.Cryptosuite,
-		"created":      p.Created,
+		"type":               p.Type,
+		"cryptosuite":        p.Cryptosuite,
+		"created":            p.Created,
 		"verificationMethod": p.VerificationMethod,
-		"proofPurpose":    p.ProofPurpose,
+		"proofPurpose":       p.ProofPurpose,
 	}
 	if p.ProofValue != "" {
 		m["proofValue"] = p.ProofValue

--- a/go-sidecar/signer/signer.go
+++ b/go-sidecar/signer/signer.go
@@ -101,17 +101,22 @@ type SensitiveVault struct {
 // composite JWS path: different parameter set, different deployment
 // profile (level-1 PQ security, smaller signatures, standards-aligned usage).
 type Signer struct {
-	did      string
-	defaultExpiry int
+	did            string
+	defaultExpiry  int
 	ed25519Private ed25519.PrivateKey
-	ed25519Public ed25519.PublicKey
-	mldsaPrivate  *mldsa65.PrivateKey
-	mldsaPublic  *mldsa65.PublicKey
+	ed25519Public  ed25519.PublicKey
+	mldsaPrivate   *mldsa65.PrivateKey
+	mldsaPublic    *mldsa65.PublicKey
 
 	// ML-DSA-44 keypair for the hybrid Data Integrity profile.
 	// Generated on demand if the caller did not supply one.
 	mldsa44Private *mldsa44.PrivateKey
-	mldsa44Public *mldsa44.PublicKey
+	mldsa44Public  *mldsa44.PublicKey
+
+	// signFunc is set for a backend Signer (NewBackend): the Ed25519 private
+	// key lives outside this process and this callback produces the signature
+	// over the digest. When set, ed25519Private is nil.
+	signFunc func(digest []byte) []byte
 }
 
 // Config holds the initialization parameters for a Signer.
@@ -177,14 +182,49 @@ func New(cfg Config) (*Signer, error) {
 	}
 
 	return &Signer{
-		did:      cfg.DID,
-		defaultExpiry: expiry,
+		did:            cfg.DID,
+		defaultExpiry:  expiry,
 		ed25519Private: edPriv,
-		ed25519Public: edPub,
-		mldsaPrivate:  mlPriv,
-		mldsaPublic:  mlPub,
+		ed25519Public:  edPub,
+		mldsaPrivate:   mlPriv,
+		mldsaPublic:    mlPub,
 		mldsa44Private: ml44Priv,
-		mldsa44Public: ml44Pub,
+		mldsa44Public:  ml44Pub,
+	}, nil
+}
+
+// NewBackend creates a Signer whose Ed25519 private key lives outside this
+// process. Instead of a seed, you supply the agent's public key and a callback
+// sign(digest) -> signature. The key can then live in an OS secure element, a
+// sidecar, a cloud KMS/HSM, or an MPC quorum. This Signer issues Data Integrity
+// credentials (the modern path); the composite JWS Sign and the hybrid profile,
+// which need the raw key in process, are not available.
+func NewBackend(
+	did string,
+	publicKey ed25519.PublicKey,
+	sign func(digest []byte) []byte,
+	defaultExpirySeconds int,
+) (*Signer, error) {
+	if did == "" {
+		return nil, errors.New("vouch: DID is required")
+	}
+	if len(publicKey) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("vouch: publicKey must be %d bytes", ed25519.PublicKeySize)
+	}
+	if sign == nil {
+		return nil, errors.New("vouch: sign callback is required")
+	}
+
+	expiry := defaultExpirySeconds
+	if expiry <= 0 {
+		expiry = 300
+	}
+
+	return &Signer{
+		did:           did,
+		defaultExpiry: expiry,
+		ed25519Public: publicKey,
+		signFunc:      sign,
 	}, nil
 }
 
@@ -194,20 +234,20 @@ func New(cfg Config) (*Signer, error) {
 
 // joseHeader is the protected header for the composite JWS.
 type joseHeader struct {
-	Algorithm string  `json:"alg"`
-	Type   string  `json:"typ"`
-	KeyID   string  `json:"kid"`
+	Algorithm string   `json:"alg"`
+	Type      string   `json:"typ"`
+	KeyID     string   `json:"kid"`
 	Composite []string `json:"vouch_composite_alg"`
 }
 
 // Claims is the JWT claims payload for a Vouch Token.
 type Claims struct {
-	JTI  string     `json:"jti"`
-	ISS  string     `json:"iss"`
-	SUB  string     `json:"sub"`
-	IAT  int64     `json:"iat"`
-	NBF  int64     `json:"nbf"`
-	EXP  int64     `json:"exp"`
+	JTI   string         `json:"jti"`
+	ISS   string         `json:"iss"`
+	SUB   string         `json:"sub"`
+	IAT   int64          `json:"iat"`
+	NBF   int64          `json:"nbf"`
+	EXP   int64          `json:"exp"`
 	Vouch map[string]any `json:"vouch"`
 }
 
@@ -219,8 +259,8 @@ type compositeSignature struct {
 
 // compositeJWS is the full composite JWS structure.
 type compositeJWS struct {
-	Protected string       `json:"protected"`
-	Payload  string       `json:"payload"`
+	Protected string             `json:"protected"`
+	Payload   string             `json:"payload"`
 	Signature compositeSignature `json:"signature"`
 }
 
@@ -228,6 +268,9 @@ type compositeJWS struct {
 // recipient ML-KEM public key is provided, the composite JWS is wrapped
 // inside an ML-KEM-768 / AES-256-GCM JWE vault.
 func (s *Signer) Sign(req SignRequest) ([]byte, error) {
+	if s.signFunc != nil {
+		return nil, errors.New("vouch: the composite JWS Sign needs the raw key and is not available for a backend Signer")
+	}
 	// 1. Build the composite JWS
 	jwsBytes, err := s.buildCompositeJWS(req)
 	if err != nil {
@@ -238,7 +281,7 @@ func (s *Signer) Sign(req SignRequest) ([]byte, error) {
 		// Standard mode: return the composite JWS directly.
 		out := VouchToken{
 			Token: string(jwsBytes),
-			Mode: "standard",
+			Mode:  "standard",
 		}
 		return json.MarshalIndent(out, "", " ")
 	}
@@ -267,8 +310,8 @@ func (s *Signer) buildCompositeJWS(req SignRequest) ([]byte, error) {
 	// Protected header
 	hdr := joseHeader{
 		Algorithm: "EdDSA+ML-DSA-65",
-		Type:   "vouch+jwt",
-		KeyID:   s.did,
+		Type:      "vouch+jwt",
+		KeyID:     s.did,
 		Composite: []string{"EdDSA", "ML-DSA-65"},
 	}
 	hdrJSON, err := json.Marshal(hdr)
@@ -311,7 +354,7 @@ func (s *Signer) buildCompositeJWS(req SignRequest) ([]byte, error) {
 	// Assemble composite JWS
 	jws := compositeJWS{
 		Protected: hdrB64,
-		Payload:  payloadB64,
+		Payload:   payloadB64,
 		Signature: compositeSignature{
 			Ed25519: base64url(edSig),
 			MLDSA65: base64url(mlSig),
@@ -379,13 +422,13 @@ func (s *Signer) wrapInJWEVault(jwsData []byte, recipientPubKeyB64 string) (*Sen
 
 	// Step 5: Assemble the JWE vault
 	return &SensitiveVault{
-		Mode:     "sensitive",
-		Algorithm:   "ML-KEM-768",
-		Encryption:  "A256GCM",
+		Mode:          "sensitive",
+		Algorithm:     "ML-KEM-768",
+		Encryption:    "A256GCM",
 		KEMCiphertext: base64url(kemCiphertext),
-		Nonce:     base64url(nonce),
-		Ciphertext:  base64url(ciphertext),
-		Tag:      base64url(tag),
+		Nonce:         base64url(nonce),
+		Ciphertext:    base64url(ciphertext),
+		Tag:           base64url(tag),
 	}, nil
 }
 

--- a/tests/test_dx_sugar.py
+++ b/tests/test_dx_sugar.py
@@ -128,7 +128,7 @@ def test_verify_accepts_json_string(keypair):
 
 
 def test_agent_mint_sign_self_verify():
-    agent = Agent("agent.example")
+    agent = Agent("agent.example", persist=False)
     assert agent.did == "did:web:agent.example"
     signed = agent.sign(action="read", target="did:web:files", resource="https://files/x")
     ok, who = agent.verify(signed)  # knows its own key, no network
@@ -138,7 +138,7 @@ def test_agent_mint_sign_self_verify():
 
 
 def test_agent_did_key_when_no_domain():
-    agent = Agent()
+    agent = Agent(persist=False)
     assert agent.did.startswith("did:key:")
     signed = agent.sign(action="write", target="t", resource="r")
     # did:key resolves offline through the default verify path.
@@ -148,7 +148,7 @@ def test_agent_did_key_when_no_domain():
 
 
 def test_agent_load_roundtrip():
-    agent = Agent("agent.example")
+    agent = Agent("agent.example", persist=False, allow_key_export=True)
     signed = agent.sign(intent=INTENT)
     reloaded = Agent.load(agent.private_key_jwk, agent.did)
     assert reloaded.did == agent.did
@@ -165,8 +165,8 @@ def test_agent_from_keypair(keypair):
 
 
 def test_agent_verify_other_issuer_offline_key():
-    a = Agent("a.example")
-    b = Agent("b.example")
+    a = Agent("a.example", persist=False)
+    b = Agent("b.example", persist=False)
     signed_by_b = b.sign(intent=INTENT)
     # a does not know b's key and b is did:web (no network here); an explicit
     # key still verifies offline.
@@ -176,11 +176,11 @@ def test_agent_verify_other_issuer_offline_key():
 
 
 def test_agent_delegate_and_chain():
-    principal = Agent("principal.example")
+    principal = Agent("principal.example", persist=False)
     grant = principal.delegate(
         action="charge", target="api.bank", resource="https://api.bank/invoices"
     )
-    worker = Agent("worker.example")
+    worker = Agent("worker.example", persist=False)
     child = worker.sign(
         action="charge",
         target="api.bank",
@@ -198,7 +198,7 @@ def test_agent_delegate_and_chain():
 
 
 def test_did_key_resolves_without_network():
-    agent = Agent()  # did:key
+    agent = Agent(persist=False)  # did:key
     signed = agent.sign(intent=INTENT)
     ok, who = verify(signed)  # no key, no trusted root -> resolved from did:key
     assert ok
@@ -206,7 +206,7 @@ def test_did_key_resolves_without_network():
 
 
 def test_did_key_resolution_allowed_even_offline_flag():
-    agent = Agent()
+    agent = Agent(persist=False)
     signed = agent.sign(intent=INTENT)
     # did:key needs no network, so it works with resolution disabled too.
     ok, _ = verify(signed, allow_did_resolution=False)
@@ -214,7 +214,7 @@ def test_did_key_resolution_allowed_even_offline_flag():
 
 
 def test_did_key_tampered_credential_fails():
-    agent = Agent()
+    agent = Agent(persist=False)
     signed = agent.sign(intent=INTENT)
     signed["credentialSubject"]["intent"]["resource"] = "https://files/evil"
     ok, _ = verify(signed)
@@ -291,7 +291,7 @@ def test_credential_wrapper_rejects_bad_input():
 @pytest.fixture
 def did_key_agent():
     """A did:key agent whose credentials verify offline (no network)."""
-    return Agent()
+    return Agent(persist=False)
 
 
 def test_require_signed_allows_trusted(did_key_agent):
@@ -314,7 +314,7 @@ def test_require_signed_rejects_unsigned(did_key_agent):
 
 
 def test_require_signed_rejects_untrusted_issuer(did_key_agent):
-    other = Agent()
+    other = Agent(persist=False)
     signed = other.sign(intent=INTENT)
 
     @require_signed(trusted_dids=[did_key_agent.did])

--- a/tests/test_secure_key_custody.py
+++ b/tests/test_secure_key_custody.py
@@ -1,0 +1,184 @@
+"""
+Tests for the secure key-custody follow-up:
+
+  - data_integrity.build_proof accepts a sign(digest) callback
+  - Signer.from_backend signs without holding the raw key
+  - KeyStore backends (memory, encrypted file) round-trip identities
+  - Agent secure-by-default persistence and the private-key consent gate
+
+These keep the credential wire format unchanged: a backend-signed credential
+verifies with the ordinary public key, identical to a locally-signed one.
+"""
+
+import json
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from jwcrypto import jwk
+from jwcrypto.common import base64url_decode
+
+from vouch import (
+    Agent,
+    EncryptedFileKeyStore,
+    MemoryKeyStore,
+    Signer,
+    Verifier,
+    generate_identity,
+)
+from vouch import data_integrity, vc
+
+INTENT = {"action": "read", "target": "did:web:files", "resource": "https://files/x"}
+
+
+def _raw_private(keypair) -> Ed25519PrivateKey:
+    priv = jwk.JWK.from_json(keypair.private_key_jwk)
+    return Ed25519PrivateKey.from_private_bytes(base64url_decode(priv.get("d")))
+
+
+# ---------------------------------------------------------------------------
+# build_proof sign-callback
+# ---------------------------------------------------------------------------
+
+
+def test_build_proof_accepts_callback(keypair):
+    raw = _raw_private(keypair)
+    calls = []
+
+    def sign(digest: bytes) -> bytes:
+        calls.append(digest)
+        return raw.sign(digest)
+
+    cred = vc.build_vouch_credential(issuer_did=keypair.did, intent=INTENT)
+    proof = data_integrity.build_proof(cred, sign, verification_method=f"{keypair.did}#key-1")
+    cred["proof"] = proof
+    assert len(calls) == 1
+    assert proof["proofValue"].startswith("z")
+    ok, _ = Verifier.verify_credential(cred, public_key=keypair.public_key_jwk)
+    assert ok
+
+
+def test_build_proof_rejects_bad_signer(keypair):
+    cred = vc.build_vouch_credential(issuer_did=keypair.did, intent=INTENT)
+    with pytest.raises(TypeError):
+        data_integrity.build_proof(cred, object(), verification_method="x")
+
+
+# ---------------------------------------------------------------------------
+# Signer.from_backend (key never in the Signer)
+# ---------------------------------------------------------------------------
+
+
+def test_signer_from_backend_jwk_public(keypair):
+    raw = _raw_private(keypair)
+    signer = Signer.from_backend(did=keypair.did, public_key=keypair.public_key_jwk, sign=raw.sign)
+    assert signer._raw_priv is None  # the Signer does not hold the key
+    cred = signer.sign_credential(action="read", target="t", resource="https://x/r")
+    ok, p = Verifier.verify_credential(cred, public_key=keypair.public_key_jwk)
+    assert ok
+    assert p.issuer == keypair.did
+
+
+def test_signer_from_backend_multikey_public(keypair):
+    raw = _raw_private(keypair)
+    local = Signer.from_keypair(keypair)
+    signer = Signer.from_backend(
+        did=keypair.did, public_key=local.get_public_key_multikey(), sign=raw.sign
+    )
+    cred = signer.sign_credential(intent=INTENT)
+    ok, _ = Verifier.verify_credential(cred, public_key=keypair.public_key_jwk)
+    assert ok
+
+
+def test_backend_signer_blocks_legacy_and_hybrid(keypair):
+    raw = _raw_private(keypair)
+    signer = Signer.from_backend(did=keypair.did, public_key=keypair.public_key_jwk, sign=raw.sign)
+    with pytest.raises(NotImplementedError):
+        signer.sign({"action": "x"})
+    with pytest.raises(NotImplementedError):
+        signer.sign_credential_hybrid(action="a", target="b", resource="c")
+
+
+# ---------------------------------------------------------------------------
+# Key stores
+# ---------------------------------------------------------------------------
+
+
+def test_memory_store_roundtrip(keypair):
+    store = MemoryKeyStore()
+    loc = store.save(keypair)
+    assert "memory" in loc
+    assert store.list() == [keypair.did]
+    loaded = store.load(keypair.did)
+    assert loaded.did == keypair.did
+    assert loaded.private_key_jwk == keypair.private_key_jwk
+    store.delete(keypair.did)
+    assert store.list() == []
+
+
+def test_encrypted_file_store_roundtrip(tmp_path, keypair):
+    store = EncryptedFileKeyStore(key_dir=str(tmp_path), password="correct horse")
+    loc = store.save(keypair)
+    assert "encrypted" in loc
+    assert keypair.did in store.list()
+    loaded = store.load(keypair.did)
+    assert loaded.private_key_jwk == keypair.private_key_jwk
+
+
+def test_encrypted_file_store_wrong_password(tmp_path, keypair):
+    EncryptedFileKeyStore(key_dir=str(tmp_path), password="right").save(keypair)
+    with pytest.raises(ValueError):
+        EncryptedFileKeyStore(key_dir=str(tmp_path), password="wrong").load(keypair.did)
+
+
+# ---------------------------------------------------------------------------
+# Agent secure-by-default persistence + consent gate
+# ---------------------------------------------------------------------------
+
+
+def test_agent_persists_to_given_store():
+    store = MemoryKeyStore()
+    agent = Agent("agent.example", store=store)
+    assert store.list() == [agent.did]
+    # The persisted identity can sign after reload.
+    reloaded = Agent.from_store(agent.did, store)
+    signed = reloaded.sign(intent=INTENT)
+    ok, _ = reloaded.verify(signed)
+    assert ok
+
+
+def test_agent_private_key_gated_by_default():
+    agent = Agent("agent.example", persist=False)
+    with pytest.raises(PermissionError):
+        _ = agent.private_key_jwk
+    with pytest.raises(PermissionError):
+        _ = agent.keypair
+
+
+def test_agent_private_key_with_explicit_consent():
+    agent = Agent("agent.example", persist=False, allow_key_export=True)
+    assert agent.private_key_jwk  # no raise
+    assert agent.keypair.did == agent.did
+
+
+def test_agent_can_still_sign_without_key_access():
+    agent = Agent("agent.example", persist=False)
+    signed = agent.sign(intent=INTENT)
+    ok, _ = agent.verify(signed)
+    assert ok  # signing works even though the raw key is not exported
+
+
+def test_agent_save_returns_location(tmp_path):
+    agent = Agent("agent.example", persist=False)
+    store = MemoryKeyStore()
+    loc = agent.save(store)
+    assert "memory" in loc
+    assert store.list() == [agent.did]
+
+
+def test_agent_from_store_keeps_key_gated():
+    store = MemoryKeyStore()
+    Agent("agent.example", store=store)
+    did = store.list()[0]
+    reloaded = Agent.from_store(did, store)
+    with pytest.raises(PermissionError):
+        _ = reloaded.private_key_jwk

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -21,6 +21,15 @@ from .credential import Credential
 from .keys import generate_identity, KeyPair
 from .kms import RotatingKeyProvider, KeyConfig
 
+# Where a minted identity is saved (secure by default). See vouch.keystore.
+from .keystore import (
+    EncryptedFileKeyStore,
+    KeyringKeyStore,
+    KeyStore,
+    MemoryKeyStore,
+    resolve_default_store,
+)
+
 # Deterministic, zero-prompt signing for agent tool calls. Wrap a tool once and
 # every call is signed in Python before it runs - no reliance on the model
 # choosing to call a signing tool. See vouch.autosign and the framework
@@ -311,6 +320,12 @@ __all__ = [
     "KeyPair",
     "RotatingKeyProvider",
     "KeyConfig",
+    # Key storage (secure by default)
+    "KeyStore",
+    "MemoryKeyStore",
+    "EncryptedFileKeyStore",
+    "KeyringKeyStore",
+    "resolve_default_store",
     # Deterministic agent-tool signing
     "protect",
     "signed",

--- a/vouch/agent.py
+++ b/vouch/agent.py
@@ -26,7 +26,8 @@ import json
 import logging
 from typing import Any, Dict, Optional, Tuple
 
-from vouch.keys import KeyManager, KeyPair, generate_identity
+from vouch.keys import KeyPair, generate_identity
+from vouch.keystore import KeyStore, resolve_default_store
 from vouch.signer import Signer
 from vouch.verifier import CredentialPassport, Verifier, verify
 
@@ -37,39 +38,73 @@ class Agent:
     """An agent identity bundled with its signer.
 
     Construct it to mint a fresh identity, or use :meth:`load` /
-    :meth:`from_keypair` to rehydrate an existing one. With a ``domain`` the
-    identity is ``did:web:<domain>``; without one it is a self-certifying
-    ``did:key`` (verifiable offline, no DID document to host).
+    :meth:`from_keypair` / :meth:`from_store` to rehydrate an existing one. With
+    a ``domain`` the identity is ``did:web:<domain>``; without one it is a
+    self-certifying ``did:key`` (verifiable offline, no DID document to host).
 
-    Storage: a freshly minted DID, private key, and public key live in memory
-    only (on this Agent and its Signer). Nothing is written to disk until you
-    call :meth:`save`, which stores the identity under ``~/.vouch/keys`` (pass a
-    ``password`` to encrypt the private key at rest).
+    Storage (secure by default): a freshly minted identity is persisted to the
+    most secure store available (OS keyring, else an encrypted file when a
+    password is set) so it is not lost when the process exits. Pass ``store=`` to
+    choose one explicitly, or ``persist=False`` to keep it in memory (logged
+    clearly, since an unsaved identity disappears on exit). See
+    :mod:`vouch.keystore`.
+
+    The private key is not handed back by default. ``private_key_jwk`` and
+    ``keypair`` raise unless the Agent was created with ``allow_key_export=True``,
+    so an end user does not accidentally pass the raw key around. Signing always
+    works regardless, through :meth:`sign`.
     """
 
-    def __init__(self, domain: Optional[str] = None, *, default_expiry_seconds: int = 300) -> None:
+    def __init__(
+        self,
+        domain: Optional[str] = None,
+        *,
+        default_expiry_seconds: int = 300,
+        store: Optional[KeyStore] = None,
+        persist: bool = True,
+        password: Optional[str] = None,
+        allow_key_export: bool = False,
+    ) -> None:
         keypair = generate_identity(domain=domain)
-        if not keypair.did:
+        is_did_key = not keypair.did
+        if is_did_key:
             keypair.did = _did_key_from_pub_jwk(keypair.public_key_jwk)
-            # No domain was given, so the identity is a self-certifying did:key:
-            # the key IS the identifier, with nothing to host and no authority to
-            # resolve. Say so once, because a caller expecting a did:web anchor
-            # would otherwise not notice. Like every freshly minted identity it
-            # lives in memory only; call agent.save(password=...) to persist it.
-            logger.info(
-                "vouch.Agent minted a self-certifying did:key identity (%s). It "
-                "is held in memory only and is not persisted; pass a domain for a "
-                "did:web identity, or call agent.save(password=...) to keep it.",
-                keypair.did,
-            )
-        else:
-            logger.info(
-                "vouch.Agent minted identity %s (in memory only; call "
-                "agent.save(password=...) to persist it).",
-                keypair.did,
-            )
         self._keypair = keypair
+        self._allow_key_export = allow_key_export
+        self._store: Optional[KeyStore] = None
         self._signer = Signer.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
+
+        # Secure by default: persist the new identity somewhere durable, or say
+        # plainly that it is memory-only so it is not silently lost.
+        resolved = (
+            store if store is not None else (resolve_default_store(password) if persist else None)
+        )
+        if persist and resolved is not None:
+            try:
+                location = resolved.save(keypair)
+                self._store = resolved
+                logger.info(
+                    "vouch.Agent saved identity %s to %s. You can also save it "
+                    "elsewhere (the CLI or another SDK) from the same keys.",
+                    keypair.did,
+                    location,
+                )
+            except Exception as e:  # never let a storage failure break minting
+                logger.warning(
+                    "vouch.Agent could not persist identity %s (%s); it is held "
+                    "in memory only. Call agent.save(...) to store it.",
+                    keypair.did,
+                    e,
+                )
+        else:
+            note = "did:key, " if is_did_key else ""
+            logger.warning(
+                "vouch.Agent minted identity %s (%sin memory only, not persisted). "
+                "It is lost when this process exits; call agent.save(...) or set a "
+                "store/password to keep it.",
+                keypair.did,
+                note,
+            )
 
     # -- constructors ---------------------------------------------------------
 
@@ -81,10 +116,13 @@ class Agent:
         *,
         public_key_jwk: Optional[str] = None,
         default_expiry_seconds: int = 300,
+        allow_key_export: bool = True,
     ) -> "Agent":
         """Rehydrate an Agent from stored keys (no new identity is minted).
 
-        The public key is derived from the private key when not supplied.
+        The public key is derived from the private key when not supplied. The
+        caller already holds the raw key here, so ``allow_key_export`` defaults
+        to True; pass False to still gate it.
         """
         if public_key_jwk is None:
             public_key_jwk = _public_jwk_from_private(private_key_jwk)
@@ -93,16 +131,51 @@ class Agent:
             public_key_jwk=public_key_jwk,
             did=did,
         )
-        return cls.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
+        return cls.from_keypair(
+            keypair,
+            default_expiry_seconds=default_expiry_seconds,
+            allow_key_export=allow_key_export,
+        )
 
     @classmethod
-    def from_keypair(cls, keypair: KeyPair, *, default_expiry_seconds: int = 300) -> "Agent":
+    def from_keypair(
+        cls,
+        keypair: KeyPair,
+        *,
+        default_expiry_seconds: int = 300,
+        allow_key_export: bool = True,
+    ) -> "Agent":
         """Build an Agent from an existing :class:`~vouch.keys.KeyPair`."""
         if not keypair.did:
             raise ValueError("Agent.from_keypair requires a keypair with a DID")
         agent = cls.__new__(cls)
         agent._keypair = keypair
+        agent._allow_key_export = allow_key_export
+        agent._store = None
         agent._signer = Signer.from_keypair(keypair, default_expiry_seconds=default_expiry_seconds)
+        return agent
+
+    @classmethod
+    def from_store(
+        cls,
+        did: str,
+        store: KeyStore,
+        *,
+        default_expiry_seconds: int = 300,
+        allow_key_export: bool = False,
+    ) -> "Agent":
+        """Load a previously persisted identity from a :class:`KeyStore`.
+
+        The raw key stays gated by default (``allow_key_export=False``): the
+        Agent can sign, but does not hand the key back.
+        """
+        keypair = store.load(did)
+        agent = cls.from_keypair(
+            keypair,
+            default_expiry_seconds=default_expiry_seconds,
+            allow_key_export=allow_key_export,
+        )
+        agent._store = store
         return agent
 
     # -- identity -------------------------------------------------------------
@@ -117,11 +190,29 @@ class Agent:
 
     @property
     def private_key_jwk(self) -> str:
+        """The raw private key. Gated: requires ``allow_key_export=True``.
+
+        The whole point of an Agent is that signing happens through it without
+        the caller touching the key. Reading the raw key is an explicit,
+        opt-in action so it does not leak by accident.
+        """
+        self._require_export("private_key_jwk")
         return self._keypair.private_key_jwk
 
     @property
     def keypair(self) -> KeyPair:
+        """The full KeyPair (includes the private key). Gated like
+        :attr:`private_key_jwk`."""
+        self._require_export("keypair")
         return self._keypair
+
+    def _require_export(self, what: str) -> None:
+        if not self._allow_key_export:
+            raise PermissionError(
+                f"Access to {what} is disabled for this Agent. The private key is "
+                "meant to stay inside the Agent and sign on your behalf. If you "
+                "really need the raw key, create the Agent with allow_key_export=True."
+            )
 
     @property
     def signer(self) -> Signer:
@@ -205,13 +296,27 @@ class Agent:
 
     # -- persistence ----------------------------------------------------------
 
-    def save(self, *, password: Optional[str] = None, key_dir: Optional[str] = None) -> None:
-        """Persist this identity to the on-disk keystore (``~/.vouch/keys``).
+    def save(
+        self,
+        store: Optional[KeyStore] = None,
+        *,
+        password: Optional[str] = None,
+        key_dir: Optional[str] = None,
+    ) -> str:
+        """Persist this identity and return where it was saved.
 
-        Pass a ``password`` to encrypt the private key (strongly recommended).
+        Pass a :class:`KeyStore` to choose the backend. With no store, this saves
+        to the on-disk encrypted keystore (``~/.vouch/keys``); pass a
+        ``password`` to encrypt the private key at rest (strongly recommended).
         """
-        km = KeyManager(key_dir) if key_dir else KeyManager()
-        km.save_identity(self._keypair, password=password)
+        if store is None:
+            from vouch.keystore import EncryptedFileKeyStore
+
+            store = EncryptedFileKeyStore(key_dir=key_dir, password=password)
+        location = store.save(self._keypair)
+        self._store = store
+        logger.info("vouch.Agent saved identity %s to %s.", self.did, location)
+        return location
 
     def __repr__(self) -> str:
         return f"Agent(did={self.did!r})"

--- a/vouch/data_integrity.py
+++ b/vouch/data_integrity.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import hashlib
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Callable, Dict, Union
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import (
@@ -37,18 +37,27 @@ from .multikey import _b58decode, _b58encode
 CRYPTOSUITE_ID = "eddsa-jcs-2022"
 PROOF_TYPE = "DataIntegrityProof"
 
+# A signer is either a raw Ed25519 private key (signs in process) or any callable
+# that takes the 32-byte digest and returns the 64-byte Ed25519 signature. The
+# callable form lets the actual key live somewhere the process cannot read it:
+# an OS secure element, a sidecar, a cloud KMS/HSM, or an MPC quorum.
+Signer = Union[Ed25519PrivateKey, Callable[[bytes], bytes]]
+
 
 def build_proof(
     credential: Dict[str, Any],
-    private_key: Ed25519PrivateKey,
+    private_key: Signer,
     verification_method: str,
     proof_purpose: str = "assertionMethod",
     created: datetime | None = None,
 ) -> Dict[str, Any]:
     """
-    Generate a Data Integrity proof object for `credential` using the given
-    Ed25519 private key. Returns the proof dict (caller attaches it to the
-    credential).
+    Generate a Data Integrity proof object for `credential`.
+
+    `private_key` is either an Ed25519 private key (signed in process) or a
+    callable `sign(digest: bytes) -> bytes` that produces the Ed25519 signature
+    over the digest without exposing the key to this process. Returns the proof
+    dict (caller attaches it to the credential).
 
     Conforms to eddsa-jcs-2022 §3.1.
     """
@@ -66,7 +75,13 @@ def build_proof(
     canonical = jcs.canonicalize(cred_with_unsigned_proof)
     digest = hashlib.sha256(canonical).digest()
 
-    signature = private_key.sign(digest)
+    if isinstance(private_key, Ed25519PrivateKey):
+        signature = private_key.sign(digest)
+    elif callable(private_key):
+        signature = private_key(digest)
+    else:
+        raise TypeError("private_key must be an Ed25519PrivateKey or a sign(digest) callable")
+
     proof["proofValue"] = "z" + _b58encode(signature)
     return proof
 

--- a/vouch/keystore.py
+++ b/vouch/keystore.py
@@ -1,0 +1,217 @@
+"""
+Where a minted identity is saved, so it is not lost when the process exits.
+
+A freshly generated identity (DID, private key, public key) lives only in memory
+until something persists it. This module gives a small, uniform ``KeyStore``
+interface and a few backends, so the SDK can save by default to the most secure
+place available rather than leaving the key to vanish:
+
+  - ``MemoryKeyStore``        in-process only (explicitly ephemeral)
+  - ``EncryptedFileKeyStore`` encrypted file on disk (~/.vouch/keys), the
+                              existing KeyManager, password-protected at rest
+  - ``KeyringKeyStore``       the OS keyring/secret service (Keychain, Windows
+                              Credential Locker, libsecret), optional dependency
+
+``resolve_default_store()`` picks the best available backend. The private key
+itself is never returned to the end user by these stores unless a caller
+explicitly loads it; the intended flow is that signing happens through the stored
+identity, not by handing the raw key around.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import List, Optional, Protocol, runtime_checkable
+
+from vouch.keys import KeyManager, KeyPair
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class KeyStore(Protocol):
+    """A place identities can be saved to and loaded from."""
+
+    name: str
+
+    def save(self, identity: KeyPair) -> str:
+        """Persist an identity. Returns a human-readable location string."""
+        ...
+
+    def load(self, did: str) -> KeyPair:
+        """Load a previously saved identity by DID."""
+        ...
+
+    def list(self) -> List[str]:
+        """List the DIDs this store holds."""
+        ...
+
+    def delete(self, did: str) -> None:
+        """Remove a stored identity."""
+        ...
+
+
+class MemoryKeyStore:
+    """In-process store. Explicitly ephemeral: nothing survives the process."""
+
+    name = "memory"
+
+    def __init__(self) -> None:
+        self._items: dict = {}
+
+    def save(self, identity: KeyPair) -> str:
+        if not identity.did:
+            raise ValueError("Cannot store an identity without a DID")
+        self._items[identity.did] = identity
+        return "memory (not persisted)"
+
+    def load(self, did: str) -> KeyPair:
+        if did not in self._items:
+            raise FileNotFoundError(f"Identity {did} not in memory store")
+        return self._items[did]
+
+    def list(self) -> List[str]:
+        return list(self._items)
+
+    def delete(self, did: str) -> None:
+        self._items.pop(did, None)
+
+
+class EncryptedFileKeyStore:
+    """Encrypted-at-rest file store under ~/.vouch/keys (wraps KeyManager).
+
+    Pass a ``password`` to encrypt the private key (strongly recommended). With
+    no password the underlying KeyManager writes plaintext and logs a warning.
+    """
+
+    name = "encrypted-file"
+
+    def __init__(self, key_dir: Optional[str] = None, password: Optional[str] = None) -> None:
+        self._manager = KeyManager(key_dir) if key_dir else KeyManager()
+        self._password = password
+
+    def save(self, identity: KeyPair) -> str:
+        self._manager.save_identity(identity, password=self._password)
+        return f"{self._manager.key_dir} ({'encrypted' if self._password else 'plaintext'})"
+
+    def load(self, did: str) -> KeyPair:
+        return self._manager.load_identity(did, password=self._password)
+
+    def list(self) -> List[str]:
+        return [entry["did"] for entry in self._manager.list_identities()]
+
+    def delete(self, did: str) -> None:
+        path = self._manager._get_filename(did)
+        if os.path.exists(path):
+            os.remove(path)
+
+
+class KeyringKeyStore:
+    """OS keyring / secret service store (Keychain, Credential Locker, libsecret).
+
+    Requires the optional ``keyring`` package. The OS protects the secret; the
+    raw key is not written to a plaintext file. An index of stored DIDs is kept
+    under a single keyring entry so :meth:`list` works.
+    """
+
+    name = "os-keyring"
+    _SERVICE = "vouch-protocol"
+    _INDEX = "__index__"
+
+    def __init__(self, service: Optional[str] = None) -> None:
+        try:
+            import keyring  # noqa: F401
+        except ImportError as e:
+            raise RuntimeError(
+                "KeyringKeyStore needs the optional 'keyring' package (pip install keyring)"
+            ) from e
+        self._service = service or self._SERVICE
+
+    def _keyring(self):
+        import keyring
+
+        return keyring
+
+    def save(self, identity: KeyPair) -> str:
+        if not identity.did:
+            raise ValueError("Cannot store an identity without a DID")
+        kr = self._keyring()
+        blob = json.dumps(
+            {
+                "did": identity.did,
+                "public_key_jwk": identity.public_key_jwk,
+                "private_key_jwk": identity.private_key_jwk,
+            }
+        )
+        kr.set_password(self._service, identity.did, blob)
+        index = set(self.list())
+        index.add(identity.did)
+        kr.set_password(self._service, self._INDEX, json.dumps(sorted(index)))
+        return f"OS keyring (service {self._service!r})"
+
+    def load(self, did: str) -> KeyPair:
+        blob = self._keyring().get_password(self._service, did)
+        if not blob:
+            raise FileNotFoundError(f"Identity {did} not in keyring")
+        data = json.loads(blob)
+        return KeyPair(
+            private_key_jwk=data["private_key_jwk"],
+            public_key_jwk=data["public_key_jwk"],
+            did=data["did"],
+        )
+
+    def list(self) -> List[str]:
+        raw = self._keyring().get_password(self._service, self._INDEX)
+        return json.loads(raw) if raw else []
+
+    def delete(self, did: str) -> None:
+        kr = self._keyring()
+        try:
+            kr.delete_password(self._service, did)
+        except Exception:  # pragma: no cover - backend-specific "not found"
+            pass
+        index = [d for d in self.list() if d != did]
+        kr.set_password(self._service, self._INDEX, json.dumps(index))
+
+
+def resolve_default_store(password: Optional[str] = None) -> Optional[KeyStore]:
+    """Pick the best available store for secure-by-default persistence.
+
+    Order:
+      1. ``VOUCH_KEYSTORE`` = ``memory`` | ``keyring`` | ``file`` (explicit).
+      2. The OS keyring, if the ``keyring`` package is installed.
+      3. The encrypted file store, if a password is available (argument or
+         ``VOUCH_KEY_PASSWORD``).
+      4. ``None`` (no secure persistence available; the caller should keep the
+         identity in memory and tell the user).
+    """
+    choice = os.getenv("VOUCH_KEYSTORE", "").strip().lower()
+    password = password or os.getenv("VOUCH_KEY_PASSWORD")
+
+    if choice == "memory":
+        return MemoryKeyStore()
+    if choice == "keyring":
+        return KeyringKeyStore()
+    if choice == "file":
+        return EncryptedFileKeyStore(password=password)
+
+    try:
+        return KeyringKeyStore()
+    except RuntimeError:
+        pass
+
+    if password:
+        return EncryptedFileKeyStore(password=password)
+
+    return None
+
+
+__all__ = [
+    "KeyStore",
+    "MemoryKeyStore",
+    "EncryptedFileKeyStore",
+    "KeyringKeyStore",
+    "resolve_default_store",
+]

--- a/vouch/signer.py
+++ b/vouch/signer.py
@@ -24,7 +24,7 @@ import json
 import time
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from jwcrypto import jwk, jws
@@ -97,6 +97,53 @@ class Signer:
         except Exception:  # pragma: no cover - defensive
             self._raw_priv = None
 
+        # A backend-signed Signer (see from_backend) leaves these set instead of
+        # holding the raw key. None here means "this Signer holds the key".
+        self._sign_func: Optional[Callable[[bytes], bytes]] = None
+        self._public_jwk_str: Optional[str] = None
+        self._public_multikey: Optional[str] = None
+
+    @classmethod
+    def from_backend(
+        cls,
+        did: str,
+        public_key: str,
+        sign: Callable[[bytes], bytes],
+        default_expiry_seconds: int = 300,
+    ) -> "Signer":
+        """Construct a Signer whose private key lives outside this process.
+
+        Instead of a private JWK, you supply the agent's public key and a
+        callable ``sign(digest: bytes) -> bytes`` that returns the Ed25519
+        signature over the digest. The raw key never enters this process, so it
+        can live in an OS secure element, a sidecar, a cloud KMS/HSM, or an MPC
+        quorum. This Signer issues Data Integrity credentials (the modern path);
+        the legacy JWS ``sign()`` is not available without the private key.
+
+        Args:
+          did: the agent's DID.
+          public_key: the agent's public key as a JWK JSON string or a Multikey
+            (z-prefixed) string.
+          sign: callable that signs a 32-byte digest and returns the 64-byte
+            Ed25519 signature.
+          default_expiry_seconds: token validity period (default 5 minutes).
+        """
+        if not did:
+            raise ValueError("Signer.from_backend requires a 'did'")
+        if not public_key:
+            raise ValueError("Signer.from_backend requires the agent 'public_key'")
+        if not callable(sign):
+            raise ValueError("Signer.from_backend requires a callable 'sign'")
+
+        self = cls.__new__(cls)
+        self.did = did
+        self.default_expiry = default_expiry_seconds
+        self._key = None
+        self._raw_priv = None
+        self._sign_func = sign
+        self._public_jwk_str, self._public_multikey = _normalize_public_key(public_key)
+        return self
+
     @classmethod
     def from_keypair(cls, keypair: Any, default_expiry_seconds: int = 300) -> "Signer":
         """Construct a Signer directly from a :class:`~vouch.keys.KeyPair`.
@@ -152,6 +199,13 @@ class Signer:
         Returns:
           A JWS compact serialized token string.
         """
+        if self._key is None:
+            raise NotImplementedError(
+                "The legacy JWS sign() needs the private key in this process and "
+                "is not available for a backend Signer (from_backend); use "
+                "sign_credential for the Data Integrity path"
+            )
+
         now = int(time.time())
         exp = expiry_seconds if expiry_seconds is not None else self.default_expiry
 
@@ -273,13 +327,9 @@ class Signer:
 
         Raises:
           ValueError: If the merged intent is missing required fields, the chain
-            exceeds max depth, or the private key bytes are unavailable.
+            exceeds max depth, or no signing key/backend is available.
         """
-        if self._raw_priv is None:
-            raise ValueError(
-                "Cannot issue Data Integrity credentials: private key bytes "
-                "could not be derived from the JWK"
-            )
+        signer = self._credential_signer()
 
         intent = _merge_intent(intent, action=action, target=target, resource=resource)
 
@@ -300,11 +350,23 @@ class Signer:
 
         proof = data_integrity.build_proof(
             credential,
-            private_key=self._raw_priv,
+            private_key=signer,
             verification_method=self.verification_method_id(),
         )
         credential["proof"] = proof
         return credential
+
+    def _credential_signer(self):
+        """Return the signer for the Data Integrity path: the raw key if this
+        Signer holds it, otherwise the backend sign callback."""
+        if self._raw_priv is not None:
+            return self._raw_priv
+        if self._sign_func is not None:
+            return self._sign_func
+        raise ValueError(
+            "Cannot issue Data Integrity credentials: no signing key is available "
+            "(construct the Signer with a private key or via Signer.from_backend)"
+        )
 
     def sign_credential_hybrid(
         self,
@@ -339,6 +401,14 @@ class Signer:
         Requires the `pqcrypto` package to be installed.
         """
         if self._raw_priv is None:
+            # The hybrid profile needs both an Ed25519 and an ML-DSA-44 signature.
+            # A backend Signer only exposes the Ed25519 sign callback, so the
+            # hybrid path is not available there yet.
+            if self._sign_func is not None:
+                raise NotImplementedError(
+                    "sign_credential_hybrid is not supported for a backend Signer "
+                    "(from_backend); use the eddsa-jcs-2022 path or hold the key locally"
+                )
             raise ValueError(
                 "Cannot issue Data Integrity credentials: private key bytes "
                 "could not be derived from the JWK"
@@ -449,7 +519,11 @@ class Signer:
 
     def get_public_key_jwk(self) -> str:
         """Return the public key in JWK format (legacy DID Documents)."""
-        return self._key.export_public()
+        if self._key is not None:
+            return self._key.export_public()
+        if self._public_jwk_str is not None:
+            return self._public_jwk_str
+        raise ValueError("No public key available for this Signer")
 
     def get_public_key_multikey(self) -> str:
         """
@@ -460,6 +534,10 @@ class Signer:
         """
         from jwcrypto.common import base64url_decode
 
+        if self._key is None:
+            if self._public_multikey is not None:
+                return self._public_multikey
+            raise ValueError("No public key available for this Signer")
         pub_b64 = self._key.get("x")
         if not pub_b64:
             raise ValueError("JWK does not expose the Ed25519 public component")
@@ -485,6 +563,40 @@ def _is_sub_resource(child: str, parent: str) -> bool:
     if child.startswith(parent.rstrip("/") + "/"):
         return True
     return False
+
+
+def _normalize_public_key(public_key: str) -> tuple:
+    """Accept a JWK JSON string or a Multikey (z...) string and return
+    (jwk_json_str, multikey_str) for both export formats."""
+    from jwcrypto.common import base64url_decode
+
+    if public_key.startswith("z"):
+        alg, raw = multikey.decode(public_key)
+        if alg != "Ed25519":
+            raise ValueError(f"Expected an Ed25519 public key, got {alg}")
+        key = jwk.JWK.from_json(
+            json.dumps(
+                {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": _b64url_nopad(raw),
+                }
+            )
+        )
+        return key.export_public(), public_key
+
+    # Otherwise treat it as a JWK JSON string.
+    key = jwk.JWK.from_json(public_key)
+    if key.get("kty") != "OKP" or key.get("crv") != "Ed25519":
+        raise ValueError("Public key JWK must be an Ed25519 key (OKP, crv=Ed25519)")
+    raw = base64url_decode(key.get("x"))
+    return key.export_public(), multikey.encode_ed25519_public(raw)
+
+
+def _b64url_nopad(raw: bytes) -> str:
+    import base64
+
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode("ascii")
 
 
 def _merge_intent(


### PR DESCRIPTION
Re-lands the Python and Go secure key-custody work onto main.

That work was originally in #192, but #192 targeted the stacked branch feat/dx-sugar rather than main, so its commits landed on that branch and never reached main when #188 was squash-merged. The TypeScript equivalent (#197) did reach main, so until now main had the secure-custody surface in TypeScript but not in Python or Go. This PR closes that gap so the three are consistent again. Everything is additive over the existing Signer and Verifier; the credential wire format is unchanged.

What it brings to main:
- build_proof accepts a sign(digest) callback in addition to a raw Ed25519 key, and Signer.from_backend issues Data Integrity credentials while the private key lives outside the process (an OS secure element, a sidecar, a cloud KMS/HSM, or an MPC quorum).
- vouch.keystore with a KeyStore interface and in-memory and encrypted-file backends, plus resolve_default_store.
- Agent persists by default to the best available store, and keeps the raw key in unless allow_key_export=True is set, while signing still works through the Agent.
- The Go signer gains the same backend signing (BuildDataIntegrityProof Sign callback and signer.NewBackend).

Security boundary: the callback signs the same SHA-256 digest of the JCS-canonical credential as the in-process path, so the proof is byte-identical and verifies with the ordinary public key. A backend Signer holds only the public key and the callback, so it cannot reveal a key it does not have; the legacy JWS sign and the hybrid profile are not part of the backend surface and report that clearly. The encrypted file store seals the private key with scrypt and ChaCha20-Poly1305. The Agent does not return the raw key unless export is explicitly enabled.

Verification: ruff clean; the new secure-custody and updated DX tests pass (54 Python tests), and the Go signer suite passes including the backend tests.
