### PR TITLE
Cross-device identity by per-device keys and delegation

### DIFF
--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -1,0 +1,175 @@
+"""
+Tests for cross-device identity by per-device keys and delegation (vouch.fleet).
+
+The model: a root identity delegates scoped, time-bound authority to a device's
+own DID; the device signs with its own key chained under that grant; a verifier
+ties the device's action back to the trusted root. The device key never travels.
+"""
+
+import pytest
+
+from vouch import Agent, enroll_device, verify_delegated_chain
+
+
+def _root_and_device():
+    root = Agent("root.example")
+    device = Agent()  # did:key minted on the device
+    return root, device
+
+
+def test_enroll_and_verify_chain():
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    action = device.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    result = verify_delegated_chain(
+        [grant, action],
+        trusted_roots={root.did: root.public_key_jwk},
+    )
+    assert result.ok
+    assert result.root_did == root.did
+    assert result.leaf.issuer == device.did
+    assert result.leaf.resource == "https://api.bank/invoices/42"
+
+
+def test_untrusted_root_rejected():
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    action = device.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    # No trusted root configured.
+    result = verify_delegated_chain([grant, action], trusted_roots={})
+    assert not result.ok
+    assert "trusted_roots" in (result.reason or "")
+
+
+def test_wrong_device_issuer_rejected():
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    # A different device signs, not the one the grant authorized.
+    impostor = Agent()
+    action = impostor.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    result = verify_delegated_chain([grant, action], trusted_roots={root.did: root.public_key_jwk})
+    assert not result.ok
+    assert "delegatee" in (result.reason or "")
+
+
+def test_resource_widening_rejected():
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    # Device tries to act outside the granted resource. sign_credential enforces
+    # narrowing at issue time, so signing itself raises.
+    with pytest.raises(ValueError):
+        device.sign(
+            action="charge",
+            target="api.bank",
+            resource="https://api.bank/payouts",
+            parent_credential=grant,
+        )
+
+
+def test_tampered_action_rejected():
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    action = device.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    action["credentialSubject"]["intent"]["resource"] = "https://api.bank/invoices/evil"
+    result = verify_delegated_chain([grant, action], trusted_roots={root.did: root.public_key_jwk})
+    assert not result.ok
+
+
+def test_leaf_intent_policy():
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    action = device.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    ok_result = verify_delegated_chain(
+        [grant, action],
+        trusted_roots={root.did: root.public_key_jwk},
+        require_action="charge",
+    )
+    assert ok_result.ok
+    bad_result = verify_delegated_chain(
+        [grant, action],
+        trusted_roots={root.did: root.public_key_jwk},
+        require_action="refund",
+    )
+    assert not bad_result.ok
+
+
+def test_did_key_root_resolves_without_trust_map_for_links():
+    # Root is did:web (must be trusted explicitly); device is did:key (resolves).
+    root, device = _root_and_device()
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="read",
+        target="t",
+        resource="https://x/y",
+    )
+    action = device.sign(
+        action="read",
+        target="t",
+        resource="https://x/y/z",
+        parent_credential=grant,
+    )
+    # Only the root key is supplied; the device link resolves from its did:key.
+    result = verify_delegated_chain([grant, action], trusted_roots={root.did: root.public_key_jwk})
+    assert result.ok

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -40,6 +40,10 @@ from .autosign import (
 from .gate import CredentialGate, GateResult
 from .mcp_guard import guard_mcp, guard_tools, require_signed
 
+# Cross-device identity: per-device keys delegated from a root, with full chain
+# verification back to a trusted root (the key never travels). See vouch.fleet.
+from .fleet import FleetResult, enroll_device, verify_delegated_chain
+
 # Audio signing
 from .audio import AudioSigner, SignedAudioResult
 
@@ -323,6 +327,9 @@ __all__ = [
     "CredentialGate",
     "GateResult",
     "require_signed",
+    "enroll_device",
+    "verify_delegated_chain",
+    "FleetResult",
     "guard_mcp",
     "guard_tools",
     # Audio

--- a/vouch/fleet.py
+++ b/vouch/fleet.py
@@ -1,0 +1,225 @@
+"""
+Cross-device identity by per-device keys and delegation (the OSS path).
+
+The private key never travels. Each device mints its OWN key locally, and the
+user's root identity delegates scoped, time-bound, revocable authority to that
+device's DID. A device signs its actions with its own key, chained under the
+root grant. Losing a device means revoking one delegation, not rotating the
+whole identity, and no key is ever copied between devices.
+
+This is the open-source, protocol-native answer to "the same identity across all
+my devices, without revealing the key". It builds entirely on shipped primitives
+(delegation grants, resource-narrowing, the credential chain). Managed
+cross-device sync and recovery, and threshold/MPC custody of the root key, are
+separate concerns and out of scope here.
+
+Two pieces:
+
+  grant = enroll_device(root, device_did=..., action=..., target=..., resource=...)
+      The root authorizes a device's DID for a scope. Hand the grant to the
+      device; it signs actions with `parent_credential=grant`.
+
+  result = verify_delegated_chain([grant, action_credential],
+                                  trusted_roots={root_did: root_public_key})
+      A verifier checks the whole chain back to a trusted root: every proof is
+      valid, each step is authorized by the one before it, the scope only
+      narrows, and the validity windows nest. This is the part that was missing:
+      tying a device credential back to a trusted root key.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from vouch.signer import Signer, _is_sub_resource
+from vouch.verifier import CredentialPassport, verify
+
+
+def _root_signer(root: Any) -> Signer:
+    """Accept a Signer or an Agent (or anything exposing `.signer`)."""
+    if isinstance(root, Signer):
+        return root
+    signer = getattr(root, "signer", None)
+    if isinstance(signer, Signer):
+        return signer
+    raise TypeError("enroll_device requires a Signer or an Agent as the root")
+
+
+def enroll_device(
+    root: Any,
+    *,
+    device_did: str,
+    action: str,
+    target: str,
+    resource: str,
+    valid_seconds: int = 86400,
+    reputation_score: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Issue a delegation grant from the root identity to a device's DID.
+
+    The returned grant authorizes `device_did` to act within the given scope.
+    The device, holding its own key, signs actions with this grant passed as
+    ``parent_credential`` so each action chains back to the root. The root never
+    sees or holds the device's key.
+
+    Args:
+      root: the root Signer or Agent (the durable user identity).
+      device_did: the DID of the device's own key (for example a did:key the
+        device minted locally).
+      action / target / resource: the scope the device is allowed to act within.
+      valid_seconds: how long the device grant is valid (default 1 day).
+      reputation_score: optional self-reported score in [0, 100].
+
+    Returns:
+      The signed delegation grant credential (a dict), to hand to the device.
+    """
+    signer = _root_signer(root)
+    intent: Dict[str, Any] = {
+        "action": action,
+        "target": target,
+        "resource": resource,
+        "delegatee": device_did,
+    }
+    return signer.sign_credential(
+        intent,
+        valid_seconds=valid_seconds,
+        reputation_score=reputation_score,
+    )
+
+
+@dataclass
+class FleetResult:
+    """Outcome of verifying a delegated device chain."""
+
+    ok: bool
+    leaf: Optional[CredentialPassport] = None
+    root_did: Optional[str] = None
+    reason: Optional[str] = None
+
+
+def verify_delegated_chain(
+    credentials: Sequence[Dict[str, Any]],
+    *,
+    trusted_roots: Optional[Dict[str, Any]] = None,
+    allow_did_resolution: bool = True,
+    require_action: Optional[str] = None,
+    require_target: Optional[str] = None,
+    require_resource: Optional[str] = None,
+) -> FleetResult:
+    """Verify a delegation chain from a trusted root down to a leaf action.
+
+    `credentials` is ordered root-first: ``[root_grant, ...intermediate grants,
+    leaf_action]``. The first credential's issuer must be a trusted root. Every
+    credential's Data Integrity proof and validity window are checked, each step
+    must be authorized by the step before it (the child's issuer is the parent's
+    delegatee), the resource may only narrow, and the validity windows must nest.
+
+    Args:
+      credentials: the presented chain, root grant first, leaf action last.
+      trusted_roots: a ``{did: public_key}`` map of accepted root issuers. The
+        root credential's issuer MUST appear here. Other links resolve their key
+        from this map, then ``did:key``/``did:web``.
+      allow_did_resolution: allow network ``did:web`` resolution for non-root
+        links (``did:key`` always resolves offline).
+      require_action / require_target / require_resource: optional exact policy
+        on the leaf action's intent.
+
+    Returns:
+      A FleetResult. ``ok`` is True only when every check passes.
+    """
+    if not credentials:
+        return FleetResult(ok=False, reason="empty chain")
+    trusted_roots = trusted_roots or {}
+
+    passports: List[CredentialPassport] = []
+    for index, cred in enumerate(credentials):
+        issuer = _issuer_of(cred)
+        if not issuer:
+            return FleetResult(ok=False, reason=f"credential {index} has no issuer")
+
+        # The root anchor must be explicitly trusted. Later links resolve their
+        # key from trusted_roots if present, otherwise by DID.
+        key = trusted_roots.get(issuer)
+        if index == 0 and key is None:
+            return FleetResult(ok=False, reason=f"root issuer {issuer!r} is not in trusted_roots")
+
+        ok, passport = verify(cred, public_key=key, allow_did_resolution=allow_did_resolution)
+        if not ok or passport is None:
+            return FleetResult(ok=False, reason=f"credential {index} failed verification")
+        passports.append(passport)
+
+    # Walk parent -> child links.
+    for i in range(len(passports) - 1):
+        parent = passports[i]
+        child = passports[i + 1]
+
+        delegatee = (parent.intent or {}).get("delegatee")
+        if not delegatee:
+            return FleetResult(
+                ok=False, reason=f"link {i} (grant by {parent.issuer!r}) names no delegatee"
+            )
+        if child.issuer != delegatee:
+            return FleetResult(
+                ok=False,
+                reason=(
+                    f"link {i}: child issuer {child.issuer!r} is not the delegatee "
+                    f"{delegatee!r} the parent authorized"
+                ),
+            )
+
+        parent_resource = (parent.intent or {}).get("resource", "")
+        child_resource = (child.intent or {}).get("resource", "")
+        if (
+            parent_resource
+            and child_resource
+            and not _is_sub_resource(child_resource, parent_resource)
+        ):
+            return FleetResult(
+                ok=False,
+                reason=(
+                    f"link {i}: resource {child_resource!r} is not within the "
+                    f"granted {parent_resource!r}"
+                ),
+            )
+
+        if not _window_within(child, parent):
+            return FleetResult(
+                ok=False, reason=f"link {i}: child validity is outside the grant window"
+            )
+
+    leaf = passports[-1]
+    intent = leaf.intent or {}
+    for field, expected in (
+        ("action", require_action),
+        ("target", require_target),
+        ("resource", require_resource),
+    ):
+        if expected is not None and intent.get(field) != expected:
+            return FleetResult(ok=False, leaf=leaf, reason=f"leaf intent.{field} != {expected!r}")
+
+    return FleetResult(ok=True, leaf=leaf, root_did=passports[0].issuer)
+
+
+def _issuer_of(cred: Dict[str, Any]) -> Optional[str]:
+    issuer = cred.get("issuer")
+    if isinstance(issuer, list):
+        return issuer[0] if issuer else None
+    return issuer
+
+
+def _window_within(child: CredentialPassport, parent: CredentialPassport) -> bool:
+    """True if the child's validity window sits inside the parent's (time-bound
+    delegation: a device cannot outlive its grant)."""
+    from vouch.verifier import _parse_iso8601
+
+    c_from = _parse_iso8601(child.valid_from)
+    c_until = _parse_iso8601(child.valid_until)
+    p_from = _parse_iso8601(parent.valid_from)
+    p_until = _parse_iso8601(parent.valid_until)
+    if not all((c_from, c_until, p_from, p_until)):
+        return False
+    return c_from >= p_from and c_until <= p_until
+
+
+__all__ = ["enroll_device", "verify_delegated_chain", "FleetResult"]


### PR DESCRIPTION
Adds cross-device identity by per-device keys and delegation. This is the first cross-device custody step: the same identity can act from many devices without the private key ever traveling.

Model: each device mints its own key locally, and the root identity delegates scoped, time-bound, revocable authority to that device's DID. A device signs its actions with its own key, chained under the root grant. Losing a device means revoking one delegation, not rotating the whole identity, and no key is copied between devices. Built entirely on existing primitives (delegation grants, resource-narrowing, the credential chain); the wire format is unchanged.

What it adds (vouch.fleet):
- enroll_device(root, device_did=..., action=..., target=..., resource=...): the root authorizes a device's DID for a scope and returns the grant. The device signs actions with parent_credential=grant.
- verify_delegated_chain([grant, action], trusted_roots={root_did: key}): verifies the whole chain back to a trusted root. It checks every Data Integrity proof and validity window, that each step is authorized by the one before it (the child's issuer is the parent's delegatee), that the resource only narrows, and that the validity windows nest. Optional exact intent policy on the leaf.

This closes a real gap: until now a device credential's delegation chain could not be cryptographically verified back to a trusted root key.

Security boundary: verify_delegated_chain anchors trust only in trusted_roots; the root credential's issuer must appear there. Each link's key is resolved from trusted_roots, then did:key (offline), then did:web. A forged device, a widened scope, a window outside the grant, or a tampered credential all fail. did:key resolution authenticates self-consistency, not real-world identity, so the root anchor is what establishes trust.

Verification: 7 new tests pass (enroll and verify, untrusted root rejected, wrong device issuer rejected, scope widening rejected at issue time, tampered action rejected, leaf intent policy, did:key link resolution); the full Python suite is green other than the pre-existing environment-only git_workflow tests.
