### PR TITLE
Add mobile rendering for the trust-gap illustrations

### DIFF
--- a/website/public/assets/how-vouch-works-mobile.svg
+++ b/website/public/assets/how-vouch-works-mobile.svg
@@ -1,0 +1,72 @@
+<svg viewBox="0 0 380 650" xmlns="http://www.w3.org/2000/svg" role="img" font-family="Georgia, 'Times New Roman', serif">
+  <title>How Vouch works, stacked for mobile in four steps: give the agent a verifiable ID, set the rules, sign every move, and anyone can check.</title>
+  <desc>Four stacked rows, each with an icon on the left and a title and caption on the right.</desc>
+
+  <rect x="1" y="1" width="378" height="648" fill="#FAF7EE" stroke="#D9CFB6" stroke-width="2"/>
+  <text x="24" y="40" font-family="ui-monospace, monospace" font-size="13" letter-spacing="3" fill="#7C2D3A">HOW VOUCH WORKS</text>
+
+  <g stroke="#D9CFB6" stroke-width="1.5">
+    <line x1="24" y1="216" x2="356" y2="216"/>
+    <line x1="24" y1="361" x2="356" y2="361"/>
+    <line x1="24" y1="506" x2="356" y2="506"/>
+  </g>
+
+  <g>
+    <rect x="48" y="116" width="80" height="52" rx="7" fill="#F2EBD9" stroke="#0F172A" stroke-width="2.5"/>
+    <rect x="55" y="123" width="30" height="30" rx="4" fill="#FAF7EE" stroke="#0F172A" stroke-width="2"/>
+    <line x1="70" y1="132" x2="70" y2="127" stroke="#0F172A" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="70" cy="125" r="2.2" fill="#7C2D3A"/>
+    <rect x="61" y="132" width="18" height="14" rx="5" fill="#F2EBD9" stroke="#0F172A" stroke-width="2"/>
+    <circle cx="66" cy="139" r="1.4" fill="#0F172A"/><circle cx="74" cy="139" r="1.4" fill="#0F172A"/>
+    <g stroke="#64748B" stroke-width="2.5" stroke-linecap="round">
+      <line x1="92" y1="126" x2="120" y2="126"/><line x1="92" y1="136" x2="120" y2="136"/><line x1="92" y1="146" x2="110" y2="146"/>
+    </g>
+    <circle cx="118" cy="158" r="8" fill="#7C2D3A"/>
+    <path d="M114 158 l3 3 l5 -7" fill="none" stroke="#FAF7EE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="150" y="112" font-family="ui-monospace, monospace" font-size="14" letter-spacing="2" fill="#7C2D3A">01</text>
+  <text x="150" y="136" font-size="19" fill="#0F172A">Give it an ID</text>
+  <text x="150" y="158" font-size="13" fill="#334155">A verifiable identity,</text>
+  <text x="150" y="176" font-size="13" fill="#334155">like a passport.</text>
+
+  <g>
+    <path d="M58 258 h40 l14 14 v62 h-54 z" fill="#FAF7EE" stroke="#0F172A" stroke-width="2.5" stroke-linejoin="round"/>
+    <path d="M98 258 v14 h14" fill="#F2EBD9" stroke="#0F172A" stroke-width="2" stroke-linejoin="round"/>
+    <circle cx="70" cy="280" r="6" fill="none" stroke="#7C2D3A" stroke-width="2"/>
+    <path d="M67 280 l2 2 l4 -5" fill="none" stroke="#7C2D3A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="70" cy="300" r="6" fill="none" stroke="#7C2D3A" stroke-width="2"/>
+    <path d="M67 300 l2 2 l4 -5" fill="none" stroke="#7C2D3A" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <g stroke="#64748B" stroke-width="2.5" stroke-linecap="round">
+      <line x1="82" y1="280" x2="104" y2="280"/><line x1="82" y1="300" x2="104" y2="300"/>
+    </g>
+    <path d="M60 322 q6 -9 12 0 t12 0" fill="none" stroke="#7C2D3A" stroke-width="2.5" stroke-linecap="round"/>
+    <circle cx="104" cy="320" r="8" fill="#7C2D3A"/>
+    <path d="M100 320 l3 3 l5 -7" fill="none" stroke="#FAF7EE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="150" y="257" font-family="ui-monospace, monospace" font-size="14" letter-spacing="2" fill="#7C2D3A">02</text>
+  <text x="150" y="281" font-size="19" fill="#0F172A">Set the rules</text>
+  <text x="150" y="303" font-size="13" fill="#334155">The human signs</text>
+  <text x="150" y="321" font-size="13" fill="#334155">what it may do.</text>
+
+  <g>
+    <rect x="48" y="405" width="80" height="52" rx="5" fill="#F2EBD9" stroke="#0F172A" stroke-width="2.5"/>
+    <path d="M50 409 L88 435 L126 409" fill="none" stroke="#0F172A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="88" cy="453" r="12" fill="#7C2D3A" stroke="#FAF7EE" stroke-width="2"/>
+    <path d="M82 453 l4 5 l8 -10" fill="none" stroke="#FAF7EE" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
+  <text x="150" y="402" font-family="ui-monospace, monospace" font-size="14" letter-spacing="2" fill="#7C2D3A">03</text>
+  <text x="150" y="426" font-size="19" fill="#0F172A">Sign every move</text>
+  <text x="150" y="448" font-size="13" fill="#334155">Each action carries</text>
+  <text x="150" y="466" font-size="13" fill="#334155">its own signature.</text>
+
+  <g>
+    <circle cx="84" cy="570" r="28" fill="#7C2D3A"/>
+    <path d="M70 570 l9 11 l19 -23" fill="none" stroke="#FAF7EE" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="120" cy="546" r="9" fill="#FAF7EE" stroke="#64748B" stroke-width="2"/>
+    <path d="M114 540 l12 12 M126 540 l-12 12" stroke="#64748B" stroke-width="2" stroke-linecap="round"/>
+  </g>
+  <text x="150" y="547" font-family="ui-monospace, monospace" font-size="14" letter-spacing="2" fill="#7C2D3A">04</text>
+  <text x="150" y="571" font-size="19" fill="#0F172A">Anyone can check</text>
+  <text x="150" y="593" font-size="13" fill="#334155">Tampering and fakes</text>
+  <text x="150" y="611" font-size="13" fill="#334155">are rejected.</text>
+</svg>

--- a/website/public/assets/trust-handoff-mobile.svg
+++ b/website/public/assets/trust-handoff-mobile.svg
@@ -1,0 +1,66 @@
+<svg viewBox="0 0 380 850" xmlns="http://www.w3.org/2000/svg" role="img" font-family="Georgia, 'Times New Roman', serif">
+  <title>The trust handoff, stacked for mobile: a human delegates down to an AI agent with a verifiable identity, which acts on an MCP server, each handoff signed.</title>
+  <desc>A vertical flow: human at top, a downward arrow labelled delegates with a check seal, a friendly AI agent with a burgundy badge, a downward arrow labelled acts with a check seal, and a stacked MCP server at the bottom.</desc>
+  <defs>
+    <marker id="ahm" markerWidth="12" markerHeight="12" refX="5" refY="8.5" orient="auto">
+      <path d="M0,0 L5,10 L10,0 Z" fill="#0F172A"/>
+    </marker>
+  </defs>
+
+  <rect x="1" y="1" width="378" height="848" fill="#FAF7EE" stroke="#D9CFB6" stroke-width="2"/>
+  <text x="24" y="40" font-family="ui-monospace, monospace" font-size="13" letter-spacing="3" fill="#7C2D3A">THE TRUST HANDOFF</text>
+
+  <g stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="190" cy="92" r="27" fill="#F2EBD9"/>
+    <path d="M151 199 C151 151 229 151 229 199 Z" fill="#F2EBD9"/>
+  </g>
+  <text x="190" y="232" text-anchor="middle" font-size="20" fill="#0F172A">Human</text>
+  <text x="190" y="251" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" letter-spacing="1.5" fill="#64748B">IN CHARGE</text>
+
+  <line x1="190" y1="268" x2="190" y2="326" stroke="#0F172A" stroke-width="3" marker-end="url(#ahm)"/>
+  <circle cx="190" cy="297" r="14" fill="#FAF7EE" stroke="#7C2D3A" stroke-width="2.5"/>
+  <path d="M183 297 l5 6 l9 -12" fill="none" stroke="#7C2D3A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="214" y="302" font-family="ui-monospace, monospace" font-size="12" letter-spacing="1.5" fill="#334155">DELEGATES</text>
+
+  <g stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <line x1="190" y1="358" x2="190" y2="342"/>
+    <circle cx="190" cy="336" r="6" fill="#7C2D3A" stroke="none"/>
+    <rect x="144" y="358" width="92" height="68" rx="18" fill="#F2EBD9"/>
+    <path d="M167 404 Q190 420 213 404" fill="none"/>
+    <rect x="152" y="438" width="76" height="80" rx="16" fill="#FAF7EE"/>
+    <path d="M152 460 q-22 6 -27 26" fill="none"/>
+    <path d="M228 456 q26 -4 35 -26" fill="none"/>
+    <line x1="170" y1="518" x2="170" y2="536"/>
+    <line x1="210" y1="518" x2="210" y2="536"/>
+  </g>
+  <circle cx="168" cy="388" r="5.5" fill="#0F172A"/>
+  <circle cx="212" cy="388" r="5.5" fill="#0F172A"/>
+  <circle cx="159" cy="400" r="5" fill="#7C2D3A" opacity="0.25"/>
+  <circle cx="221" cy="400" r="5" fill="#7C2D3A" opacity="0.25"/>
+  <circle cx="263" cy="426" r="6" fill="#F2EBD9" stroke="#0F172A" stroke-width="2.5"/>
+  <circle cx="190" cy="476" r="18" fill="#7C2D3A"/>
+  <path d="M181 476 l6 7 l12 -15" fill="none" stroke="#FAF7EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="190" y="560" text-anchor="middle" font-size="20" fill="#0F172A">AI Agent</text>
+  <text x="190" y="579" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" letter-spacing="1.5" fill="#7C2D3A">VERIFIABLE IDENTITY</text>
+
+  <line x1="190" y1="598" x2="190" y2="656" stroke="#0F172A" stroke-width="3" marker-end="url(#ahm)"/>
+  <circle cx="190" cy="627" r="14" fill="#FAF7EE" stroke="#7C2D3A" stroke-width="2.5"/>
+  <path d="M183 627 l5 6 l9 -12" fill="none" stroke="#7C2D3A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <text x="214" y="622" font-family="ui-monospace, monospace" font-size="12" letter-spacing="1.5" fill="#334155">ACTS</text>
+  <text x="214" y="638" font-family="ui-monospace, monospace" font-size="11" letter-spacing="1" fill="#64748B">BUY · EMAIL · CODE</text>
+
+  <g stroke="#0F172A" stroke-width="3">
+    <rect x="125" y="678" width="130" height="32" rx="7" fill="#F2EBD9"/>
+    <rect x="125" y="714" width="130" height="32" rx="7" fill="#F2EBD9"/>
+    <rect x="125" y="750" width="130" height="32" rx="7" fill="#FAF7EE"/>
+  </g>
+  <circle cx="141" cy="694" r="4" fill="#7C2D3A"/>
+  <circle cx="141" cy="730" r="4" fill="#334155"/>
+  <circle cx="141" cy="766" r="4" fill="#334155"/>
+  <g stroke="#64748B" stroke-width="2" stroke-linecap="round">
+    <line x1="225" y1="690" x2="243" y2="690"/><line x1="225" y1="698" x2="243" y2="698"/>
+    <line x1="225" y1="726" x2="243" y2="726"/><line x1="225" y1="734" x2="243" y2="734"/>
+  </g>
+  <text x="190" y="808" text-anchor="middle" font-size="20" fill="#0F172A">MCP Server</text>
+  <text x="190" y="827" text-anchor="middle" font-family="ui-monospace, monospace" font-size="12" letter-spacing="1.5" fill="#64748B">MONEY · DATA · TOOLS</text>
+</svg>

--- a/website/src/app/the-trust-gap/page.tsx
+++ b/website/src/app/the-trust-gap/page.tsx
@@ -60,7 +60,13 @@ export default function TrustGapPage() {
                     <img
                         src="/assets/trust-handoff.svg"
                         alt="A human delegates to an AI agent that carries a verifiable identity, and the agent acts on an MCP server. Each handoff is signed."
-                        className="w-full h-auto max-w-[940px] mx-auto"
+                        className="hidden md:block w-full h-auto max-w-[940px] mx-auto"
+                    />
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                        src="/assets/trust-handoff-mobile.svg"
+                        alt="A human delegates to an AI agent that carries a verifiable identity, and the agent acts on an MCP server. Each handoff is signed."
+                        className="block md:hidden w-full h-auto max-w-[340px] mx-auto"
                     />
                 </div>
             </section>
@@ -73,7 +79,13 @@ export default function TrustGapPage() {
                     <img
                         src="/assets/how-vouch-works.svg"
                         alt="How Vouch works: give the agent a verifiable ID, the human sets the rules, every action is signed, and anyone can check it. Tampering and fakes are rejected."
-                        className="w-full h-auto max-w-[940px] mx-auto"
+                        className="hidden md:block w-full h-auto max-w-[940px] mx-auto"
+                    />
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                        src="/assets/how-vouch-works-mobile.svg"
+                        alt="How Vouch works: give the agent a verifiable ID, the human sets the rules, every action is signed, and anyone can check it. Tampering and fakes are rejected."
+                        className="block md:hidden w-full h-auto max-w-[360px] mx-auto"
                     />
                 </div>
             </section>


### PR DESCRIPTION
Adds phone-friendly vertical versions of the two trust-gap illustrations and swaps them in below the md breakpoint.

- On small screens the handoff scene and the four-step how-it-works stack top to bottom with readable labels, instead of the wide desktop graphics scaling down too far.
- On tablet and desktop the original horizontal illustrations still show.

Signed-off-by: Ramprasad Gaddam <groups.rampy1@gmail.com>