### PR TITLE
Device revocation for the cross-device fleet

### DIFF
--- a/tests/test_fleet.py
+++ b/tests/test_fleet.py
@@ -8,13 +8,30 @@ ties the device's action back to the trusted root. The device key never travels.
 
 import pytest
 
-from vouch import Agent, enroll_device, verify_delegated_chain
+from vouch import Agent, DeviceRegistry, enroll_device, verify_delegated_chain
 
 
 def _root_and_device():
     root = Agent("root.example")
     device = Agent()  # did:key minted on the device
     return root, device
+
+
+def _signed_chain(root, device):
+    grant = enroll_device(
+        root,
+        device_did=device.did,
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices",
+    )
+    action = device.sign(
+        action="charge",
+        target="api.bank",
+        resource="https://api.bank/invoices/42",
+        parent_credential=grant,
+    )
+    return grant, action
 
 
 def test_enroll_and_verify_chain():
@@ -173,3 +190,72 @@ def test_did_key_root_resolves_without_trust_map_for_links():
     # Only the root key is supplied; the device link resolves from its did:key.
     result = verify_delegated_chain([grant, action], trusted_roots={root.did: root.public_key_jwk})
     assert result.ok
+
+
+# ---------------------------------------------------------------------------
+# Device revocation
+# ---------------------------------------------------------------------------
+
+
+def test_revoked_device_did_rejected():
+    root, device = _root_and_device()
+    grant, action = _signed_chain(root, device)
+    roots = {root.did: root.public_key_jwk}
+
+    # Before revocation: valid.
+    assert verify_delegated_chain([grant, action], trusted_roots=roots).ok
+
+    # Revoke the device DID: the chain through it stops verifying.
+    result = verify_delegated_chain([grant, action], trusted_roots=roots, revoked={device.did})
+    assert not result.ok
+    assert "revoked" in (result.reason or "")
+
+
+def test_revoked_grant_credential_id_rejected():
+    root, device = _root_and_device()
+    grant, action = _signed_chain(root, device)
+    roots = {root.did: root.public_key_jwk}
+    result = verify_delegated_chain([grant, action], trusted_roots=roots, revoked={grant["id"]})
+    assert not result.ok
+
+
+def test_revoked_predicate_callable():
+    root, device = _root_and_device()
+    grant, action = _signed_chain(root, device)
+    roots = {root.did: root.public_key_jwk}
+    blocked = {device.did}
+    result = verify_delegated_chain(
+        [grant, action], trusted_roots=roots, revoked=lambda i: i in blocked
+    )
+    assert not result.ok
+
+
+def test_other_device_unaffected_by_revocation():
+    root, device_a = _root_and_device()
+    device_b = Agent()
+    grant_b, action_b = _signed_chain(root, device_b)
+    roots = {root.did: root.public_key_jwk}
+    # Revoking device A does not affect device B's chain.
+    result = verify_delegated_chain(
+        [grant_b, action_b], trusted_roots=roots, revoked={device_a.did}
+    )
+    assert result.ok
+
+
+def test_device_registry():
+    root, device = _root_and_device()
+    grant, action = _signed_chain(root, device)
+    roots = {root.did: root.public_key_jwk}
+
+    registry = DeviceRegistry()
+    registry.enroll(device.did, grant)
+    assert registry.active_devices() == [device.did]
+    assert verify_delegated_chain(
+        [grant, action], trusted_roots=roots, revoked=registry.is_revoked
+    ).ok
+
+    registry.revoke(device.did)
+    assert registry.active_devices() == []
+    assert not verify_delegated_chain(
+        [grant, action], trusted_roots=roots, revoked=registry.is_revoked
+    ).ok

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -51,7 +51,7 @@ from .mcp_guard import guard_mcp, guard_tools, require_signed
 
 # Cross-device identity: per-device keys delegated from a root, with full chain
 # verification back to a trusted root (the key never travels). See vouch.fleet.
-from .fleet import FleetResult, enroll_device, verify_delegated_chain
+from .fleet import DeviceRegistry, FleetResult, enroll_device, verify_delegated_chain
 
 # Audio signing
 from .audio import AudioSigner, SignedAudioResult
@@ -345,6 +345,7 @@ __all__ = [
     "enroll_device",
     "verify_delegated_chain",
     "FleetResult",
+    "DeviceRegistry",
     "guard_mcp",
     "guard_tools",
     # Audio

--- a/vouch/fleet.py
+++ b/vouch/fleet.py
@@ -30,7 +30,7 @@ Two pieces:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Union
 
 from vouch.signer import Signer, _is_sub_resource
 from vouch.verifier import CredentialPassport, verify
@@ -103,6 +103,7 @@ def verify_delegated_chain(
     *,
     trusted_roots: Optional[Dict[str, Any]] = None,
     allow_did_resolution: bool = True,
+    revoked: Optional[Union[Iterable[str], Callable[[str], bool]]] = None,
     require_action: Optional[str] = None,
     require_target: Optional[str] = None,
     require_resource: Optional[str] = None,
@@ -122,6 +123,11 @@ def verify_delegated_chain(
         from this map, then ``did:key``/``did:web``.
       allow_did_resolution: allow network ``did:web`` resolution for non-root
         links (``did:key`` always resolves offline).
+      revoked: revocation oracle. Either a collection of revoked identifiers
+        (device DIDs and/or credential ids) or a callable ``is_revoked(id) ->
+        bool``. The chain is rejected if any link's issuer, any credential id, or
+        any grant's delegatee is revoked. This is how losing a device is handled:
+        revoke that device's DID and every chain through it stops verifying.
       require_action / require_target / require_resource: optional exact policy
         on the leaf action's intent.
 
@@ -131,6 +137,7 @@ def verify_delegated_chain(
     if not credentials:
         return FleetResult(ok=False, reason="empty chain")
     trusted_roots = trusted_roots or {}
+    is_revoked = _revocation_oracle(revoked)
 
     passports: List[CredentialPassport] = []
     for index, cred in enumerate(credentials):
@@ -147,6 +154,17 @@ def verify_delegated_chain(
         ok, passport = verify(cred, public_key=key, allow_did_resolution=allow_did_resolution)
         if not ok or passport is None:
             return FleetResult(ok=False, reason=f"credential {index} failed verification")
+
+        # Revocation: a revoked issuer (device or root) or a revoked specific
+        # credential breaks the chain.
+        if is_revoked(passport.issuer):
+            return FleetResult(
+                ok=False, reason=f"credential {index} issuer {passport.issuer!r} is revoked"
+            )
+        if passport.credential_id and is_revoked(passport.credential_id):
+            return FleetResult(
+                ok=False, reason=f"credential {index} ({passport.credential_id}) is revoked"
+            )
         passports.append(passport)
 
     # Walk parent -> child links.
@@ -159,6 +177,8 @@ def verify_delegated_chain(
             return FleetResult(
                 ok=False, reason=f"link {i} (grant by {parent.issuer!r}) names no delegatee"
             )
+        if is_revoked(delegatee):
+            return FleetResult(ok=False, reason=f"link {i}: delegatee {delegatee!r} is revoked")
         if child.issuer != delegatee:
             return FleetResult(
                 ok=False,
@@ -222,4 +242,50 @@ def _window_within(child: CredentialPassport, parent: CredentialPassport) -> boo
     return c_from >= p_from and c_until <= p_until
 
 
-__all__ = ["enroll_device", "verify_delegated_chain", "FleetResult"]
+def _revocation_oracle(
+    revoked: Optional[Iterable[str] | Callable[[str], bool]],
+) -> Callable[[str], bool]:
+    """Normalize the `revoked` argument into an `is_revoked(id) -> bool` callable."""
+    if revoked is None:
+        return lambda _id: False
+    if callable(revoked):
+        return revoked
+    revoked_set = set(revoked)
+    return lambda _id: _id in revoked_set
+
+
+class DeviceRegistry:
+    """A small in-memory record of a root's enrolled and revoked devices.
+
+    Convenience for the common case: track which device DIDs a root has enrolled
+    and which it has revoked, and pass :meth:`is_revoked` straight to
+    :func:`verify_delegated_chain`. Back it with your own store (a database, a
+    BitstringStatusList) by subclassing or by passing a different oracle; this is
+    only the simplest default.
+    """
+
+    def __init__(self) -> None:
+        self._enrolled: Dict[str, Dict[str, Any]] = {}
+        self._revoked: Set[str] = set()
+
+    def enroll(self, device_did: str, grant: Optional[Dict[str, Any]] = None) -> None:
+        """Record a device as enrolled (optionally keeping its grant)."""
+        self._enrolled[device_did] = {"grant": grant}
+        self._revoked.discard(device_did)
+
+    def revoke(self, device_did: str) -> None:
+        """Revoke a device. Chains issued by or delegated to it stop verifying."""
+        self._revoked.add(device_did)
+
+    def is_revoked(self, identifier: str) -> bool:
+        return identifier in self._revoked
+
+    def active_devices(self) -> List[str]:
+        return [d for d in self._enrolled if d not in self._revoked]
+
+    @property
+    def revoked(self) -> Set[str]:
+        return set(self._revoked)
+
+
+__all__ = ["enroll_device", "verify_delegated_chain", "FleetResult", "DeviceRegistry"]


### PR DESCRIPTION
Adds device revocation to the cross-device fleet (phase 2, increment 2). Lose a device, revoke it, and any delegation chain through it stops verifying.

What it adds (vouch.fleet):
- verify_delegated_chain gains a `revoked` oracle: either a collection of revoked identifiers (device DIDs and/or credential ids) or a callable is_revoked(id) -> bool. The chain is rejected if any link's issuer, any credential id, or any grant's delegatee is revoked.
- DeviceRegistry: a small in-memory helper that tracks a root's enrolled and revoked devices and exposes is_revoked to feed straight into verify_delegated_chain. Back it with your own store (a database, a BitstringStatusList) by passing a different oracle; this is the simplest default.

This builds on the chain verification from the previous increment; the credential wire format is unchanged.

Security boundary: revocation is enforced at verify time against the oracle the verifier supplies, so the verifier (the relying party) controls the revocation source of truth. Revoking a device DID stops every chain issued by or delegated to it; revoking a specific credential id stops just that grant or action. Revocation does not rewrite or weaken any signature; a revoked-but-otherwise-valid credential simply fails the chain check.

Verification: 5 new tests pass (revoked device DID rejected, revoked grant id rejected, callable predicate, an unrelated device unaffected, and the DeviceRegistry enroll and revoke flow), alongside the existing fleet tests. Full Python suite green other than the pre-existing environment-only git_workflow tests.
