### PR TITLE
Root-identity recovery by Shamir secret sharing

### DIFF
--- a/docs/cross-device-identity.md
+++ b/docs/cross-device-identity.md
@@ -1,0 +1,111 @@
+# Cross-device identity
+
+One identity across all your devices, without ever copying your private key.
+
+Each device makes its own key and keeps it local. Your root identity signs a
+scoped permission slip (a delegation grant) for each device. Anyone verifying an
+action can trace it back to your trusted root. Lose a device and you revoke it;
+lose all of them and you rebuild the root from recovery shares.
+
+The full runnable version is `examples/cross_device_identity.py`.
+
+## 1. A root identity
+
+The root is your durable anchor. Keep it off day-to-day devices.
+
+```python
+from vouch import Agent
+
+root = Agent("alice.example")
+trusted_roots = {root.did: root.public_key_jwk}
+```
+
+## 2. Enroll a device
+
+Each device mints its own key. The root delegates a scope to that device's DID.
+The root never sees the device's private key.
+
+```python
+from vouch import enroll_device
+
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
+)
+```
+
+## 3. Sign and verify
+
+The device signs actions with its own key, chained under the grant. A verifier
+checks the whole chain back to the trusted root.
+
+```python
+from vouch import verify_delegated_chain
+
+action = phone.sign(
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/42",
+    parent_credential=grant,
+)
+
+result = verify_delegated_chain([grant, action], trusted_roots=trusted_roots)
+assert result.ok
+```
+
+`verify_delegated_chain` confirms every signature, that each step is authorized
+by the one before it, that the resource only narrows, and that the validity
+windows nest.
+
+## 4. Revoke a lost device
+
+Track devices with a `DeviceRegistry` and revoke one when it is lost. Its actions
+stop verifying; other devices are unaffected.
+
+```python
+from vouch import DeviceRegistry
+
+registry = DeviceRegistry()
+registry.enroll(phone.did, grant)
+
+registry.revoke(phone.did)
+
+result = verify_delegated_chain(
+    [grant, action], trusted_roots=trusted_roots, revoked=registry.is_revoked
+)
+assert not result.ok
+```
+
+The `revoked` argument also accepts a plain set of DIDs or credential ids, or any
+`is_revoked(id) -> bool` callable, so you can back it with your own store.
+
+## 5. Recover the root
+
+Split the root into shares so any threshold rebuild it. Hand shares to guardians
+or separate locations. Fewer than the threshold reveal nothing.
+
+```python
+from vouch import split_identity, recover_identity, Signer
+
+# Splitting needs the root's key, so create the root with allow_key_export=True.
+root = Agent("alice.example", allow_key_export=True)
+shares = split_identity(root, threshold=2, shares=3)
+
+# Later, any two shares rebuild the exact same identity.
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+signer = Signer.from_keypair(recovered)
+```
+
+The recovered key is identical to the original, so it can enroll new devices and
+carry on as the same identity.
+
+## What travels, and what does not
+
+- The private key of a device never leaves that device.
+- The root's key is only ever assembled during a deliberate recovery; do that on
+  a trusted device and re-seal afterwards.
+- What moves between devices is authority (a signed grant), never key material.

--- a/examples/cross_device_identity.py
+++ b/examples/cross_device_identity.py
@@ -104,7 +104,7 @@ print(f"   Laptop still works? {laptop_ok.ok}")
 # ---------------------------------------------------------------------------
 rule("5. Recover the root from guardian shares")
 shares = split_identity(root, threshold=2, shares=3)
-print(f"   Split the root into 3 shares (any 2 rebuild it).")
+print("   Split the root into 3 shares (any 2 rebuild it).")
 
 # Two guardians hand back their shares. Rebuild the exact same root key.
 recovered = recover_identity([shares[0], shares[2]], did=root.did)

--- a/examples/cross_device_identity.py
+++ b/examples/cross_device_identity.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""
+cross_device_identity.py - One identity across many devices, key never travels.
+
+Shows the whole cross-device custody story end to end:
+
+  1. A root identity (your durable anchor).
+  2. Enroll two devices. Each device mints its OWN key locally; the root only
+     signs a scoped permission slip (a delegation grant). No key is copied.
+  3. A device signs an action; a verifier ties it back to the trusted root.
+  4. Lose a device: revoke it. Its actions stop verifying; the other device is
+     unaffected.
+  5. Recovery: split the root across guardians, "lose" it, then rebuild it from
+     a threshold of shares and keep operating.
+
+Run: python cross_device_identity.py
+"""
+
+from vouch import (
+    Agent,
+    DeviceRegistry,
+    Signer,
+    enroll_device,
+    recover_identity,
+    split_identity,
+    verify_delegated_chain,
+)
+
+
+def rule(title):
+    print(f"\n{'=' * 64}\n{title}\n{'=' * 64}")
+
+
+# ---------------------------------------------------------------------------
+# 1. The root identity (kept safe, off the day-to-day devices).
+# ---------------------------------------------------------------------------
+rule("1. Root identity")
+# allow_key_export=True lets us split the root for recovery later (step 5). By
+# default an Agent keeps its private key in and signs on your behalf; exporting
+# the key is an explicit, opt-in action.
+root = Agent("alice.example", allow_key_export=True)
+trusted_roots = {root.did: root.public_key_jwk}
+print(f"   Root DID: {root.did}")
+
+# ---------------------------------------------------------------------------
+# 2. Enroll two devices. Each mints its own key; the root delegates a scope.
+# ---------------------------------------------------------------------------
+rule("2. Enroll a phone and a laptop (each holds its own key)")
+phone = Agent()  # did:key minted on the phone
+laptop = Agent()  # did:key minted on the laptop
+registry = DeviceRegistry()
+
+phone_grant = enroll_device(
+    root, device_did=phone.did, action="charge",
+    target="api.bank", resource="https://api.bank/invoices",
+)
+laptop_grant = enroll_device(
+    root, device_did=laptop.did, action="charge",
+    target="api.bank", resource="https://api.bank/invoices",
+)
+registry.enroll(phone.did, phone_grant)
+registry.enroll(laptop.did, laptop_grant)
+print(f"   Phone:  {phone.did[:24]}... enrolled")
+print(f"   Laptop: {laptop.did[:24]}... enrolled")
+print("   The root never saw either device's private key.")
+
+# ---------------------------------------------------------------------------
+# 3. A device signs an action; a verifier checks it back to the root.
+# ---------------------------------------------------------------------------
+rule("3. The phone signs an action, and it verifies back to the root")
+phone_action = phone.sign(
+    action="charge", target="api.bank",
+    resource="https://api.bank/invoices/42", parent_credential=phone_grant,
+)
+result = verify_delegated_chain(
+    [phone_grant, phone_action], trusted_roots=trusted_roots,
+    revoked=registry.is_revoked,
+)
+print(f"   Verified: {result.ok}  (issued by {result.leaf.issuer[:24]}...)")
+
+# ---------------------------------------------------------------------------
+# 4. Lose the phone: revoke it. Laptop keeps working.
+# ---------------------------------------------------------------------------
+rule("4. The phone is lost: revoke it")
+registry.revoke(phone.did)
+after_revoke = verify_delegated_chain(
+    [phone_grant, phone_action], trusted_roots=trusted_roots,
+    revoked=registry.is_revoked,
+)
+print(f"   Phone action still valid? {after_revoke.ok}  ({after_revoke.reason})")
+
+laptop_action = laptop.sign(
+    action="charge", target="api.bank",
+    resource="https://api.bank/invoices/99", parent_credential=laptop_grant,
+)
+laptop_ok = verify_delegated_chain(
+    [laptop_grant, laptop_action], trusted_roots=trusted_roots,
+    revoked=registry.is_revoked,
+)
+print(f"   Laptop still works? {laptop_ok.ok}")
+
+# ---------------------------------------------------------------------------
+# 5. Recovery: split the root, "lose" it, rebuild from a threshold of shares.
+# ---------------------------------------------------------------------------
+rule("5. Recover the root from guardian shares")
+shares = split_identity(root, threshold=2, shares=3)
+print(f"   Split the root into 3 shares (any 2 rebuild it).")
+
+# Two guardians hand back their shares. Rebuild the exact same root key.
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+recovered_signer = Signer.from_keypair(recovered)
+print(f"   Recovered root DID matches: {recovered.did == root.did}")
+
+# The recovered root can enroll a new device, proving it is the same identity.
+new_tablet = Agent()
+tablet_grant = enroll_device(
+    recovered_signer, device_did=new_tablet.did, action="charge",
+    target="api.bank", resource="https://api.bank/invoices",
+)
+tablet_action = new_tablet.sign(
+    action="charge", target="api.bank",
+    resource="https://api.bank/invoices/7", parent_credential=tablet_grant,
+)
+tablet_ok = verify_delegated_chain(
+    [tablet_grant, tablet_action],
+    trusted_roots={recovered.did: recovered.public_key_jwk},
+)
+print(f"   Recovered root enrolled a new tablet, verified? {tablet_ok.ok}")
+
+print("""
+Takeaway: one identity, many devices, and the private key never travels.
+Each device holds its own key; the root delegates; losing a device is a revoke;
+and the root itself survives via threshold recovery shares.
+""")

--- a/examples/cross_device_identity.py
+++ b/examples/cross_device_identity.py
@@ -51,12 +51,18 @@ laptop = Agent()  # did:key minted on the laptop
 registry = DeviceRegistry()
 
 phone_grant = enroll_device(
-    root, device_did=phone.did, action="charge",
-    target="api.bank", resource="https://api.bank/invoices",
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
 )
 laptop_grant = enroll_device(
-    root, device_did=laptop.did, action="charge",
-    target="api.bank", resource="https://api.bank/invoices",
+    root,
+    device_did=laptop.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
 )
 registry.enroll(phone.did, phone_grant)
 registry.enroll(laptop.did, laptop_grant)
@@ -69,11 +75,14 @@ print("   The root never saw either device's private key.")
 # ---------------------------------------------------------------------------
 rule("3. The phone signs an action, and it verifies back to the root")
 phone_action = phone.sign(
-    action="charge", target="api.bank",
-    resource="https://api.bank/invoices/42", parent_credential=phone_grant,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/42",
+    parent_credential=phone_grant,
 )
 result = verify_delegated_chain(
-    [phone_grant, phone_action], trusted_roots=trusted_roots,
+    [phone_grant, phone_action],
+    trusted_roots=trusted_roots,
     revoked=registry.is_revoked,
 )
 print(f"   Verified: {result.ok}  (issued by {result.leaf.issuer[:24]}...)")
@@ -84,17 +93,21 @@ print(f"   Verified: {result.ok}  (issued by {result.leaf.issuer[:24]}...)")
 rule("4. The phone is lost: revoke it")
 registry.revoke(phone.did)
 after_revoke = verify_delegated_chain(
-    [phone_grant, phone_action], trusted_roots=trusted_roots,
+    [phone_grant, phone_action],
+    trusted_roots=trusted_roots,
     revoked=registry.is_revoked,
 )
 print(f"   Phone action still valid? {after_revoke.ok}  ({after_revoke.reason})")
 
 laptop_action = laptop.sign(
-    action="charge", target="api.bank",
-    resource="https://api.bank/invoices/99", parent_credential=laptop_grant,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/99",
+    parent_credential=laptop_grant,
 )
 laptop_ok = verify_delegated_chain(
-    [laptop_grant, laptop_action], trusted_roots=trusted_roots,
+    [laptop_grant, laptop_action],
+    trusted_roots=trusted_roots,
     revoked=registry.is_revoked,
 )
 print(f"   Laptop still works? {laptop_ok.ok}")
@@ -114,12 +127,17 @@ print(f"   Recovered root DID matches: {recovered.did == root.did}")
 # The recovered root can enroll a new device, proving it is the same identity.
 new_tablet = Agent()
 tablet_grant = enroll_device(
-    recovered_signer, device_did=new_tablet.did, action="charge",
-    target="api.bank", resource="https://api.bank/invoices",
+    recovered_signer,
+    device_did=new_tablet.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
 )
 tablet_action = new_tablet.sign(
-    action="charge", target="api.bank",
-    resource="https://api.bank/invoices/7", parent_credential=tablet_grant,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/7",
+    parent_credential=tablet_grant,
 )
 tablet_ok = verify_delegated_chain(
     [tablet_grant, tablet_action],

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -7,6 +7,7 @@ deterministic), proven by signing with the recovered key and verifying against
 the original public key.
 """
 
+import json
 import os
 
 import pytest
@@ -88,14 +89,16 @@ def test_split_and_recover_identity_signs_identically():
     cred = signer.sign_credential(action="read", target="t", resource="https://x/y")
     ok, _ = Verifier.verify_credential(cred, public_key=keys.public_key_jwk)
     assert ok
-    assert recovered.public_key_jwk == keys.public_key_jwk
+    # The public key material matches (compare the JWK 'x', not the serialized
+    # string, which can differ by jwcrypto version).
+    assert json.loads(recovered.public_key_jwk)["x"] == json.loads(keys.public_key_jwk)["x"]
 
 
 def test_recover_from_private_jwk_string():
     keys = generate_identity("root.example")
     shares = split_identity(keys.private_key_jwk, threshold=2, shares=3)
     recovered = recover_identity([shares[0], shares[2]])
-    assert recovered.public_key_jwk == keys.public_key_jwk
+    assert json.loads(recovered.public_key_jwk)["x"] == json.loads(keys.public_key_jwk)["x"]
 
 
 def test_too_few_shares_does_not_recover_identity():

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,110 @@
+"""
+Tests for root-identity recovery by Shamir secret sharing (vouch.recovery).
+
+The model: split a root identity's seed into n shares so any t reconstruct it and
+fewer reveal nothing. Recovery rebuilds the exact same key (the seed is
+deterministic), proven by signing with the recovered key and verifying against
+the original public key.
+"""
+
+import os
+
+import pytest
+
+from vouch import (
+    Verifier,
+    combine_shares,
+    generate_identity,
+    recover_identity,
+    split_identity,
+    split_secret,
+    Signer,
+)
+
+
+# ---------------------------------------------------------------------------
+# Byte-level Shamir
+# ---------------------------------------------------------------------------
+
+
+def test_split_and_combine_roundtrip():
+    secret = os.urandom(32)
+    shares = split_secret(secret, threshold=3, shares=5)
+    assert len(shares) == 5
+    # Any 3 of the 5 reconstruct.
+    assert combine_shares(shares[:3]) == secret
+    assert combine_shares(shares[2:5]) == secret
+    assert combine_shares([shares[0], shares[2], shares[4]]) == secret
+    # All 5 also reconstruct.
+    assert combine_shares(shares) == secret
+
+
+def test_threshold_minus_one_does_not_reveal_secret():
+    secret = os.urandom(32)
+    shares = split_secret(secret, threshold=3, shares=5)
+    # Two shares (below threshold) must not yield the secret.
+    assert combine_shares(shares[:2]) != secret
+
+
+def test_two_of_two():
+    secret = b"a-32-byte-seed-for-shamir-test!!"
+    shares = split_secret(secret, threshold=2, shares=2)
+    assert combine_shares(shares) == secret
+
+
+def test_invalid_parameters():
+    with pytest.raises(ValueError):
+        split_secret(b"", threshold=2, shares=3)
+    with pytest.raises(ValueError):
+        split_secret(b"x", threshold=1, shares=3)  # threshold must be >= 2
+    with pytest.raises(ValueError):
+        split_secret(b"x", threshold=4, shares=3)  # threshold > shares
+
+
+def test_combine_rejects_inconsistent_shares():
+    secret = os.urandom(16)
+    shares = split_secret(secret, threshold=2, shares=3)
+    with pytest.raises(ValueError):
+        combine_shares([shares[0], shares[0]])  # duplicate index
+    with pytest.raises(ValueError):
+        combine_shares([shares[0], shares[1][:5]])  # inconsistent length
+
+
+# ---------------------------------------------------------------------------
+# Identity recovery
+# ---------------------------------------------------------------------------
+
+
+def test_split_and_recover_identity_signs_identically():
+    keys = generate_identity("root.example")
+    shares = split_identity(keys, threshold=2, shares=3)
+    assert len(shares) == 3
+
+    recovered = recover_identity(shares[:2], did=keys.did)
+    assert recovered.did == keys.did
+    # The recovered key is the original key: a credential it signs verifies
+    # against the ORIGINAL public key.
+    signer = Signer(private_key=recovered.private_key_jwk, did=recovered.did)
+    cred = signer.sign_credential(action="read", target="t", resource="https://x/y")
+    ok, _ = Verifier.verify_credential(cred, public_key=keys.public_key_jwk)
+    assert ok
+    assert recovered.public_key_jwk == keys.public_key_jwk
+
+
+def test_recover_from_private_jwk_string():
+    keys = generate_identity("root.example")
+    shares = split_identity(keys.private_key_jwk, threshold=2, shares=3)
+    recovered = recover_identity([shares[0], shares[2]])
+    assert recovered.public_key_jwk == keys.public_key_jwk
+
+
+def test_too_few_shares_does_not_recover_identity():
+    keys = generate_identity("root.example")
+    shares = split_identity(keys, threshold=3, shares=5)
+    # Two shares when three are required: the recovered seed is wrong, so the
+    # public key does not match (and may not even be 32 bytes).
+    try:
+        recovered = recover_identity(shares[:2])
+        assert recovered.public_key_jwk != keys.public_key_jwk
+    except ValueError:
+        pass  # also acceptable: wrong-length seed is rejected

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -53,6 +53,15 @@ from .mcp_guard import guard_mcp, guard_tools, require_signed
 # verification back to a trusted root (the key never travels). See vouch.fleet.
 from .fleet import DeviceRegistry, FleetResult, enroll_device, verify_delegated_chain
 
+# Root-identity recovery by Shamir secret sharing (split the root across
+# guardians; any threshold reconstruct it). See vouch.recovery.
+from .recovery import (
+    combine_shares,
+    recover_identity,
+    split_identity,
+    split_secret,
+)
+
 # Audio signing
 from .audio import AudioSigner, SignedAudioResult
 
@@ -346,6 +355,10 @@ __all__ = [
     "verify_delegated_chain",
     "FleetResult",
     "DeviceRegistry",
+    "split_secret",
+    "combine_shares",
+    "split_identity",
+    "recover_identity",
     "guard_mcp",
     "guard_tools",
     # Audio

--- a/vouch/recovery.py
+++ b/vouch/recovery.py
@@ -1,0 +1,218 @@
+"""
+Root-identity recovery by Shamir secret sharing (the OSS recovery path).
+
+A root identity is the durable anchor that issues per-device grants (see
+:mod:`vouch.fleet`). If every device is lost, the root must still be
+recoverable. This module splits the root's Ed25519 seed into ``n`` shares so
+that any ``t`` of them reconstruct it, and none fewer reveal anything. Hand the
+shares to guardians, a safe-deposit box, or separate locations; gather ``t`` only
+during a deliberate recovery.
+
+This is the recovery / escrow primitive. It is distinct from threshold signing
+(FROST), where the key is never reassembled: here the seed IS reconstructed at
+recovery time, so do it on a trusted device and re-seal afterwards. Use it for
+cold recovery of a root, not for hot signing.
+
+  shares = split_identity(keypair, threshold=2, shares=3)   # give one each to 3 guardians
+  recovered = recover_identity(shares[:2])                   # any 2 rebuild the identity
+
+The arithmetic is textbook Shamir over GF(2^8) (the AES field). Shares carry no
+integrity tag, so a corrupted share yields a wrong secret rather than an error;
+pair with your own checksum if you need to detect a bad share.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import secrets
+from typing import Any, List, Optional
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from vouch.keys import KeyPair
+
+# ---------------------------------------------------------------------------
+# GF(2^8) arithmetic (AES field, reducing polynomial 0x11b)
+# ---------------------------------------------------------------------------
+
+_EXP = [0] * 512
+_LOG = [0] * 256
+
+
+def _init_tables() -> None:
+    # 3 (not 2) is a primitive element of GF(2^8) under 0x11b, so powers of 3
+    # cycle through all 255 non-zero elements. Multiply by 3 = (x*2) XOR x.
+    x = 1
+    for i in range(255):
+        _EXP[i] = x
+        _LOG[x] = i
+        x2 = x << 1
+        if x2 & 0x100:
+            x2 ^= 0x11B
+        x = x2 ^ x
+    for i in range(255, 512):
+        _EXP[i] = _EXP[i - 255]
+
+
+_init_tables()
+
+
+def _gf_mul(a: int, b: int) -> int:
+    if a == 0 or b == 0:
+        return 0
+    return _EXP[_LOG[a] + _LOG[b]]
+
+
+def _gf_inv(a: int) -> int:
+    if a == 0:
+        raise ZeroDivisionError("no inverse for 0 in GF(2^8)")
+    return _EXP[255 - _LOG[a]]
+
+
+def _eval_poly(coeffs: List[int], x: int) -> int:
+    """Evaluate a polynomial (coeffs low-order first) at x in GF(2^8)."""
+    result = 0
+    for coeff in reversed(coeffs):
+        result = _gf_mul(result, x) ^ coeff
+    return result
+
+
+def _interpolate_at_zero(points: List[tuple]) -> int:
+    """Lagrange-interpolate the points and return the value at x = 0."""
+    result = 0
+    for i, (xi, yi) in enumerate(points):
+        num = 1
+        den = 1
+        for j, (xj, _yj) in enumerate(points):
+            if i == j:
+                continue
+            num = _gf_mul(num, xj)  # (0 - xj) == xj in GF(2^8)
+            den = _gf_mul(den, xi ^ xj)  # (xi - xj) == xi ^ xj
+        result ^= _gf_mul(yi, _gf_mul(num, _gf_inv(den)))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Byte-level split / combine
+# ---------------------------------------------------------------------------
+
+
+def split_secret(secret: bytes, *, threshold: int, shares: int) -> List[bytes]:
+    """Split `secret` into `shares` pieces; any `threshold` reconstruct it.
+
+    Each returned share is ``bytes([index]) + share_body`` where index is in
+    1..shares. Fewer than `threshold` shares reveal nothing about the secret.
+    """
+    if not isinstance(secret, (bytes, bytearray)) or len(secret) == 0:
+        raise ValueError("secret must be non-empty bytes")
+    if not (2 <= threshold <= shares <= 255):
+        raise ValueError("require 2 <= threshold <= shares <= 255")
+
+    out = [bytearray([x]) for x in range(1, shares + 1)]
+    for byte in secret:
+        coeffs = [byte] + [secrets.randbelow(256) for _ in range(threshold - 1)]
+        for i, x in enumerate(range(1, shares + 1)):
+            out[i].append(_eval_poly(coeffs, x))
+    return [bytes(s) for s in out]
+
+
+def combine_shares(shares: List[bytes]) -> bytes:
+    """Reconstruct a secret from `threshold` (or more) shares.
+
+    Shares are the byte strings returned by :func:`split_secret`. Supplying
+    fewer than the original threshold returns a wrong value, not an error.
+    """
+    if not shares or len(shares) < 2:
+        raise ValueError("need at least 2 shares")
+    bodies = []
+    xs = []
+    for s in shares:
+        if len(s) < 2:
+            raise ValueError("malformed share")
+        xs.append(s[0])
+        bodies.append(s[1:])
+    if len(set(xs)) != len(xs):
+        raise ValueError("shares must have distinct indices")
+    length = len(bodies[0])
+    if any(len(b) != length for b in bodies):
+        raise ValueError("shares have inconsistent length")
+
+    secret = bytearray()
+    for j in range(length):
+        points = [(xs[k], bodies[k][j]) for k in range(len(shares))]
+        secret.append(_interpolate_at_zero(points))
+    return bytes(secret)
+
+
+# ---------------------------------------------------------------------------
+# Vouch identity recovery
+# ---------------------------------------------------------------------------
+
+
+def _seed_from_private_jwk(private_key_jwk: str) -> bytes:
+    from jwcrypto.common import base64url_decode
+
+    data = json.loads(private_key_jwk)
+    if data.get("kty") != "OKP" or data.get("crv") != "Ed25519" or not data.get("d"):
+        raise ValueError("expected an Ed25519 private JWK with a 'd' seed")
+    return base64url_decode(data["d"])
+
+
+def split_identity(
+    keypair: Any,
+    *,
+    threshold: int,
+    shares: int,
+) -> List[str]:
+    """Split a root identity's Ed25519 seed into base64 recovery shares.
+
+    Accepts a :class:`~vouch.keys.KeyPair`, an Agent (anything exposing
+    ``private_key_jwk``), or a private JWK string. Returns `shares` base64
+    strings; any `threshold` of them recover the identity via
+    :func:`recover_identity`. Distribute them to separate guardians or locations.
+    """
+    if isinstance(keypair, str):
+        private_jwk = keypair
+    else:
+        private_jwk = getattr(keypair, "private_key_jwk", None)
+        if private_jwk is None:
+            raise TypeError("split_identity needs a KeyPair, Agent, or private JWK string")
+    seed = _seed_from_private_jwk(private_jwk)
+    return [
+        base64.b64encode(s).decode("ascii")
+        for s in split_secret(seed, threshold=threshold, shares=shares)
+    ]
+
+
+def recover_identity(shares: List[str], *, did: Optional[str] = None) -> KeyPair:
+    """Recover a root identity from `threshold` base64 recovery shares.
+
+    Returns a :class:`~vouch.keys.KeyPair` with the original private and public
+    keys (the seed is deterministic, so the rebuilt key is identical). Pass
+    ``did`` to set it on the returned KeyPair.
+    """
+    from jwcrypto import jwk as jwk_mod
+
+    raw = [base64.b64decode(s) for s in shares]
+    seed = combine_shares(raw)
+    if len(seed) != 32:
+        raise ValueError("recovered seed is not 32 bytes; wrong or too few shares")
+
+    # Rebuild the JWK through jwcrypto (as generate_identity does) so the
+    # recovered key's serialization matches a freshly minted one byte for byte.
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    key = jwk_mod.JWK.from_pyca(priv)
+    return KeyPair(
+        private_key_jwk=key.export_private(),
+        public_key_jwk=key.export_public(),
+        did=did,
+    )
+
+
+__all__ = [
+    "split_secret",
+    "combine_shares",
+    "split_identity",
+    "recover_identity",
+]


### PR DESCRIPTION
Adds root-identity recovery by Shamir secret sharing (phase 2, increment 3). Cross-device custody needs the root identity to survive losing every device; this lets it be split across guardians and recovered.

What it adds (vouch.recovery):
- split_secret / combine_shares: textbook Shamir over GF(2^8). Split bytes into n shares so any threshold reconstruct them, and fewer reveal nothing.
- split_identity(keypair, threshold=, shares=): split a root identity's Ed25519 seed into base64 shares to hand to guardians or store in separate locations.
- recover_identity(shares): rebuild the exact same KeyPair from any threshold of shares (the seed is deterministic, so the recovered key is identical, proven by signing with it and verifying against the original public key).

This is the recovery and escrow primitive, distinct from threshold signing. The seed IS reconstructed at recovery time, so recovery should happen on a trusted device and the identity be re-sealed afterwards. Use it for cold recovery of a root, not for hot signing.

Security boundary: fewer than `threshold` shares reveal nothing about the secret (the defining property of Shamir). Randomness for the sharing polynomials comes from the `secrets` module. Shares carry no integrity tag, so a corrupted or wrong-set-of share yields a wrong secret rather than an error; recover_identity additionally rejects a reconstructed seed that is not 32 bytes, and callers who need to detect a bad share should add their own checksum. This is a reference implementation of a standard scheme for recovery use; it is not constant-time and is not intended for high-frequency online signing.

Verification: 8 new tests pass (split/combine round-trip with any threshold subset, below-threshold does not reveal the secret, parameter validation, malformed-share rejection, and identity split/recover that signs identically to the original key). Full Python suite green other than the pre-existing environment-only git_workflow tests.
