### PR TITLE
feat(transport): deployable HTTPS rendezvous resolver, assistant-surface sync, and PAD-074/075

### DIFF
--- a/agents-and-skills/FAQ-DRAFT.md
+++ b/agents-and-skills/FAQ-DRAFT.md
@@ -369,16 +369,28 @@ investigate within five business days.
 
 **Q: How does an agent reach another agent that has no domain or IP?**
 A: By its DID. The transport layer (`vouch.transport`) addresses a peer by
-identity, not location. It prefers identity-first routing over UDNA (Universal
-DID-Native Addressing) and falls back to standard DNS and HTTPS when the peer is
-not on the overlay. The agent dispatches to a DID and does not care which path
-the bytes take.
+identity, not location. The agent publishes a signed record that binds its DID
+to its current endpoint, and a sender resolves the DID to that endpoint and
+verifies the agent itself asserted the route. This ships today over plain HTTPS
+through a rendezvous, and falls back to standard DNS and HTTPS (`did:web`) for
+any peer that has a domain. The agent dispatches to a DID and does not care
+which path the bytes take.
 
-**Q: Do I have to run UDNA to use Vouch?**
-A: No. The transport is optional and experimental, and it is dormant unless you
-opt in with `pip install vouch-protocol[udna]`. Without it, dispatch falls
-through to HTTP, so your code runs unchanged. UDNA is aligned with the W3C UDNA
-Community Group.
+**Q: Do I need UDNA, or a special network, to be reached by identity?**
+A: No. The identity-first resolver runs on commodity HTTPS today, so you do not
+wait on any overlay. Vouch builds on UDNA (Universal DID-Native Addressing) as a
+general identity-native substrate when one is present, and tracks the W3C UDNA
+Community Group so the two interoperate as UDNA's baseline lands. The UDNA SDK is
+an optional extra (`pip install vouch-protocol[udna]`); without it, dispatch
+falls through to the rendezvous or HTTP, so your code runs unchanged.
+
+**Q: If the rendezvous is a single server, is it a single point of trust?**
+A: No. The rendezvous is untrusted. It stores and serves signed route records
+but never has to be believed: the sender re-verifies every record's signature
+itself and checks the record's DID against the one it asked for. A malicious or
+compromised rendezvous can withhold a record or serve a stale one, but it cannot
+forge a route or point you at a different identity, because it does not hold the
+agent's key.
 
 **Q: Are my credentials safe if the message switches from UDNA to HTTP?**
 A: Yes. The message is a `VouchEnvelope` that carries the signed credential, its

--- a/agents-and-skills/HELP-GUIDE-DRAFT.md
+++ b/agents-and-skills/HELP-GUIDE-DRAFT.md
@@ -1,4 +1,4 @@
-# Help Guide Draft (NOT PUBLISHED — awaiting your approval)
+# Help Guide Draft (NOT PUBLISHED: awaiting your approval)
 
 Long-form help content for the website. Probable home: a new page under
 `/help/ai-assistants` (or merged into the existing `/help` route) for
@@ -7,7 +7,7 @@ tiering. Show the user this file before merging.
 
 ---
 
-# Part 1 — Pick your sidecar
+# Part 1: Pick your sidecar
 
 The Vouch sidecar holds the agent's signing key. Three implementations
 ship today (Go, Python, TypeScript) and they are not interchangeable in
@@ -59,10 +59,10 @@ design intent, not a workaround.
 
 All three sidecars expose the same HTTP API:
 
-- `GET  /health` — liveness probe
-- `GET  /did` — the sidecar's DID
-- `GET  /.well-known/did.json` — DID Document (optional, dev-friendly)
-- `POST /sign` — sign an intent, return a Verifiable Credential
+- `GET  /health`: liveness probe
+- `GET  /did`: the sidecar's DID
+- `GET  /.well-known/did.json`: DID Document (optional, dev-friendly)
+- `POST /sign`: sign an intent, return a Verifiable Credential
 
 A contract test suite (`test-vectors/sidecar-contract/`) verifies that
 each implementation accepts and rejects the same inputs and emits
@@ -92,7 +92,7 @@ a real did:web rooted on your domain), and the key material changes
 
 ---
 
-# Part 2 — Use the Vouch AI assistants
+# Part 2: Use the Vouch AI assistants
 
 Vouch ships four AI surfaces. Pick the one that matches the tool you
 already use; all four route to the same canonical documentation.
@@ -115,7 +115,7 @@ already use; all four route to the same canonical documentation.
 
 ---
 
-## Walkthrough — Claude Skill
+## Walkthrough: Claude Skill
 
 ### Install
 
@@ -195,7 +195,7 @@ new cryptosuite or SDK shape.
 
 ---
 
-## Walkthrough — Vouch Agent
+## Walkthrough: Vouch Agent
 
 ### Where to find it
 
@@ -343,7 +343,7 @@ Or set them in `website-agent/.env` (auto-loaded on backend start).
 
 ---
 
-## Walkthrough — OpenAI Custom GPT
+## Walkthrough: OpenAI Custom GPT
 
 ### Build your own
 
@@ -397,7 +397,7 @@ note in the Instructions.
 
 ---
 
-## Walkthrough — Gemini Gem
+## Walkthrough: Gemini Gem
 
 ### Build the Gem
 
@@ -477,30 +477,58 @@ release notifications on https://github.com/vouch-protocol/vouch.
 
 # Part 3: Reach agents by identity (transport)
 
-Optional and experimental. Use this when agents need to reach each other by
-identity rather than by a fixed domain or IP. It is aligned with the W3C UDNA
-Community Group and is dormant unless you opt in.
+Optional. Use this when agents need to reach each other by identity rather than
+by a fixed domain or IP. The identity-first resolver ships today over commodity
+HTTPS, and a standard HTTP path is always there as the fallback, so it is never
+all-or-nothing.
 
 ## When to use it
 
 - Agents are ephemeral or move across hosts, so a stable domain or IP is not
   available, but a DID always is.
 - You want delivery to follow the identity, with a standard HTTP path as the
-  fallback for peers that are not on the overlay.
+  fallback for peers that have a domain.
 
 ## How it works
 
-`TransportManager` tries transports in order: UDNA first (identity-first), then
-HTTP (did:web, DNS, HTTPS). A peer that cannot be reached over one transport
+An agent binds its DID to its current endpoint, signs that binding with its own
+key, and publishes it to a rendezvous. A sender that knows only the DID resolves
+it to the endpoint and verifies the agent itself asserted the route, then
+delivers. `TransportManager` tries transports in order, identity-first and then
+HTTP (did:web, DNS, HTTPS); a peer that cannot be reached over one transport
 falls through to the next, and `DeliveryResult.attempts` records the path taken.
 The message is a `VouchEnvelope` that carries the signed credential, liability
 attestations, and provenance unchanged, with a content digest checked on
 receipt, so the trust properties hold whichever path delivers it.
 
-## Enable it
+The rendezvous is untrusted: the sender re-verifies every signed record locally
+and checks its DID, so a rendezvous cannot forge a route or redirect you to a
+different identity. Swapping the rendezvous for a real overlay (libp2p, or
+UDNA's DHT when its baseline lands) reuses the same record format and
+verification, so what you build now keeps working.
+
+## Reach an agent by DID
+
+```python
+from vouch.transport import (
+    HttpRendezvousResolver, HttpRendezvousChannel, build_route_record,
+)
+
+# The agent announces its current inbox, signed under its DID.
+resolver = HttpRendezvousResolver("https://rendezvous.example.com")
+await resolver.announce(build_route_record(
+    did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_ed25519,
+))
+
+# A sender that knows only the DID resolves it and delivers, verifying locally.
+channel = HttpRendezvousChannel(resolver)
+reply = await channel.exchange(f"udna://{agent_did}/vouch.message", frame)
+```
+
+## Use the manager with HTTP fallback
 
 ```bash
-pip install vouch-protocol[udna]
+pip install vouch-protocol[udna]   # optional; SDK-backed UDNA path
 ```
 
 ```python
@@ -511,8 +539,8 @@ manager = TransportManager.default(private_key_jwk=my_private_key_jwk)
 result = await manager.dispatch(envelope)   # result.transport -> "udna" or "http"
 ```
 
-Without the extra installed, the UDNA transport stays dormant and dispatch falls
-through to HTTP, so the same code runs unchanged.
+Without the extra installed, the SDK-backed UDNA path stays dormant and dispatch
+falls through to the rendezvous or HTTP, so the same code runs unchanged.
 
 ## Security note
 

--- a/claude-skill/skills/vouch-protocol/reference/transport.md
+++ b/claude-skill/skills/vouch-protocol/reference/transport.md
@@ -1,13 +1,16 @@
 # Identity-Native Transport Reference
 
 Vouch addresses a peer by its DID, not its IP or domain. The transport
-layer (`vouch.transport`) prefers identity-first routing over UDNA
-(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
-when a peer is not on the overlay. An agent dispatches a message to a DID
-and stays agnostic about how the bytes are routed.
+layer (`vouch.transport`) routes a message to an identity and stays agnostic
+about how the bytes get there. It ships its own identity-first resolver that
+works today over commodity HTTPS, builds on UDNA (Universal DID-Native
+Addressing) as a general identity-native substrate when one is present, and
+falls back to standard DNS and HTTPS for any `did:web` peer.
 
-This is optional and experimental. It is aligned with the W3C UDNA
-Community Group and is dormant unless you opt in.
+This is optional. The identity-first path is opt-in, and the HTTP fallback
+means an agent is always reachable. Vouch develops the resolver in the open
+and tracks the W3C UDNA Community Group so the two interoperate as UDNA's
+baseline lands.
 
 ## Why it exists
 
@@ -15,28 +18,57 @@ Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
 They rarely hold a stable domain or IP, but they always hold a key, so a
 DID is the only stable handle. Identity-first routing matches how agents
 actually run. Vouch already makes a DID accountable (identity, reputation,
-liability); UDNA answers how to reach it.
+liability); the transport layer answers how to reach it.
 
 ## How it routes
 
 `TransportManager` holds an ordered list of transports and tries them in
 preference order:
 
-1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+1. Identity-first routing (resolve the DID to the agent's current endpoint)
+   when the peer has published a route.
 2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
 
 A transport that cannot reach a peer raises `TransportUnavailable`, and the
 manager moves to the next one. `DeliveryResult.attempts` records the path
 taken, for example `["udna", "http"]`.
 
+## Reaching an agent by DID, today
+
+`did:web` answers "where is this domain." It cannot answer the question an
+agent actually has, "where is this identity right now," without a domain and
+DNS. The rendezvous resolver answers it directly, and it ships now:
+
+- An agent binds its DID to a current endpoint, signs that binding with the
+  DID's own key (a `RouteRecord`), and publishes it.
+- A sender that knows only the DID resolves it to the live endpoint and
+  verifies that the agent itself asserted the route.
+- The routing key on the wire is `sha256(did)`, so a lookup never leaks the
+  DID itself.
+
+Two backends ship behind the same record format and the same verification: an
+in-memory resolver for tests and single-process use, and a deployable HTTPS
+rendezvous (`RendezvousService` / `build_rendezvous_app` on the server,
+`HttpRendezvousResolver` / `HttpRendezvousChannel` on the client) that runs the
+whole path over plain HTTPS with no DNS binding the agent to a location.
+
+The rendezvous is untrusted. It stores and serves signed records but never has
+to be believed: the client re-verifies every record's signature locally and
+checks the record's DID against the one it asked for. A malicious or
+compromised rendezvous can withhold a record or serve a stale one, but it
+cannot forge a route or substitute another identity's, because it does not hold
+the agent's key. Swapping the single rendezvous for a real overlay (libp2p, or
+UDNA's DHT when its baseline lands) reuses this record format and verification
+unchanged and plugs in behind the same channel seam.
+
 ## What "route by DID" means
 
 The DID Document (the json with the DID and public key) is a key store, not
 a routing target. Its job is to give you the public key so you can verify
 signatures. Location comes from elsewhere. In `did:web`, the location is a
-`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
-a signed route record under its DID, and a resolver maps the DID to the
-agent's current endpoint, so there is no domain to seize and no DNS to
+`serviceEndpoint` you fetch over DNS and HTTPS. In identity-first routing, the
+agent publishes a signed route record under its DID and a resolver maps the DID
+to the agent's current endpoint, so there is no domain to seize and no DNS to
 poison. The key is the constant; the location is dynamic and self-published.
 
 ## Payload preservation
@@ -45,8 +77,7 @@ The message is a `VouchEnvelope` that carries three things unchanged: the
 signed Vouch credential (with its Data Integrity proof), liability
 attestations, and provenance metadata. A JCS-canonical SHA-256 content
 digest is verified on receipt, so the trust properties hold whichever path
-the bytes take. Switching from UDNA to HTTP never re-signs or strips the
-payload.
+the bytes take. Switching transports never re-signs or strips the payload.
 
 ## Quick start
 
@@ -73,9 +104,27 @@ result = await manager.dispatch(envelope)
 print(result.transport)   # "udna" or "http"
 ```
 
-Install the optional dependency with `pip install vouch-protocol[udna]`.
-Without it, the UDNA transport stays dormant and dispatch falls through to
-HTTP, so the code above runs unchanged.
+To reach an agent by DID over a rendezvous instead of did:web:
+
+```python
+from vouch.transport import (
+    HttpRendezvousResolver, HttpRendezvousChannel, build_route_record,
+)
+
+# The agent announces its current inbox, signed under its DID.
+resolver = HttpRendezvousResolver("https://rendezvous.example.com")
+await resolver.announce(build_route_record(
+    did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_ed25519,
+))
+
+# A sender that knows only the DID resolves it and delivers, verifying locally.
+channel = HttpRendezvousChannel(resolver)
+reply = await channel.exchange(f"udna://{agent_did}/vouch.message", frame)
+```
+
+The UDNA SDK is an optional extra (`pip install vouch-protocol[udna]`). Without
+it, the SDK-backed path stays dormant and dispatch falls through to HTTP or the
+rendezvous, so the code above runs unchanged.
 
 ## Security note
 
@@ -90,6 +139,6 @@ encryption.
 
 ## See also
 
-- `docs/HYBRID_TRANSPORT.md` for the architecture.
-- `docs/udna-upstream-proposal.md` for the security finding and a proposed
-  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).
+- `docs/HYBRID_TRANSPORT.md` for the architecture and the rendezvous resolver.
+- `docs/udna-upstream-proposal.md` for interoperability notes, including the
+  handshake confidentiality finding and an ephemeral-X25519-with-HKDF approach.

--- a/docs/HYBRID_TRANSPORT.md
+++ b/docs/HYBRID_TRANSPORT.md
@@ -172,6 +172,77 @@ print(result.attempts)    # e.g. ["udna", "http"], the fallback path taken
 A runnable, network-free demo lives at
 [`examples/hybrid_transport_demo.py`](../examples/hybrid_transport_demo.py).
 
+## Identity-first routing: the rendezvous resolver
+
+`did:web` answers "where is this domain." It cannot answer the question an agent
+actually has, "where is this identity right now," without a domain and DNS. The
+rendezvous resolver answers it directly: an agent binds its DID to a current
+endpoint, signs that binding with the DID's own key, and publishes it. A sender
+that knows only the DID resolves it to the live endpoint and verifies the agent
+itself asserted the route. The contract is announce, resolve, verify, deliver.
+
+The unit of trust is the `RouteRecord`: a small signed object binding a DID to
+an endpoint, a facet, and an expiry. The signature covers everything but itself,
+so the record is self-authenticating; the verifier recovers the public key from
+the DID (`did:key`) and checks it, with no network lookup. The routing key on
+the wire is `sha256(did)`, so a lookup never leaks the DID itself.
+
+Two backends ship, behind the same record format and the same verification:
+
+- **In-memory (`RendezvousRegistry`, `RendezvousChannel`).** The simplest thing
+  that proves the contract end to end, with no network and no server. Useful for
+  tests, single-process deployments, and as the reference for the record format.
+  Demo: [`examples/udna_rendezvous_demo.py`](../examples/udna_rendezvous_demo.py).
+
+- **Deployable HTTPS (`RendezvousService`, `build_rendezvous_app`,
+  `HttpRendezvousResolver`, `HttpRendezvousChannel`).** The same contract over
+  commodity infrastructure: a small HTTPS service any operator can run, and a
+  client that announces and resolves over TLS. `HttpRendezvousChannel` completes
+  the path, resolving a `udna://` address to the agent's announced `https://`
+  inbox and delivering the sealed envelope there, so identity-first routing works
+  today with no DNS binding the agent to a location.
+
+The rendezvous is **untrusted**. It stores and serves signed records but never
+has to be believed: the client re-verifies every record's signature locally and
+checks that the record's DID is the one it asked for. A malicious or compromised
+rendezvous can withhold a record or serve a stale one, but it cannot forge a
+route or substitute another identity's, because it does not hold the agent's
+Ed25519 key. That is the property that lets the resolver run on a host the agent
+does not control, and it is why the single fixed host (the rendezvous) does not
+become a single point of trust.
+
+The lookup here is a single rendezvous, deliberately not a distributed hash
+table. Swapping it for a real overlay (a Kademlia DHT, libp2p, or UDNA's DHT
+when it lands) is a later step that reuses this record format and verification
+unchanged, and plugs in behind the same `UdnaChannel` seam. Run the deployable
+path, network-free, at
+[`examples/http_rendezvous_demo.py`](../examples/http_rendezvous_demo.py).
+
+```python
+from vouch.transport import (
+    HttpRendezvousResolver, HttpRendezvousChannel, build_route_record,
+)
+
+# The agent announces its current inbox, signed under its DID.
+resolver = HttpRendezvousResolver("https://rendezvous.example.com")
+await resolver.announce(build_route_record(
+    did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_ed25519,
+))
+
+# A sender that knows only the DID resolves it and delivers, verifying locally.
+channel = HttpRendezvousChannel(resolver)
+reply = await channel.exchange(f"udna://{agent_did}/vouch.message", frame)
+```
+
+To run the rendezvous itself, mount the FastAPI app under any ASGI server:
+
+```python
+import uvicorn
+from vouch.transport import build_rendezvous_app
+
+uvicorn.run(build_rendezvous_app(), host="0.0.0.0", port=8080)
+```
+
 ## Extending
 
 To add a transport (libp2p, Tor, a message bus), subclass `Transport`,

--- a/docs/disclosures/PAD-074-trust-preserving-transport-failover.md
+++ b/docs/disclosures/PAD-074-trust-preserving-transport-failover.md
@@ -1,0 +1,209 @@
+# PAD-074: Trust-Preserving Multi-Transport Failover for Liability-Bearing Credential Envelopes
+
+**Identifier:** PAD-074  
+**Title:** Method for Delivering a Self-Protecting Credential Envelope Across Heterogeneous Transports Selected at Runtime, in Which the Same Envelope Is Handed Byte-for-Byte to Whichever Transport Succeeds and an Integrity-Versus-Availability Error Taxonomy Forbids Re-Routing a Corrupted Payload, So the Trust Properties Are Invariant Under Failover  
+**Publication Date:** June 30, 2026  
+**Prior Art Effective Date:** June 30, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Agent Identity / Transport / Verifiable Credentials / Liability  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-002 (Chain of Custody), PAD-003 (Identity Sidecar), PAD-075 (Untrusted-Resolver Identity Routing)  
+
+---
+
+## 1. Abstract
+
+A method for moving a trust-bearing message between autonomous agents over more
+than one network transport, chosen at the moment of delivery, without ever
+weakening the message's trust properties. The message is a self-protecting
+envelope that carries a signed Verifiable Credential, one or more liability
+attestations, and provenance metadata, together with a canonical content digest
+over that payload. A dispatcher holds an ordered set of transports (for example
+an identity-first overlay and a location-first DNS/HTTPS path) and hands the
+**same** envelope, byte-for-byte, to whichever transport can reach the peer.
+Delivery distinguishes two failure classes: a transport-availability failure is
+recoverable and advances to the next transport, while a payload-integrity
+failure is fatal and stops delivery, so a corrupted or tampered envelope is never
+re-routed across transports in search of one that will accept it.
+
+Key innovations:
+
+- **Trust carried by the payload, not the channel.** The cryptographic
+  properties (integrity, authenticity, accountability) live in the signed
+  envelope, so they do not depend on which transport carries the bytes. Failover
+  is a pure reachability operation and cannot change the security posture.
+- **Byte-identical handoff across transports.** The winning transport receives
+  the exact envelope produced once at the source. Failover never re-signs,
+  re-wraps, re-canonicalizes, or strips the credential, attestations, or
+  provenance, so nothing about the trust evidence changes between attempts.
+- **Integrity-versus-availability error taxonomy.** Delivery classifies failures
+  as either "transport unavailable" (try the next transport) or "payload
+  integrity violated" (stop immediately and never re-route). A corrupted payload
+  cannot be laundered by trying another channel.
+- **Liability and provenance travel with the credential.** The envelope binds
+  the accountability evidence (who is answerable, and the origin trail) to the
+  same digest as the credential, so an intermediary cannot deliver the credential
+  while dropping the attestations that make the actor accountable.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Channel-rooted trust breaks under failover
+
+Conventional secure delivery roots trust in the channel: TLS, a libp2p secure
+stream, or an overlay's encrypted session. When an agent must reach a peer over
+whichever path happens to be available, channel-rooted trust forces a separate
+trust negotiation per transport, and the security posture silently varies with
+the path actually taken. Two transports with different channel guarantees give
+the same message two different trust stories.
+
+### 2.2 Agents are multi-homed and ephemeral
+
+Autonomous agents move across hosts and clouds, are reachable sometimes by a
+stable domain and sometimes only by identity, and frequently fail over between
+paths within a single conversation. A delivery layer that must be reconfigured,
+or that changes the message, on each path is fragile exactly where agents operate.
+
+### 2.3 Failover can launder a bad payload
+
+A naive failover loop that simply tries the next transport on any error will,
+on a payload that fails an integrity check at one endpoint, keep trying other
+endpoints until one accepts it. Without distinguishing "could not reach" from
+"payload is corrupt," failover becomes an oracle that searches for a transport
+willing to take a tampered message.
+
+### 2.4 Stripping accountability in transit
+
+When liability and provenance are carried separately from the credential, an
+intermediary can forward the credential while quietly dropping the attestations
+that make the actor answerable, leaving an authentic-looking but unaccountable
+message.
+
+---
+
+## 3. Solution (The Invention)
+
+A source agent builds a single envelope object that wraps the signed credential
+as its payload and carries, alongside it, the liability attestations, the
+provenance metadata, an envelope version, and a content digest computed as a
+SHA-256 over the RFC 8785 (JCS) canonical form of the payload. The envelope is
+produced once.
+
+A transport manager holds an ordered list of transports, each implementing a
+small uniform interface: a cheap pre-filter that says whether it can route a
+given DID, a resolution step that returns a peer address or declines, and a send
+step. For a given envelope the manager walks the list: it skips a transport whose
+pre-filter declines, skips a transport whose resolution declines (the peer is not
+reachable that way), and otherwise attempts the send. The exact same envelope
+instance is passed to whichever transport attempts delivery.
+
+Failures are typed. A transport that cannot reach the peer raises a recoverable
+"transport unavailable" condition, and the manager advances to the next
+transport, recording the attempt so the delivery result reports the path taken
+(for example, identity-first first, then DNS/HTTPS). A failure that indicates the
+payload's integrity is in question raises a fatal "payload integrity" condition,
+and the manager stops at once and does not try any further transport. If every
+transport is exhausted by availability failures, the manager raises a terminal
+error carrying the last cause.
+
+Because the trust evidence is entirely inside the signed envelope and the digest
+is verifiable on receipt, a receiver validates the message identically no matter
+which transport delivered it, and switching transports is provably incapable of
+altering the credential, the attestations, or the provenance.
+
+---
+
+## 4. Prior Art Differentiation
+
+Connection-level failover (happy-eyeballs across IPv4/IPv6, QUIC-to-TCP
+fallback, libp2p multistream transport selection) and signed messages over a
+retrying transport (S/MIME over SMTP) are established prior art. This disclosure
+does **not** claim transport failover or message signing in general. What is
+differentiated is their composition for accountable agent messaging:
+
+- **Trust invariance under failover, not connection liveness.** Existing failover
+  selects a working connection and roots trust in that connection's channel
+  security. Here trust is carried by the payload and is therefore invariant
+  across whichever transport wins; the channel is reduced to a pure reachability
+  concern. The protected property is that failover cannot change the security
+  posture, which connection-level failover does not provide.
+- **Integrity-versus-availability error taxonomy governing failover.** The
+  delivery loop is explicitly forbidden from re-routing on a payload-integrity
+  failure and only advances on a reachability failure. Generic retry/failover
+  loops do not make this distinction and can re-route a corrupted payload.
+- **A single byte-identical envelope across heterogeneous transports.** The
+  message is produced once and handed unchanged to an identity-first overlay or a
+  location-first DNS/HTTPS path alike, with no per-transport re-signing or
+  re-wrapping. Multi-transport stacks typically re-frame the message per
+  transport.
+- **Liability and provenance bound to the credential digest.** The envelope binds
+  accountability evidence to the same canonical digest as the credential, so an
+  intermediary cannot deliver the credential while stripping the attestations.
+  Signed-email and signed-payload schemes carry a signature over content but not a
+  co-bound liability-and-provenance composite with this digest discipline.
+
+### Relationship to UDNA
+
+The identity-first transport used as one of the failover options may be UDNA
+(Universal DID-Native Addressing) or any other overlay. This disclosure does not
+claim DID-as-routing-primitive, the DID-fingerprint routing key, or the facet
+model, which are UDNA's. The claimed method is the transport-agnostic,
+trust-preserving failover discipline and its error taxonomy, which sit above any
+particular overlay and apply equally to DNS/HTTPS.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation ships in the Python SDK under `vouch.transport`:
+`VouchEnvelope` / `build_envelope` produce the self-protecting envelope with an
+`ENVELOPE_VERSION` and a JCS SHA-256 content digest over the payload;
+`TransportManager.dispatch` performs the ordered walk and returns a
+`DeliveryResult` carrying the winning transport name and the `attempts` path; the
+`Transport` abstract base defines the `can_route` / `resolve` / `send` interface;
+`TransportUnavailable` is the recoverable condition that advances failover and
+`PayloadIntegrityError` is the fatal condition that stops it; `TransportError`
+carries the terminal cause when all transports are exhausted. Two transports ship
+(`UdnaTransport` identity-first, `HttpTransport` did:web over DNS/HTTPS), and a
+deployable HTTPS rendezvous path is available; all use the same envelope and the
+same digest, so the trust properties hold whichever delivers the bytes. The
+canonicalization and digest reuse the SDK's shared JCS path, so an envelope is
+verified identically across language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for delivering a trust-bearing message between agents in which a
+   single envelope carrying a signed credential, one or more liability
+   attestations, and provenance, together with a canonical content digest over
+   that payload, is handed byte-for-byte to whichever of an ordered set of
+   runtime-selected transports succeeds, so the trust properties are invariant
+   under the choice of transport.
+2. The method of claim 1 wherein delivery distinguishes a recoverable
+   transport-availability failure, which advances to the next transport, from a
+   fatal payload-integrity failure, which stops delivery, so a corrupted payload
+   is never re-routed.
+3. The method of claim 1 wherein the trust evidence is carried entirely within
+   the signed envelope so that a receiver validates the message identically
+   regardless of which transport delivered it.
+4. The method of claim 1 wherein the ordered set includes an identity-first
+   transport that routes by a decentralized identifier and a location-first
+   transport that resolves a domain over DNS and HTTPS, and the delivery result
+   records the sequence of transports attempted.
+5. The method of claim 1 wherein the liability attestations and provenance are
+   bound to the same canonical digest as the credential, so an intermediary
+   cannot deliver the credential while stripping the accountability evidence.
+6. The method of claim 1 wherein the envelope canonicalization and digest are
+   shared across language SDKs, so the same envelope verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/PAD-075-untrusted-resolver-identity-routing.md
+++ b/docs/disclosures/PAD-075-untrusted-resolver-identity-routing.md
@@ -1,0 +1,208 @@
+# PAD-075: Untrusted-Resolver Identity Routing via Self-Signed Route Records with Anti-Substitution Binding
+
+**Identifier:** PAD-075  
+**Title:** Method for Reaching an Agent by Its Decentralized Identifier in Which the Agent Self-Signs a Record Binding Its Identifier to a Current Network Endpoint, the Resolving Infrastructure Is Treated as an Untrusted Cache, and the Requesting Party Re-Verifies the Record and Confirms Its Subject Equals the Queried Identifier, So a Resolver Can Neither Forge a Route Nor Substitute Another Identity's Record  
+**Publication Date:** June 30, 2026  
+**Prior Art Effective Date:** June 30, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Agent Identity / Decentralized Identifiers / Routing / Trust  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-005 (Detached Signature Recovery), PAD-074 (Trust-Preserving Transport Failover)  
+
+---
+
+## 1. Abstract
+
+A method for resolving an autonomous agent's decentralized identifier (DID) to
+the network endpoint at which it can currently be reached, without DNS, without
+the agent owning a domain, and without trusting the resolving infrastructure. The
+agent publishes a compact route record that binds its DID to a current endpoint,
+an optional capability lane, an expiry, and a nonce, and signs the record with
+the DID's own key. The resolving infrastructure, whether a single rendezvous
+service, a registry, or a distributed overlay, is treated as an untrusted cache:
+it may withhold, delay, or replay a record but is never believed. On resolving,
+the requesting party re-verifies the record's signature against the key recovered
+from the DID and, critically, confirms that the record's subject DID equals the
+DID it queried for. A resolver therefore cannot forge a route, and cannot answer
+a query for one identity with a different identity's validly-signed record.
+
+Key innovations:
+
+- **Self-signed route, not authority-signed.** The agent asserts its own location
+  by signing the binding with its identity key, so the record is self-certifying;
+  no naming authority, registrar, or zone signs on the agent's behalf.
+- **Untrusted resolving infrastructure.** The resolver is explicitly modeled as a
+  cache that cannot be believed. Security does not depend on the honesty or
+  integrity of the host that stores and serves records, which lets the resolver
+  run on infrastructure the agent does not control.
+- **Anti-substitution binding to the queried identifier.** Re-verification checks
+  not only that the record is validly signed but that its subject equals the
+  identifier the caller asked for, defeating an infrastructure that returns
+  another identity's genuine record in response to a query.
+- **Bounded freshness via signed expiry and nonce.** The expiry and nonce are
+  inside the signed body, so a stale or replayed record is detectable and is
+  rejected on read as well as on write.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 The identifier is a key store, not a location
+
+A DID Document answers "what is this identity's public key," not "where is this
+identity right now." `did:web` recovers a location only by borrowing DNS and a
+domain, which ephemeral agents rarely hold and which reintroduces a seizable,
+poisonable naming authority. The location an agent actually needs is dynamic and
+self-asserted, not delegated to a registrar.
+
+### 2.2 Trusting the resolver reintroduces the problem it solves
+
+A directory that maps identifiers to endpoints is only as honest as its operator.
+If the resolver is trusted, it becomes a single point that can redirect any agent
+to an endpoint of its choosing, which is the same seizure-and-poisoning risk that
+identity-first routing set out to remove.
+
+### 2.3 A valid signature is not enough
+
+Re-verifying that a returned record is validly signed is necessary but not
+sufficient. A malicious resolver can hold many genuine, validly-signed records
+and answer a query for identity A with identity B's record. Unless the caller
+binds the answer to the identifier it asked for, signature checking alone does not
+prevent substitution.
+
+### 2.4 Stale and replayed routes
+
+An endpoint binding is time-sensitive: agents move. A record with no signed
+freshness bound can be replayed by infrastructure long after the agent has moved,
+directing traffic to a dead or reassigned endpoint.
+
+---
+
+## 3. Solution (The Invention)
+
+An agent constructs a route record with its DID, a current endpoint, an optional
+capability-lane selector, an expiry, and a fresh nonce, and signs the canonical
+(JCS) form of that body with the Ed25519 key behind its DID. The signature covers
+every field but itself, so the record is tamper-evident and self-authenticating.
+
+To publish, the agent hands the record to resolving infrastructure: a single
+rendezvous service, a registry, or a distributed overlay. The infrastructure
+verifies the record on write (rejecting anything not validly self-signed or
+already expired) purely as hygiene, but no party relies on it having done so. The
+record is indexed under a one-way fingerprint of the DID so the identifier itself
+need not appear in a lookup key or URL.
+
+To resolve, a requesting party computes the same fingerprint for the DID it wants,
+fetches the record, and then performs the verification that actually matters,
+independent of and not trusting the infrastructure:
+
+1. recover the public key from the DID and verify the record's signature;
+2. confirm the record has not expired;
+3. confirm the record's subject DID is exactly the DID that was queried.
+
+Only if all three hold does the caller use the endpoint. Because step 3 binds the
+answer to the question, an infrastructure that serves a different identity's
+genuine record is caught; because steps 1 and 2 are done by the caller, an
+infrastructure that forges or replays is caught. The same record format and the
+same three-step verification apply whether the infrastructure is an in-memory
+rendezvous, an HTTPS service, or a distributed overlay, so the resolver can be
+swapped without changing the trust argument.
+
+---
+
+## 4. Prior Art Differentiation
+
+Self-certifying names (SFS), IPNS, DNSSEC, and DID resolution methods that publish
+to a distributed store (for example DHT-published DID Documents) are established
+prior art. This disclosure does **not** claim self-certifying identifiers, signed
+name records, or DHT publication in general. What is differentiated is the
+combination that makes the resolving infrastructure untrusted for agent endpoint
+routing:
+
+- **Authority model: the identity signs its own route.** DNSSEC records are signed
+  by the zone authority, and the resolver trust chain is rooted in that hierarchy.
+  Here the named identity itself signs the endpoint binding and no authority signs
+  on its behalf, so there is no naming authority to trust or seize.
+- **Explicit untrusted-resolver threat model with anti-substitution.** Self-
+  certifying and DHT-published schemes establish that a record is authentic, but
+  do not, as a defined verification step, bind the served record to the exact
+  identifier the caller queried. The disclosed method makes "subject equals
+  queried identifier" a mandatory verification step precisely to defeat a resolver
+  that substitutes another identity's genuine record. This is the non-obvious
+  addition when the resolver is assumed hostile.
+- **Endpoint-route attestation, not content addressing or document publication.**
+  IPNS binds a key to content; DID-Document publication serves a document. The
+  unit here is a compact, freshness-bound endpoint route for reaching a live
+  agent, designed to be re-verified per resolution and composed with an
+  accountability-bearing message envelope (see PAD-074).
+- **Resolver as interchangeable untrusted cache.** Because the trust argument is
+  entirely on the caller's side, the same record and verification hold across an
+  in-memory rendezvous, an HTTPS service, or a distributed overlay, and the
+  infrastructure may run on hosts the agent does not control.
+
+### Relationship to UDNA
+
+This method is designed to run on, and interoperate with, UDNA (Universal
+DID-Native Addressing). It does **not** claim UDNA's primitives: DID-as-routing-
+primitive, the `sha256(did)` fingerprint used as the routing key, and the
+capability-lane (facet) model are UDNA's, and the disclosed method adopts them for
+interoperability rather than claiming them. What is claimed is the untrusted-
+resolver verification model, the self-signed endpoint-route attestation, and the
+anti-substitution binding to the queried identifier, which are independent of any
+particular overlay and apply equally to a single rendezvous or to DNS-free HTTPS
+resolution.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation ships in the Python SDK under `vouch.transport`:
+`RouteRecord` and `build_route_record` produce and self-sign the binding (DID,
+endpoint, facet, expiry, nonce) over the shared JCS canonical form; `RouteRecord.
+verify` performs the three-step check (signature against the key recovered from
+the `did:key`, non-expiry, and subject equality enforced by the caller via the
+queried DID); `route_fingerprint` computes the one-way DID fingerprint used as the
+lookup key. Two interchangeable resolvers ship behind one record format:
+`RendezvousRegistry` / `RendezvousChannel` in memory, and a deployable HTTPS
+rendezvous (`RendezvousService` / `build_rendezvous_app` server,
+`HttpRendezvousResolver` / `HttpRendezvousChannel` client) in which the client
+re-verifies every served record and rejects any whose subject differs from the
+queried DID. Outbound endpoints are screened for SSRF before use. The resolved
+route then carries a `VouchEnvelope`, so the trust evidence is preserved end to
+end regardless of the resolver.
+
+---
+
+## 6. Claims Summary
+
+1. A method for reaching an agent by its decentralized identifier in which the
+   agent signs, with the key behind that identifier, a record binding the
+   identifier to a current network endpoint with a signed expiry, and resolving
+   infrastructure stores and serves the record without being trusted.
+2. The method of claim 1 wherein the requesting party, on resolving, recovers the
+   public key from the identifier, verifies the record's signature, confirms the
+   record is unexpired, and confirms the record's subject identifier equals the
+   identifier queried, before using the endpoint.
+3. The method of claim 2 wherein confirming the subject equals the queried
+   identifier defeats infrastructure that answers a query for one identity with
+   another identity's validly-signed record.
+4. The method of claim 1 wherein the record is indexed under a one-way function of
+   the identifier so the identifier does not appear in the lookup key, and the
+   record carries a nonce within the signed body to bound replay.
+5. The method of claim 1 wherein the same record format and verification apply
+   across an in-memory rendezvous, a hosted service, and a distributed overlay, so
+   the resolving infrastructure is interchangeable and may run on hosts the agent
+   does not control.
+6. The method of claim 1 wherein the resolved endpoint carries a self-protecting
+   credential envelope, so the message's integrity, authenticity, and
+   accountability hold independently of the resolver and the transport.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -79,6 +79,24 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-069](./PAD-069-confidential-tamper-evident-robot-blackbox.md) | Confidential, Tamper-Evident Robot Black-Box with Separable Confidentiality and Integrity | 2026-06-15 | Published |
 | [PAD-070](./PAD-070-scannable-offline-robot-passport.md) | Self-Contained, Offline-Verifiable Robot Passport for Physical-World Scanning | 2026-06-15 | Published |
 | [PAD-071](./PAD-071-outcome-evidence-commit-before-outcome-credential.md) | Commit-Before-Outcome Verdict Credential with Neutral-Settler Outcome Attestation | 2026-06-17 | Published |
+| [PAD-074](./PAD-074-trust-preserving-transport-failover.md) | Trust-Preserving Multi-Transport Failover for Liability-Bearing Credential Envelopes | 2026-06-30 | Published |
+| [PAD-075](./PAD-075-untrusted-resolver-identity-routing.md) | Untrusted-Resolver Identity Routing via Self-Signed Route Records with Anti-Substitution Binding | 2026-06-30 | Published |
+
+
+## June 30, 2026: Identity-First Transport Primitives (PAD-074, PAD-075)
+
+Two disclosures covering the `vouch.transport` identity-first routing layer.
+PAD-074 is a trust-preserving multi-transport failover discipline: a
+self-protecting envelope carrying a credential, liability attestations, and
+provenance is handed byte-for-byte to whichever transport succeeds, with an
+integrity-versus-availability error taxonomy that forbids re-routing a corrupted
+payload, so the trust posture is invariant under failover. PAD-075 is an
+untrusted-resolver routing model: an agent self-signs a record binding its DID to
+a current endpoint, and the requesting party re-verifies the record and confirms
+its subject equals the queried DID, so resolving infrastructure can neither forge
+a route nor substitute another identity's record. Both build on, and explicitly
+do not claim, UDNA's DID-as-routing-primitive, fingerprint scheme, and facet
+model.
 
 
 ## June 17, 2026: Commit-Before-Outcome Verdict Evidence (PAD-071)

--- a/examples/http_rendezvous_demo.py
+++ b/examples/http_rendezvous_demo.py
@@ -1,0 +1,121 @@
+"""
+Vouch Protocol: identity-first routing over commodity HTTPS.
+
+The rendezvous resolver, made deployable. An agent announces a signed route
+under its did:key to an HTTPS rendezvous; a sender that knows only the DID
+resolves it to the agent's current inbox and delivers a sealed envelope. No DNS
+binds the agent to a location, and the rendezvous is never trusted: the sender
+re-verifies the signed record itself, so a lying rendezvous cannot forge a route.
+
+This runs the real client against the real server logic over an in-process
+transport, so it needs no network and no running server.
+
+Run:  python examples/http_rendezvous_demo.py
+"""
+
+import asyncio
+import json
+
+import httpx
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Signer, generate_identity
+from vouch.transport import (
+    HttpRendezvousChannel,
+    HttpRendezvousResolver,
+    RendezvousService,
+    build_envelope,
+    build_route_record,
+    route_fingerprint,
+    udna_address,
+)
+from vouch.transport.did_key import did_key_from_public_jwk
+from vouch.transport.http_rendezvous import RECORDS_PATH
+
+
+def _priv(private_key_jwk: str) -> Ed25519PrivateKey:
+    seed = base64url_decode(json.loads(private_key_jwk)["d"])
+    return Ed25519PrivateKey.from_private_bytes(seed)
+
+
+async def main():
+    print("\nIdentity-first routing over HTTPS (no DNS, untrusted rendezvous)\n" + "=" * 62)
+
+    agent = generate_identity()
+    agent_did = did_key_from_public_jwk(agent.public_key_jwk)
+    agent_priv = _priv(agent.private_key_jwk)
+    print(f"Agent DID:    {agent_did[:40]}...")
+    print(
+        f"Routing key:  {route_fingerprint(agent_did)[:16]}...  (sha256 of the DID, sent on the wire)"
+    )
+
+    service = RendezvousService()
+    received = {}
+
+    # One in-process transport stands in for both the rendezvous and the agent's
+    # HTTPS inbox, so the demo needs no open ports.
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path == RECORDS_PATH:
+            status, body = service.put(json.loads(request.content))
+            return httpx.Response(204) if status == 204 else httpx.Response(status, json=body)
+        if request.method == "GET" and path.startswith(RECORDS_PATH + "/"):
+            fingerprint = path.rsplit("/", 1)[1]
+            facet = request.url.params.get("facet", "vouch.message")
+            status, body = service.get(fingerprint, facet)
+            return httpx.Response(status, json=body)
+        if request.method == "POST" and path == "/inbox":
+            received["frame"] = request.content
+            print(
+                f"   agent inbox received envelope for {json.loads(request.content)['to'][:32]}..."
+            )
+            return httpx.Response(200, json={"status": "delivered"})
+        return httpx.Response(404)
+
+    client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    resolver = HttpRendezvousResolver(
+        "https://rv.example.com", client=client, validate_target=False
+    )
+    channel = HttpRendezvousChannel(resolver, client=client, validate_endpoint=False)
+
+    # 1. The agent announces its current HTTPS inbox, signed under its DID.
+    record = build_route_record(
+        did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_priv
+    )
+    await resolver.announce(record)
+    print("\n[1] Agent announced a signed route to the rendezvous")
+    print(f"    endpoint:  {record.endpoint}")
+    print(f"    signature: {record.signature[:20]}...  (Ed25519 over the record)")
+
+    # 2. A sender that knows only the DID resolves it, with no DNS.
+    addr = udna_address(agent_did)
+    print("\n[2] Sender resolves the DID over HTTPS, verifying the record itself")
+    print(f"    udna address: {addr[:48]}...")
+    print(f"    resolved to:  {await resolver.resolve(agent_did)}")
+    print(f"    reachable:    {await channel.reachable(addr)}")
+
+    # 3. Deliver a sealed Vouch envelope over the resolved route.
+    signer = Signer(private_key=agent.private_key_jwk, did="did:web:sender.example.com")
+    credential = signer.sign_credential(
+        intent={
+            "action": "settle_invoice",
+            "target": "invoice-42",
+            "resource": "https://api.example.com/invoices/42",
+        }
+    )
+    envelope = build_envelope(
+        from_did="did:web:sender.example.com", to_did=agent_did, payload=credential
+    )
+    print("\n[3] Sender delivers a sealed envelope over the resolved HTTPS route")
+    reply = await channel.exchange(addr, json.dumps(envelope.to_wire()).encode("utf-8"))
+    print(f"    reply: {json.loads(reply)}")
+    delivered = json.loads(received["frame"])
+    print(f"    proof preserved end to end: {delivered['payload']['proof'] == credential['proof']}")
+
+    await channel.close()
+    print("\nDone.\n")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/gemini-gem/knowledge/transport.md
+++ b/gemini-gem/knowledge/transport.md
@@ -1,13 +1,16 @@
 # Identity-Native Transport Reference
 
 Vouch addresses a peer by its DID, not its IP or domain. The transport
-layer (`vouch.transport`) prefers identity-first routing over UDNA
-(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
-when a peer is not on the overlay. An agent dispatches a message to a DID
-and stays agnostic about how the bytes are routed.
+layer (`vouch.transport`) routes a message to an identity and stays agnostic
+about how the bytes get there. It ships its own identity-first resolver that
+works today over commodity HTTPS, builds on UDNA (Universal DID-Native
+Addressing) as a general identity-native substrate when one is present, and
+falls back to standard DNS and HTTPS for any `did:web` peer.
 
-This is optional and experimental. It is aligned with the W3C UDNA
-Community Group and is dormant unless you opt in.
+This is optional. The identity-first path is opt-in, and the HTTP fallback
+means an agent is always reachable. Vouch develops the resolver in the open
+and tracks the W3C UDNA Community Group so the two interoperate as UDNA's
+baseline lands.
 
 ## Why it exists
 
@@ -15,28 +18,57 @@ Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
 They rarely hold a stable domain or IP, but they always hold a key, so a
 DID is the only stable handle. Identity-first routing matches how agents
 actually run. Vouch already makes a DID accountable (identity, reputation,
-liability); UDNA answers how to reach it.
+liability); the transport layer answers how to reach it.
 
 ## How it routes
 
 `TransportManager` holds an ordered list of transports and tries them in
 preference order:
 
-1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+1. Identity-first routing (resolve the DID to the agent's current endpoint)
+   when the peer has published a route.
 2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
 
 A transport that cannot reach a peer raises `TransportUnavailable`, and the
 manager moves to the next one. `DeliveryResult.attempts` records the path
 taken, for example `["udna", "http"]`.
 
+## Reaching an agent by DID, today
+
+`did:web` answers "where is this domain." It cannot answer the question an
+agent actually has, "where is this identity right now," without a domain and
+DNS. The rendezvous resolver answers it directly, and it ships now:
+
+- An agent binds its DID to a current endpoint, signs that binding with the
+  DID's own key (a `RouteRecord`), and publishes it.
+- A sender that knows only the DID resolves it to the live endpoint and
+  verifies that the agent itself asserted the route.
+- The routing key on the wire is `sha256(did)`, so a lookup never leaks the
+  DID itself.
+
+Two backends ship behind the same record format and the same verification: an
+in-memory resolver for tests and single-process use, and a deployable HTTPS
+rendezvous (`RendezvousService` / `build_rendezvous_app` on the server,
+`HttpRendezvousResolver` / `HttpRendezvousChannel` on the client) that runs the
+whole path over plain HTTPS with no DNS binding the agent to a location.
+
+The rendezvous is untrusted. It stores and serves signed records but never has
+to be believed: the client re-verifies every record's signature locally and
+checks the record's DID against the one it asked for. A malicious or
+compromised rendezvous can withhold a record or serve a stale one, but it
+cannot forge a route or substitute another identity's, because it does not hold
+the agent's key. Swapping the single rendezvous for a real overlay (libp2p, or
+UDNA's DHT when its baseline lands) reuses this record format and verification
+unchanged and plugs in behind the same channel seam.
+
 ## What "route by DID" means
 
 The DID Document (the json with the DID and public key) is a key store, not
 a routing target. Its job is to give you the public key so you can verify
 signatures. Location comes from elsewhere. In `did:web`, the location is a
-`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
-a signed route record under its DID, and a resolver maps the DID to the
-agent's current endpoint, so there is no domain to seize and no DNS to
+`serviceEndpoint` you fetch over DNS and HTTPS. In identity-first routing, the
+agent publishes a signed route record under its DID and a resolver maps the DID
+to the agent's current endpoint, so there is no domain to seize and no DNS to
 poison. The key is the constant; the location is dynamic and self-published.
 
 ## Payload preservation
@@ -45,8 +77,7 @@ The message is a `VouchEnvelope` that carries three things unchanged: the
 signed Vouch credential (with its Data Integrity proof), liability
 attestations, and provenance metadata. A JCS-canonical SHA-256 content
 digest is verified on receipt, so the trust properties hold whichever path
-the bytes take. Switching from UDNA to HTTP never re-signs or strips the
-payload.
+the bytes take. Switching transports never re-signs or strips the payload.
 
 ## Quick start
 
@@ -73,9 +104,27 @@ result = await manager.dispatch(envelope)
 print(result.transport)   # "udna" or "http"
 ```
 
-Install the optional dependency with `pip install vouch-protocol[udna]`.
-Without it, the UDNA transport stays dormant and dispatch falls through to
-HTTP, so the code above runs unchanged.
+To reach an agent by DID over a rendezvous instead of did:web:
+
+```python
+from vouch.transport import (
+    HttpRendezvousResolver, HttpRendezvousChannel, build_route_record,
+)
+
+# The agent announces its current inbox, signed under its DID.
+resolver = HttpRendezvousResolver("https://rendezvous.example.com")
+await resolver.announce(build_route_record(
+    did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_ed25519,
+))
+
+# A sender that knows only the DID resolves it and delivers, verifying locally.
+channel = HttpRendezvousChannel(resolver)
+reply = await channel.exchange(f"udna://{agent_did}/vouch.message", frame)
+```
+
+The UDNA SDK is an optional extra (`pip install vouch-protocol[udna]`). Without
+it, the SDK-backed path stays dormant and dispatch falls through to HTTP or the
+rendezvous, so the code above runs unchanged.
 
 ## Security note
 
@@ -90,6 +139,6 @@ encryption.
 
 ## See also
 
-- `docs/HYBRID_TRANSPORT.md` for the architecture.
-- `docs/udna-upstream-proposal.md` for the security finding and a proposed
-  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).
+- `docs/HYBRID_TRANSPORT.md` for the architecture and the rendezvous resolver.
+- `docs/udna-upstream-proposal.md` for interoperability notes, including the
+  handshake confidentiality finding and an ephemeral-X25519-with-HKDF approach.

--- a/openai-gpt/knowledge/transport.md
+++ b/openai-gpt/knowledge/transport.md
@@ -1,13 +1,16 @@
 # Identity-Native Transport Reference
 
 Vouch addresses a peer by its DID, not its IP or domain. The transport
-layer (`vouch.transport`) prefers identity-first routing over UDNA
-(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
-when a peer is not on the overlay. An agent dispatches a message to a DID
-and stays agnostic about how the bytes are routed.
+layer (`vouch.transport`) routes a message to an identity and stays agnostic
+about how the bytes get there. It ships its own identity-first resolver that
+works today over commodity HTTPS, builds on UDNA (Universal DID-Native
+Addressing) as a general identity-native substrate when one is present, and
+falls back to standard DNS and HTTPS for any `did:web` peer.
 
-This is optional and experimental. It is aligned with the W3C UDNA
-Community Group and is dormant unless you opt in.
+This is optional. The identity-first path is opt-in, and the HTTP fallback
+means an agent is always reachable. Vouch develops the resolver in the open
+and tracks the W3C UDNA Community Group so the two interoperate as UDNA's
+baseline lands.
 
 ## Why it exists
 
@@ -15,28 +18,57 @@ Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
 They rarely hold a stable domain or IP, but they always hold a key, so a
 DID is the only stable handle. Identity-first routing matches how agents
 actually run. Vouch already makes a DID accountable (identity, reputation,
-liability); UDNA answers how to reach it.
+liability); the transport layer answers how to reach it.
 
 ## How it routes
 
 `TransportManager` holds an ordered list of transports and tries them in
 preference order:
 
-1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+1. Identity-first routing (resolve the DID to the agent's current endpoint)
+   when the peer has published a route.
 2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
 
 A transport that cannot reach a peer raises `TransportUnavailable`, and the
 manager moves to the next one. `DeliveryResult.attempts` records the path
 taken, for example `["udna", "http"]`.
 
+## Reaching an agent by DID, today
+
+`did:web` answers "where is this domain." It cannot answer the question an
+agent actually has, "where is this identity right now," without a domain and
+DNS. The rendezvous resolver answers it directly, and it ships now:
+
+- An agent binds its DID to a current endpoint, signs that binding with the
+  DID's own key (a `RouteRecord`), and publishes it.
+- A sender that knows only the DID resolves it to the live endpoint and
+  verifies that the agent itself asserted the route.
+- The routing key on the wire is `sha256(did)`, so a lookup never leaks the
+  DID itself.
+
+Two backends ship behind the same record format and the same verification: an
+in-memory resolver for tests and single-process use, and a deployable HTTPS
+rendezvous (`RendezvousService` / `build_rendezvous_app` on the server,
+`HttpRendezvousResolver` / `HttpRendezvousChannel` on the client) that runs the
+whole path over plain HTTPS with no DNS binding the agent to a location.
+
+The rendezvous is untrusted. It stores and serves signed records but never has
+to be believed: the client re-verifies every record's signature locally and
+checks the record's DID against the one it asked for. A malicious or
+compromised rendezvous can withhold a record or serve a stale one, but it
+cannot forge a route or substitute another identity's, because it does not hold
+the agent's key. Swapping the single rendezvous for a real overlay (libp2p, or
+UDNA's DHT when its baseline lands) reuses this record format and verification
+unchanged and plugs in behind the same channel seam.
+
 ## What "route by DID" means
 
 The DID Document (the json with the DID and public key) is a key store, not
 a routing target. Its job is to give you the public key so you can verify
 signatures. Location comes from elsewhere. In `did:web`, the location is a
-`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
-a signed route record under its DID, and a resolver maps the DID to the
-agent's current endpoint, so there is no domain to seize and no DNS to
+`serviceEndpoint` you fetch over DNS and HTTPS. In identity-first routing, the
+agent publishes a signed route record under its DID and a resolver maps the DID
+to the agent's current endpoint, so there is no domain to seize and no DNS to
 poison. The key is the constant; the location is dynamic and self-published.
 
 ## Payload preservation
@@ -45,8 +77,7 @@ The message is a `VouchEnvelope` that carries three things unchanged: the
 signed Vouch credential (with its Data Integrity proof), liability
 attestations, and provenance metadata. A JCS-canonical SHA-256 content
 digest is verified on receipt, so the trust properties hold whichever path
-the bytes take. Switching from UDNA to HTTP never re-signs or strips the
-payload.
+the bytes take. Switching transports never re-signs or strips the payload.
 
 ## Quick start
 
@@ -73,9 +104,27 @@ result = await manager.dispatch(envelope)
 print(result.transport)   # "udna" or "http"
 ```
 
-Install the optional dependency with `pip install vouch-protocol[udna]`.
-Without it, the UDNA transport stays dormant and dispatch falls through to
-HTTP, so the code above runs unchanged.
+To reach an agent by DID over a rendezvous instead of did:web:
+
+```python
+from vouch.transport import (
+    HttpRendezvousResolver, HttpRendezvousChannel, build_route_record,
+)
+
+# The agent announces its current inbox, signed under its DID.
+resolver = HttpRendezvousResolver("https://rendezvous.example.com")
+await resolver.announce(build_route_record(
+    did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_ed25519,
+))
+
+# A sender that knows only the DID resolves it and delivers, verifying locally.
+channel = HttpRendezvousChannel(resolver)
+reply = await channel.exchange(f"udna://{agent_did}/vouch.message", frame)
+```
+
+The UDNA SDK is an optional extra (`pip install vouch-protocol[udna]`). Without
+it, the SDK-backed path stays dormant and dispatch falls through to HTTP or the
+rendezvous, so the code above runs unchanged.
 
 ## Security note
 
@@ -90,6 +139,6 @@ encryption.
 
 ## See also
 
-- `docs/HYBRID_TRANSPORT.md` for the architecture.
-- `docs/udna-upstream-proposal.md` for the security finding and a proposed
-  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).
+- `docs/HYBRID_TRANSPORT.md` for the architecture and the rendezvous resolver.
+- `docs/udna-upstream-proposal.md` for interoperability notes, including the
+  handshake confidentiality finding and an ephemeral-X25519-with-HKDF approach.

--- a/tests/test_transport_http_rendezvous.py
+++ b/tests/test_transport_http_rendezvous.py
@@ -1,0 +1,221 @@
+"""
+Tests for the deployable HTTPS rendezvous.
+
+These drive the real client (:class:`HttpRendezvousResolver`) against the real
+server logic (:class:`RendezvousService`) over an in-process ``httpx`` transport,
+so the announce/resolve/verify/deliver contract is exercised end to end with no
+network and no web framework. The trust model is the point: the client verifies
+every record itself, so a lying rendezvous cannot forge or substitute a route.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Signer, generate_identity
+from vouch.transport import (
+    HttpRendezvousChannel,
+    HttpRendezvousResolver,
+    RendezvousService,
+    build_envelope,
+    build_route_record,
+    route_fingerprint,
+    udna_address,
+)
+from vouch.transport.did_key import did_key_from_public_jwk
+from vouch.transport.http_rendezvous import RECORDS_PATH
+
+
+def _identity():
+    kp = generate_identity()
+    did = did_key_from_public_jwk(kp.public_key_jwk)
+    seed = base64url_decode(json.loads(kp.private_key_jwk)["d"])
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    return kp, did, priv
+
+
+def _service_client(service: RendezvousService) -> httpx.AsyncClient:
+    """An httpx client that dispatches requests straight into the service."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if request.method == "POST" and path == RECORDS_PATH:
+            status, body = service.put(json.loads(request.content))
+            if status == 204:
+                return httpx.Response(204)
+            return httpx.Response(status, json=body)
+        if request.method == "GET" and path.startswith(RECORDS_PATH + "/"):
+            fingerprint = path.rsplit("/", 1)[1]
+            facet = request.url.params.get("facet", "vouch.message")
+            status, body = service.get(fingerprint, facet)
+            return httpx.Response(status, json=body)
+        return httpx.Response(404, json={"error": "not found"})
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+
+def _resolver(service: RendezvousService) -> HttpRendezvousResolver:
+    return HttpRendezvousResolver(
+        "https://rv.example.com",
+        client=_service_client(service),
+        validate_target=False,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Service: verify on write and read
+# --------------------------------------------------------------------------- #
+class TestService:
+    def test_put_then_get_by_fingerprint(self):
+        _, did, priv = _identity()
+        svc = RendezvousService()
+        rec = build_route_record(did=did, endpoint="https://a.example/inbox", private_key=priv)
+        assert svc.put(rec.to_wire())[0] == 204
+        status, body = svc.get(route_fingerprint(did))
+        assert status == 200
+        assert body["endpoint"] == "https://a.example/inbox"
+        assert body["did"] == did
+
+    def test_get_unknown_is_404(self):
+        _, did, _ = _identity()
+        status, _ = RendezvousService().get(route_fingerprint(did))
+        assert status == 404
+
+    def test_put_rejects_forged_record(self):
+        _, did, priv = _identity()
+        svc = RendezvousService()
+        rec = build_route_record(did=did, endpoint="https://a.example/inbox", private_key=priv)
+        wire = rec.to_wire()
+        wire["endpoint"] = "https://attacker.example/inbox"  # break the signature
+        status, body = svc.put(wire)
+        assert status == 400
+        assert "error" in body
+
+    def test_put_malformed_is_400(self):
+        status, body = RendezvousService().put({"did": "did:key:z6Mk"})
+        assert status == 400
+
+
+# --------------------------------------------------------------------------- #
+# Client: announce / resolve, verifying locally
+# --------------------------------------------------------------------------- #
+class TestResolver:
+    async def test_announce_then_resolve(self):
+        _, did, priv = _identity()
+        resolver = _resolver(RendezvousService())
+        await resolver.announce(
+            build_route_record(did=did, endpoint="https://a.example/inbox", private_key=priv)
+        )
+        assert await resolver.resolve(did) == "https://a.example/inbox"
+        await resolver.close()
+
+    async def test_resolve_unknown_returns_none(self):
+        _, did, _ = _identity()
+        resolver = _resolver(RendezvousService())
+        assert await resolver.resolve(did) is None
+        await resolver.close()
+
+    async def test_announce_refuses_unsigned_record(self):
+        from vouch.transport import RouteRecord
+
+        _, did, _ = _identity()
+        resolver = _resolver(RendezvousService())
+        with pytest.raises(ValueError):
+            await resolver.announce(RouteRecord(did=did, endpoint="x", signature="zbad"))
+        await resolver.close()
+
+    async def test_client_rejects_a_lying_rendezvous(self):
+        """
+        A rendezvous that returns a record for a different DID than asked is
+        rejected: the client checks record.did against the requested DID.
+        """
+        _, alice, _ = _identity()
+        _, bob, bob_priv = _identity()
+
+        # Bob has a validly signed record; the rendezvous will try to pass it off
+        # as Alice's when Alice is queried.
+        bob_rec = build_route_record(
+            did=bob, endpoint="https://bob.example/inbox", private_key=bob_priv
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            # However Alice is queried, hand back Bob's (validly signed) record.
+            return httpx.Response(200, json=bob_rec.to_wire())
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        resolver = HttpRendezvousResolver(
+            "https://rv.example.com", client=client, validate_target=False
+        )
+        # The signature is valid, but it is not Alice's route, so resolve refuses.
+        assert await resolver.resolve(alice) is None
+        await resolver.close()
+
+
+# --------------------------------------------------------------------------- #
+# Channel: resolve a udna:// address and deliver over HTTPS
+# --------------------------------------------------------------------------- #
+class TestChannel:
+    async def test_resolve_and_deliver_preserves_payload(self):
+        kp, did, priv = _identity()
+        svc = RendezvousService()
+
+        received = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            path = request.url.path
+            if request.method == "POST" and path == RECORDS_PATH:
+                status, body = svc.put(json.loads(request.content))
+                return httpx.Response(204) if status == 204 else httpx.Response(status, json=body)
+            if request.method == "GET" and path.startswith(RECORDS_PATH + "/"):
+                fingerprint = path.rsplit("/", 1)[1]
+                facet = request.url.params.get("facet", "vouch.message")
+                status, body = svc.get(fingerprint, facet)
+                return httpx.Response(status, json=body)
+            # The agent's inbox: capture the delivered frame, reply ok.
+            if request.method == "POST" and path == "/inbox":
+                received["frame"] = request.content
+                return httpx.Response(200, json={"status": "ok"})
+            return httpx.Response(404)
+
+        client = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+        resolver = HttpRendezvousResolver(
+            "https://rv.example.com", client=client, validate_target=False
+        )
+        channel = HttpRendezvousChannel(resolver, client=client, validate_endpoint=False)
+
+        # The agent announces an https inbox as its route.
+        await resolver.announce(
+            build_route_record(did=did, endpoint="https://agent.example/inbox", private_key=priv)
+        )
+
+        addr = udna_address(did)
+        assert await channel.reachable(addr) is True
+
+        signer = Signer(private_key=kp.private_key_jwk, did="did:web:sender.example.com")
+        cred = signer.sign_credential(
+            intent={"action": "ping", "target": "t", "resource": "https://x/t"}
+        )
+        env = build_envelope(from_did="did:web:sender.example.com", to_did=did, payload=cred)
+        reply = await channel.exchange(addr, json.dumps(env.to_wire()).encode("utf-8"))
+
+        assert json.loads(reply) == {"status": "ok"}
+        delivered = json.loads(received["frame"])
+        assert delivered["payload"]["proof"] == cred["proof"]
+        await channel.close()
+
+    async def test_unreachable_when_not_announced(self):
+        _, did, _ = _identity()
+        resolver = _resolver(RendezvousService())
+        channel = HttpRendezvousChannel(
+            resolver, client=_service_client(RendezvousService()), validate_endpoint=False
+        )
+        assert await channel.reachable(udna_address(did)) is False
+        with pytest.raises(KeyError):
+            await channel.exchange(udna_address(did), b"{}")
+        await channel.close()

--- a/vouch/transport/__init__.py
+++ b/vouch/transport/__init__.py
@@ -63,6 +63,12 @@ from .envelope import (
     VouchEnvelope,
     build_envelope,
 )
+from .http_rendezvous import (
+    HttpRendezvousChannel,
+    HttpRendezvousResolver,
+    RendezvousService,
+    build_rendezvous_app,
+)
 from .http_transport import HttpTransport
 from .manager import TransportManager
 from .rendezvous import (
@@ -118,6 +124,11 @@ __all__ = [
     "RendezvousRegistry",
     "RendezvousChannel",
     "ROUTE_RECORD_TYPE",
+    # HTTPS rendezvous (deployable identity-first resolver)
+    "RendezvousService",
+    "build_rendezvous_app",
+    "HttpRendezvousResolver",
+    "HttpRendezvousChannel",
     # did:key helpers
     "is_did_key",
     "did_key_from_ed25519_public",

--- a/vouch/transport/http_rendezvous.py
+++ b/vouch/transport/http_rendezvous.py
@@ -1,0 +1,332 @@
+"""
+A deployable HTTPS rendezvous for identity-first routing.
+
+:mod:`vouch.transport.rendezvous` proves the announce-resolve-verify contract
+with an in-memory registry. This module makes that contract real over commodity
+infrastructure: a small HTTPS service any operator can run, plus a client that
+resolves a DID to the agent's current endpoint without DNS and without a domain
+of its own.
+
+The point worth stressing is the trust model. The rendezvous is *untrusted*. It
+stores signed :class:`RouteRecord` objects and serves them back, but it never
+needs to be believed: the client re-verifies every record's signature locally
+and checks that the record's DID is the one it asked for. A malicious or
+compromised rendezvous can withhold a record or serve a stale one, but it cannot
+forge a route, because it does not hold the agent's Ed25519 key. This is the
+property that lets identity-first routing run on a host you do not control.
+
+Three parts:
+
+  * :class:`RendezvousService` is the server logic, free of any web framework so
+    it can be tested directly and embedded anywhere. It verifies on write and on
+    read, and serves records by fingerprint, so the DID never appears in a URL.
+  * :func:`build_rendezvous_app` wraps the service in a FastAPI app for
+    deployment. FastAPI is imported lazily, so the rest of this module (and the
+    client) works without it installed.
+  * :class:`HttpRendezvousResolver` is the client: announce a signed record,
+    resolve a DID to an endpoint, re-verifying locally before trusting it.
+  * :class:`HttpRendezvousChannel` completes the path. It resolves a ``udna://``
+    address to an ``https://`` inbox and delivers the frame there over TLS, so
+    the full identity-first round trip works today on plain HTTPS, with UDNA able
+    to drop in behind the same :class:`UdnaChannel` seam later.
+
+Wire contract:
+
+  * ``POST {base}/vouch/rendezvous/records`` with a route-record JSON body
+    announces a route. ``204`` on success, ``400`` if the record fails
+    verification.
+  * ``GET {base}/vouch/rendezvous/records/{fingerprint}?facet={facet}`` returns
+    the current signed record as JSON, or ``404`` if there is none.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import httpx
+
+from .. import ssrf
+from .rendezvous import (
+    RendezvousRegistry,
+    RouteRecord,
+    route_fingerprint,
+)
+from .udna import DEFAULT_FACET
+
+#: Path prefix the service mounts its two routes under.
+RECORDS_PATH = "/vouch/rendezvous/records"
+
+DEFAULT_TIMEOUT = 10.0
+
+
+# --------------------------------------------------------------------------- #
+# Server: framework-free core
+# --------------------------------------------------------------------------- #
+class RendezvousService:
+    """
+    The rendezvous server logic, with no web framework attached.
+
+    It owns a :class:`RendezvousRegistry` and exposes the two operations a
+    deployment needs as plain methods that return ``(status_code, body)``. Both
+    verify the record: ``put`` rejects anything the DID holder did not sign, and
+    ``get`` re-verifies before serving, so an expired or tampered entry is never
+    returned.
+    """
+
+    def __init__(self, registry: Optional[RendezvousRegistry] = None) -> None:
+        self._registry = registry or RendezvousRegistry()
+
+    @property
+    def registry(self) -> RendezvousRegistry:
+        return self._registry
+
+    def put(self, wire: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+        """
+        Announce a route record. Returns ``(204, {})`` when stored, or
+        ``(400, {"error": ...})`` when the record is malformed or fails
+        verification. The registry verifies, so a forged or expired record is
+        never accepted.
+        """
+        try:
+            record = RouteRecord.from_wire(wire)
+        except (KeyError, TypeError) as exc:
+            return 400, {"error": f"malformed route record: {exc}"}
+        try:
+            self._registry.announce(record)
+        except ValueError as exc:
+            return 400, {"error": str(exc)}
+        return 204, {}
+
+    def get(self, fingerprint: str, facet: str = DEFAULT_FACET) -> Tuple[int, Dict[str, Any]]:
+        """
+        Resolve a fingerprint to its current signed record. Returns
+        ``(200, record_wire)`` or ``(404, {"error": ...})``. The record is
+        re-verified on read, so a stale entry returns ``404`` rather than a dead
+        route.
+        """
+        record = self._registry.get(fingerprint, facet)
+        if record is None:
+            return 404, {"error": "no route record for fingerprint on this facet"}
+        return 200, record.to_wire()
+
+
+def build_rendezvous_app(service: Optional[RendezvousService] = None) -> Any:
+    """
+    Build a FastAPI app exposing a :class:`RendezvousService`.
+
+    FastAPI is imported here, not at module load, so importing this module (and
+    using the client) does not require the web framework. Run the returned app
+    under any ASGI server::
+
+        uvicorn.run(build_rendezvous_app(), host="0.0.0.0", port=8080)
+    """
+    try:
+        from fastapi import FastAPI, Request, Response
+        from fastapi.responses import JSONResponse
+    except ImportError as exc:  # pragma: no cover - exercised only without FastAPI
+        raise RuntimeError(
+            "build_rendezvous_app requires FastAPI; install vouch with the server "
+            "extra or add fastapi to the environment"
+        ) from exc
+
+    service = service or RendezvousService()
+    app = FastAPI(title="Vouch Rendezvous", version="1")
+
+    @app.post(RECORDS_PATH)
+    async def _put(request: Request) -> Response:
+        body = await request.json()
+        status, payload = service.put(body)
+        if status == 204:
+            return Response(status_code=204)
+        return JSONResponse(status_code=status, content=payload)
+
+    @app.get(RECORDS_PATH + "/{fingerprint}")
+    async def _get(fingerprint: str, facet: str = DEFAULT_FACET) -> Response:
+        status, payload = service.get(fingerprint, facet)
+        return JSONResponse(status_code=status, content=payload)
+
+    return app
+
+
+# --------------------------------------------------------------------------- #
+# Client: announce and resolve over HTTPS, verifying locally
+# --------------------------------------------------------------------------- #
+class HttpRendezvousResolver:
+    """
+    Client for an HTTPS rendezvous.
+
+    The resolver never trusts the rendezvous. It announces signed records and,
+    on resolve, re-verifies the returned record's signature and confirms the
+    record's DID is the one requested before handing back an endpoint. The
+    fingerprint sent on the wire is ``sha256(did)``, so the DID itself never
+    appears in the request path.
+
+    Args:
+      base_url: the rendezvous root, for example ``https://rv.example.com``.
+        Validated against SSRF rules (https-only, public IPs) before each call.
+      client: an optional pre-built ``httpx.AsyncClient`` (mainly for tests).
+      timeout: per-request timeout in seconds.
+      verify_ssl: whether to verify TLS certificates (leave on in production).
+      validate_target: SSRF-validate ``base_url`` before each request. Leave on
+        in production; tests against an in-process app turn it off.
+    """
+
+    def __init__(
+        self,
+        base_url: str,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify_ssl: bool = True,
+        validate_target: bool = True,
+    ) -> None:
+        self._base = base_url.rstrip("/")
+        self._client = client
+        self._owns_client = client is None
+        self._timeout = timeout
+        self._verify_ssl = verify_ssl
+        self._validate_target = validate_target
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=False,
+            )
+        return self._client
+
+    def _records_url(self, suffix: str = "") -> str:
+        url = f"{self._base}{RECORDS_PATH}{suffix}"
+        if self._validate_target:
+            ssrf.validate_url(url)
+        return url
+
+    async def announce(self, record: RouteRecord) -> None:
+        """
+        Publish a signed route record. Verifies the record locally first, so a
+        caller never ships an unsigned or expired record, then POSTs it. Raises
+        :class:`ValueError` if the record does not verify, or
+        :class:`httpx.HTTPStatusError` if the rendezvous rejects it.
+        """
+        if not record.verify():
+            raise ValueError("refusing to announce a route record that fails verification")
+        client = self._get_client()
+        response = await client.post(self._records_url(), json=record.to_wire())
+        response.raise_for_status()
+
+    async def resolve(self, did: str, facet: str = DEFAULT_FACET) -> Optional[str]:
+        """
+        Resolve ``did`` to its current endpoint, or ``None`` if the rendezvous
+        has no live record. The returned record is re-verified locally and its
+        DID is checked against ``did``, so a rendezvous cannot substitute another
+        agent's route or serve a forged one.
+        """
+        record = await self.resolve_record(did, facet)
+        return record.endpoint if record is not None else None
+
+    async def resolve_record(self, did: str, facet: str = DEFAULT_FACET) -> Optional[RouteRecord]:
+        """Resolve to the full verified :class:`RouteRecord`, or ``None``."""
+        fingerprint = route_fingerprint(did)
+        client = self._get_client()
+        response = await client.get(self._records_url(f"/{fingerprint}"), params={"facet": facet})
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+
+        record = RouteRecord.from_wire(response.json())
+        # Trust the signature, not the server: the record must verify, and it
+        # must be the DID we asked for (a rendezvous cannot redirect us to a
+        # different identity it happens to hold a record for).
+        if not record.verify() or record.did != did:
+            return None
+        return record
+
+    async def close(self) -> None:
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+
+# --------------------------------------------------------------------------- #
+# Channel: resolve a udna:// address, then deliver over HTTPS
+# --------------------------------------------------------------------------- #
+class HttpRendezvousChannel:
+    """
+    A :class:`UdnaChannel` that runs entirely on commodity HTTPS.
+
+    It resolves a ``udna://`` address through an :class:`HttpRendezvousResolver`
+    to the agent's announced ``https://`` inbox, then POSTs the frame there over
+    TLS. No DNS binds the agent's identity to a location; the only fixed host is
+    the rendezvous, and even that is not trusted, since the resolved record is
+    verified before any byte is sent. This is the shippable identity-first path,
+    and it sits behind the same seam UDNA will plug into.
+
+    Args:
+      resolver: the rendezvous client used to turn a DID into an endpoint.
+      client: an optional ``httpx.AsyncClient`` for delivery (mainly for tests).
+      timeout: per-request timeout in seconds.
+      verify_ssl: whether to verify TLS certificates for delivery.
+      validate_endpoint: SSRF-validate the resolved endpoint before POSTing.
+        Leave on in production; tests against an in-process app turn it off.
+    """
+
+    def __init__(
+        self,
+        resolver: HttpRendezvousResolver,
+        *,
+        client: Optional[httpx.AsyncClient] = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        verify_ssl: bool = True,
+        validate_endpoint: bool = True,
+    ) -> None:
+        self._resolver = resolver
+        self._client = client
+        self._owns_client = client is None
+        self._timeout = timeout
+        self._verify_ssl = verify_ssl
+        self._validate_endpoint = validate_endpoint
+
+    def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=False,
+            )
+        return self._client
+
+    @staticmethod
+    def _split(udna_address: str) -> Tuple[str, str]:
+        body = udna_address.split("://", 1)[1] if "://" in udna_address else udna_address
+        if "/" in body:
+            did, facet = body.rsplit("/", 1)
+            return did, facet
+        return body, DEFAULT_FACET
+
+    async def reachable(self, udna_address: str) -> bool:
+        did, facet = self._split(udna_address)
+        return await self._resolver.resolve(did, facet) is not None
+
+    async def exchange(self, udna_address: str, frame: bytes) -> bytes:
+        did, facet = self._split(udna_address)
+        endpoint = await self._resolver.resolve(did, facet)
+        if endpoint is None:
+            raise KeyError(f"no route record for {did} on facet {facet}")
+        if self._validate_endpoint:
+            ssrf.validate_url(endpoint)
+
+        client = self._get_client()
+        response = await client.post(
+            endpoint,
+            content=frame,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+        )
+        response.raise_for_status()
+        return response.content
+
+    async def close(self) -> None:
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+        await self._resolver.close()

--- a/vouch/transport/rendezvous.py
+++ b/vouch/transport/rendezvous.py
@@ -208,6 +208,18 @@ class RendezvousRegistry:
             return None
         return record.endpoint
 
+    def get(self, fingerprint: str, facet: str = DEFAULT_FACET) -> Optional[RouteRecord]:
+        """
+        Return the full signed :class:`RouteRecord` indexed under ``fingerprint``
+        on ``facet``, re-verified on read, or ``None``. An HTTP rendezvous serves
+        by fingerprint (the DID never appears in the request path) and returns
+        the whole signed record so the client can verify it for itself.
+        """
+        record = self._records.get((fingerprint, facet))
+        if record is None or not record.verify():
+            return None
+        return record
+
 
 # An inbox handler takes a request frame and returns a reply frame.
 InboxHandler = Callable[[bytes], Awaitable[bytes]]

--- a/website-agent/backend/knowledge/transport.md
+++ b/website-agent/backend/knowledge/transport.md
@@ -1,13 +1,16 @@
 # Identity-Native Transport Reference
 
 Vouch addresses a peer by its DID, not its IP or domain. The transport
-layer (`vouch.transport`) prefers identity-first routing over UDNA
-(Universal DID-Native Addressing) and falls back to standard DNS and HTTPS
-when a peer is not on the overlay. An agent dispatches a message to a DID
-and stays agnostic about how the bytes are routed.
+layer (`vouch.transport`) routes a message to an identity and stays agnostic
+about how the bytes get there. It ships its own identity-first resolver that
+works today over commodity HTTPS, builds on UDNA (Universal DID-Native
+Addressing) as a general identity-native substrate when one is present, and
+falls back to standard DNS and HTTPS for any `did:web` peer.
 
-This is optional and experimental. It is aligned with the W3C UDNA
-Community Group and is dormant unless you opt in.
+This is optional. The identity-first path is opt-in, and the HTTP fallback
+means an agent is always reachable. Vouch develops the resolver in the open
+and tracks the W3C UDNA Community Group so the two interoperate as UDNA's
+baseline lands.
 
 ## Why it exists
 
@@ -15,28 +18,57 @@ Agents are ephemeral, spawn sub-agents, and move across hosts and clouds.
 They rarely hold a stable domain or IP, but they always hold a key, so a
 DID is the only stable handle. Identity-first routing matches how agents
 actually run. Vouch already makes a DID accountable (identity, reputation,
-liability); UDNA answers how to reach it.
+liability); the transport layer answers how to reach it.
 
 ## How it routes
 
 `TransportManager` holds an ordered list of transports and tries them in
 preference order:
 
-1. `UdnaTransport` (identity-first) when the peer is on the overlay.
+1. Identity-first routing (resolve the DID to the agent's current endpoint)
+   when the peer has published a route.
 2. `HttpTransport` (did:web, DNS, HTTPS) as the universal fallback.
 
 A transport that cannot reach a peer raises `TransportUnavailable`, and the
 manager moves to the next one. `DeliveryResult.attempts` records the path
 taken, for example `["udna", "http"]`.
 
+## Reaching an agent by DID, today
+
+`did:web` answers "where is this domain." It cannot answer the question an
+agent actually has, "where is this identity right now," without a domain and
+DNS. The rendezvous resolver answers it directly, and it ships now:
+
+- An agent binds its DID to a current endpoint, signs that binding with the
+  DID's own key (a `RouteRecord`), and publishes it.
+- A sender that knows only the DID resolves it to the live endpoint and
+  verifies that the agent itself asserted the route.
+- The routing key on the wire is `sha256(did)`, so a lookup never leaks the
+  DID itself.
+
+Two backends ship behind the same record format and the same verification: an
+in-memory resolver for tests and single-process use, and a deployable HTTPS
+rendezvous (`RendezvousService` / `build_rendezvous_app` on the server,
+`HttpRendezvousResolver` / `HttpRendezvousChannel` on the client) that runs the
+whole path over plain HTTPS with no DNS binding the agent to a location.
+
+The rendezvous is untrusted. It stores and serves signed records but never has
+to be believed: the client re-verifies every record's signature locally and
+checks the record's DID against the one it asked for. A malicious or
+compromised rendezvous can withhold a record or serve a stale one, but it
+cannot forge a route or substitute another identity's, because it does not hold
+the agent's key. Swapping the single rendezvous for a real overlay (libp2p, or
+UDNA's DHT when its baseline lands) reuses this record format and verification
+unchanged and plugs in behind the same channel seam.
+
 ## What "route by DID" means
 
 The DID Document (the json with the DID and public key) is a key store, not
 a routing target. Its job is to give you the public key so you can verify
 signatures. Location comes from elsewhere. In `did:web`, the location is a
-`serviceEndpoint` you fetch over DNS and HTTPS. In UDNA, the agent publishes
-a signed route record under its DID, and a resolver maps the DID to the
-agent's current endpoint, so there is no domain to seize and no DNS to
+`serviceEndpoint` you fetch over DNS and HTTPS. In identity-first routing, the
+agent publishes a signed route record under its DID and a resolver maps the DID
+to the agent's current endpoint, so there is no domain to seize and no DNS to
 poison. The key is the constant; the location is dynamic and self-published.
 
 ## Payload preservation
@@ -45,8 +77,7 @@ The message is a `VouchEnvelope` that carries three things unchanged: the
 signed Vouch credential (with its Data Integrity proof), liability
 attestations, and provenance metadata. A JCS-canonical SHA-256 content
 digest is verified on receipt, so the trust properties hold whichever path
-the bytes take. Switching from UDNA to HTTP never re-signs or strips the
-payload.
+the bytes take. Switching transports never re-signs or strips the payload.
 
 ## Quick start
 
@@ -73,9 +104,27 @@ result = await manager.dispatch(envelope)
 print(result.transport)   # "udna" or "http"
 ```
 
-Install the optional dependency with `pip install vouch-protocol[udna]`.
-Without it, the UDNA transport stays dormant and dispatch falls through to
-HTTP, so the code above runs unchanged.
+To reach an agent by DID over a rendezvous instead of did:web:
+
+```python
+from vouch.transport import (
+    HttpRendezvousResolver, HttpRendezvousChannel, build_route_record,
+)
+
+# The agent announces its current inbox, signed under its DID.
+resolver = HttpRendezvousResolver("https://rendezvous.example.com")
+await resolver.announce(build_route_record(
+    did=agent_did, endpoint="https://agent.example/inbox", private_key=agent_ed25519,
+))
+
+# A sender that knows only the DID resolves it and delivers, verifying locally.
+channel = HttpRendezvousChannel(resolver)
+reply = await channel.exchange(f"udna://{agent_did}/vouch.message", frame)
+```
+
+The UDNA SDK is an optional extra (`pip install vouch-protocol[udna]`). Without
+it, the SDK-backed path stays dormant and dispatch falls through to HTTP or the
+rendezvous, so the code above runs unchanged.
 
 ## Security note
 
@@ -90,6 +139,6 @@ encryption.
 
 ## See also
 
-- `docs/HYBRID_TRANSPORT.md` for the architecture.
-- `docs/udna-upstream-proposal.md` for the security finding and a proposed
-  fix (ephemeral X25519 with HKDF, keeping Ed25519 for authentication).
+- `docs/HYBRID_TRANSPORT.md` for the architecture and the rendezvous resolver.
+- `docs/udna-upstream-proposal.md` for interoperability notes, including the
+  handshake confidentiality finding and an ephemeral-X25519-with-HKDF approach.


### PR DESCRIPTION
## Description

Follow-up to the identity-first transport work merged in #179. Makes the rendezvous resolver deployable over commodity HTTPS, syncs the assistant-facing surfaces to the shipping resolver, and publishes two defensive disclosures for the track. Branched fresh from current `main` so the change is purely additive.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Follow-up to #179. Closes nothing directly.

## Changes Made

- **Deployable HTTPS rendezvous** (`vouch/transport/http_rendezvous.py`):
  - `RendezvousService` / `build_rendezvous_app`: a framework-free server core plus a lazily-imported FastAPI adapter, verifying signed route records on write and read and serving by `sha256(did)` (the DID never appears in a URL).
  - `HttpRendezvousResolver`: a client that announces and resolves over HTTPS and re-verifies every record locally, checking the record's DID against the one requested. The rendezvous is untrusted; it cannot forge or substitute a route.
  - `HttpRendezvousChannel`: a `UdnaChannel` that resolves a `udna://` address to the agent's announced `https://` inbox and delivers the sealed envelope there, completing the identity-first path on plain HTTPS behind the same seam a real overlay plugs into later.
  - `RendezvousRegistry.get` (lookup by fingerprint), a network-free demo (`examples/http_rendezvous_demo.py`), tests, and a transport-doc section. Record format and verification are unchanged from the in-memory resolver.
- **Assistant-facing surfaces**: reframe the transport as a resolver that ships today over commodity HTTPS, building on UDNA as a general substrate when present, with did:web/HTTPS always available. Adds a reach-by-DID code path and the untrusted-rendezvous trust model to the shared knowledge file (kept byte-identical across all four surfaces), the FAQ, and the Help guide.
- **Prior-art disclosures**: PAD-074 (trust-preserving multi-transport failover) and PAD-075 (untrusted-resolver identity routing), both explicitly disclaiming UDNA's DID-as-routing-primitive, fingerprint scheme, and facet model.

## Testing

- [x] Existing tests pass (`pytest tests/`)
- [x] New tests added for new functionality
- [x] Manual testing performed

Transport suite passes (rendezvous plus HTTP rendezvous). `ruff check` and `ruff format --check` pass. The demo runs end to end.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)