### PR TITLE
Add PAD-072 and PAD-073 recognition credential disclosures

### DIFF
--- a/docs/disclosures/PAD-072-proof-of-integration-recognition-credential.md
+++ b/docs/disclosures/PAD-072-proof-of-integration-recognition-credential.md
@@ -1,0 +1,186 @@
+# PAD-072: Proof-of-Integration Recognition Credential Gated by a Live Keyed Challenge-Response
+
+**Identifier:** PAD-072  
+**Title:** Method for Issuing a Recognition Credential Only After a Cryptographic Challenge-Response in Which the Candidate Answers a Fresh Nonce Through Its Own Live Protocol Surface Using the Key Bound to Its Claimed Decentralized Identifier, So the Credential Proves a Working, Keyed Deployment Rather Than an Asserted or Manually Reviewed Integration  
+**Publication Date:** July 3, 2026  
+**Prior Art Effective Date:** July 3, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Agent Accountability / Verifiable Credentials / Recognition / Proof of Capability  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-002 (Chain of Custody Delegation), PAD-016 (Heartbeat), PAD-039 (JCS Deterministic Multi-Party Trust State), PAD-071 (Commit-Before-Outcome Verdict Credential)  
+
+---
+
+## 1. Abstract
+
+A recognition credential, for example a badge attesting that an independent
+system integrates a protocol, is normally issued on the issuer's assertion or on
+a one-time manual review. Such a credential says an integration exists but does
+not prove that the recognized party operates a working, keyed deployment. This
+method gates issuance on a cryptographic challenge-response. Before issuing, the
+recognition authority generates a fresh nonce and requires the candidate to
+answer it through the candidate's own live protocol surface, signing the nonce
+with the private key bound to the decentralized identifier (DID) the candidate
+claims. The authority resolves the candidate's published DID document, verifies
+the response against it, and only then mints a credential that embeds the
+challenge, a digest of the signed response, the probed live-surface locator, and
+the observation time, itself chained to a delegated issuing authority. The result
+is a recognition credential that is also a proof of capability: any later
+verifier can confirm that, at issuance, the holder controlled the DID key and
+served a conforming live surface.
+
+Key innovations:
+
+- **Issuance gated by demonstrated capability.** The credential is not signed
+  until the candidate proves, live, that it holds the key for its claimed DID and
+  serves a working endpoint. A badge cannot be aspirational or fabricated because
+  the working system is a precondition of issuance.
+- **Answered over the holder's own protocol surface.** The response is served
+  from the candidate's declared endpoint and signed by the candidate's DID-bound
+  key, so the proof is of that deployment, not of a name, an account, or an
+  offline claim.
+- **Capability-specific challenge.** The challenge MAY require the candidate to
+  return a valid protocol artifact of exactly the type the badge attests, so the
+  credential proves the deployment performs the recognized function, not merely
+  that it is reachable.
+- **Embedded, re-checkable proof.** The challenge nonce, a digest of the signed
+  response, and the surface locator are carried inside the issued credential, so
+  the capability proof is independently re-verifiable long after issuance,
+  against the candidate's own DID, without trusting the authority's word.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A recognition credential is issued on assertion
+
+Open Badges and Verifiable Credentials attest a claim by the issuer's signature.
+The issuer's honesty and diligence are the only guard. A badge can be
+aspirational, mistaken, or fabricated, and nothing in it proves the recognized
+system exists or works.
+
+### 2.2 Domain or account control is not integration capability
+
+Proofs of domain control (ACME) or account control (OIDC) show that the holder
+controls a name or a login. They do not show that the holder operates a working,
+keyed deployment of a particular protocol, still less that the deployment
+performs the specific function being recognized.
+
+### 2.3 A one-time manual review binds to nothing
+
+Human review at issuance is unrepeatable and unverifiable later. The resulting
+credential carries no artifact a third party can re-check, so a reader must trust
+that a review happened and was correct.
+
+---
+
+## 3. Solution (The Invention)
+
+The recognition authority runs a challenge-response before issuance:
+
+1. **Challenge.** The authority generates a fresh random nonce and a challenge
+   descriptor naming the expected live surface and the capability to demonstrate.
+2. **Response over the live surface.** The candidate answers by returning, from
+   its own published protocol endpoint, a signed object binding the nonce, the
+   candidate's DID, and optionally a protocol artifact of the recognized type,
+   signed with the candidate's DID-bound key.
+3. **Verification.** The authority resolves the candidate's DID document, verifies
+   the signature over the nonce against the published verification method,
+   confirms the response came from the declared live surface, and, when a
+   capability artifact is required, verifies that artifact under the protocol's
+   own rules.
+4. **Issuance.** Only on success does the authority mint the recognition
+   credential, embedding the challenge nonce, a digest of the candidate's signed
+   response, the probed surface locator, the verification-method identifier used,
+   and the observation timestamp. The credential is chained to the root authority
+   through the delegation the issuing authority already holds.
+
+Because the embedded proof references the candidate's own DID and signed nonce, a
+later verifier re-checks it without trusting the authority: resolve the candidate
+DID, confirm the embedded response verifies under it, and confirm the nonce
+matches. The recognition is thereby evidence that, at issuance, the holder
+controlled the claimed key and served a conforming surface.
+
+---
+
+## 4. Prior Art Differentiation
+
+Challenge-response authentication, proof-of-possession, domain-control
+validation, and Verifiable Credential badges are each established prior art. This
+disclosure does **not** claim those general mechanisms. What is differentiated is
+their composition into a recognition primitive whose issuance proves live, keyed
+integration:
+
+- **Recognition bound to demonstrated capability rather than assertion.** Unlike
+  an Open Badge, which is valid on the issuer's signature alone, this credential
+  cannot be issued until the candidate proves a live keyed deployment, so the
+  working system is a structural precondition of the badge.
+- **Answered over the holder's own protocol surface with the DID-bound key.**
+  Generic proof-of-possession or OIDC proves control of a key or account in the
+  abstract. Here the response is served from the recognized deployment itself
+  and, optionally, is a valid protocol artifact of the recognized type, so it
+  proves that this deployment does the recognized thing.
+- **Embedded, independently re-verifiable proof.** The challenge and signed
+  response are carried in the issued credential, so the capability proof is
+  re-checkable indefinitely against the candidate's DID. A manual review leaves
+  no such artifact.
+- **Chained to a delegated recognition authority.** The issuing key is a
+  namespace-scoped delegate of a root authority, so the recognition traces to the
+  root while the root key is never used for routine issuance.
+- **Cross-language verification.** Challenge, response, and credential use the
+  shared RFC 8785 JCS canonicalization and eddsa-jcs-2022 Data Integrity path, so
+  the same proof verifies across language SDKs.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation ships in the Python SDK. `build_integration_challenge`
+returns a challenge object carrying a CSPRNG nonce, the expected live-surface
+locator, and the required capability descriptor. The candidate answers with
+`answer_integration_challenge`, which returns an eddsa-jcs-2022 signed object over
+the JCS-canonical form of `{nonce, did, artifactDigest}`, signed by the
+candidate's DID-bound key and served from the candidate's endpoint.
+`verify_integration_response` resolves the candidate DID document (did:web or
+did:key), verifies the signature against the published verification method,
+checks the nonce, and, when required, verifies the returned protocol artifact.
+The issuance path embeds a `ProofOfIntegration` block, holding the nonce, a
+multibase digest of the signed response, the surface locator, the
+verification-method identifier, and the observation time, in the recognition
+credential's subject, alongside the delegation that chains it to the root
+authority. Fetching the live surface is out of band; the embedded locator lets a
+verifier re-probe.
+
+---
+
+## 6. Claims Summary
+
+1. A method for issuing a recognition credential in which issuance is gated by a
+   challenge-response that proves the candidate operates a live deployment holding
+   the key bound to its claimed decentralized identifier.
+2. The method of claim 1 wherein the candidate answers the challenge through its
+   own published protocol surface, and the authority verifies the signed response
+   against the candidate's resolved DID document before issuing.
+3. The method of claim 1 wherein the challenge requires the candidate to return a
+   valid protocol artifact of the type the credential attests, so the credential
+   proves the deployment performs the recognized function.
+4. The method of claim 1 wherein the challenge nonce, a digest of the signed
+   response, and the live-surface locator are embedded in the issued credential,
+   so the capability proof is independently re-verifiable against the candidate's
+   DID after issuance.
+5. The method of claim 1 wherein the issuing authority is a namespace-scoped
+   delegate of a root authority, so the recognition chains to the root without the
+   root key performing routine issuance.
+6. The method of claim 1 wherein the challenge, response, and credential use
+   canonicalization and signature primitives shared across language SDKs, so the
+   same proof verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/PAD-073-liveness-conformance-decaying-recognition-credential.md
+++ b/docs/disclosures/PAD-073-liveness-conformance-decaying-recognition-credential.md
@@ -1,0 +1,171 @@
+# PAD-073: Liveness-Conformance-Decaying Recognition Credential with Automatic Revocation
+
+**Identifier:** PAD-073  
+**Title:** Method for a Recognition or Reputation Credential Whose Consumable Trust Continuously Decays as a Function of Elapsed Time Since the Last Independently Verified Liveness-Conformance Observation of the Holder's Deployment, With Signed Conformance Receipts That Make the Decay Recomputable and Automatic Revocation When Conformance Lapses Beyond a Threshold  
+**Publication Date:** July 3, 2026  
+**Prior Art Effective Date:** July 3, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Agent Accountability / Reputation / Verifiable Credentials / Revocation  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-016 (Heartbeat), PAD-030 (ZK Reputation Portability), PAD-032 (Cryptographic Mortality), PAD-036 (Aggregated Reputation Scoring via Verifiable State Receipts), PAD-071 (Commit-Before-Outcome Verdict Credential), PAD-072 (Proof-of-Integration Recognition Credential)  
+
+---
+
+## 1. Abstract
+
+A point-in-time recognition or reputation credential stays valid after the
+recognized system goes offline, stops conforming, or is decommissioned, so the
+trust it displays becomes stale. This method binds a credential's consumable
+trust to a continuously updated liveness-conformance signal. An automated prober
+periodically checks the holder's live surface against published conformance
+criteria and emits a signed conformance receipt per observation. The credential
+carries a decay function and its parameters (for example a half-life) and the
+time of last confirmed conformance. At read time the consumable trust is computed
+as a function of elapsed time since that last confirmed conformance, so a
+credential no longer backed by a live conforming deployment loses trust on its
+own. When conformance lapses beyond a threshold, the credential is auto-revoked
+through the status list. Because each observation is a signed receipt, the decay
+is recomputable from evidence rather than asserted.
+
+Key innovations:
+
+- **Validity as a continuous function of third-party liveness-conformance.** The
+  trust a verifier consumes is not a stored constant but a value computed from how
+  recently the holder's deployment was independently observed to still conform.
+- **Recomputable decay from signed conformance receipts.** Each probe emits a
+  signed receipt, so any verifier can reconstruct the decay curve from evidence
+  rather than trust a displayed number.
+- **Conformance-lapse-driven automatic revocation.** Revocation is triggered by
+  the failure of continuous external conformance, not by a manual event, so a
+  quietly dead deployment loses its credential without anyone filing a revocation.
+- **Probe over the holder's own surface using the protocol's own conformance
+  test.** The liveness signal is a re-run of the same conformance the credential
+  attests, against the holder's declared endpoint, so decay tracks the exact
+  property recognized.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A badge outlives the thing it certifies
+
+A recognition credential issued once remains cryptographically valid even after
+the recognized deployment stops responding or stops conforming. A reader sees a
+valid badge for a system that no longer works.
+
+### 2.2 Revocation is event-driven and manual
+
+Certificate revocation lists, OCSP, and status lists flip on an explicit event
+that some party must initiate. Nobody files a revocation because a site quietly
+went dark, so stale recognition persists.
+
+### 2.3 A displayed score is asserted, not evidenced over time
+
+A trust value stored in or alongside a credential is a number a reader must
+trust. Without periodic, signed, independent observation, there is no evidence
+that the recognized property still holds.
+
+---
+
+## 3. Solution (The Invention)
+
+1. **Conformance criteria and prober.** The credential names the conformance
+   criteria and the holder's live surface. An automated prober, run by a neutral
+   party, periodically re-checks the surface against those criteria, reusing the
+   protocol's own conformance test.
+2. **Signed conformance receipt.** Each observation produces a signed
+   `ConformanceReceipt` binding the holder, the surface, the criteria, the
+   observed result, and the time. Receipts are appended to a recomputable log so a
+   verifier can replay the observation history.
+3. **Embedded decay function.** The credential carries a decay function and its
+   parameters (for example a half-life) and the time of last confirmed
+   conformance.
+4. **Read-time trust.** A verifier computes consumable trust as a function of
+   elapsed time since the last confirmed-conformance receipt, so the value falls
+   automatically as observations age and rises again when a fresh passing receipt
+   arrives.
+5. **Automatic revocation on lapse.** When conformance fails, or no passing
+   receipt arrives, for longer than a configured threshold, the credential is
+   revoked through the status list, so it reads as revoked and not merely
+   low-trust.
+
+The liveness cadence reuses the heartbeat mechanism, the decay reuses the
+state-verifiability trust-entropy model, and the receipts are the same verifiable
+state receipts that aggregated reputation already consumes, so the same evidence
+feeds both a live decay and an aggregate score.
+
+---
+
+## 4. Prior Art Differentiation
+
+Certificate monitoring, revocation lists, credential renewal, and reputation
+scoring from receipts are each established prior art. This disclosure does **not**
+claim them generally. What is differentiated is binding a recognition credential's
+validity to continuous third-party liveness-conformance:
+
+- **Decay on liveness lapse rather than detection of mis-issuance.** Certificate
+  Transparency and monitoring detect that a bad certificate exists. They do not
+  make a credential's trust fall because the recognized deployment stopped
+  conforming.
+- **Revocation driven by conformance lapse rather than an explicit event.** CRL,
+  OCSP, and status lists revoke when a party acts. Here revocation is the
+  automatic consequence of failed or absent continuous conformance.
+- **Computed decay rather than re-issuance.** Heartbeat renewal (PAD-016) keeps a
+  credential fresh by re-signing it. Here the credential's own trust is a computed
+  function of externally observed conformance over time, and lapse triggers
+  revocation rather than expiry.
+- **Receipts of a specific deployment's liveness-conformance.** Aggregated
+  reputation (PAD-036) scores from state receipts in general. Here the receipts
+  are liveness-conformance observations of the exact deployment the credential
+  recognizes, and they drive both the decay and the revocation of that credential.
+- **Recomputable trust.** Because the decay is reconstructable from signed
+  receipts, the trust shown is evidence a verifier can replay, not an asserted
+  number.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation ships in the Python SDK. A prober loop re-runs the
+conformance check (or a surface probe) against the holder's declared endpoint and
+emits a `ConformanceReceipt`, an eddsa-jcs-2022 credential signed by the prober
+authority, appended to the holder's record through the existing Merkle-backed
+log. `consumable_trust(record, at_time)` computes the decayed value using the
+existing trust-entropy half-life over the elapsed time since the last passing
+receipt. A configured lapse threshold triggers a `build_status_list_entry`
+revocation through the existing BitstringStatusList path. The probe cadence
+reuses the heartbeat scheduler, and receipts share the JCS canonicalization and
+signature primitives used across the SDK, so the same receipts verify
+cross-language and can be consumed by aggregated reputation.
+
+---
+
+## 6. Claims Summary
+
+1. A method for a recognition or reputation credential whose consumable trust is
+   computed as a function of elapsed time since the last independently verified
+   liveness-conformance observation of the holder's deployment.
+2. The method of claim 1 wherein an automated prober periodically checks the
+   holder's live surface against published conformance criteria and emits a signed
+   conformance receipt for each observation.
+3. The method of claim 2 wherein the decay of consumable trust is recomputable by
+   a verifier from the signed conformance receipts.
+4. The method of claim 1 wherein the credential is automatically revoked through a
+   status list when conformance fails, or no passing observation arrives, for
+   longer than a configured threshold.
+5. The method of claim 1 wherein the credential embeds the decay function, its
+   parameters, and the time of last confirmed conformance.
+6. The method of claim 1 wherein the liveness signal reuses the protocol's own
+   heartbeat cadence and conformance test, and the receipts share canonicalization
+   and signature primitives across language SDKs so they verify cross-language and
+   feed aggregated reputation.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -79,8 +79,26 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-069](./PAD-069-confidential-tamper-evident-robot-blackbox.md) | Confidential, Tamper-Evident Robot Black-Box with Separable Confidentiality and Integrity | 2026-06-15 | Published |
 | [PAD-070](./PAD-070-scannable-offline-robot-passport.md) | Self-Contained, Offline-Verifiable Robot Passport for Physical-World Scanning | 2026-06-15 | Published |
 | [PAD-071](./PAD-071-outcome-evidence-commit-before-outcome-credential.md) | Commit-Before-Outcome Verdict Credential with Neutral-Settler Outcome Attestation | 2026-06-17 | Published |
+| [PAD-072](./PAD-072-proof-of-integration-recognition-credential.md) | Proof-of-Integration Recognition Credential Gated by a Live Keyed Challenge-Response | 2026-07-03 | Published |
+| [PAD-073](./PAD-073-liveness-conformance-decaying-recognition-credential.md) | Liveness-Conformance-Decaying Recognition Credential with Automatic Revocation | 2026-07-03 | Published |
 | [PAD-074](./PAD-074-trust-preserving-transport-failover.md) | Trust-Preserving Multi-Transport Failover for Liability-Bearing Credential Envelopes | 2026-06-30 | Published |
 | [PAD-075](./PAD-075-untrusted-resolver-identity-routing.md) | Untrusted-Resolver Identity Routing via Self-Signed Route Records with Anti-Substitution Binding | 2026-06-30 | Published |
+
+
+## July 3, 2026: Proof-of-Integration and Liveness-Decaying Recognition (PAD-072, PAD-073)
+
+Two disclosures covering how a recognition credential, a badge attesting that an
+independent system integrates the protocol, is made evidence rather than
+assertion. PAD-072 gates issuance on a challenge-response: the candidate answers a
+fresh nonce through its own live surface, signed with the key bound to its
+claimed DID, so the credential proves a working, keyed deployment and embeds a
+proof any verifier can re-check. PAD-073 makes such a credential's trust a
+continuous function of independently observed liveness-conformance: an automated
+prober emits signed conformance receipts, the credential's consumable trust
+decays with elapsed time since the last passing observation, and it auto-revokes
+through the status list when conformance lapses. Both build on the same
+eddsa-jcs-2022 credentials, heartbeat cadence (PAD-016), and verifiable state
+receipts (PAD-036, PAD-071) as the rest of Vouch.
 
 
 ## June 30, 2026: Identity-First Transport Primitives (PAD-074, PAD-075)


### PR DESCRIPTION
Adds two defensive prior-art disclosures for how a recognition credential, a badge attesting that an independent system integrates the protocol, is made evidence rather than assertion.

- **PAD-072** describes a recognition credential whose issuance is gated by a challenge-response: the candidate answers a fresh nonce through its own live surface, signed with the key bound to its claimed DID, so the credential proves a working, keyed deployment and embeds a proof any verifier can re-check.
- **PAD-073** describes a recognition credential whose consumable trust decays as a function of independently observed liveness-conformance, with signed conformance receipts that make the decay recomputable and automatic revocation through the status list when conformance lapses.

Both build on the existing eddsa-jcs-2022 credentials, heartbeat cadence, and verifiable state receipts. Updates the disclosures index.
