### PR TITLE
feat(conformance): implement L2 and L3 checks in the runner

### DIFF
--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,23 +1,35 @@
-"""Conformance runner: the L1 level must fully pass against the reference SDK."""
+"""Conformance runner: L1 through L3 must fully pass against the reference SDK."""
 
+from vouch import conformance
 from vouch.conformance import Status, run_conformance
 
 
-def test_l1_fully_passes():
+def test_all_levels_pass():
     report = run_conformance()
-    l1 = report.results["L1"]
-    failures = [(r.name, r.detail) for r in l1 if r.status is not Status.PASS]
-    assert not failures, f"L1 checks did not all pass: {failures}"
-    assert report.achieved == "L1"
+    failures = [
+        (level, r.name, r.status.value, r.detail)
+        for level, results in report.results.items()
+        for r in results
+        if r.status is not Status.PASS
+    ]
+    assert not failures, f"conformance checks did not all pass: {failures}"
+    assert report.achieved == "L3"
 
 
-def test_validity_window_rejects_expired():
-    from vouch.conformance import check_validity_window
-
-    assert check_validity_window().status is Status.PASS
-
-
-def test_nonce_replay_detects_reuse():
-    from vouch.conformance import check_nonce_replay
-
-    assert check_nonce_replay().status is Status.PASS
+def test_each_check_passes():
+    checks = [
+        conformance.check_canonicalization,
+        conformance.check_sign_verify,
+        conformance.check_validity_window,
+        conformance.check_nonce_replay,
+        conformance.check_revocation,
+        conformance.check_delegation_narrowing,
+        conformance.check_sidecar_allow_deny,
+        conformance.check_audit_trail,
+        conformance.check_hybrid_pq,
+        conformance.check_heartbeat,
+        conformance.check_validator_quorum,
+    ]
+    for check in checks:
+        result = check()
+        assert result.status is Status.PASS, f"{result.name}: {result.detail}"

--- a/vouch/conformance.py
+++ b/vouch/conformance.py
@@ -34,9 +34,19 @@ from enum import Enum
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
 
-from vouch import jcs, keys
+from vouch import jcs, keys, vc
+from vouch.audit_trail import AuditTrail, verify_entries
+from vouch.gate import CredentialGate
+from vouch.heartbeat import HeartbeatSession, HeartbeatValidator
 from vouch.nonce import MemoryNonceTracker
+from vouch.quorum import HeartbeatQuorum, QuorumValidator
 from vouch.signer import Signer
+from vouch.status_list import (
+    StatusList,
+    build_status_list_credential,
+    build_status_list_entry,
+    verify_status,
+)
 from vouch.verifier import Verifier
 
 VECTORS_DIR = Path(__file__).resolve().parent.parent / "test-vectors"
@@ -158,14 +168,272 @@ def check_nonce_replay() -> CheckResult:
     return CheckResult("nonce_replay", Status.PASS, "first use accepted, replay rejected")
 
 
-# --- L2 / L3 checks (contract defined, implementation pending) --------------
+# --- L2 checks (Structural-Security) ----------------------------------------
 
 
-def _pending(name: str, contract: str) -> Callable[[], CheckResult]:
-    def run() -> CheckResult:
-        return CheckResult(name, Status.SKIP, contract)
+def check_revocation() -> CheckResult:
+    """BitstringStatusList: a set status bit reads as revoked, a clear bit reads as active."""
+    status_list = StatusList(status_list_id="https://conformance.test/status/1")
+    revoked_index = status_list.allocate_index()
+    active_index = status_list.allocate_index()
+    status_list.revoke(revoked_index)
+    status_list_credential = build_status_list_credential(
+        issuer_did="did:web:conformance.test",
+        status_list=status_list,
+    )
+    revoked_entry = build_status_list_entry(
+        status_list_credential="https://conformance.test/status/1",
+        status_list_index=revoked_index,
+    )
+    active_entry = build_status_list_entry(
+        status_list_credential="https://conformance.test/status/1",
+        status_list_index=active_index,
+    )
+    if not verify_status(
+        credential_status=revoked_entry, status_list_credential=status_list_credential
+    ):
+        return CheckResult(
+            "revocation", Status.FAIL, "a revoked credential did not read as revoked"
+        )
+    if verify_status(credential_status=active_entry, status_list_credential=status_list_credential):
+        return CheckResult("revocation", Status.FAIL, "an active credential read as revoked")
+    return CheckResult("revocation", Status.PASS, "set bit reads revoked, clear bit reads active")
 
-    return run
+
+def check_delegation_narrowing() -> CheckResult:
+    """Delegation: a child chains to its parent, and the five-link depth bound is enforced."""
+    root = keys.generate_identity("conformance.test")
+    root_signer = Signer(private_key=root.private_key_jwk, did=root.did)
+    parent = root_signer.sign_credential(
+        intent={
+            "action": "manage",
+            "target": "all_tables",
+            "resource": "https://conformance.test/db",
+        }
+    )
+    child_id = keys.generate_identity("conformance.test")
+    child_signer = Signer(private_key=child_id.private_key_jwk, did=child_id.did)
+    child = child_signer.sign_credential(
+        intent={
+            "action": "read",
+            "target": "users_table",
+            "resource": "https://conformance.test/db/users",
+        },
+        parent_credential=parent,
+    )
+    chain = child.get("credentialSubject", {}).get("delegationChain") or []
+    if len(chain) != 1 or chain[0].get("issuer") != root.did:
+        return CheckResult(
+            "delegation_narrowing",
+            Status.FAIL,
+            "the child did not record its parent in the delegation chain",
+        )
+
+    # Extend the chain link by link; the depth bound must reject a further link.
+    current = parent
+    depth_enforced = False
+    for _ in range(8):
+        link_id = keys.generate_identity("conformance.test")
+        link_signer = Signer(private_key=link_id.private_key_jwk, did=link_id.did)
+        try:
+            current = link_signer.sign_credential(
+                intent={
+                    "action": "read",
+                    "target": "users_table",
+                    "resource": "https://conformance.test/db/users",
+                },
+                parent_credential=current,
+            )
+        except ValueError:
+            depth_enforced = True
+            break
+    if not depth_enforced:
+        return CheckResult(
+            "delegation_narrowing", Status.FAIL, "the five-link depth bound was not enforced"
+        )
+    return CheckResult(
+        "delegation_narrowing", Status.PASS, "child chains to parent, depth bound enforced"
+    )
+
+
+def check_sidecar_allow_deny() -> CheckResult:
+    """Identity Sidecar: an allowed intent passes the gate, a disallowed one is rejected with a reason."""
+    ident = keys.generate_identity("conformance.test")
+    signer = Signer(private_key=ident.private_key_jwk, did=ident.did)
+    credential = signer.sign_credential(
+        intent={
+            "action": "read",
+            "target": "data",
+            "resource": "https://conformance.test/data",
+        }
+    )
+    allow_gate = CredentialGate(
+        public_key=ident.public_key_jwk, require_action="read", allow_did_resolution=False
+    )
+    allowed = allow_gate.check(credential)
+    if not allowed.ok:
+        return CheckResult(
+            "sidecar_allow_deny", Status.FAIL, f"an allowed intent was rejected: {allowed.reason}"
+        )
+
+    deny_gate = CredentialGate(
+        public_key=ident.public_key_jwk, require_action="write", allow_did_resolution=False
+    )
+    denied = deny_gate.check(credential)
+    if denied.ok:
+        return CheckResult("sidecar_allow_deny", Status.FAIL, "a disallowed intent was allowed")
+    if not denied.reason:
+        return CheckResult(
+            "sidecar_allow_deny", Status.FAIL, "a rejection carried no structured reason"
+        )
+    return CheckResult(
+        "sidecar_allow_deny",
+        Status.PASS,
+        "allowed intent passes, disallowed rejected with a reason",
+    )
+
+
+def check_audit_trail() -> CheckResult:
+    """Audit trail: a sequence of actions is hash-linked and verifies, and a tampered entry is caught."""
+    trail = AuditTrail()
+    trail.append(action="ALLOWED", actor="did:web:conformance.test", resource="read_file")
+    trail.append(
+        action="BLOCKED",
+        actor="did:web:conformance.test",
+        resource="run_command",
+        decision="untrusted",
+    )
+    trail.append(action="ALLOWED", actor="did:web:conformance.test", resource="write_file")
+
+    ok, broken = trail.verify()
+    if not ok or broken is not None:
+        return CheckResult(
+            "audit_trail", Status.FAIL, f"a valid trail failed verification (broken={broken})"
+        )
+
+    entries = trail.entries
+    if (
+        entries[1].prev_hash != entries[0].entry_hash
+        or entries[2].prev_hash != entries[1].entry_hash
+    ):
+        return CheckResult("audit_trail", Status.FAIL, "entries are not hash-linked")
+
+    entries[1].resource = "exfiltrate_secrets"
+    bad_ok, bad_broken = verify_entries(entries)
+    if bad_ok or bad_broken is None:
+        return CheckResult("audit_trail", Status.FAIL, "a tampered trail was not caught")
+    return CheckResult("audit_trail", Status.PASS, "hash-linked, verifies, tamper detected")
+
+
+# --- L3 checks (State Verifiable + Post-Quantum) ----------------------------
+
+
+def check_hybrid_pq() -> CheckResult:
+    """Hybrid dual-proof: a credential carrying eddsa-jcs-2022 and mldsa44 proofs verifies under both."""
+    try:
+        from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+        from vouch.data_integrity_hybrid import (
+            build_hybrid_proof,
+            generate_mldsa44_keypair,
+            verify_hybrid_proof,
+        )
+    except ImportError as exc:  # post-quantum support is optional at runtime
+        return CheckResult("hybrid_pq", Status.SKIP, f"post-quantum support unavailable: {exc}")
+
+    ed_priv = Ed25519PrivateKey.generate()
+    ed_pub = ed_priv.public_key()
+    ml_pub, ml_sec = generate_mldsa44_keypair()
+    credential = vc.build_vouch_credential(
+        issuer_did="did:web:conformance.test",
+        intent={
+            "action": "conformance_probe",
+            "target": "vector:hybrid",
+            "resource": "https://conformance.test/probe",
+        },
+    )
+    credential["proof"] = build_hybrid_proof(
+        credential,
+        ed25519_private_key=ed_priv,
+        mldsa44_secret_key=ml_sec,
+        verification_method="did:web:conformance.test#key-1",
+    )
+    if credential["proof"].get("cryptosuite") != "hybrid-eddsa-mldsa44-jcs-2026":
+        return CheckResult("hybrid_pq", Status.FAIL, "the proof is not the hybrid cryptosuite")
+    if not verify_hybrid_proof(credential, ed25519_public_key=ed_pub, mldsa44_public_key=ml_pub):
+        return CheckResult("hybrid_pq", Status.FAIL, "both proofs did not verify")
+
+    tampered = json.loads(json.dumps(credential))
+    tampered["credentialSubject"]["intent"]["action"] = "tampered"
+    if verify_hybrid_proof(tampered, ed25519_public_key=ed_pub, mldsa44_public_key=ml_pub):
+        return CheckResult("hybrid_pq", Status.FAIL, "a tampered hybrid credential verified")
+    return CheckResult("hybrid_pq", Status.PASS, "eddsa-jcs-2022 and mldsa44 proofs both verify")
+
+
+def check_heartbeat() -> CheckResult:
+    """Heartbeat: a renewed chain validates, and each interval is distinct and advancing."""
+    session = HeartbeatSession(subject_did="did:web:conformance.test")
+    validator = HeartbeatValidator(validator_did="did:web:validator.conformance.test")
+
+    session.record_action(b"conformance-1")
+    req1 = session.build_request()
+    r1 = validator.validate(req1.to_dict())
+    if not r1.ok:
+        return CheckResult(
+            "heartbeat", Status.FAIL, f"the first heartbeat was rejected: {r1.reasons}"
+        )
+
+    session.record_action(b"conformance-2")
+    req2 = session.build_request()
+    r2 = validator.validate(req2.to_dict())
+    if not r2.ok:
+        return CheckResult(
+            "heartbeat", Status.FAIL, f"a renewed heartbeat was rejected: {r2.reasons}"
+        )
+
+    if req1.interval_index != 0 or req2.interval_index != 1:
+        return CheckResult("heartbeat", Status.FAIL, "the interval index did not advance")
+    if req1.action_merkle_root == req2.action_merkle_root:
+        return CheckResult("heartbeat", Status.FAIL, "consecutive intervals were not distinct")
+    return CheckResult(
+        "heartbeat", Status.PASS, "renewal chain valid, intervals linked and advancing"
+    )
+
+
+def check_validator_quorum() -> CheckResult:
+    """Validator quorum: an M-of-N quorum approves at threshold, and denies when fewer approve."""
+    session = HeartbeatSession(subject_did="did:web:conformance.test")
+    session.record_action(b"conformance-quorum")
+    request = session.build_request().to_dict()
+
+    def make_validators() -> List[HeartbeatValidator]:
+        return [
+            HeartbeatValidator(validator_did=f"did:web:v{i}.conformance.test") for i in range(3)
+        ]
+
+    # Met: two of three is enough, and all three approve a fresh request.
+    met = HeartbeatQuorum(
+        validators=[QuorumValidator(validator=v) for v in make_validators()],
+        threshold=2,
+    )
+    met_result = met.validate(request)
+    if not met_result.ok or met_result.votes_for < 2:
+        return CheckResult("validator_quorum", Status.FAIL, "a met quorum was not approved")
+
+    # Denied: require all three, but pre-seed one validator so it rejects the
+    # replayed interval as stale, leaving only two approvals under a threshold of three.
+    validators = make_validators()
+    validators[0].validate(request)
+    denied = HeartbeatQuorum(
+        validators=[QuorumValidator(validator=v) for v in validators],
+        threshold=3,
+    )
+    denied_result = denied.validate(request)
+    if denied_result.ok:
+        return CheckResult("validator_quorum", Status.FAIL, "a quorum below threshold was approved")
+    return CheckResult(
+        "validator_quorum", Status.PASS, "approves at threshold, denies below threshold"
+    )
 
 
 # The level contract: each level lists (check name, callable). A level is
@@ -178,57 +446,15 @@ LEVELS: Dict[str, List[Tuple[str, Callable[[], CheckResult]]]] = {
         ("nonce_replay", check_nonce_replay),
     ],
     "L2": [
-        (
-            "revocation",
-            _pending(
-                "revocation",
-                "A BitstringStatusList with the credential's bit set verifies as revoked.",
-            ),
-        ),
-        (
-            "delegation_narrowing",
-            _pending(
-                "delegation_narrowing",
-                "A delegated credential narrows its parent and honours the five-link depth bound.",
-            ),
-        ),
-        (
-            "sidecar_allow_deny",
-            _pending(
-                "sidecar_allow_deny",
-                "Behavioural: an allowed intent signs, a disallowed intent is rejected with a structured code.",
-            ),
-        ),
-        (
-            "audit_trail",
-            _pending(
-                "audit_trail",
-                "A sequence of actions produces a valid hash-linked audit trail.",
-            ),
-        ),
+        ("revocation", check_revocation),
+        ("delegation_narrowing", check_delegation_narrowing),
+        ("sidecar_allow_deny", check_sidecar_allow_deny),
+        ("audit_trail", check_audit_trail),
     ],
     "L3": [
-        (
-            "hybrid_pq",
-            _pending(
-                "hybrid_pq",
-                "Dual-proof: both eddsa-jcs-2022 and mldsa44-jcs-2026 proofs over the same JCS bytes verify.",
-            ),
-        ),
-        (
-            "heartbeat",
-            _pending(
-                "heartbeat",
-                "Behavioural: a renewed heartbeat chain is valid, hash-linked, and within interval.",
-            ),
-        ),
-        (
-            "validator_quorum",
-            _pending(
-                "validator_quorum",
-                "Attested: an M-of-N quorum-signed digest verifies against the threshold.",
-            ),
-        ),
+        ("hybrid_pq", check_hybrid_pq),
+        ("heartbeat", check_heartbeat),
+        ("validator_quorum", check_validator_quorum),
     ],
 }
 


### PR DESCRIPTION
Implements the seven remaining conformance checks in the runner, so it certifies through L3 against the reference SDK.

- L2: BitstringStatusList revocation, delegation chaining with the five-link depth bound, Identity Sidecar allow/deny, and a hash-linked audit trail.
- L3: hybrid dual-proof (eddsa-jcs-2022 and mldsa44-jcs-2026), the heartbeat renewal chain, and an M-of-N validator quorum.

Each check exercises the real SDK module and includes a negative case (tamper, deny, or below-threshold). The hybrid check degrades to skip if post-quantum support is unavailable at runtime. The runner now reports L3 as the highest passing level, and `tests/test_conformance.py` locks all three levels.
