### PR TITLE
Animate the illustration seals and tighten the trust-gap layout

### DIFF
--- a/website/public/assets/how-vouch-works.svg
+++ b/website/public/assets/how-vouch-works.svg
@@ -1,6 +1,14 @@
 <svg viewBox="0 0 1120 340" xmlns="http://www.w3.org/2000/svg" role="img" font-family="Georgia, 'Times New Roman', serif">
   <title>How Vouch works in four steps: give the agent a verifiable ID, have the human sign the rules, sign every action, and let anyone verify.</title>
   <desc>Four illustrated columns. One: an ID card with an agent photo and a seal. Two: a signed permission document. Three: an action sealed like a stamped envelope. Four: a large verification check with fakes rejected.</desc>
+  <style>
+    @keyframes stamp{0%,68%{transform:scale(1)}80%{transform:scale(1.16)}90%{transform:scale(.99)}100%{transform:scale(1)}}
+    @keyframes stamplg{0%,68%{transform:scale(1)}80%{transform:scale(1.07)}90%{transform:scale(.995)}100%{transform:scale(1)}}
+    .seal{transform-box:fill-box;transform-origin:center;animation:stamp 4.5s ease-in-out infinite}
+    .seal-lg{transform-box:fill-box;transform-origin:center;animation:stamplg 4.5s ease-in-out infinite}
+    .s0{animation-delay:0s}.s1{animation-delay:.4s}.s2{animation-delay:.8s}.s3{animation-delay:1.2s}
+    @media(prefers-reduced-motion:reduce){.seal,.seal-lg{animation:none}}
+  </style>
 
   <rect x="1" y="1" width="1118" height="338" fill="#FAF7EE" stroke="#D9CFB6" stroke-width="2"/>
   <text x="40" y="42" font-family="ui-monospace, monospace" font-size="13" letter-spacing="4" fill="#7C2D3A">HOW VOUCH WORKS</text>
@@ -23,8 +31,8 @@
     <g stroke="#64748B" stroke-width="3" stroke-linecap="round">
       <line x1="158" y1="130" x2="212" y2="130"/><line x1="158" y1="146" x2="212" y2="146"/><line x1="158" y1="162" x2="196" y2="162"/>
     </g>
-    <circle cx="205" cy="186" r="12" fill="#7C2D3A"/>
-    <path d="M199 186 l4 5 l8 -10" fill="none" stroke="#FAF7EE" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+    <g class="seal s0"><circle cx="205" cy="186" r="12" fill="#7C2D3A"/>
+    <path d="M199 186 l4 5 l8 -10" fill="none" stroke="#FAF7EE" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></g>
   </g>
   <text x="155" y="248" text-anchor="middle" font-size="19" fill="#0F172A">Give it an ID</text>
   <text x="155" y="272" text-anchor="middle" font-size="13" fill="#334155">A verifiable identity,</text>
@@ -45,8 +53,8 @@
       <line x1="422" y1="134" x2="470" y2="134"/><line x1="422" y1="158" x2="470" y2="158"/>
     </g>
     <path d="M398 190 q8 -12 16 0 t16 0" fill="none" stroke="#7C2D3A" stroke-width="2.5" stroke-linecap="round"/>
-    <circle cx="468" cy="188" r="10" fill="#7C2D3A"/>
-    <path d="M463 188 l3 4 l7 -8" fill="none" stroke="#FAF7EE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <g class="seal s1"><circle cx="468" cy="188" r="10" fill="#7C2D3A"/>
+    <path d="M463 188 l3 4 l7 -8" fill="none" stroke="#FAF7EE" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></g>
   </g>
   <text x="435" y="248" text-anchor="middle" font-size="19" fill="#0F172A">Set the rules</text>
   <text x="435" y="272" text-anchor="middle" font-size="13" fill="#334155">The human signs</text>
@@ -57,8 +65,8 @@
   <g>
     <rect x="655" y="118" width="120" height="82" rx="6" fill="#F2EBD9" stroke="#0F172A" stroke-width="3"/>
     <path d="M657 124 L715 160 L773 124" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
-    <circle cx="715" cy="196" r="16" fill="#7C2D3A" stroke="#FAF7EE" stroke-width="2.5"/>
-    <path d="M706 196 l6 7 l11 -14" fill="none" stroke="#FAF7EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+    <g class="seal s2"><circle cx="715" cy="196" r="16" fill="#7C2D3A" stroke="#FAF7EE" stroke-width="2.5"/>
+    <path d="M706 196 l6 7 l11 -14" fill="none" stroke="#FAF7EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/></g>
   </g>
   <text x="715" y="248" text-anchor="middle" font-size="19" fill="#0F172A">Sign every move</text>
   <text x="715" y="272" text-anchor="middle" font-size="13" fill="#334155">Each action carries</text>
@@ -67,8 +75,8 @@
   <!-- 04 ANYONE CAN CHECK -->
   <text x="985" y="92" text-anchor="middle" font-family="ui-monospace, monospace" font-size="20" letter-spacing="2" fill="#7C2D3A">04</text>
   <g>
-    <circle cx="978" cy="152" r="40" fill="#7C2D3A"/>
-    <path d="M958 152 l13 15 l27 -33" fill="none" stroke="#FAF7EE" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/>
+    <g class="seal-lg s3"><circle cx="978" cy="152" r="40" fill="#7C2D3A"/>
+    <path d="M958 152 l13 15 l27 -33" fill="none" stroke="#FAF7EE" stroke-width="5" stroke-linecap="round" stroke-linejoin="round"/></g>
     <circle cx="1034" cy="120" r="13" fill="#FAF7EE" stroke="#64748B" stroke-width="2.5"/>
     <path d="M1026 112 l16 16 M1042 112 l-16 16" stroke="#64748B" stroke-width="2.5" stroke-linecap="round"/>
   </g>

--- a/website/public/assets/trust-handoff.svg
+++ b/website/public/assets/trust-handoff.svg
@@ -1,6 +1,12 @@
 <svg viewBox="0 0 1120 380" xmlns="http://www.w3.org/2000/svg" role="img" font-family="Georgia, 'Times New Roman', serif">
   <title>The trust handoff: a human delegates to a humanified AI agent that carries a verifiable identity badge, which then acts on an MCP server, with a signed checkpoint on each handoff.</title>
   <desc>A human figure on the left, an arrow labelled delegates with a check seal, a friendly AI agent character with a burgundy identity badge in the centre, an arrow labelled acts with a check seal, and a stacked MCP server on the right.</desc>
+  <style>
+    @keyframes stamp{0%,70%{transform:scale(1)}80%{transform:scale(1.14)}90%{transform:scale(.99)}100%{transform:scale(1)}}
+    .seal{transform-box:fill-box;transform-origin:center;animation:stamp 4s ease-in-out infinite}
+    .s0{animation-delay:0s}.s1{animation-delay:.45s}.s2{animation-delay:.9s}
+    @media(prefers-reduced-motion:reduce){.seal{animation:none}}
+  </style>
   <defs>
     <marker id="ah" markerWidth="12" markerHeight="12" refX="8.5" refY="5" orient="auto">
       <path d="M0,0 L10,5 L0,10 Z" fill="#0F172A"/>
@@ -21,7 +27,7 @@
   <!-- ARROW 1 -->
   <line x1="214" y1="160" x2="486" y2="160" stroke="#0F172A" stroke-width="3" marker-end="url(#ah)"/>
   <text x="350" y="138" text-anchor="middle" font-family="ui-monospace, monospace" font-size="11" letter-spacing="2" fill="#334155">DELEGATES</text>
-  <g>
+  <g class="seal s1">
     <circle cx="350" cy="160" r="14" fill="#FAF7EE" stroke="#7C2D3A" stroke-width="2.5"/>
     <path d="M343 160 l5 6 l9 -12" fill="none" stroke="#7C2D3A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>
@@ -43,15 +49,17 @@
   <circle cx="508" cy="131" r="5" fill="#7C2D3A" opacity="0.25"/>
   <circle cx="572" cy="131" r="5" fill="#7C2D3A" opacity="0.25"/>
   <circle cx="614" cy="156" r="6" fill="#F2EBD9" stroke="#0F172A" stroke-width="2.5"/>
-  <circle cx="540" cy="206" r="18" fill="#7C2D3A"/>
-  <path d="M531 206 l6 7 l12 -15" fill="none" stroke="#FAF7EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <g class="seal s0">
+    <circle cx="540" cy="206" r="18" fill="#7C2D3A"/>
+    <path d="M531 206 l6 7 l12 -15" fill="none" stroke="#FAF7EE" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </g>
   <text x="540" y="292" text-anchor="middle" font-size="20" fill="#0F172A">AI Agent</text>
   <text x="540" y="312" text-anchor="middle" font-family="ui-monospace, monospace" font-size="11" letter-spacing="2" fill="#7C2D3A">VERIFIABLE IDENTITY</text>
 
   <!-- ARROW 2 -->
   <line x1="630" y1="160" x2="908" y2="160" stroke="#0F172A" stroke-width="3" marker-end="url(#ah)"/>
   <text x="772" y="138" text-anchor="middle" font-family="ui-monospace, monospace" font-size="11" letter-spacing="2" fill="#334155">ACTS · BUY · EMAIL · CODE</text>
-  <g>
+  <g class="seal s2">
     <circle cx="772" cy="160" r="14" fill="#FAF7EE" stroke="#7C2D3A" stroke-width="2.5"/>
     <path d="M765 160 l5 6 l9 -12" fill="none" stroke="#7C2D3A" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
   </g>

--- a/website/src/app/the-trust-gap/page.tsx
+++ b/website/src/app/the-trust-gap/page.tsx
@@ -31,16 +31,16 @@ export default function TrustGapPage() {
     return (
         <main className="min-h-screen bg-parchment text-ink">
             {/* HERO */}
-            <section className="container-wide pt-20 md:pt-28 pb-14">
+            <section className="container-wide pt-20 md:pt-28 pb-16 md:pb-20">
                 <p className="eyebrow text-burgundy mb-5">The Agent Trust Index</p>
                 <h1 className="font-serif font-semibold text-[clamp(2.6rem,7vw,5rem)] leading-[1.02] tracking-tight mb-6">
                     &ldquo;Trust me,
                     <br />
                     I&rsquo;m an AI agent.&rdquo;
                 </h1>
-                <p className="text-[clamp(1.3rem,3vw,1.9rem)] text-ink-soft mb-9">
+                <p className="text-[clamp(1.25rem,3vw,1.75rem)] leading-snug text-ink-soft mb-9 max-w-[24ch]">
                     <strong className="text-burgundy font-semibold">{ATI_SUMMARY.pctCannot}%</strong> can&rsquo;t
-                    back that up.
+                    back that up. Only {VERIFIABLE} of {TOTAL} public agents can prove who they are.
                 </p>
                 <div className="flex flex-wrap gap-3">
                     <Link href="/agent-trust-index/" className="btn-primary">
@@ -52,78 +52,75 @@ export default function TrustGapPage() {
                 </div>
             </section>
 
-            {/* THE PROBLEM: the trust handoff */}
-            <section className="border-t border-rule bg-parchment-warm/40">
-                <div className="container-wide py-12 md:py-16">
-                    <p className="eyebrow text-burgundy mb-6">The handoff</p>
+            {/* THE PROBLEM */}
+            <section className="border-t border-rule">
+                <div className="container-wide py-16 md:py-20">
+                    <p className="eyebrow text-burgundy mb-4">The gap</p>
+                    <h2 className="font-serif font-semibold text-[clamp(1.7rem,4vw,2.6rem)] leading-tight tracking-tight mb-4 max-w-[16ch]">
+                        Your AI already acts on real systems.
+                    </h2>
+                    <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-[52ch] mb-10">
+                        It books, buys, emails, and ships code for you. The open question is whether it can prove
+                        who it is, and who allowed it.
+                    </p>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                         src="/assets/trust-handoff.svg"
                         alt="A human delegates to an AI agent that carries a verifiable identity, and the agent acts on an MCP server. Each handoff is signed."
-                        className="hidden md:block w-full h-auto max-w-[940px] mx-auto"
+                        className="hidden md:block w-full h-auto max-w-[880px]"
                     />
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                         src="/assets/trust-handoff-mobile.svg"
                         alt="A human delegates to an AI agent that carries a verifiable identity, and the agent acts on an MCP server. Each handoff is signed."
-                        className="block md:hidden w-full h-auto max-w-[340px] mx-auto"
+                        className="block md:hidden w-full h-auto max-w-[320px]"
                     />
                 </div>
             </section>
 
-            {/* THE SOLUTION: how Vouch works */}
+            {/* THE SOLUTION */}
             <section className="border-t border-rule">
-                <div className="container-wide py-12 md:py-16">
-                    <p className="eyebrow text-burgundy mb-6">The fix, in four steps</p>
+                <div className="container-wide py-16 md:py-20">
+                    <p className="eyebrow text-burgundy mb-4">The fix</p>
+                    <h2 className="font-serif font-semibold text-[clamp(1.7rem,4vw,2.6rem)] leading-tight tracking-tight mb-4 max-w-[16ch]">
+                        Give every agent a way to prove it.
+                    </h2>
+                    <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-[52ch] mb-10">
+                        A verifiable identity, a signed permission slip, and a signature on every action that
+                        anyone can check.
+                    </p>
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                         src="/assets/how-vouch-works.svg"
                         alt="How Vouch works: give the agent a verifiable ID, the human sets the rules, every action is signed, and anyone can check it. Tampering and fakes are rejected."
-                        className="hidden md:block w-full h-auto max-w-[940px] mx-auto"
+                        className="hidden md:block w-full h-auto max-w-[880px]"
                     />
                     {/* eslint-disable-next-line @next/next/no-img-element */}
                     <img
                         src="/assets/how-vouch-works-mobile.svg"
                         alt="How Vouch works: give the agent a verifiable ID, the human sets the rules, every action is signed, and anyone can check it. Tampering and fakes are rejected."
-                        className="block md:hidden w-full h-auto max-w-[360px] mx-auto"
+                        className="block md:hidden w-full h-auto max-w-[340px]"
                     />
                 </div>
             </section>
 
-            {/* THE NUMBER */}
-            <section className="container-wide py-16 md:py-24">
-                <div className="flex flex-col md:flex-row md:items-baseline gap-5 md:gap-12">
-                    <div className="font-serif font-semibold text-[clamp(4.5rem,13vw,9rem)] leading-none tracking-tight">
-                        {ATI_SUMMARY.pctCannot}%
-                    </div>
-                    <p className="text-[1.3rem] leading-snug text-ink-soft max-w-[22ch]">
-                        of AI agents <strong className="text-ink font-semibold">cannot prove who they are.</strong>{' '}
-                        Only {VERIFIABLE} of {TOTAL} can.
-                    </p>
-                </div>
-            </section>
-
-            {/* ONE-LINER */}
-            <section className="border-t border-rule">
-                <div className="container-wide py-14 md:py-16">
-                    <p className="font-serif italic text-[clamp(1.5rem,4vw,2.5rem)] tracking-tight">
+            {/* CLOSING LINE + CTA */}
+            <section className="bg-ink text-parchment border-t border-rule">
+                <div className="container-wide py-16 md:py-20">
+                    <p className="font-serif italic text-[clamp(1.6rem,4vw,2.6rem)] leading-tight tracking-tight mb-8 max-w-[20ch]">
                         The web got a padlock. Agents get Vouch.
                     </p>
-                </div>
-            </section>
-
-            {/* CTA BAND */}
-            <section className="bg-ink text-parchment">
-                <div className="container-wide py-14 md:py-16 flex flex-col md:flex-row md:items-center md:justify-between gap-6">
-                    <p className="font-serif font-semibold text-[clamp(1.6rem,4vw,2.4rem)] tracking-tight">
-                        Can your agent prove it?
-                    </p>
-                    <Link
-                        href="/agent-trust-index/"
-                        className="inline-flex items-center gap-2 font-mono uppercase text-[0.75rem] tracking-[0.16em] px-6 py-[0.85rem] bg-burgundy text-parchment border border-burgundy no-underline transition-colors hover:bg-[#5f222c] hover:border-[#5f222c]"
-                    >
-                        Grade it in 10 seconds
-                    </Link>
+                    <div className="flex flex-col sm:flex-row sm:items-center gap-5">
+                        <span className="font-serif font-semibold text-[1.4rem] tracking-tight">
+                            Can your agent prove it?
+                        </span>
+                        <Link
+                            href="/agent-trust-index/"
+                            className="inline-flex items-center gap-2 font-mono uppercase text-[0.75rem] tracking-[0.16em] px-6 py-[0.85rem] bg-burgundy text-parchment border border-burgundy no-underline transition-colors hover:bg-[#5f222c] hover:border-[#5f222c] self-start"
+                        >
+                            Grade it in 10 seconds
+                        </Link>
+                    </div>
                 </div>
             </section>
 


### PR DESCRIPTION
Two related polish changes to /the-trust-gap.

- The seals on both desktop illustrations now do a subtle, staggered stamp pulse (pure CSS inside the SVG, and it holds still under reduce-motion).
- The page layout is tightened into a single left-aligned column: one headline stat instead of two, the illustrations aligned under their own headings, parallel problem-and-fix blocks, and a combined closing line and call to action.

Signed-off-by: Ramprasad Gaddam <groups.rampy1@gmail.com>