### PR TITLE
Make first-time setup a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@
 ## Quick Start
 
 ```bash
+# Install (Linux and macOS). On Windows, use: pip install vouch-protocol
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Run vouch with no arguments and pick what you want to do
+vouch
+```
+
+Prefer to do it by hand? It is three commands:
+
+```bash
 pip install vouch-protocol
 
 # One command to configure SSH signing + Vouch branding
@@ -44,6 +54,8 @@ vouch git init
 # All future commits are now signed and show ✅ Verified on GitHub
 git commit -m "Secure commit"
 ```
+
+Setting up an agent instead of git signing? `vouch onboard --quick` generates a working identity, allow-list, verifier, and heartbeat config in one command.
 
 ---
 
@@ -230,6 +242,10 @@ flowchart TB
 
 ### 1. Install
 ```bash
+# Linux and macOS: one line
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Or with pip (any platform)
 pip install vouch-protocol
 ```
 

--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -69,6 +69,16 @@ A credential signed in Python verifies in TypeScript or Go and vice versa.
 
 ## Tasks and quickstarts
 
+### "What is the fastest way to get started, with no code?"
+
+Install the CLI in one line on Linux or macOS (on Windows, `pip install vouch-protocol`):
+
+```bash
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+```
+
+Then run `vouch` with no arguments for a short menu (sign git commits, or create an agent identity). For a full agent setup with recommended defaults and no prompts, `vouch onboard --quick` writes a working identity, allow-list, verifier, and heartbeat config in one command. Point non-programmers here first, then move to the SDK snippets below when they want to write code.
+
 ### "How do I sign my agent's action?"
 
 Three-line Python:

--- a/claude-skill/skills/vouch-protocol/reference/quickstart.md
+++ b/claude-skill/skills/vouch-protocol/reference/quickstart.md
@@ -3,6 +3,29 @@
 Make an agent sign every tool call in one line, or sign a single credential by
 hand. Both take about five minutes.
 
+## Fastest start, no code
+
+If you just want Vouch working without writing any code:
+
+```bash
+# Install on Linux or macOS (on Windows: pip install vouch-protocol)
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Run vouch with no arguments and choose from the menu
+vouch
+```
+
+The menu covers the two common goals: signing your git commits (a verified badge
+on GitHub) and giving an agent its own identity. For a full agent setup with
+recommended defaults and no questions, run:
+
+```bash
+vouch onboard --quick
+```
+
+That writes a working identity, allow-list, verifier, and heartbeat config in one
+command. When you are ready to write code against the SDK, continue below.
+
 ## Python: make an agent sign every tool call (one line)
 
 ```bash

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -46,6 +46,11 @@ The old "minting" tools (`VouchSignerTool`, `sign_request`, `sign_action`,
 5. **If the answer is not in the knowledge**, say so, then either
    search for it or point the user at https://github.com/vouch-protocol/vouch/issues
    and https://discord.gg/mMqx5cG9Y.
+6. **For newcomers who are not ready to code**, point at the one-line
+   install on Linux or macOS (`curl -fsSL https://vouch-protocol.com/install.sh | sh`,
+   or `pip install vouch-protocol` on Windows), then `vouch` with no
+   arguments for a short menu, or `vouch onboard --quick` for a full
+   agent setup in one command.
 
 ## Use of Workspace tools
 

--- a/gemini-gem/knowledge/quickstart.md
+++ b/gemini-gem/knowledge/quickstart.md
@@ -3,6 +3,29 @@
 Make an agent sign every tool call in one line, or sign a single credential by
 hand. Both take about five minutes.
 
+## Fastest start, no code
+
+If you just want Vouch working without writing any code:
+
+```bash
+# Install on Linux or macOS (on Windows: pip install vouch-protocol)
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Run vouch with no arguments and choose from the menu
+vouch
+```
+
+The menu covers the two common goals: signing your git commits (a verified badge
+on GitHub) and giving an agent its own identity. For a full agent setup with
+recommended defaults and no questions, run:
+
+```bash
+vouch onboard --quick
+```
+
+That writes a working identity, allow-list, verifier, and heartbeat config in one
+command. When you are ready to write code against the SDK, continue below.
+
 ## Python: make an agent sign every tool call (one line)
 
 ```bash

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -169,6 +169,15 @@ can run locally with the SDK; do not pretend you signed something.
 Concise. Code first. No emoji. No filler ("Great question!", "Absolutely!").
 Markdown for structure. Code in fenced blocks with the language tag.
 
+## When the user is new
+
+If someone wants the fastest way to start and is not ready to write code, point
+them at the one-line install on Linux or macOS
+(`curl -fsSL https://vouch-protocol.com/install.sh | sh`, or `pip install
+vouch-protocol` on Windows). Then `vouch` with no arguments gives a short menu
+(sign git commits, or create an agent identity), and `vouch onboard --quick`
+generates a full agent setup with recommended defaults in one command.
+
 ## When the user is stuck
 
 If the user pastes an error message, walk them through `troubleshooting.md`

--- a/openai-gpt/knowledge/quickstart.md
+++ b/openai-gpt/knowledge/quickstart.md
@@ -3,6 +3,29 @@
 Make an agent sign every tool call in one line, or sign a single credential by
 hand. Both take about five minutes.
 
+## Fastest start, no code
+
+If you just want Vouch working without writing any code:
+
+```bash
+# Install on Linux or macOS (on Windows: pip install vouch-protocol)
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Run vouch with no arguments and choose from the menu
+vouch
+```
+
+The menu covers the two common goals: signing your git commits (a verified badge
+on GitHub) and giving an agent its own identity. For a full agent setup with
+recommended defaults and no questions, run:
+
+```bash
+vouch onboard --quick
+```
+
+That writes a working identity, allow-list, verifier, and heartbeat config in one
+command. When you are ready to write code against the SDK, continue below.
+
 ## Python: make an agent sign every tool call (one line)
 
 ```bash

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -1327,6 +1327,29 @@ def cmd_scan(args) -> int:
     return 0
 
 
+def _guided_start() -> "list[str] | None":
+    """Interactive picker shown when ``vouch`` is run with no subcommand.
+
+    Turns a first-time user with no idea which command to run into a single
+    choice. Returns the argv for the chosen action (fed back through the same
+    parser), or ``None`` to exit.
+    """
+    print("Vouch Protocol\n")
+    print("What would you like to do?\n")
+    print("  1) Sign my git commits        (verified badge on GitHub)")
+    print("  2) Give my agent an identity  (a DID and a keypair)")
+    print("  3) Full guided setup          (identity, allow-list, verifier, heartbeat)")
+    print("  4) Quit\n")
+    mapping = {"1": ["git", "init"], "2": ["init"], "3": ["onboard"]}
+    while True:
+        choice = input("Choose 1-4 [1]: ").strip() or "1"
+        if choice in mapping:
+            return mapping[choice]
+        if choice == "4" or choice.lower() in {"q", "quit", "exit"}:
+            return None
+        print("  Please enter 1, 2, 3, or 4.")
+
+
 def main() -> int:
     """Main entry point for the CLI."""
     parser = argparse.ArgumentParser(
@@ -1500,6 +1523,11 @@ def main() -> int:
         help="Do not prompt, use presets and defaults only",
     )
     p_onboard.add_argument(
+        "--quick",
+        action="store_true",
+        help="Zero-question setup: accept every recommended default and generate a working config in one command",
+    )
+    p_onboard.add_argument(
         "--dry-run",
         dest="dry_run",
         action="store_true",
@@ -1509,6 +1537,14 @@ def main() -> int:
     args = parser.parse_args()
 
     setup_logging(args.verbose if hasattr(args, "verbose") else False)
+
+    # Bare `vouch` at an interactive terminal: offer a short menu instead of a
+    # wall of help. Piped/non-TTY runs keep the old behaviour (print help).
+    if args.command is None and sys.stdin.isatty() and sys.stdout.isatty():
+        chosen = _guided_start()
+        if chosen is None:
+            return 0
+        args = parser.parse_args(chosen)
 
     if args.command == "init":
         return cmd_init(args)

--- a/vouch/onboard.py
+++ b/vouch/onboard.py
@@ -730,19 +730,37 @@ def run_wizard(
 
 
 def cmd_onboard(args: argparse.Namespace) -> int:
+    quick = getattr(args, "quick", False)
+    domain_supplied = bool(getattr(args, "domain", None))
     preset: Dict[str, str] = {}
-    if getattr(args, "domain", None):
+    if domain_supplied:
         preset["domain"] = args.domain
     if getattr(args, "tier", None):
         preset["tier"] = args.tier
     if getattr(args, "lang", None):
         preset["toolwire_lang"] = args.lang
         preset["verifier_lang"] = args.lang
-    return run_wizard(
+
+    # Quick mode: run start-to-finish with no questions. Every other field
+    # already has a recommended default; domain is the only one that does not,
+    # so seed a placeholder the summary tells the user to replace.
+    if quick and not domain_supplied:
+        preset.setdefault("domain", "agent.example")
+
+    rc = run_wizard(
         resume=getattr(args, "resume", False),
-        reset=getattr(args, "reset", False),
-        interactive=not getattr(args, "non_interactive", False),
+        # Quick mode always starts fresh so re-running it just works instead of
+        # short-circuiting on a prior completed run.
+        reset=getattr(args, "reset", False) or quick,
+        interactive=not (getattr(args, "non_interactive", False) or quick),
         dry_run=getattr(args, "dry_run", False),
         out_dir=getattr(args, "out_dir", ".") or ".",
         preset_answers=preset,
     )
+
+    if rc == 0 and quick and not domain_supplied:
+        print(
+            "\nNote: used the placeholder domain 'agent.example'. "
+            "Re-run with --domain your.domain to bind the identity to a real host."
+        )
+    return rc

--- a/website-agent/backend/knowledge/quickstart.md
+++ b/website-agent/backend/knowledge/quickstart.md
@@ -3,6 +3,29 @@
 Make an agent sign every tool call in one line, or sign a single credential by
 hand. Both take about five minutes.
 
+## Fastest start, no code
+
+If you just want Vouch working without writing any code:
+
+```bash
+# Install on Linux or macOS (on Windows: pip install vouch-protocol)
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Run vouch with no arguments and choose from the menu
+vouch
+```
+
+The menu covers the two common goals: signing your git commits (a verified badge
+on GitHub) and giving an agent its own identity. For a full agent setup with
+recommended defaults and no questions, run:
+
+```bash
+vouch onboard --quick
+```
+
+That writes a working identity, allow-list, verifier, and heartbeat config in one
+command. When you are ready to write code against the SDK, continue below.
+
 ## Python: make an agent sign every tool call (one line)
 
 ```bash

--- a/website/public/install.sh
+++ b/website/public/install.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+# Vouch Protocol installer.
+#
+#   curl -fsSL https://vouch-protocol.com/install.sh | sh
+#
+# Installs the `vouch` command line tool. Prefers pipx (an isolated install),
+# falls back to pip. Prints the one thing to run next.
+set -e
+
+info() { printf '  %s\n' "$1"; }
+err() { printf 'Error: %s\n' "$1" >&2; }
+
+printf '\nInstalling Vouch Protocol...\n\n'
+
+# 1. Python 3.9+ is required. We cannot install it for you reliably, so if it
+#    is missing we point you at the download and stop.
+if command -v python3 >/dev/null 2>&1; then
+  PY=python3
+elif command -v python >/dev/null 2>&1; then
+  PY=python
+else
+  err "Python 3.9 or newer is required, and no python was found."
+  info "Install Python from https://www.python.org/downloads/ then run this again."
+  exit 1
+fi
+
+# 2. Install. pipx keeps the tool in its own environment and puts `vouch` on
+#    PATH; it is the smoothest path on modern Linux and macOS. If pipx is not
+#    present we use pip.
+if command -v pipx >/dev/null 2>&1; then
+  info "Installing with pipx..."
+  pipx install vouch-protocol >/dev/null
+elif "$PY" -m pip --version >/dev/null 2>&1; then
+  info "Installing with pip..."
+  if ! "$PY" -m pip install --user --upgrade vouch-protocol >/dev/null 2>&1; then
+    err "pip could not install into your user environment."
+    info "The easiest fix is pipx. Install it, then run this again:"
+    info "  $PY -m pip install --user pipx  &&  $PY -m pipx ensurepath"
+    exit 1
+  fi
+else
+  err "Neither pipx nor pip is available for $PY."
+  info "Bootstrap pip with:  $PY -m ensurepip --upgrade   (see https://pip.pypa.io)"
+  exit 1
+fi
+
+# 3. Confirm, and show the single next step.
+printf '\nVouch Protocol is installed.\n\n'
+if command -v vouch >/dev/null 2>&1; then
+  info "Run this and pick what you want to do:"
+  info "  vouch"
+else
+  info 'Almost there: the "vouch" command is not on your PATH yet.'
+  info "Add your user scripts directory to PATH, then run  vouch :"
+  info '  export PATH="$HOME/.local/bin:$PATH"'
+fi
+printf '\n'

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -648,6 +648,17 @@ Every tool call is now signed in Python before it runs. There is no prompt to wr
         meta: 'Shipped v1.6.x',
       },
       {
+        q: 'What is the fastest way to start using Vouch?',
+        a: `On Linux or macOS, one line installs the \`vouch\` command (on Windows, use \`pip install vouch-protocol\`):
+
+\`\`\`bash
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+\`\`\`
+
+Then run \`vouch\` with no arguments and pick from a short menu: sign your git commits (a verified badge on GitHub), or give an agent its own identity. For a full agent setup with recommended defaults and no questions, run \`vouch onboard --quick\`, which writes a working identity, allow-list, verifier, and heartbeat config in one command.`,
+        helpLinks: [{ label: 'Getting started', href: '/help/#quickstart-python' }],
+      },
+      {
         q: 'Which languages have Vouch SDKs?',
         a: `One canonical Rust core does the cryptography once, and every language is a thin wrapper over it, so a credential signed on any platform verifies on every other, byte for byte (JCS canonicalization):
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -42,10 +42,16 @@ export const HELP_SECTIONS: HelpSection[] = [
 ## Install
 
 \`\`\`bash
+# Linux and macOS: one line (on Windows, use pip below)
+curl -fsSL https://vouch-protocol.com/install.sh | sh
+
+# Or with pip on any platform
 pip install vouch-protocol
 \`\`\`
 
 The hybrid post-quantum profile (\`hybrid-eddsa-mldsa44-jcs-2026\`) is bundled by default; nothing else to install.
+
+Not ready to write code yet? Run \`vouch\` with no arguments for a short menu (sign your git commits, or create an agent identity), or run \`vouch onboard --quick\` to generate a full agent setup with recommended defaults in one command.
 
 ## Step 1 - Sign and verify locally
 


### PR DESCRIPTION
This makes first-time setup as short as possible, especially for people who are not programmers.

- A one-line installer served from the site: `curl -fsSL https://vouch-protocol.com/install.sh | sh` installs the `vouch` command on Linux and macOS. `pip install vouch-protocol` still works on any platform.
- Running `vouch` with no arguments now shows a short menu: sign your git commits, create an agent identity, or run the full setup. Piped and non-interactive runs keep printing the usual help.
- `vouch onboard --quick` runs the whole onboarding with recommended defaults and no questions, writing a working identity, allow-list, verifier, and heartbeat config in one command.
- README, FAQ, help pages, the knowledge base, and the assistant skill, GPT, and gem instructions all show these shorter paths.
