### PR TITLE
ci(contributors): credit the commit author for the verified-contributor certificate

### DIFF
--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -5,7 +5,12 @@ name: Verified Contributor credential
 # /c/<login>/<pr>/, list them on /contributors, and post a congratulatory
 # comment linking to the certificate. One certificate per merged PR.
 #
-# Skips merges authored by the maintainer (rampyg) and by bots.
+# The credited contributor is the author of the pull request's commits, meaning
+# the person who wrote the code, rather than whoever opened the pull request.
+# This keeps credit correct when a maintainer relays a contribution for someone
+# else.
+#
+# Skips when the commit author is the maintainer (rampyg) or a bot.
 #
 # Setup: repository secrets VOUCH_PRIVATE_KEY (the contributor-issuer Ed25519
 # JWK) and VOUCH_DID (did:web:vouch-protocol.com:contributors). The job is a
@@ -26,28 +31,51 @@ permissions:
 
 jobs:
   mint:
-    if: >
-      github.event.pull_request.merged == true &&
-      github.event.pull_request.user.login != 'rampyg' &&
-      !endsWith(github.event.pull_request.user.login, '[bot]')
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve contributor from commit authors
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Credit the person who wrote the code. Pick the most frequent commit
+          # author login that is neither the maintainer nor a bot.
+          login=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/commits?per_page=100" \
+            --jq '[.[].author.login // empty]
+                  | map(select(. != "rampyg" and (endswith("[bot]") | not)))
+                  | (group_by(.) | max_by(length) | .[0]) // ""')
+          if [ -z "$login" ]; then
+            echo "No external contributor to credit (authored by the maintainer or bots)."
+            echo "should_run=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Crediting contributor: ${login}"
+            echo "login=${login}" >> "$GITHUB_OUTPUT"
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v6
+        if: steps.resolve.outputs.should_run == 'true'
 
       - uses: actions/setup-python@v6
+        if: steps.resolve.outputs.should_run == 'true'
         with:
           python-version: "3.11"
 
       - name: Install vouch
+        if: steps.resolve.outputs.should_run == 'true'
         run: |
           python -m pip install --upgrade pip
           pip install -e .
 
       - name: Mint credential
+        if: steps.resolve.outputs.should_run == 'true'
         env:
           VOUCH_PRIVATE_KEY: ${{ secrets.VOUCH_PRIVATE_KEY }}
           VOUCH_DID: ${{ secrets.VOUCH_DID }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR: ${{ steps.resolve.outputs.login }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
@@ -89,7 +117,7 @@ jobs:
         if: hashFiles('credential.json') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR: ${{ steps.resolve.outputs.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
@@ -135,11 +163,11 @@ jobs:
         if: hashFiles('credential.json') != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_AUTHOR: ${{ steps.resolve.outputs.login }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
           BADGE: "https://img.shields.io/badge/Vouch-Verified_Contributor-7C2D3A?style=for-the-badge&labelColor=2d2d2d"
-          CERT_URL: "https://vouch-protocol.com/c/${{ github.event.pull_request.user.login }}/${{ github.event.pull_request.number }}"
+          CERT_URL: "https://vouch-protocol.com/c/${{ steps.resolve.outputs.login }}/${{ github.event.pull_request.number }}"
         run: |
           {
             echo "### Vouch Verified Contributor :sparkles:"


### PR DESCRIPTION
The verified-contributor workflow issues the Vouch Verified Contributor certificate to the account that opened a pull request. This change credits the author of the pull request commits instead, so when a maintainer relays a contribution the certificate, the /contributors listing, and the congratulatory comment all go to the person who wrote the code.

The job now resolves the contributor by picking the most frequent commit-author login on the PR, skipping the maintainer and bot accounts. Behavior is unchanged for pull requests opened by their own author.