### PR TITLE
feat(conformance): hosted conformance worker (challenge, re-check, mint, badge)

### DIFF
--- a/conformance-worker/.gitignore
+++ b/conformance-worker/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.wrangler/
+dist/

--- a/conformance-worker/README.md
+++ b/conformance-worker/README.md
@@ -1,0 +1,36 @@
+# Vouch conformance worker
+
+Cloudflare Worker that turns Vouch conformance from a self-declared claim into a
+Vouch-verified, re-checkable result. It issues fresh per-session challenges,
+re-checks submitted responses server-side with the canonical Vouch core (WASM),
+derives the level, mints a signed `VouchConformanceCredential`, and serves the
+badge. Because the worker recomputes every expected answer, a transcript cannot
+be faked by replaying the public test vectors.
+
+## Endpoints
+
+- `POST /conformance/session` , body `{ implementation: { name, repo, commit, did?, publicKeyB64 }, levelRequested? }` returns `{ sessionId, expiresAt, challenges }`.
+- `POST /conformance/session/{id}/submit` , body `{ responses: [{ challengeId, output }] }` returns `{ levelAchieved, checks, badgeUrl, verifyUrl, credential }`.
+- `GET /conformance/{id}` , the stored result and signed credential, for re-verification.
+- `GET /conformance/{id}/badge.svg` , the badge.
+
+Checks re-checked today (L1): canonicalization and sign/verify are verified
+cryptographically with the core; validity-window and nonce-replay are behavioural
+(the implementation reports, the worker holds the expected answer). L2 and L3
+challenges reuse the same shape and land next.
+
+## Local check
+
+```
+npm install
+node smoke.mjs
+```
+
+The smoke test runs the whole loop (issue, honest responses, re-check, mint,
+verify) plus a cheating implementation that must be denied a level.
+
+## Deploy
+
+See the Cloudflare setup steps in the pull request / chat. In short: create the
+KV namespace and set its id in `wrangler.toml`, set the issuer seed as a secret,
+then `wrangler deploy`.

--- a/conformance-worker/lib.js
+++ b/conformance-worker/lib.js
@@ -1,0 +1,210 @@
+// Pure conformance logic: fresh challenge generation, server-side re-check,
+// level derivation, and credential minting. No Cloudflare or wall-clock
+// dependency (timestamps are passed in), so it runs identically in the Worker
+// and in the node smoke test. Every crypto operation goes through the canonical
+// Vouch core (WASM), so re-check and minting match the reference SDK by
+// construction, a submitted transcript cannot be faked by replaying the public
+// test vectors because the worker recomputes the expected answers itself.
+
+const CANON_COUNT = 3;
+
+// The L1 checks a level requires. Extend with L2 / L3 as those challenges land.
+export const LEVEL_CHECKS = {
+  L1: ["canonicalization", "sign_verify", "validity_window", "nonce_replay"],
+};
+const LEVEL_ORDER = ["L1"];
+
+function randInt(max) {
+  const a = new Uint32Array(1);
+  crypto.getRandomValues(a);
+  return a[0] % max;
+}
+
+function randomJson(depth) {
+  if (depth <= 0) {
+    const kind = randInt(3);
+    if (kind === 0) return "v" + randInt(1_000_000);
+    if (kind === 1) return randInt(1_000_000);
+    return randInt(2) === 1;
+  }
+  const obj = {};
+  const count = 2 + randInt(3);
+  for (let i = 0; i < count; i++) obj["k" + randInt(1_000_000)] = randomJson(depth - 1);
+  return obj;
+}
+
+function credentialSkeleton(issuerDid, intent, validFrom, validUntil) {
+  return {
+    "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+    id: `urn:uuid:${crypto.randomUUID()}`,
+    type: ["VerifiableCredential", "VouchCredential"],
+    issuer: issuerDid,
+    validFrom,
+    validUntil,
+    credentialSubject: { id: issuerDid, vouchVersion: "1.0", intent },
+  };
+}
+
+// Build the challenge set plus the server-only expected answers. `expected` is
+// stored server-side and never sent to the implementation.
+export function buildSession(core, implementation, nowIso) {
+  const challenges = [];
+  const expected = {};
+
+  // canonicalization: fresh random JSON; the implementation returns RFC 8785 bytes.
+  for (let i = 0; i < CANON_COUNT; i++) {
+    const input = randomJson(2);
+    challenges.push({ challengeId: `canon-${i}`, check: "canonicalization", level: "L1", input });
+    expected[`canon-${i}`] = core.canonicalize(JSON.stringify(input));
+  }
+
+  // sign_verify: the implementation signs a credential over this intent with its own key.
+  const intent = {
+    action: "conformance_probe",
+    target: `vector:${randInt(1_000_000_000)}`,
+    resource: "https://conformance.vouch-protocol.com/probe",
+  };
+  challenges.push({ challengeId: "sign-0", check: "sign_verify", level: "L1", input: { intent } });
+
+  // validity_window: a credential we sign with a throwaway key, already expired;
+  // the implementation must report it invalid.
+  const vk = JSON.parse(core.generateEd25519());
+  const expired = credentialSkeleton(vk.did_key, intent, "2000-01-01T00:00:00Z", "2000-01-02T00:00:00Z");
+  const expiredSigned = core.signCredential(
+    JSON.stringify(expired), vk.seed_b64, `${vk.did_key}#key-1`, "2000-01-01T00:00:00Z"
+  );
+  challenges.push({
+    challengeId: "validity-0",
+    check: "validity_window",
+    level: "L1",
+    input: { credential: JSON.parse(expiredSigned), publicKeyB64: vk.public_b64 },
+  });
+  expected["validity-0"] = { valid: false };
+
+  // nonce_replay: the implementation is shown the same credential id twice and
+  // must flag the second presentation as a replay.
+  const nk = JSON.parse(core.generateEd25519());
+  const fresh = credentialSkeleton(nk.did_key, intent, nowIso, "2100-01-01T00:00:00Z");
+  const freshSigned = core.signCredential(
+    JSON.stringify(fresh), nk.seed_b64, `${nk.did_key}#key-1`, nowIso
+  );
+  challenges.push({
+    challengeId: "nonce-0",
+    check: "nonce_replay",
+    level: "L1",
+    input: { credential: JSON.parse(freshSigned), publicKeyB64: nk.public_b64, presentations: 2 },
+  });
+  expected["nonce-0"] = { firstAccepted: true, secondAccepted: false };
+
+  return { implementation, createdAt: nowIso, challenges, expected };
+}
+
+// Re-check every response against the server-held expected answers, using the
+// canonical core for the cryptographic checks.
+export function recheck(core, session, responses) {
+  const byId = Object.fromEntries((responses || []).map((r) => [r.challengeId, r]));
+  const checks = [];
+  for (const ch of session.challenges) {
+    const resp = byId[ch.challengeId];
+    let pass = false;
+    let detail = "no response submitted";
+    try {
+      if (ch.check === "canonicalization") {
+        pass = resp?.output === session.expected[ch.challengeId];
+        detail = pass ? "byte-identical to the canonical core" : "canonical bytes differ";
+      } else if (ch.check === "sign_verify") {
+        const cred = resp?.output;
+        pass = !!cred && core.verifyProof(JSON.stringify(cred), session.implementation.publicKeyB64) === true;
+        detail = pass ? "signature verifies against the registered key" : "signature did not verify";
+      } else if (ch.check === "validity_window") {
+        pass = resp?.output?.valid === false;
+        detail = pass ? "expired credential rejected" : "expired credential was not rejected";
+      } else if (ch.check === "nonce_replay") {
+        const out = resp?.output || {};
+        pass = out.firstAccepted === true && out.secondAccepted === false;
+        detail = pass ? "replay rejected on the second presentation" : "replay was not detected";
+      }
+    } catch (err) {
+      detail = `error: ${err && err.message ? err.message : err}`;
+    }
+    checks.push({ name: ch.check, level: ch.level, challengeId: ch.challengeId, pass, detail });
+  }
+  return checks;
+}
+
+// Highest level for which every required check passed.
+export function deriveLevel(checks) {
+  const byName = {};
+  for (const c of checks) byName[c.name] = (byName[c.name] ?? true) && c.pass;
+  let achieved = null;
+  for (const level of LEVEL_ORDER) {
+    if (LEVEL_CHECKS[level].every((name) => byName[name] === true)) achieved = level;
+    else break;
+  }
+  return achieved;
+}
+
+export function buildConformanceCredential({ implementation, level, issuerDid, nowIso, validUntilIso, transcriptHash }) {
+  return {
+    "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+    id: `urn:uuid:${crypto.randomUUID()}`,
+    type: ["VerifiableCredential", "VouchCredential", "VouchConformanceCredential"],
+    issuer: issuerDid,
+    validFrom: nowIso,
+    validUntil: validUntilIso,
+    credentialSubject: {
+      id: implementation.did || `git:${implementation.repo}@${implementation.commit}`,
+      vouchVersion: "1.0",
+      conformance: {
+        level,
+        implementation: {
+          name: implementation.name,
+          repo: implementation.repo,
+          commit: implementation.commit,
+        },
+        transcriptHash,
+      },
+      intent: {
+        action: "attest",
+        target: implementation.repo || implementation.name,
+        resource: "https://conformance.vouch-protocol.com",
+        role: `conformant-${level}`,
+      },
+    },
+  };
+}
+
+export function mint(core, credential, issuerSeedB64, verificationMethod, createdIso) {
+  return JSON.parse(
+    core.signCredential(JSON.stringify(credential), issuerSeedB64, verificationMethod, createdIso)
+  );
+}
+
+export async function transcriptHash(session, responses) {
+  const payload = JSON.stringify({
+    challenges: session.challenges.map((c) => ({ id: c.challengeId, input: c.input })),
+    responses: (responses || []).map((r) => ({ id: r.challengeId, output: r.output })),
+  });
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(payload));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+const DARK = "#333333";
+const BURGUNDY = "#7C2D3A";
+const CHECK = "#34D399";
+
+export function badgeSvg(level, id) {
+  const right = `L${level.replace(/^L/, "")} Conformant`;
+  return `<svg role="img" aria-label="Vouch Verified, ${right}" viewBox="0 0 252 22" xmlns="http://www.w3.org/2000/svg">
+  <clipPath id="r"><rect width="252" height="22" rx="3" fill="#fff"/></clipPath>
+  <g clip-path="url(#r)">
+    <rect width="132" height="22" fill="${DARK}"/>
+    <rect x="132" width="120" height="22" fill="${BURGUNDY}"/>
+  </g>
+  <path d="M9 11 l2.7 2.7 L17.8 7.4" fill="none" stroke="${CHECK}" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/>
+  <g font-family="Verdana,DejaVu Sans,sans-serif" font-size="11.5" fill="#fff">
+    <text x="79" y="15" text-anchor="middle">Vouch Verified</text>
+    <text x="192" y="15" text-anchor="middle">${right}</text>
+  </g>
+</svg>`;
+}

--- a/conformance-worker/package.json
+++ b/conformance-worker/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "vouch-conformance-worker",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@vouch-protocol-official/core-wasm": "^0.1.0"
+  }
+}

--- a/conformance-worker/smoke.mjs
+++ b/conformance-worker/smoke.mjs
@@ -1,0 +1,102 @@
+// End-to-end smoke test for the conformance logic, run with node (no Cloudflare).
+// It exercises the full loop against the canonical core: the worker issues fresh
+// challenges, an honest implementation answers them, the worker re-checks and
+// derives the level, mints and verifies the badge credential, and a cheating
+// implementation is caught. Run: node smoke.mjs
+import init, * as core from "@vouch-protocol-official/core-wasm";
+import { readFileSync } from "fs";
+import { webcrypto } from "node:crypto";
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+import {
+  buildSession,
+  recheck,
+  deriveLevel,
+  buildConformanceCredential,
+  mint,
+  transcriptHash,
+} from "./lib.js";
+
+const wasm = readFileSync(
+  new URL("./node_modules/@vouch-protocol-official/core-wasm/vouch_core_wasm_bg.wasm", import.meta.url)
+);
+await init({ module_or_path: wasm });
+
+const now = "2026-07-03T00:00:00Z";
+let pass = 0;
+let fail = 0;
+const ok = (name, cond) => {
+  console.log(`  ${cond ? "PASS" : "FAIL"}  ${name}`);
+  cond ? pass++ : fail++;
+};
+
+const issuer = JSON.parse(core.generateEd25519());
+const impl = JSON.parse(core.generateEd25519());
+const implementation = {
+  name: "reference",
+  repo: "vouch-protocol/vouch",
+  commit: "abc123",
+  did: impl.did_key,
+  publicKeyB64: impl.public_b64,
+};
+
+function implCredential(intent) {
+  const skel = {
+    "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+    id: `urn:uuid:${crypto.randomUUID()}`,
+    type: ["VerifiableCredential", "VouchCredential"],
+    issuer: impl.did_key,
+    validFrom: now,
+    validUntil: "2100-01-01T00:00:00Z",
+    credentialSubject: { id: impl.did_key, vouchVersion: "1.0", intent },
+  };
+  return JSON.parse(core.signCredential(JSON.stringify(skel), impl.seed_b64, `${impl.did_key}#key-1`, now));
+}
+
+function honestResponses(session) {
+  return session.challenges.map((ch) => {
+    if (ch.check === "canonicalization") {
+      return { challengeId: ch.challengeId, output: core.canonicalize(JSON.stringify(ch.input)) };
+    }
+    if (ch.check === "sign_verify") {
+      return { challengeId: ch.challengeId, output: implCredential(ch.input.intent) };
+    }
+    if (ch.check === "validity_window") {
+      const r = JSON.parse(
+        core.verifyCredential(JSON.stringify(ch.input.credential), ch.input.publicKeyB64, now, 30)
+      );
+      return { challengeId: ch.challengeId, output: { valid: r.valid } };
+    }
+    return { challengeId: ch.challengeId, output: { firstAccepted: true, secondAccepted: false } };
+  });
+}
+
+const session = buildSession(core, implementation, now);
+ok("session issues at least four challenges", session.challenges.length >= 4);
+
+const honest = honestResponses(session);
+const checks = recheck(core, session, honest);
+ok("all honest checks pass", checks.every((c) => c.pass));
+ok("derives L1", deriveLevel(checks) === "L1");
+
+const th = await transcriptHash(session, honest);
+const credential = buildConformanceCredential({
+  implementation,
+  level: deriveLevel(checks),
+  issuerDid: "did:web:vouch-protocol.com:conformance",
+  nowIso: now,
+  validUntilIso: "2027-07-03T00:00:00Z",
+  transcriptHash: th,
+});
+const signed = mint(core, credential, issuer.seed_b64, "did:web:vouch-protocol.com:conformance#key-1", now);
+ok("minted badge credential verifies", core.verifyProof(JSON.stringify(signed), issuer.public_b64) === true);
+
+const cheat = honest.map((r) =>
+  r.challengeId.startsWith("canon-") ? { challengeId: r.challengeId, output: r.output + " " } : r
+);
+const cheatChecks = recheck(core, session, cheat);
+ok("cheating canonicalization is caught", cheatChecks.some((c) => c.name === "canonicalization" && !c.pass));
+ok("cheating implementation is denied a level", deriveLevel(cheatChecks) === null);
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/conformance-worker/worker.js
+++ b/conformance-worker/worker.js
@@ -1,0 +1,136 @@
+// Vouch conformance worker (Cloudflare). Issues fresh per-session challenges,
+// re-checks submitted responses server-side with the canonical Vouch core (WASM),
+// derives the conformance level, mints a signed VouchConformanceCredential, and
+// serves the badge and a re-verifiable result. A submitted transcript cannot be
+// faked by replaying public vectors: the worker recomputes every expected answer.
+//
+// Endpoints:
+//   POST /conformance/session                -> { sessionId, expiresAt, challenges }
+//   POST /conformance/session/{id}/submit    -> { levelAchieved, checks, badgeUrl, verifyUrl, credential }
+//   GET  /conformance/{id}                   -> { level, credential, transcriptHash, checks }
+//   GET  /conformance/{id}/badge.svg         -> SVG badge
+import init, * as core from "@vouch-protocol-official/core-wasm";
+import wasmModule from "@vouch-protocol-official/core-wasm/vouch_core_wasm_bg.wasm";
+import {
+  buildSession,
+  recheck,
+  deriveLevel,
+  buildConformanceCredential,
+  mint,
+  transcriptHash,
+  badgeSvg,
+} from "./lib.js";
+
+const SESSION_TTL = 600; // seconds
+
+let ready;
+async function loadCore() {
+  if (!ready) ready = init({ module_or_path: wasmModule });
+  await ready;
+  return core;
+}
+
+const CORS = { "access-control-allow-origin": "*", "access-control-allow-methods": "GET,POST,OPTIONS", "access-control-allow-headers": "content-type" };
+const json = (obj, status = 200) =>
+  new Response(JSON.stringify(obj, null, 2), { status, headers: { "content-type": "application/json", ...CORS } });
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const path = url.pathname;
+    if (request.method === "OPTIONS") return new Response(null, { status: 204, headers: CORS });
+    try {
+      if (request.method === "POST" && path === "/conformance/session") return await createSession(request, env);
+
+      let m = path.match(/^\/conformance\/session\/([^/]+)\/submit$/);
+      if (request.method === "POST" && m) return await submit(request, env, m[1]);
+
+      m = path.match(/^\/conformance\/([^/]+)\/badge\.svg$/);
+      if (request.method === "GET" && m) return await badge(env, m[1]);
+
+      m = path.match(/^\/conformance\/([^/]+)$/);
+      if (request.method === "GET" && m) return await getResult(env, m[1]);
+
+      return json({ error: "not found" }, 404);
+    } catch (err) {
+      return json({ error: String(err && err.message ? err.message : err) }, 500);
+    }
+  },
+};
+
+async function createSession(request, env) {
+  const c = await loadCore();
+  const body = await request.json();
+  const implementation = body.implementation || {};
+  if (!implementation.publicKeyB64) return json({ error: "implementation.publicKeyB64 is required" }, 400);
+  const session = buildSession(c, implementation, new Date().toISOString());
+  const sessionId = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + SESSION_TTL * 1000).toISOString();
+  await env.CONFORMANCE.put(`session:${sessionId}`, JSON.stringify({ ...session, expiresAt }), {
+    expirationTtl: SESSION_TTL,
+  });
+  return json({ sessionId, expiresAt, challenges: session.challenges });
+}
+
+async function submit(request, env, sessionId) {
+  const c = await loadCore();
+  const raw = await env.CONFORMANCE.get(`session:${sessionId}`);
+  if (!raw) return json({ error: "session not found or expired" }, 404);
+  const session = JSON.parse(raw);
+  if (session.submitted) return json({ error: "session already submitted" }, 409);
+
+  const body = await request.json();
+  const responses = body.responses || [];
+  const checks = recheck(c, session, responses);
+  const level = deriveLevel(checks);
+  const th = await transcriptHash(session, responses);
+
+  let credential = null;
+  if (level && env.ISSUER_SEED_B64) {
+    const nowIso = new Date().toISOString();
+    const validUntilIso = new Date(Date.now() + 365 * 86400 * 1000).toISOString();
+    const unsigned = buildConformanceCredential({
+      implementation: session.implementation,
+      level,
+      issuerDid: env.ISSUER_DID,
+      nowIso,
+      validUntilIso,
+      transcriptHash: th,
+    });
+    credential = mint(c, unsigned, env.ISSUER_SEED_B64, env.ISSUER_VM || `${env.ISSUER_DID}#key-1`, nowIso);
+  }
+
+  const resultId = crypto.randomUUID();
+  await env.CONFORMANCE.put(
+    `result:${resultId}`,
+    JSON.stringify({ resultId, level, checks, transcriptHash: th, implementation: session.implementation, credential })
+  );
+  // Burn the session so it cannot be submitted twice.
+  await env.CONFORMANCE.put(`session:${sessionId}`, JSON.stringify({ ...session, submitted: true }), { expirationTtl: 60 });
+
+  const origin = new URL(request.url).origin;
+  return json({
+    levelAchieved: level,
+    checks,
+    transcriptHash: th,
+    badgeUrl: level ? `${origin}/conformance/${resultId}/badge.svg` : null,
+    verifyUrl: `${origin}/conformance/${resultId}`,
+    credential,
+  });
+}
+
+async function getResult(env, resultId) {
+  const raw = await env.CONFORMANCE.get(`result:${resultId}`);
+  if (!raw) return json({ error: "not found" }, 404);
+  const r = JSON.parse(raw);
+  return json({ level: r.level, implementation: r.implementation, transcriptHash: r.transcriptHash, credential: r.credential, checks: r.checks });
+}
+
+async function badge(env, resultId) {
+  const raw = await env.CONFORMANCE.get(`result:${resultId}`);
+  const level = raw ? JSON.parse(raw).level : null;
+  if (!level) return json({ error: "no conformant result for this id" }, 404);
+  return new Response(badgeSvg(level, resultId), {
+    headers: { "content-type": "image/svg+xml", "cache-control": "max-age=300", ...CORS },
+  });
+}

--- a/conformance-worker/wrangler.toml
+++ b/conformance-worker/wrangler.toml
@@ -1,0 +1,20 @@
+name = "vouch-conformance"
+main = "worker.js"
+compatibility_date = "2025-01-01"
+
+# Served on the conformance subdomain the website wizard and the Action call.
+routes = [
+  { pattern = "conformance.vouch-protocol.com", custom_domain = true }
+]
+
+# KV for short-lived sessions and issued results. Create the namespace and paste
+# its id here (see README).
+[[kv_namespaces]]
+binding = "CONFORMANCE"
+id = "REPLACE_WITH_KV_NAMESPACE_ID"
+
+# Public issuer identity (not secret). The Ed25519 seed is set separately as a
+# secret: `wrangler secret put ISSUER_SEED_B64`.
+[vars]
+ISSUER_DID = "did:web:vouch-protocol.com:conformance"
+ISSUER_VM = "did:web:vouch-protocol.com:conformance#key-1"


### PR DESCRIPTION
Adds the Cloudflare worker that turns Vouch conformance from a self-declared claim into a Vouch-verified, re-checkable result. It issues fresh per-session challenges, re-checks submitted responses server-side with the canonical Vouch core (WASM), derives the level, mints a signed VouchConformanceCredential, and serves the badge and a re-verifiable result.

- L1 re-check: canonicalization and sign/verify are verified cryptographically with the core; validity-window and nonce-replay are behavioural, with the worker holding the expected answer. L2 and L3 reuse the same challenge shape.
- A submitted transcript cannot be faked by replaying the public vectors, because the worker recomputes every expected answer itself.
-  runs the whole loop against the canonical core (issue, honest responses, re-check, mint, verify) and a cheating implementation that must be denied a level.

Deploy needs a KV namespace and an issuer-seed secret on Cloudflare; steps are in the worker README.
