### PR TITLE
ci: keep the welcome greeter from failing on non-newcomer PRs

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,7 +18,11 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
+      # The greeter posts only on a contributor's first issue or PR. On every
+      # other open (maintainers, returning contributors) it has nothing to do
+      # and exits non-zero, so never let that mark the check as failed.
       - uses: actions/first-interaction@v3
+        continue-on-error: true
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |


### PR DESCRIPTION
The welcome greeter runs on every issue and PR open, but actions/first-interaction exits non-zero when there is nothing to post (maintainer PRs, returning contributors). Marks the step continue-on-error so a greeting that has nothing to do never shows as a failed check.
