### PR TITLE
Pin first-interaction to v1 so the welcome workflow runs

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -18,7 +18,7 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v3
+      - uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |


### PR DESCRIPTION
Pins actions/first-interaction to v1, whose hyphenated issue-message and pr-message inputs match this workflow, so the first-time-contributor greeting posts instead of erroring on a missing input.
