### PR TITLE
Run the welcome greeter only for outside contributors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -16,6 +16,9 @@ permissions:
 
 jobs:
   welcome:
+    # Only greet outside contributors. Skip owners, members, and collaborators,
+    # for whom there is no first interaction to greet.
+    if: ${{ !contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association || github.event.issue.author_association) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/first-interaction@v1


### PR DESCRIPTION
The welcome greeter uses `actions/first-interaction`, which posts a greeting only for a contributor's first issue or pull request. On a PR opened by an owner, member, or collaborator there is no first interaction to greet, so the action errors and the job shows a red X on the PR even though every real check is green.

This gates the `welcome` job to run only when the author is an outside contributor (skipping `OWNER`, `MEMBER`, and `COLLABORATOR`). For a maintainer PR the job is skipped and shows a neutral status instead of a red X, and it still greets genuine first-time contributors, including those opening PRs from forks via `pull_request_target`.

Touches only `.github/workflows/welcome.yml`.
