### PR TITLE
docs: document conformance levels and the self-test across the assistant surfaces and FAQ/help

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -294,6 +294,7 @@ Verifiable Credentials as the rest of Vouch, so they verify in every language. S
 - **User cares about audit trail** -> all of the above, plus the reputation engine for behaviour tracking.
 - **User wants a track record that cannot be backdated or cherry-picked** -> outcome evidence (`vouch.accountability`): commit the verdict before the outcome, settle it later with a neutral settler.
 - **User is building a robot or embodied agent** -> the `vouch.robotics` capabilities: hardware-rooted identity, model and config provenance, physical capability scope, robot-to-robot handshake, encrypted black box with kill switch, a scannable passport, a liveness heartbeat (fresh plus in-envelope, so a robot stays trusted only while renewed), robot credential revocation (per-credential and whole-DID), an accountable safety record (a portable tamper-evident incident ledger), perception provenance (a hash-linked log of signed sensor-frame records, so a verifier holding a frame can confirm what the robot perceived), a delegation lease (a short-lived scope-bounded grant a robot verifies and acts on entirely offline, attenuating down a cross-vendor chain), a physical quorum (a cryptographic two-person rule authorizing a high-consequence action only when M of N attested approvers have each signed it), and robot lifecycle (signed ownership transfers forming a chain of custody, a key rotation history, and a decommission credential a verifier honors by refusing to trust a retired robot), and regulatory conformance (machine-checkable reference profiles for ISO 10218, ISO/TS 15066, the EU Machinery Regulation, the EU AI Act, and UL 3300 that map the robot's credentials to the clauses of a regulation and produce a deterministic report an authority can sign as a conformance attestation).
+- **User wants to test, certify, or prove that an implementation, SDK, or port is conformant** -> the conformance levels L1 to L3 and the self-test runner (`python -m vouch.conformance`), with a hosted verifier that mints a re-checkable badge coming. See `reference/conformance.md`.
 
 ## Reference files
 
@@ -312,6 +313,7 @@ For depth on any topic, read the relevant file under `reference/`:
 - `reference/robotics.md` - Robot identity, provenance, physical scope, handshake, black box and kill switch, passport, liveness heartbeat, revocation, safety record, perception provenance, delegation lease, physical quorum, lifecycle (ownership transfer, key rotation, decommission), regulatory conformance (ISO 10218, ISO/TS 15066, EU Machinery Regulation, EU AI Act, UL 3300 profiles plus signed conformance attestation)
 - `reference/integrations.md` - LangChain, CrewAI, MCP, AutoGen, Vertex AI patterns
 - `reference/sidecar.md` - Identity Sidecar architecture and deployment
+- `reference/conformance.md` - Implementation conformance levels (L1-L3), the self-test runner, and the verified re-checkable badge
 - `reference/troubleshooting.md` - Common errors and fixes
 
 ## What this skill does NOT do

--- a/claude-skill/skills/vouch-protocol/reference/conformance.md
+++ b/claude-skill/skills/vouch-protocol/reference/conformance.md
@@ -1,0 +1,58 @@
+# Conformance Reference
+
+Vouch conformance proves that an implementation, an SDK, a fork, or a
+port, produces byte-correct protocol output and supports the required
+feature sets. It is implementation-level, and distinct from robotics
+regulatory conformance (`check_conformance`, the ISO and EU profiles),
+which grades a robot against a regulation.
+
+Levels are cumulative: a level is achieved only when every check at that
+level and all lower levels passes.
+
+## The three levels
+
+**L1 Credential.** RFC 8785 JCS canonicalization, `eddsa-jcs-2022` sign
+and verify, the validity window (an expired credential is rejected), and
+nonce replay resistance.
+
+**L2 Structural-Security.** Everything in L1, plus BitstringStatusList
+revocation, delegation narrowing with the five-link depth bound, the
+Identity Sidecar allow and deny behaviour, and a hash-linked audit trail.
+
+**L3 State Verifiable + Post-Quantum.** Everything in L2, plus the hybrid
+dual-proof (`eddsa-jcs-2022` and `mldsa44-jcs-2026` over the same JCS
+bytes), the Heartbeat renewal chain, and an M-of-N validator quorum.
+
+Robotics is a separate profile, Robotics Conformant, not part of L1 to L3.
+
+## Test your implementation (self-test)
+
+The reference runner checks an implementation against the levels and
+reports the highest it fully satisfies:
+
+```
+python -m vouch.conformance
+```
+
+It runs the checks in-process against the SDK (canonicalization against
+the shared JCS vectors, a sign and verify round-trip with tamper
+rejection, revocation, delegation narrowing, the sidecar allow and deny
+behaviour, the audit trail, the hybrid dual-proof, the heartbeat chain,
+and the validator quorum) and prints a per-check pass or fail with the
+highest passing level.
+
+## The verified badge (coming)
+
+The self-test proves conformance to yourself. A hosted verifier turns it
+into a Vouch-verified, re-checkable result: it issues fresh random
+challenges, re-checks every response server-side with the canonical
+core, derives the level, and mints a signed `VouchConformanceCredential`
+unique to your implementation. Because the verifier recomputes every
+expected answer, a pass cannot be faked by replaying the public test
+vectors. The badge links to the credential, so anyone can re-verify
+Vouch's signature and re-run the challenges.
+
+Until that is live, the `/conformance` page carries a self-declaration
+and shows what a verified pass will earn.
+
+Spec: section 17 (Conformance Levels).

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -80,6 +80,10 @@ Never share user data with external sites.
   Regulated production should use M-of-N validators with role tags.
 - "DID-level or per-credential revocation?" -> Both. DID-level for key
   compromise, BitstringStatusList for surgical retraction.
+- "How do I test or certify my implementation is conformant?" -> Vouch
+  conformance levels L1 to L3 and the self-test runner (`python -m
+  vouch.conformance`); a hosted verifier that mints a re-checkable badge is
+  coming. See `conformance.md`.
 - "How do I prove an agent's track record without faking it?" -> Outcome
   evidence (`vouch.accountability`): commit the verdict before the outcome with
   `commit_outcome`, settle it later with `attest_outcome`. Verification rejects a

--- a/gemini-gem/knowledge/conformance.md
+++ b/gemini-gem/knowledge/conformance.md
@@ -1,0 +1,58 @@
+# Conformance Reference
+
+Vouch conformance proves that an implementation, an SDK, a fork, or a
+port, produces byte-correct protocol output and supports the required
+feature sets. It is implementation-level, and distinct from robotics
+regulatory conformance (`check_conformance`, the ISO and EU profiles),
+which grades a robot against a regulation.
+
+Levels are cumulative: a level is achieved only when every check at that
+level and all lower levels passes.
+
+## The three levels
+
+**L1 Credential.** RFC 8785 JCS canonicalization, `eddsa-jcs-2022` sign
+and verify, the validity window (an expired credential is rejected), and
+nonce replay resistance.
+
+**L2 Structural-Security.** Everything in L1, plus BitstringStatusList
+revocation, delegation narrowing with the five-link depth bound, the
+Identity Sidecar allow and deny behaviour, and a hash-linked audit trail.
+
+**L3 State Verifiable + Post-Quantum.** Everything in L2, plus the hybrid
+dual-proof (`eddsa-jcs-2022` and `mldsa44-jcs-2026` over the same JCS
+bytes), the Heartbeat renewal chain, and an M-of-N validator quorum.
+
+Robotics is a separate profile, Robotics Conformant, not part of L1 to L3.
+
+## Test your implementation (self-test)
+
+The reference runner checks an implementation against the levels and
+reports the highest it fully satisfies:
+
+```
+python -m vouch.conformance
+```
+
+It runs the checks in-process against the SDK (canonicalization against
+the shared JCS vectors, a sign and verify round-trip with tamper
+rejection, revocation, delegation narrowing, the sidecar allow and deny
+behaviour, the audit trail, the hybrid dual-proof, the heartbeat chain,
+and the validator quorum) and prints a per-check pass or fail with the
+highest passing level.
+
+## The verified badge (coming)
+
+The self-test proves conformance to yourself. A hosted verifier turns it
+into a Vouch-verified, re-checkable result: it issues fresh random
+challenges, re-checks every response server-side with the canonical
+core, derives the level, and mints a signed `VouchConformanceCredential`
+unique to your implementation. Because the verifier recomputes every
+expected answer, a pass cannot be faked by replaying the public test
+vectors. The badge links to the credential, so anyone can re-verify
+Vouch's signature and re-run the challenges.
+
+Until that is live, the `/conformance` page carries a self-declaration
+and shows what a verified pass will earn.
+
+Spec: section 17 (Conformance Levels).

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -79,6 +79,10 @@ been removed. See `integrations.md`.
 - "DID-level revocation or BitstringStatusList?" -> Both. DID-level for
   key compromise; BitstringStatusList for surgical per-credential
   retraction. Most production deployments run both.
+- "How do I test or certify that my implementation is conformant?" -> The
+  Vouch conformance levels L1 to L3 and the self-test runner (`python -m
+  vouch.conformance`), with a hosted verifier that mints a re-checkable badge
+  coming. See `conformance.md`.
 - "Single validator or quorum?" -> Single is fine for development. For
   regulated production, M-of-N with role-tagged validators.
 - "How do I prove an agent was right, or track a record I cannot fake?" ->

--- a/openai-gpt/knowledge/conformance.md
+++ b/openai-gpt/knowledge/conformance.md
@@ -1,0 +1,58 @@
+# Conformance Reference
+
+Vouch conformance proves that an implementation, an SDK, a fork, or a
+port, produces byte-correct protocol output and supports the required
+feature sets. It is implementation-level, and distinct from robotics
+regulatory conformance (`check_conformance`, the ISO and EU profiles),
+which grades a robot against a regulation.
+
+Levels are cumulative: a level is achieved only when every check at that
+level and all lower levels passes.
+
+## The three levels
+
+**L1 Credential.** RFC 8785 JCS canonicalization, `eddsa-jcs-2022` sign
+and verify, the validity window (an expired credential is rejected), and
+nonce replay resistance.
+
+**L2 Structural-Security.** Everything in L1, plus BitstringStatusList
+revocation, delegation narrowing with the five-link depth bound, the
+Identity Sidecar allow and deny behaviour, and a hash-linked audit trail.
+
+**L3 State Verifiable + Post-Quantum.** Everything in L2, plus the hybrid
+dual-proof (`eddsa-jcs-2022` and `mldsa44-jcs-2026` over the same JCS
+bytes), the Heartbeat renewal chain, and an M-of-N validator quorum.
+
+Robotics is a separate profile, Robotics Conformant, not part of L1 to L3.
+
+## Test your implementation (self-test)
+
+The reference runner checks an implementation against the levels and
+reports the highest it fully satisfies:
+
+```
+python -m vouch.conformance
+```
+
+It runs the checks in-process against the SDK (canonicalization against
+the shared JCS vectors, a sign and verify round-trip with tamper
+rejection, revocation, delegation narrowing, the sidecar allow and deny
+behaviour, the audit trail, the hybrid dual-proof, the heartbeat chain,
+and the validator quorum) and prints a per-check pass or fail with the
+highest passing level.
+
+## The verified badge (coming)
+
+The self-test proves conformance to yourself. A hosted verifier turns it
+into a Vouch-verified, re-checkable result: it issues fresh random
+challenges, re-checks every response server-side with the canonical
+core, derives the level, and mints a signed `VouchConformanceCredential`
+unique to your implementation. Because the verifier recomputes every
+expected answer, a pass cannot be faked by replaying the public test
+vectors. The badge links to the credential, so anyone can re-verify
+Vouch's signature and re-run the challenges.
+
+Until that is live, the `/conformance` page carries a self-declaration
+and shows what a verified pass will earn.
+
+Spec: section 17 (Conformance Levels).

--- a/website-agent/backend/knowledge/conformance.md
+++ b/website-agent/backend/knowledge/conformance.md
@@ -1,0 +1,58 @@
+# Conformance Reference
+
+Vouch conformance proves that an implementation, an SDK, a fork, or a
+port, produces byte-correct protocol output and supports the required
+feature sets. It is implementation-level, and distinct from robotics
+regulatory conformance (`check_conformance`, the ISO and EU profiles),
+which grades a robot against a regulation.
+
+Levels are cumulative: a level is achieved only when every check at that
+level and all lower levels passes.
+
+## The three levels
+
+**L1 Credential.** RFC 8785 JCS canonicalization, `eddsa-jcs-2022` sign
+and verify, the validity window (an expired credential is rejected), and
+nonce replay resistance.
+
+**L2 Structural-Security.** Everything in L1, plus BitstringStatusList
+revocation, delegation narrowing with the five-link depth bound, the
+Identity Sidecar allow and deny behaviour, and a hash-linked audit trail.
+
+**L3 State Verifiable + Post-Quantum.** Everything in L2, plus the hybrid
+dual-proof (`eddsa-jcs-2022` and `mldsa44-jcs-2026` over the same JCS
+bytes), the Heartbeat renewal chain, and an M-of-N validator quorum.
+
+Robotics is a separate profile, Robotics Conformant, not part of L1 to L3.
+
+## Test your implementation (self-test)
+
+The reference runner checks an implementation against the levels and
+reports the highest it fully satisfies:
+
+```
+python -m vouch.conformance
+```
+
+It runs the checks in-process against the SDK (canonicalization against
+the shared JCS vectors, a sign and verify round-trip with tamper
+rejection, revocation, delegation narrowing, the sidecar allow and deny
+behaviour, the audit trail, the hybrid dual-proof, the heartbeat chain,
+and the validator quorum) and prints a per-check pass or fail with the
+highest passing level.
+
+## The verified badge (coming)
+
+The self-test proves conformance to yourself. A hosted verifier turns it
+into a Vouch-verified, re-checkable result: it issues fresh random
+challenges, re-checks every response server-side with the canonical
+core, derives the level, and mints a signed `VouchConformanceCredential`
+unique to your implementation. Because the verifier recomputes every
+expected answer, a pass cannot be faked by replaying the public test
+vectors. The badge links to the credential, so anyone can re-verify
+Vouch's signature and re-run the challenges.
+
+Until that is live, the `/conformance` page carries a self-declaration
+and shows what a verified pass will earn.
+
+Spec: section 17 (Conformance Levels).

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -179,6 +179,30 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
   },
 
   // =====================================================================
+  // CONFORMANCE
+  // =====================================================================
+  {
+    id: 'conformance',
+    audience: 'Conformance',
+    title: 'Proving an implementation is conformant',
+    items: [
+      {
+        q: 'What does Vouch conformance mean?',
+        a: `Conformance proves that an implementation, an SDK, a fork, or a port, produces byte-correct protocol output and supports the required feature sets. It is graded in three cumulative levels. L1 Credential: canonicalization, eddsa-jcs-2022 sign and verify, the validity window, and nonce replay resistance. L2 Structural-Security: everything in L1 plus BitstringStatusList revocation, delegation narrowing with the five-link depth bound, the Identity Sidecar allow and deny behaviour, and a hash-linked audit trail. L3 State Verifiable plus Post-Quantum: everything in L2 plus the hybrid dual-proof, the Heartbeat renewal chain, and an M-of-N validator quorum. This is separate from robotics regulatory conformance, which grades a robot against a regulation.`,
+        meta: 'Spec section 17',
+      },
+      {
+        q: 'How do I test my implementation?',
+        a: `Run the reference runner. It checks your implementation against the levels and reports the highest it fully satisfies: \`python -m vouch.conformance\`. It runs the checks in-process against the SDK and prints a per-check pass or fail with the highest passing level.`,
+      },
+      {
+        q: 'Is there a verified badge?',
+        a: `The self-test proves conformance to yourself. A hosted verifier is coming that turns it into a Vouch-verified, re-checkable result: it issues fresh random challenges, re-checks every response server-side with the canonical core, and mints a signed credential unique to your implementation. Because it recomputes every expected answer, a pass cannot be faked by replaying the public test vectors. Until it is live, the conformance page carries a self-declaration and shows what a verified pass will earn.`,
+      },
+    ],
+  },
+
+  // =====================================================================
   // EMBODIED AGENTS (ROBOTICS)
   // =====================================================================
   {

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -1955,6 +1955,51 @@ The agent code does not change. What changes is the DID (production agents use a
     ],
   },
   {
+    id: 'conformance',
+    title: 'Conformance',
+    description:
+      'Test whether an implementation, an SDK, fork, or port, produces byte-correct protocol output and supports the required feature sets, graded L1 to L3.',
+    articles: [
+      {
+        id: 'test-your-implementation',
+        title: 'Test your conformance level',
+        summary:
+          'Run the reference conformance runner against your implementation and read the highest level it passes.',
+        body: `
+## What conformance checks
+
+Conformance grades an implementation in three cumulative levels. A level is achieved only when every check at that level and all lower levels passes.
+
+- **L1 Credential**: RFC 8785 JCS canonicalization, \`eddsa-jcs-2022\` sign and verify, the validity window (an expired credential is rejected), and nonce replay resistance.
+- **L2 Structural-Security**: everything in L1, plus BitstringStatusList revocation, delegation narrowing with the five-link depth bound, the Identity Sidecar allow and deny behaviour, and a hash-linked audit trail.
+- **L3 State Verifiable plus Post-Quantum**: everything in L2, plus the hybrid dual-proof (\`eddsa-jcs-2022\` and \`mldsa44-jcs-2026\` over the same JCS bytes), the Heartbeat renewal chain, and an M-of-N validator quorum.
+
+Robotics is a separate profile, Robotics Conformant, not part of L1 to L3.
+
+## Run the self-test
+
+\`\`\`bash
+python -m vouch.conformance
+\`\`\`
+
+It runs the checks in-process against the SDK and prints a per-check pass or fail, then the highest fully-passing level:
+
+\`\`\`
+L1
+  [PASS] canonicalization: 13 vectors
+  [PASS] sign_verify: round-trip and tamper rejection
+  ...
+Highest fully-passing level: L3
+\`\`\`
+
+## The verified badge (coming)
+
+The self-test proves conformance to yourself. A hosted verifier is coming that issues fresh random challenges, re-checks every response server-side with the canonical core, and mints a signed \`VouchConformanceCredential\` unique to your implementation. Because it recomputes every expected answer, a pass cannot be faked by replaying the public test vectors, and anyone can re-verify Vouch's signature and re-run the challenges. Until it is live, the [conformance page](/conformance) carries a self-declaration and shows what a verified pass earns.
+`,
+      },
+    ],
+  },
+  {
     id: 'robotics',
     title: 'Robotics: getting started',
     domain: 'robotics',


### PR DESCRIPTION
Documents Vouch conformance (the implementation L1 to L3 levels, the vouch.conformance self-test runner, and the coming verified badge) across the user-facing and assistant-facing surfaces, which previously carried none of it.

- Knowledge base: a new conformance.md, mirrored across the four knowledge directories.
- Claude skill: a decision rule and a reference entry.
- OpenAI GPT and Gemini gem: a routing example plus the knowledge file.
- FAQ: a Conformance section.
- Help: a Conformance section with a test-your-implementation article.

The verified badge and hosted verifier are described as coming, matching the live conformance page, so the assistants do not promise a service that is not deployed.
