### PR TITLE
ci(contributors): make certificate publishing resilient to concurrent merges

### DIFF
--- a/.github/workflows/verified-contributor.yml
+++ b/.github/workflows/verified-contributor.yml
@@ -121,15 +121,29 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          # Render the certificate page, served at /c/<login>/<pr>/.
-          python scripts/render_contributor_cert.py \
-            --credential credential.json \
-            --login "$PR_AUTHOR" \
-            --pr "$PR_NUMBER" \
-            --title "$PR_TITLE" \
-            --out "website/public/c/${PR_AUTHOR}/${PR_NUMBER}/index.html"
-          # Add this contribution to the index list (idempotent per login+pr).
-          python - <<'PY'
+          # Publish the certificate page and the contributors list to main. This
+          # runs after a merge, and several merges can happen close together, so
+          # each attempt re-syncs to the latest main and rebuilds its files on
+          # top of it. Rendering the page and adding the index entry are both
+          # idempotent, so a retry after a rejected push is safe and concurrent
+          # certificate jobs cannot overwrite each other.
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          published=0
+          for attempt in 1 2 3 4 5 6; do
+            git fetch --quiet origin main
+            git reset --hard --quiet origin/main
+
+            # Render the certificate page, served at /c/<login>/<pr>/.
+            python scripts/render_contributor_cert.py \
+              --credential credential.json \
+              --login "$PR_AUTHOR" \
+              --pr "$PR_NUMBER" \
+              --title "$PR_TITLE" \
+              --out "website/public/c/${PR_AUTHOR}/${PR_NUMBER}/index.html"
+            # Add this contribution to the index list (idempotent per login+pr).
+            python - <<'PY'
           import json, os
           path = "website/src/data/contributors.json"
           login = os.environ["PR_AUTHOR"]
@@ -142,22 +156,33 @@ jobs:
                   json.dump(data, f, indent=2)
                   f.write("\n")
           PY
-          # Commit to main so the website redeploys with the new certificate.
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add "website/public/c/${PR_AUTHOR}/${PR_NUMBER}/index.html" website/src/data/contributors.json
-          if ! git diff --cached --quiet; then
-            git commit -m "chore(contributors): certificate for @${PR_AUTHOR} (#${PR_NUMBER})"
-            for i in 1 2 3; do
-              git pull --rebase origin main && git push origin HEAD:main && break
-              sleep $((2 ** i))
-            done
-            # The commit above is pushed with GITHUB_TOKEN, which does not trigger
-            # the on:push deploy workflow. Dispatch it explicitly so the cert and
-            # the contributors list go live. workflow_dispatch still fires from
-            # GITHUB_TOKEN, unlike push.
-            gh workflow run deploy-website.yml --ref main
+            git add "website/public/c/${PR_AUTHOR}/${PR_NUMBER}/index.html" website/src/data/contributors.json
+
+            if git diff --cached --quiet; then
+              echo "Certificate already present on main; nothing to publish."
+              published=1
+              break
+            fi
+
+            git commit -q -m "chore(contributors): certificate for @${PR_AUTHOR} (#${PR_NUMBER})"
+            if git push origin HEAD:main; then
+              published=1
+              break
+            fi
+            echo "Push rejected because main advanced. Re-syncing and retrying (attempt ${attempt})."
+            sleep $((2 ** attempt))
+          done
+
+          if [ "$published" -ne 1 ]; then
+            echo "::error::Could not publish the contributor certificate for @${PR_AUTHOR} (#${PR_NUMBER}) after several attempts."
+            exit 1
           fi
+
+          # The push above uses GITHUB_TOKEN, which does not trigger the on:push
+          # deploy workflow. Dispatch it explicitly so the certificate and the
+          # contributors list go live. workflow_dispatch still fires from
+          # GITHUB_TOKEN, unlike push.
+          gh workflow run deploy-website.yml --ref main
 
       - name: Congratulate the contributor
         if: hashFiles('credential.json') != ''


### PR DESCRIPTION
Follow-up to #227.

When several pull requests merge close together, each triggers the verified-contributor job, and the publish step commits the certificate page and the contributors list to main. The previous version committed first and then rebased, which conflicts on contributors.json when main has advanced, and the retry loop could not recover from that state and still reported success. That could drop a certificate silently.

This change makes the publish step re-sync to the latest main and rebuild its files on each attempt. Rendering the certificate page and adding the index entry are both idempotent, so retrying after a rejected push is safe and two certificate jobs running at once cannot overwrite each other. If publishing still does not succeed after several attempts, the job now fails instead of reporting success.