### PR TITLE
feat(mcp): full-feature Vouch MCP server (verify, revocation, PQC, heartbeat, HTTP)

### DIFF
--- a/examples/mcp-vouch/README.md
+++ b/examples/mcp-vouch/README.md
@@ -1,0 +1,148 @@
+# Using Vouch Protocol from any framework, over MCP
+
+`vouch-mcp` is a Model Context Protocol server. Any MCP-capable agent framework
+can connect to it and gain two tools: `sign_action` (authorize an action with a
+Verifiable Credential) and `verify_credential` (check one someone else
+presented), plus `create_session`, `check_revocation`, and `get_identity`.
+
+The payoff: you do **not** need a bespoke Vouch connector per framework. You run
+one server and wire it in through each framework's standard MCP client. The
+agent's private key stays in the server process, never in the model's context.
+
+```
+ LangChain ─┐
+ CrewAI    ─┤
+ AutoGen   ─┤   standard MCP client   ┌───────────────┐
+ ADK       ─┼──────────────────────► │  vouch-mcp     │  holds the key,
+ Vertex AI ─┤                         │  (FastMCP)     │  issues + verifies VCs
+ AutoGPT   ─┤                         └───────────────┘
+ n8n       ─┤   (MCP Client node)
+ Hasura    ─┘   (verifies at the API gateway)
+```
+
+Start the server once (stdio for local, HTTP for hosted):
+
+```bash
+# local
+VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+# hosted
+VOUCH_MCP_TRANSPORT=http VOUCH_MCP_PORT=8080 \
+  VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+```
+
+Below, the **only Vouch-specific lines are the MCP client pointing at
+`vouch-mcp`**: everything else is each framework's normal setup.
+
+---
+
+## LangChain / LangGraph: `langchain-mcp-adapters`
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient({
+    "vouch": {"command": "vouch-mcp", "transport": "stdio",
+              "env": {"VOUCH_DID": "did:web:agent.example.com",
+                      "VOUCH_PRIVATE_KEY": "<jwk>"}}
+})
+tools = await client.get_tools()          # sign_action, verify_credential, ...
+
+# hand `tools` to any LangChain/LangGraph agent as usual:
+from langgraph.prebuilt import create_react_agent
+agent = create_react_agent(model, tools)
+```
+
+## CrewAI: `crewai-tools` `MCPServerAdapter`
+
+```python
+from crewai import Agent
+from crewai_tools import MCPServerAdapter
+from mcp import StdioServerParameters
+
+params = StdioServerParameters(command="vouch-mcp",
+    env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"})
+
+with MCPServerAdapter(params) as vouch_tools:
+    agent = Agent(role="Claims agent", goal="Submit claims accountably",
+                  tools=vouch_tools)      # sign_action available to the crew
+```
+
+## AutoGen: `autogen_ext` MCP workbench
+
+```python
+from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
+
+params = StdioServerParams(command="vouch-mcp",
+    env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"})
+
+async with McpWorkbench(params) as workbench:
+    # pass `workbench` to an AssistantAgent; it can now call sign_action
+    ...
+```
+
+## Google ADK: `MCPToolset`
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+
+toolset = MCPToolset(connection_params=StdioServerParameters(
+    command="vouch-mcp",
+    env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"}))
+
+agent = LlmAgent(model="gemini-2.0-flash", name="claims_agent", tools=[toolset])
+```
+
+## Vertex AI (Gemini)
+
+Vertex reaches MCP through ADK (above) when you deploy on Agent Engine, or you
+can bridge the `vouch-mcp` tool schema into Gemini function-calling. Either way
+the model calls `sign_action`; the credential is minted in the server process.
+
+## AutoGPT
+
+AutoGPT's platform consumes MCP servers as tool providers. Register `vouch-mcp`
+in the block/tool configuration with the same `command` + `env`, and the agent
+gains `sign_action` / `verify_credential` as callable blocks.
+
+## n8n: MCP Client Tool node
+
+n8n ships an **MCP Client Tool** node. Point it at the server:
+
+```
+Connection:  Command Line (stdio)
+Command:     vouch-mcp
+Environment: VOUCH_DID=did:web:agent.example.com
+             VOUCH_PRIVATE_KEY=<jwk>
+```
+
+Then any workflow can call `sign_action` before an outbound HTTP node and attach
+the returned credential as a `Vouch-Credential` header.
+
+## Hasura: verify at the gateway (the receiving side)
+
+Hasura is not an MCP client; it is where you **enforce** the credential. Have
+your webhook authorizer call `verify_credential` (via the same MCP server, or
+the `vouch` SDK directly) and reject requests whose credential is missing,
+invalid, or out of scope:
+
+```yaml
+# hasura config: authorization webhook that runs Vouch verification
+authorization_webhook:
+  url: https://your-verifier.example.com/verify   # calls Verifier.verify_credential
+  timeout: 5
+```
+
+---
+
+## The two-sided demo
+
+The point of `verify_credential` is that signing and verifying can live in
+different frameworks and still interoperate:
+
+1. A **CrewAI** agent calls `sign_action("submit_claim", ...)` → credential.
+2. A **LangGraph** service receives it and calls `verify_credential(...)` → it
+   confirms the issuer DID and the exact authorized intent, or rejects it.
+
+Same credential, two frameworks, one protocol. That is the interoperability MCP
+users are looking for.

--- a/packages/vouch-mcp/README.md
+++ b/packages/vouch-mcp/README.md
@@ -1,12 +1,19 @@
 # vouch-mcp
 
-A Model Context Protocol (MCP) server that issues [Vouch](https://vouch-protocol.com)
-Credentials so an AI agent can cryptographically authorize the actions it takes.
+A Model Context Protocol (MCP) server that lets AI agents **issue and verify**
+[Vouch](https://vouch-protocol.com) Credentials, so every action an agent takes
+carries cryptographic proof of who authorized it.
 
-MCP standardized how agents call tools. It does not say who is calling, or on
-whose authority. `vouch-mcp` adds that layer: every signed action carries a
-W3C Verifiable Credential with an `eddsa-jcs-2022` Data Integrity proof, and
-optionally a delegation chain back to an accountable human principal.
+MCP standardized how agents call tools. It does not say *who* is calling, or on
+*whose authority*. `vouch-mcp` adds that layer: every authorized action carries
+a W3C Verifiable Credential with an `eddsa-jcs-2022` Data Integrity proof (or the
+post-quantum hybrid profile), and any party can verify one over the same MCP
+connection.
+
+**The key stays out of the model.** MCP already runs this server in its own
+process, so the agent's private key lives here, never in the LLM's context. That
+is the Identity Sidecar boundary, provided natively by MCP's client/server split:
+a prompt-injected model cannot exfiltrate a key it never holds.
 
 ## Install
 
@@ -14,11 +21,12 @@ optionally a delegation chain back to an accountable human principal.
 pip install vouch-mcp
 ```
 
-This pulls in `vouch-protocol[mcp]`, including the official MCP SDK.
+This pulls in `vouch-protocol[mcp]`, including the official MCP SDK. For the
+post-quantum profile, install `pip install 'vouch-protocol[mcp,pq]'`.
 
 ## Configure
 
-The server reads two environment variables:
+The server reads its identity from the environment:
 
 - `VOUCH_PRIVATE_KEY` the agent's private key (JWK JSON string).
 - `VOUCH_DID` the agent's DID, e.g. `did:web:agent.example.com`.
@@ -27,33 +35,69 @@ Generate a development identity:
 
 ```python
 from vouch import generate_identity
-kp = generate_identity()
+kp = generate_identity("agent.example.com")
+print(kp.did)               # did:web:agent.example.com
 print(kp.private_key_jwk)   # set as VOUCH_PRIVATE_KEY
 ```
 
 ## Run
 
+**Local (stdio)** for Claude Desktop, Cursor, and desktop agents:
+
 ```bash
 VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
 ```
 
-Register it with an MCP client (Claude Desktop, Cursor, ...) as an stdio server
-running the `vouch-mcp` command.
+**Remote (Streamable HTTP)** for hosted / networked deployments:
+
+```bash
+VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
+  VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+```
+
+Register it with an MCP client as an stdio server running `vouch-mcp`, or point
+a networked client at `http://<host>:<port>/mcp`.
+
+```jsonc
+// Claude Desktop / Cursor MCP config
+{
+  "mcpServers": {
+    "vouch": {
+      "command": "vouch-mcp",
+      "env": {
+        "VOUCH_DID": "did:web:agent.example.com",
+        "VOUCH_PRIVATE_KEY": "<jwk-json-string>"
+      }
+    }
+  }
+}
+```
 
 ## Tools
 
 | Tool | What it does |
 |---|---|
-| `sign_action(action, target, resource)` | Issue a credential authorizing one action. Returns compact JSON to attach as a `Vouch-Credential` header. |
-| `create_session(purpose, valid_seconds)` | Issue a longer-lived credential covering multiple actions. |
+| `sign_action(action, target, resource, post_quantum=False)` | Issue a credential authorizing one action, bound to that exact resource. Set `post_quantum=True` for the `hybrid-eddsa-mldsa44-jcs-2026` profile. Returns compact JSON to attach as a `Vouch-Credential` header. |
+| `verify_credential(credential_json, public_key=None)` | Verify a credential another agent or service presented. Any MCP client can verify without installing an SDK. |
+| `create_session(purpose, valid_seconds, decay_lambda, initial_trust)` | Issue a trust-decaying session voucher (Heartbeat Protocol). Trust decays over time; a verifier can refuse high-stakes actions once it drops below a threshold. |
+| `check_revocation(credential_json)` | Check a credential's `BitstringStatusList` entry: `ACTIVE`, `REVOKED`, or not individually revocable. |
 | `get_identity()` | Return the agent's DID. |
 
-## Verify on the receiving side
+## Why `verify_credential` matters
 
-```python
-from vouch import Verifier
-ok, passport = Verifier.verify_credential(received_json, public_key=agent_pubkey)
+Signing proves *you* acted. Verifying is how *everyone else* benefits: any
+MCP-capable agent, in any framework, can confirm another agent's credential with
+a single tool call and no SDK. That is what turns Vouch from a per-app library
+into an interoperable trust layer.
+
 ```
+Agent A  --sign_action-->  credential  --verify_credential-->  Agent B / gateway
+```
+
+## Registry
+
+This server ships a `server.json` manifest for the MCP registry, so it can be
+discovered and installed like any other MCP server.
 
 ## License
 

--- a/packages/vouch-mcp/server.json
+++ b/packages/vouch-mcp/server.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.vouch-protocol/vouch-mcp",
+  "description": "Issue and verify W3C Verifiable Credentials (eddsa-jcs-2022, optional post-quantum) so AI agents can cryptographically authorize the actions they take.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/vouch-protocol/vouch",
+    "source": "github"
+  },
+  "version": "0.2.0",
+  "packages": [
+    {
+      "registry_type": "pypi",
+      "identifier": "vouch-mcp",
+      "version": "0.2.0",
+      "transport": { "type": "stdio" },
+      "environment_variables": [
+        {
+          "name": "VOUCH_PRIVATE_KEY",
+          "description": "The agent's private signing key as a JWK JSON string. Held only in this server process, never in the LLM's context.",
+          "is_required": true,
+          "is_secret": true
+        },
+        {
+          "name": "VOUCH_DID",
+          "description": "The agent's DID, e.g. did:web:agent.example.com",
+          "is_required": true
+        },
+        {
+          "name": "VOUCH_MCP_TRANSPORT",
+          "description": "Transport to serve: 'stdio' (default), 'http' (Streamable HTTP), or 'sse'.",
+          "is_required": false
+        },
+        {
+          "name": "VOUCH_MCP_HOST",
+          "description": "Bind host when VOUCH_MCP_TRANSPORT=http (default 127.0.0.1).",
+          "is_required": false
+        },
+        {
+          "name": "VOUCH_MCP_PORT",
+          "description": "Bind port when VOUCH_MCP_TRANSPORT=http (default 8080).",
+          "is_required": false
+        }
+      ]
+    }
+  ]
+}

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -2,18 +2,37 @@
 Vouch Protocol MCP Server.
 
 A Model Context Protocol server, built on the official MCP Python SDK
-(FastMCP), that lets MCP-compatible clients (Claude Desktop, Cursor, ...)
-issue v1.0 Vouch Credentials to authorize sensitive actions.
+(FastMCP), that lets MCP-compatible clients (Claude Desktop, Cursor, agent
+frameworks) both *issue* and *verify* v1.0 Vouch Credentials.
 
-Replaces the earlier hand-rolled JSON-RPC loop and the legacy JWS signing
-path. Credentials now carry an eddsa-jcs-2022 Data Integrity proof.
+MCP standardized how agents call tools. It does not say who is calling, or on
+whose authority. This server adds that layer: every authorized action carries
+a W3C Verifiable Credential with an eddsa-jcs-2022 Data Integrity proof (or the
+post-quantum hybrid profile), and any party can verify one over the same MCP
+connection.
 
-Run:
+Because MCP already runs this server in its own process, the agent's private
+key lives here, never in the LLM's context. That is the Identity Sidecar
+boundary, provided natively by MCP's client/server split.
+
+Tools:
+    sign_action        Issue a credential authorizing one action (PQC optional).
+    verify_credential  Verify a credential someone else presented.
+    create_session     Issue a trust-decaying session voucher (Heartbeat).
+    check_revocation   Check a credential's BitstringStatusList entry.
+    get_identity       Return this agent's DID.
+
+Run (stdio, for Claude Desktop / Cursor):
     VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
+
+Run (Streamable HTTP, for remote / hosted use):
+    VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
+        VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
 """
 
 from __future__ import annotations
 
+import json
 import os
 from typing import Optional
 
@@ -28,10 +47,18 @@ except ImportError as exc:  # pragma: no cover
         f"(import error: {exc})"
     )
 
-from vouch.integrations._common import load_signer, sign_tool_call_json
+from vouch.integrations._common import (
+    load_signer,
+    sign_tool_call_json,
+    verify_tool_call,
+)
 
 
-mcp = FastMCP("vouch")
+mcp = FastMCP(
+    "vouch",
+    host=os.getenv("VOUCH_MCP_HOST", "127.0.0.1"),
+    port=int(os.getenv("VOUCH_MCP_PORT", "8080")),
+)
 
 
 def _did() -> str:
@@ -39,55 +66,182 @@ def _did() -> str:
 
 
 @mcp.tool()
-def sign_action(action: str, target: str, resource: Optional[str] = None) -> str:
+def sign_action(
+    action: str,
+    target: str,
+    resource: Optional[str] = None,
+    post_quantum: bool = False,
+) -> str:
     """Issue a Vouch Credential authorizing a single sensitive action.
 
-    Call this before any authenticated request to an external service.
+    Call this before any authenticated request to an external service. The
+    returned credential binds *this* agent's identity to *this* exact action
+    and resource, so a downstream service can confirm the call was authorized.
 
     Args:
         action: The verb, e.g. 'read', 'write', 'execute', 'send'.
         target: The service or URL being called.
         resource: The specific object, e.g. 'customer:123'. Defaults to target.
+        post_quantum: If true, sign under the hybrid post-quantum profile
+            (hybrid-eddsa-mldsa44-jcs-2026) for regulated deployments.
+            Requires the server to have 'vouch-protocol[pq]' installed.
 
     Returns:
         A compact JSON Vouch Credential to attach as a 'Vouch-Credential' header.
     """
     try:
         signer = load_signer()
-        return sign_tool_call_json(signer, action, target, resource)
+        return sign_tool_call_json(signer, action, target, resource, hybrid=post_quantum)
     except Exception as e:
         return f"Error issuing Vouch Credential: {e}"
 
 
 @mcp.tool()
-def create_session(purpose: str, valid_seconds: int = 3600) -> str:
-    """Issue a longer-lived session credential covering multiple actions.
+def verify_credential(credential_json: str, public_key: Optional[str] = None) -> str:
+    """Verify a Vouch Credential that another agent or service presented.
+
+    This is the receiving side: given a credential (the JSON another party's
+    sign_action produced), confirm the signature, validity window, and intent
+    binding. Any MCP client can call this without installing an SDK.
+
+    Args:
+        credential_json: The credential as a JSON string.
+        public_key: Optional Multikey public key of the issuer. If omitted,
+            the issuer's DID is resolved to fetch its key.
+
+    Returns:
+        A human-readable verdict: the issuer DID and authorized intent when
+        valid, or a rejection reason.
+    """
+    try:
+        credential = json.loads(credential_json)
+    except json.JSONDecodeError as e:
+        return f"REJECTED: not valid JSON ({e})"
+
+    try:
+        is_valid, passport = verify_tool_call(credential, public_key=public_key)
+    except Exception as e:
+        return f"REJECTED: verification error ({e})"
+
+    if not is_valid or passport is None:
+        return "REJECTED: signature, validity window, or schema check failed."
+
+    intent = getattr(passport, "intent", {}) or {}
+    issuer = getattr(passport, "iss", None) or getattr(passport, "sub", "(unknown)")
+    return (
+        "VERIFIED\n"
+        f"  issuer:   {issuer}\n"
+        f"  action:   {intent.get('action')}\n"
+        f"  target:   {intent.get('target')}\n"
+        f"  resource: {intent.get('resource')}"
+    )
+
+
+@mcp.tool()
+def create_session(
+    purpose: str,
+    valid_seconds: int = 3600,
+    decay_lambda: float = 0.0005,
+    initial_trust: float = 1.0,
+) -> str:
+    """Issue a trust-decaying session voucher (Heartbeat Protocol).
+
+    Unlike a plain long-lived credential, a session voucher carries a trust
+    value that decays over time (Trust Entropy). A verifier recomputes the
+    current trust with compute_trust_at and can refuse a high-stakes action
+    once trust falls below a threshold, unless the session is refreshed.
 
     Args:
         purpose: What the session is for, e.g. 'calendar_access'.
-        valid_seconds: Session lifetime in seconds (default 3600).
+        valid_seconds: Voucher lifetime in seconds (default 3600).
+        decay_lambda: Trust decay rate per second (default 0.0005).
+        initial_trust: Starting trust in [0, 1] (default 1.0).
 
     Returns:
-        A compact JSON session credential.
+        A compact JSON session voucher with an eddsa-jcs-2022 proof.
     """
     try:
+        from vouch import data_integrity
+        from vouch.vc import build_session_voucher
+
         signer = load_signer()
-        return sign_tool_call_json(
-            signer, "session", purpose, f"session:{purpose}", valid_seconds=valid_seconds
+        voucher = build_session_voucher(
+            subject_did=signer.did,
+            validator_dids=[signer.did],
+            decay_lambda=decay_lambda,
+            initial_trust=initial_trust,
+            max_ttl_seconds=valid_seconds,
+            scope=[purpose],
+            valid_seconds=valid_seconds,
         )
+        proof = data_integrity.build_proof(
+            voucher,
+            private_key=signer._raw_priv,
+            verification_method=signer.verification_method_id(),
+        )
+        voucher["proof"] = proof
+        return json.dumps(voucher, separators=(",", ":"))
     except Exception as e:
         return f"Error creating session: {e}"
 
 
 @mcp.tool()
+def check_revocation(credential_json: str) -> str:
+    """Check whether a credential has been revoked via its status list.
+
+    Reads the credential's BitstringStatusList entry (credentialStatus),
+    fetches the referenced status list, and reports whether the bit is set.
+
+    Args:
+        credential_json: The credential as a JSON string.
+
+    Returns:
+        'ACTIVE', 'REVOKED', or a note that the credential is not individually
+        revocable (no credentialStatus attached).
+    """
+    try:
+        credential = json.loads(credential_json)
+    except json.JSONDecodeError as e:
+        return f"Error: not valid JSON ({e})"
+
+    status = credential.get("credentialStatus")
+    if not status:
+        return "NOT REVOCABLE: credential has no credentialStatus entry."
+
+    try:
+        from vouch import StatusListFetcher, verify_status
+
+        fetcher = StatusListFetcher(cache_ttl_seconds=300)
+        status_credential = fetcher.get(status["statusListCredential"])
+        revoked = verify_status(
+            credential_status=status,
+            status_list_credential=status_credential,
+        )
+        return "REVOKED" if revoked else "ACTIVE"
+    except Exception as e:
+        return f"Error checking revocation: {e}"
+
+
+@mcp.tool()
 def get_identity() -> str:
-    """Return the agent's DID (Decentralized Identifier)."""
+    """Return this agent's DID (Decentralized Identifier)."""
     return f"Agent DID: {_did()}"
 
 
 def main() -> None:
-    """Entry point: run the MCP server over stdio."""
-    mcp.run()
+    """Entry point. Transport is selected by VOUCH_MCP_TRANSPORT.
+
+    - 'stdio' (default): for local clients like Claude Desktop and Cursor.
+    - 'http' / 'streamable-http': for remote / hosted deployments.
+    - 'sse': legacy Server-Sent Events transport.
+    """
+    transport = os.getenv("VOUCH_MCP_TRANSPORT", "stdio").lower().replace("_", "-")
+    if transport in ("http", "streamable-http"):
+        mcp.run(transport="streamable-http")
+    elif transport == "sse":
+        mcp.run(transport="sse")
+    else:
+        mcp.run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Builds on the standalone integration packages and the modernized MCP server to
make `vouch-mcp` a complete, shareable Model Context Protocol server. Any MCP
client can now both issue and verify Vouch Credentials over one connection.

New MCP tools:

- `verify_credential`: verify a credential another agent or service presented, so signing and verifying can live in different frameworks and still interoperate.
- `check_revocation`: read a credential's BitstringStatusList entry.
- `sign_action` gains a `post_quantum` toggle for the hybrid-eddsa-mldsa44-jcs-2026 profile.
- `create_session` issues a trust-decaying session voucher (Heartbeat Protocol).

Also included:

- Streamable HTTP transport alongside stdio, selected by `VOUCH_MCP_TRANSPORT`.
- A `server.json` manifest so the server can be listed on the MCP registry.
- A cross-framework guide showing LangChain, CrewAI, AutoGen, Google ADK, Vertex AI, AutoGPT, n8n, and Hasura connecting to the same server.

Credentials carry an `eddsa-jcs-2022` Data Integrity proof. Because MCP runs the
server in its own process, the agent's private key stays out of the model's
context.
