### PR TITLE
Document robotics access from the C, C++, .NET, JVM, and Swift SDKs

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -285,8 +285,12 @@ with `HYBRID_CRYPTOSUITE`, a hybrid Ed25519 and ML-DSA-44 proof so a robot
 identity signed today stays safe over a ten to twenty year service life, with
 verification that auto-detects classical or hybrid so a fleet migrates gradually
 without breaking credentials already in the field). Same
-Verifiable Credentials as the rest of Vouch, so they verify in every language. See
-`reference/robotics.md`.
+Verifiable Credentials as the rest of Vouch, so they verify in every language. A
+curated robotics surface (verify a robot credential, mint and verify identity,
+conformance, passport, action check, and PQ sign) is also callable from the C,
+C++, .NET, JVM, and Swift wrappers through a `VouchRobotics` class (a
+`vouch::robotics` namespace in C++), for verifying and integrating from those
+languages. See `reference/robotics.md`.
 
 ## Decision rules
 

--- a/claude-skill/skills/vouch-protocol/reference/robotics.md
+++ b/claude-skill/skills/vouch-protocol/reference/robotics.md
@@ -761,3 +761,34 @@ AI regulations as an open reference crosswalk.
 The novel methods are published as open defensive disclosures: PAD-064
 (hardware-rooted identity), PAD-067 (robot-to-robot handshake), PAD-069
 (confidential tamper-evident black box), and PAD-070 (scannable offline passport).
+
+## From the wrapper SDKs (C, C++, .NET, JVM, Swift)
+
+The reference SDKs (Python, TypeScript, Go, and the Rust core) carry the full
+robotics surface. The C, C++, .NET, JVM (Java and Kotlin), and Swift wrappers
+expose a curated consumer surface over the same core, the same way they expose the
+agent operations: a `VouchRobotics` class in .NET, JVM, and Swift, and a
+`vouch::robotics` namespace in C++. The curated surface is what an application
+verifies and integrates with:
+
+- `verify_robot_credential`: verify a robot credential whether it carries a
+  classical or a hybrid post-quantum proof, auto-detected from the proof.
+- `mint_identity` and `verify_identity` for a hardware-rooted robot identity.
+- `check_conformance` with `build_conformance_attestation` and
+  `verify_conformance_attestation` for regulatory conformance.
+- `verify_passport` for an offline passport scan.
+- `check_action` to enforce a physical capability scope.
+- `sign_pq` to attach a hybrid post-quantum proof.
+
+Output is byte-identical to the reference SDKs, so a robot credential produced in
+one language verifies in every other. The producer-side operations (handshakes,
+the black box, physical quorum, the liveness heartbeat) stay in the reference SDKs;
+a wrapper application that needs one of those calls a reference SDK or a service
+built on it. Example, verifying a robot credential from .NET:
+
+```csharp
+using VouchProtocol.Core;
+
+bool ok = VouchRobotics.VerifyRobotCredential(credentialJson, ed25519PublicB64);
+string report = VouchRobotics.CheckConformance(credentialsJson, "eu-ai-act-high-risk");
+```

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -158,6 +158,13 @@ Never share user data with external sites.
   field; `verify_pq` verifies a hybrid proof, `is_pq` reports whether a credential
   is hybrid-signed, and `migrate_to_pq` re-signs a fielded robot's classical
   credential under PQ. See `robotics.md`.
+- "Can I verify a robot credential from .NET, Java, Swift, or C++?" -> Yes. The
+  reference SDKs (Python, TypeScript, Go, Rust) carry the full robotics surface,
+  and the C, C++, .NET, JVM, and Swift wrappers expose a curated consumer surface
+  over the same core: `verify_robot_credential` (classical or hybrid, auto-detected),
+  identity mint and verify, conformance, passport, action check, and `sign_pq`, via
+  a `VouchRobotics` class (a `vouch::robotics` namespace in C++). Output is
+  byte-identical across languages. See `robotics.md`.
 
 ## Safety rules
 

--- a/gemini-gem/knowledge/robotics.md
+++ b/gemini-gem/knowledge/robotics.md
@@ -761,3 +761,34 @@ AI regulations as an open reference crosswalk.
 The novel methods are published as open defensive disclosures: PAD-064
 (hardware-rooted identity), PAD-067 (robot-to-robot handshake), PAD-069
 (confidential tamper-evident black box), and PAD-070 (scannable offline passport).
+
+## From the wrapper SDKs (C, C++, .NET, JVM, Swift)
+
+The reference SDKs (Python, TypeScript, Go, and the Rust core) carry the full
+robotics surface. The C, C++, .NET, JVM (Java and Kotlin), and Swift wrappers
+expose a curated consumer surface over the same core, the same way they expose the
+agent operations: a `VouchRobotics` class in .NET, JVM, and Swift, and a
+`vouch::robotics` namespace in C++. The curated surface is what an application
+verifies and integrates with:
+
+- `verify_robot_credential`: verify a robot credential whether it carries a
+  classical or a hybrid post-quantum proof, auto-detected from the proof.
+- `mint_identity` and `verify_identity` for a hardware-rooted robot identity.
+- `check_conformance` with `build_conformance_attestation` and
+  `verify_conformance_attestation` for regulatory conformance.
+- `verify_passport` for an offline passport scan.
+- `check_action` to enforce a physical capability scope.
+- `sign_pq` to attach a hybrid post-quantum proof.
+
+Output is byte-identical to the reference SDKs, so a robot credential produced in
+one language verifies in every other. The producer-side operations (handshakes,
+the black box, physical quorum, the liveness heartbeat) stay in the reference SDKs;
+a wrapper application that needs one of those calls a reference SDK or a service
+built on it. Example, verifying a robot credential from .NET:
+
+```csharp
+using VouchProtocol.Core;
+
+bool ok = VouchRobotics.VerifyRobotCredential(credentialJson, ed25519PublicB64);
+string report = VouchRobotics.CheckConformance(credentialsJson, "eu-ai-act-high-risk");
+```

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -160,6 +160,13 @@ been removed. See `integrations.md`.
   field; `verify_pq` verifies a hybrid proof, `is_pq` reports whether a credential
   is hybrid-signed, and `migrate_to_pq` re-signs a fielded robot's classical
   credential under PQ. See `robotics.md`.
+- "Can I verify a robot credential from .NET, Java, Swift, or C++?" -> Yes. The
+  reference SDKs (Python, TypeScript, Go, Rust) carry the full robotics surface,
+  and the C, C++, .NET, JVM, and Swift wrappers expose a curated consumer surface
+  over the same core: `verify_robot_credential` (classical or hybrid, auto-detected),
+  identity mint and verify, conformance, passport, action check, and `sign_pq`, via
+  a `VouchRobotics` class (a `vouch::robotics` namespace in C++). Output is
+  byte-identical across languages. See `robotics.md`.
 
 ## Actions (if enabled)
 

--- a/openai-gpt/knowledge/robotics.md
+++ b/openai-gpt/knowledge/robotics.md
@@ -761,3 +761,34 @@ AI regulations as an open reference crosswalk.
 The novel methods are published as open defensive disclosures: PAD-064
 (hardware-rooted identity), PAD-067 (robot-to-robot handshake), PAD-069
 (confidential tamper-evident black box), and PAD-070 (scannable offline passport).
+
+## From the wrapper SDKs (C, C++, .NET, JVM, Swift)
+
+The reference SDKs (Python, TypeScript, Go, and the Rust core) carry the full
+robotics surface. The C, C++, .NET, JVM (Java and Kotlin), and Swift wrappers
+expose a curated consumer surface over the same core, the same way they expose the
+agent operations: a `VouchRobotics` class in .NET, JVM, and Swift, and a
+`vouch::robotics` namespace in C++. The curated surface is what an application
+verifies and integrates with:
+
+- `verify_robot_credential`: verify a robot credential whether it carries a
+  classical or a hybrid post-quantum proof, auto-detected from the proof.
+- `mint_identity` and `verify_identity` for a hardware-rooted robot identity.
+- `check_conformance` with `build_conformance_attestation` and
+  `verify_conformance_attestation` for regulatory conformance.
+- `verify_passport` for an offline passport scan.
+- `check_action` to enforce a physical capability scope.
+- `sign_pq` to attach a hybrid post-quantum proof.
+
+Output is byte-identical to the reference SDKs, so a robot credential produced in
+one language verifies in every other. The producer-side operations (handshakes,
+the black box, physical quorum, the liveness heartbeat) stay in the reference SDKs;
+a wrapper application that needs one of those calls a reference SDK or a service
+built on it. Example, verifying a robot credential from .NET:
+
+```csharp
+using VouchProtocol.Core;
+
+bool ok = VouchRobotics.VerifyRobotCredential(credentialJson, ed25519PublicB64);
+string report = VouchRobotics.CheckConformance(credentialsJson, "eu-ai-act-high-risk");
+```

--- a/sdks/cpp/README.md
+++ b/sdks/cpp/README.md
@@ -20,7 +20,10 @@ sdks/cpp/
 JCS canonicalization, Ed25519, did:key/multikey, Data Integrity proofs
 (eddsa-jcs-2022), credential verify, delegation (build a link, validate a chain's
 time-bound rule), dual-proof ML-DSA-44 and composite verify, and
-BitstringStatusList revocation. Every value crossing the ABI is a NUL-terminated
+BitstringStatusList revocation. A curated robotics surface in the
+`vouch::robotics` namespace verifies a robot credential (classical or hybrid
+post-quantum), mints and verifies identity, checks regulatory conformance, verifies
+a passport, and checks a physical action. Every value crossing the ABI is a NUL-terminated
 UTF-8 C string: JSON for credentials and proofs, base64 for binary. Returned
 strings are heap allocated and must be freed with `vouch_string_free`. On error a
 function returns NULL and writes a message to the `err_out` argument (also freed

--- a/sdks/dotnet/README.md
+++ b/sdks/dotnet/README.md
@@ -10,6 +10,7 @@ the exact same bytes as every other Vouch SDK. Apache-2.0.
 - Data Integrity proofs (`eddsa-jcs-2022`): sign + verify, with validity-window checks
 - Post-quantum dual-proof and composite verification
 - BitstringStatusList revocation checks
+- Robotics (`VouchRobotics`): verify a robot credential (classical or hybrid post-quantum, auto-detected), mint and verify identity, regulatory conformance, passport, and physical action checks
 
 ## Build
 

--- a/sdks/jvm/README.md
+++ b/sdks/jvm/README.md
@@ -17,6 +17,7 @@ Two entry points over the same native core:
 - Data Integrity proofs (`eddsa-jcs-2022`): sign + verify, with validity-window checks
 - Post-quantum dual-proof and composite verification
 - BitstringStatusList revocation checks
+- Robotics (`VouchRobotics`): verify a robot credential (classical or hybrid post-quantum, auto-detected), mint and verify identity, regulatory conformance, passport, and physical action checks
 
 ## Build
 

--- a/sdks/swift/README.md
+++ b/sdks/swift/README.md
@@ -11,6 +11,7 @@ and .NET SDKs. Apache-2.0.
 - Data Integrity proofs (`eddsa-jcs-2022`): sign + verify, with validity-window checks
 - Post-quantum: ML-DSA-44 and dual proofs (Ed25519 + ML-DSA), plus composite verify
 - BitstringStatusList revocation checks
+- Robotics (`VouchRobotics`): verify a robot credential (classical or hybrid post-quantum, auto-detected), mint and verify identity, regulatory conformance, passport, and physical action checks
 
 ## Build
 

--- a/website-agent/backend/knowledge/robotics.md
+++ b/website-agent/backend/knowledge/robotics.md
@@ -761,3 +761,34 @@ AI regulations as an open reference crosswalk.
 The novel methods are published as open defensive disclosures: PAD-064
 (hardware-rooted identity), PAD-067 (robot-to-robot handshake), PAD-069
 (confidential tamper-evident black box), and PAD-070 (scannable offline passport).
+
+## From the wrapper SDKs (C, C++, .NET, JVM, Swift)
+
+The reference SDKs (Python, TypeScript, Go, and the Rust core) carry the full
+robotics surface. The C, C++, .NET, JVM (Java and Kotlin), and Swift wrappers
+expose a curated consumer surface over the same core, the same way they expose the
+agent operations: a `VouchRobotics` class in .NET, JVM, and Swift, and a
+`vouch::robotics` namespace in C++. The curated surface is what an application
+verifies and integrates with:
+
+- `verify_robot_credential`: verify a robot credential whether it carries a
+  classical or a hybrid post-quantum proof, auto-detected from the proof.
+- `mint_identity` and `verify_identity` for a hardware-rooted robot identity.
+- `check_conformance` with `build_conformance_attestation` and
+  `verify_conformance_attestation` for regulatory conformance.
+- `verify_passport` for an offline passport scan.
+- `check_action` to enforce a physical capability scope.
+- `sign_pq` to attach a hybrid post-quantum proof.
+
+Output is byte-identical to the reference SDKs, so a robot credential produced in
+one language verifies in every other. The producer-side operations (handshakes,
+the black box, physical quorum, the liveness heartbeat) stay in the reference SDKs;
+a wrapper application that needs one of those calls a reference SDK or a service
+built on it. Example, verifying a robot credential from .NET:
+
+```csharp
+using VouchProtocol.Core;
+
+bool ok = VouchRobotics.VerifyRobotCredential(credentialJson, ed25519PublicB64);
+string report = VouchRobotics.CheckConformance(credentialsJson, "eu-ai-act-high-risk");
+```

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -674,6 +674,11 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
         a: `To verify a hybrid credential, yes: pass the ML-DSA-44 public key (raw bytes or a multikey) to \`verify_pq\` or \`verify_robot_credential\`. Both the classical and the post-quantum signature must validate for the credential to pass.`,
         meta: 'Shipped - vouch.robotics.pq',
       },
+      {
+        q: 'Can I verify a robot credential from .NET, Java, Swift, or C++?',
+        a: `Yes. The reference SDKs (Python, TypeScript, Go, Rust) carry the full robotics surface, and the C, C++, .NET, JVM, and Swift wrappers expose a curated consumer surface over the same core: verify a robot credential (classical or hybrid, auto-detected), mint and verify identity, conformance, passport, action check, and post-quantum sign. In .NET, JVM, and Swift these are a \`VouchRobotics\` class; in C++ a \`vouch::robotics\` namespace. Output is byte-identical across languages.`,
+        meta: 'Shipped - C, C++, .NET, JVM, Swift',
+      },
     ],
   },
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -2495,6 +2495,25 @@ ok = verify_robot_credential(identity, robot_ed25519_public_key,
 Security boundary: a hybrid credential passes only when both the classical and the post-quantum signature validate, so it is at least as strong as the classical signature and stays safe once classical signatures do not. Verifying a hybrid credential needs the ML-DSA-44 public key. The open layer is software signing, backward-compatible verification, and a software re-sign migration; managed post-quantum key custody and fleet migration are commercial.
 `,
       },
+      {
+        id: 'robotics-wrapper-sdks',
+        title: 'Robotics from the C, C++, .NET, JVM, and Swift SDKs',
+        summary: 'Verify and integrate robot credentials from the wrapper SDKs through a curated VouchRobotics surface over the same Rust core.',
+        body: `
+The reference SDKs (Python, TypeScript, Go, and the Rust core) carry the full robotics surface. The C, C++, .NET, JVM (Java and Kotlin), and Swift wrappers expose a curated consumer surface over the same core, the same way they expose the agent operations, so an application in those languages can verify and integrate robot credentials without leaving its stack.
+
+The curated surface: \`verify_robot_credential\` (verify a classical or a hybrid post-quantum proof, auto-detected), \`mint_identity\` and \`verify_identity\`, \`check_conformance\` with \`build_conformance_attestation\` and \`verify_conformance_attestation\`, \`verify_passport\`, \`check_action\`, and \`sign_pq\`. In .NET, JVM, and Swift these are a \`VouchRobotics\` class; in C++ a \`vouch::robotics\` namespace.
+
+\`\`\`csharp
+using VouchProtocol.Core;
+
+bool ok = VouchRobotics.VerifyRobotCredential(credentialJson, ed25519PublicB64);
+string report = VouchRobotics.CheckConformance(credentialsJson, "eu-ai-act-high-risk");
+\`\`\`
+
+Output is byte-identical to the reference SDKs, so a robot credential produced in one language verifies in every other. The producer-side operations (handshakes, the black box, physical quorum, the liveness heartbeat) stay in the reference SDKs; a wrapper application that needs one of those calls a reference SDK or a service built on it.
+`,
+      },
     ],
   },
 ];

--- a/website/src/app/robotics/page.tsx
+++ b/website/src/app/robotics/page.tsx
@@ -118,9 +118,12 @@ export default function RoboticsPage() {
                     </p>
                     <p className="text-ink-soft text-[1rem] leading-relaxed max-w-prose">
                         Every piece below is built on the same Verifiable Credentials as the rest of
-                        Vouch, so it verifies with the Python, Rust, TypeScript, and Go SDKs. These are
-                        open formats and reference implementations; hosted black-box storage and
-                        fleet-scale infrastructure are left to whoever deploys them.
+                        Vouch, so it verifies with the Python, Rust, TypeScript, and Go SDKs. A curated
+                        surface, verifying a robot credential, identity, conformance, passport, action
+                        checks, and post-quantum signing, is also callable from the C, C++, .NET, JVM,
+                        and Swift wrappers, so an app in any of those languages can verify and integrate.
+                        These are open formats and reference implementations; hosted black-box storage
+                        and fleet-scale infrastructure are left to whoever deploys them.
                     </p>
                 </div>
             </section>


### PR DESCRIPTION
Documents that robotics is callable from the C, C++, .NET, JVM, and Swift SDKs, which shipped as code but was not yet reflected in the developer-facing surfaces.

## What changed

The fifteen robotics capabilities were already documented everywhere. This adds the cross-language reach: the wrapper SDKs expose a curated `VouchRobotics` surface over the same core (verify a robot credential, mint and verify identity, conformance, passport, action check, and post-quantum sign), for verifying and integrating from those languages.

- **Knowledge base** (all four mirrors, kept byte-identical): a "From the wrapper SDKs" section with the curated surface and a .NET snippet.
- **Claude skill, OpenAI GPT, Gemini gem**: a one-line note and a decision-rule answer for "Can I verify a robot credential from .NET, Java, Swift, or C++?".
- **Website**: a line on the robotics page, one FAQ entry, and one Help guide.
- **Wrapper SDK READMEs** (.NET, JVM, Swift, C++): a robotics bullet in the feature list.

## Notes

Positive scope only; the producer-side operations stay in the reference SDKs, and the consumer-side curated surface is what the wrappers expose, matching how the agent operations are exposed.

## Verified

- Website builds; the robotics, FAQ, and Help pages render the new content.
- The four knowledge mirrors are byte-identical.
