### PR TITLE
feat(mcp): full-feature FastMCP server on the autosign signing core

### DIFF
--- a/examples/mcp-vouch/README.md
+++ b/examples/mcp-vouch/README.md
@@ -1,0 +1,146 @@
+# Using Vouch Protocol from any framework, over MCP
+
+`vouch-mcp` is a Model Context Protocol server. Any MCP-capable agent framework
+can connect to it and gain two tools: `sign_action` (authorize an action with a
+Verifiable Credential) and `verify_credential` (check one someone else
+presented), plus `create_session`, `check_revocation`, and `get_identity`.
+
+The payoff: you do not need a bespoke Vouch connector per framework. You run one
+server and wire it in through each framework's standard MCP client. The agent's
+private key stays in the server process, never in the model's context.
+
+> Python-only agent? You may prefer `vouch.autosign`: `protect([tool1, tool2])`
+> signs every call deterministically in-process, no MCP round-trip. Use
+> `vouch-mcp` when you want cross-language reach, key isolation, or verification
+> as a shared service. Both produce identical credentials.
+
+```
+ LangChain ─┐
+ CrewAI    ─┤
+ AutoGen   ─┤   standard MCP client   ┌───────────────┐
+ ADK       ─┼──────────────────────► │  vouch-mcp     │  holds the key,
+ Vertex AI ─┤                         │  (FastMCP)     │  issues + verifies VCs
+ AutoGPT   ─┤                         └───────────────┘
+ n8n       ─┤   (MCP Client node)
+ Hasura    ─┘   (verifies at the API gateway)
+```
+
+Start the server once (stdio for local, HTTP for hosted):
+
+```bash
+# local
+VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+# hosted
+VOUCH_MCP_TRANSPORT=http VOUCH_MCP_PORT=8080 \
+  VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+```
+
+Below, the only Vouch-specific lines are the MCP client pointing at `vouch-mcp`.
+Everything else is each framework's normal setup.
+
+## LangChain / LangGraph: `langchain-mcp-adapters`
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient({
+    "vouch": {"command": "vouch-mcp", "transport": "stdio",
+              "env": {"VOUCH_DID": "did:web:agent.example.com",
+                      "VOUCH_PRIVATE_KEY": "<jwk>"}}
+})
+tools = await client.get_tools()          # sign_action, verify_credential, ...
+
+from langgraph.prebuilt import create_react_agent
+agent = create_react_agent(model, tools)
+```
+
+## CrewAI: `crewai-tools` `MCPServerAdapter`
+
+```python
+from crewai import Agent
+from crewai_tools import MCPServerAdapter
+from mcp import StdioServerParameters
+
+params = StdioServerParameters(command="vouch-mcp",
+    env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"})
+
+with MCPServerAdapter(params) as vouch_tools:
+    agent = Agent(role="Claims agent", goal="Submit claims accountably",
+                  tools=vouch_tools)
+```
+
+## AutoGen: `autogen_ext` MCP workbench
+
+```python
+from autogen_ext.tools.mcp import McpWorkbench, StdioServerParams
+
+params = StdioServerParams(command="vouch-mcp",
+    env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"})
+
+async with McpWorkbench(params) as workbench:
+    ...  # pass workbench to an AssistantAgent; it can call sign_action
+```
+
+## Google ADK: `MCPToolset`
+
+```python
+from google.adk.agents import LlmAgent
+from google.adk.tools.mcp_tool.mcp_toolset import MCPToolset, StdioServerParameters
+
+toolset = MCPToolset(connection_params=StdioServerParameters(
+    command="vouch-mcp",
+    env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"}))
+
+agent = LlmAgent(model="gemini-2.0-flash", name="claims_agent", tools=[toolset])
+```
+
+## Vertex AI (Gemini)
+
+Vertex reaches MCP through ADK (above) when you deploy on Agent Engine, or you
+can bridge the `vouch-mcp` tool schema into Gemini function-calling. Either way
+the model calls `sign_action`; the credential is minted in the server process.
+
+## AutoGPT
+
+AutoGPT's platform consumes MCP servers as tool providers. Register `vouch-mcp`
+in the block/tool configuration with the same `command` + `env`, and the agent
+gains `sign_action` / `verify_credential` as callable blocks.
+
+## n8n: MCP Client Tool node
+
+n8n ships an MCP Client Tool node. Point it at the server:
+
+```
+Connection:  Command Line (stdio)
+Command:     vouch-mcp
+Environment: VOUCH_DID=did:web:agent.example.com
+             VOUCH_PRIVATE_KEY=<jwk>
+```
+
+Then any workflow can call `sign_action` before an outbound HTTP node and attach
+the returned credential as a `Vouch-Credential` header.
+
+## Hasura: verify at the gateway (the receiving side)
+
+Hasura is not an MCP client; it is where you enforce the credential. Have your
+webhook authorizer call `verify_credential` (via the same MCP server, or the
+`vouch` SDK directly) and reject requests whose credential is missing, invalid,
+or out of scope:
+
+```yaml
+# hasura config: authorization webhook that runs Vouch verification
+authorization_webhook:
+  url: https://your-verifier.example.com/verify   # calls Verifier.verify_credential
+  timeout: 5
+```
+
+## The two-sided demo
+
+The point of `verify_credential` is that signing and verifying can live in
+different frameworks and still interoperate:
+
+1. A CrewAI agent calls `sign_action("submit_claim", ...)` and gets a credential.
+2. A LangGraph service receives it and calls `verify_credential(...)`, which
+   confirms the issuer DID and the exact authorized intent, or rejects it.
+
+Same credential, two frameworks, one protocol.

--- a/packages/vouch-mcp/README.md
+++ b/packages/vouch-mcp/README.md
@@ -1,0 +1,104 @@
+# vouch-mcp
+
+A Model Context Protocol (MCP) server that lets AI agents **issue and verify**
+[Vouch](https://vouch-protocol.com) Credentials, so every action an agent takes
+carries cryptographic proof of who authorized it.
+
+MCP standardized how agents call tools. It does not say *who* is calling, or on
+*whose authority*. `vouch-mcp` adds that layer: every authorized action carries
+a W3C Verifiable Credential with an `eddsa-jcs-2022` Data Integrity proof (or the
+post-quantum hybrid profile), and any party can verify one over the same MCP
+connection.
+
+**The key stays out of the model.** MCP already runs this server in its own
+process, so the agent's private key lives here, never in the LLM's context. A
+prompt-injected model cannot exfiltrate a key it never holds.
+
+## When to use this vs `vouch.autosign`
+
+Vouch gives you two front doors onto one signing primitive:
+
+- **`vouch.autosign`** (in-process, Python): wrap a tool with `protect([...])`
+  and every call is signed deterministically, before the tool runs, with no
+  LLM cooperation. Best when your agent is Python and you want zero-effort,
+  can't-forget signing.
+- **`vouch-mcp`** (this package): the out-of-process, cross-language path. Any
+  MCP client in any language calls `sign_action` / `verify_credential` over the
+  wire, and the key is isolated in the server process. Best for non-Python
+  agents, key isolation, or exposing verification as a shared service.
+
+Both call the same `sign_intent` core, so credentials are identical either way.
+
+## Install
+
+```bash
+pip install vouch-mcp          # or: uvx vouch-mcp
+```
+
+This pulls in `vouch-protocol[mcp]`, including the official MCP SDK. For the
+post-quantum profile, install `pip install 'vouch-protocol[mcp,pq]'`.
+
+## Configure
+
+```python
+from vouch import generate_identity
+kp = generate_identity("agent.example.com")
+print(kp.did)               # did:web:agent.example.com
+print(kp.private_key_jwk)   # set as VOUCH_PRIVATE_KEY
+```
+
+## Run
+
+**Local (stdio)** for Claude Desktop, Cursor, and desktop agents:
+
+```bash
+VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+```
+
+**Remote (Streamable HTTP)** for hosted / networked deployments:
+
+```bash
+VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
+  VOUCH_PRIVATE_KEY='...' VOUCH_DID='did:web:agent.example.com' vouch-mcp
+```
+
+```jsonc
+// Claude Desktop / Cursor MCP config
+{
+  "mcpServers": {
+    "vouch": {
+      "command": "vouch-mcp",
+      "env": {
+        "VOUCH_DID": "did:web:agent.example.com",
+        "VOUCH_PRIVATE_KEY": "<jwk-json-string>"
+      }
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `sign_action(action, target, resource, post_quantum=False)` | Issue a credential authorizing one action, bound to that exact resource. Set `post_quantum=True` for the `hybrid-eddsa-mldsa44-jcs-2026` profile. |
+| `verify_credential(credential_json, public_key=None)` | Verify a credential another agent or service presented. Any MCP client can verify without installing an SDK. |
+| `create_session(purpose, valid_seconds, decay_lambda, initial_trust)` | Issue a trust-decaying session voucher (Heartbeat Protocol). |
+| `check_revocation(credential_json)` | Check a credential's `BitstringStatusList` entry: `ACTIVE`, `REVOKED`, or not individually revocable. |
+| `get_identity()` | Return the agent's DID. |
+
+## Why `verify_credential` matters
+
+Signing proves *you* acted. Verifying is how *everyone else* benefits: any
+MCP-capable agent, in any framework, can confirm another agent's credential with
+a single tool call and no SDK. That is what turns Vouch from a per-app library
+into an interoperable trust layer.
+
+## Registry
+
+This package ships a `server.json` manifest for the MCP registry, so it can be
+discovered and installed like any other MCP server.
+
+## License
+
+Apache-2.0.

--- a/packages/vouch-mcp/VERIFY.md
+++ b/packages/vouch-mcp/VERIFY.md
@@ -1,0 +1,55 @@
+# vouch-mcp: your verification checklist (do this before publishing)
+
+Nothing here has been published. Run these steps yourself, confirm each, then
+you decide whether to publish to PyPI and submit to `modelcontextprotocol/servers`.
+
+## 1. Clean install in a throwaway venv
+
+```bash
+python -m venv /tmp/vouch-mcp-test && source /tmp/vouch-mcp-test/bin/activate
+pip install -e packages/vouch-mcp        # pulls vouch-protocol[mcp]
+```
+
+Expect: install succeeds, `vouch-mcp` is on PATH (`which vouch-mcp`).
+
+## 2. Run the smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-mcp/tests -q
+```
+
+Expect: 3 passed. They check the package exports, that the FastMCP server has
+`sign_action` / `create_session` / `get_identity` registered, and that the
+issued credential is `eddsa-jcs-2022` and verifies.
+
+## 3. Build the distribution
+
+```bash
+pip install build
+python -m build packages/vouch-mcp
+```
+
+Expect: a wheel and sdist in `packages/vouch-mcp/dist/`. Inspect the wheel
+contents (`unzip -l dist/*.whl`) and confirm only `vouch_mcp` is included.
+
+## 4. End-to-end with a real MCP client (optional but recommended)
+
+```bash
+python -c "from vouch import generate_identity; print(generate_identity().private_key_jwk)"
+```
+
+Set that as `VOUCH_PRIVATE_KEY` and a DID as `VOUCH_DID`, then register the
+`vouch-mcp` command as an stdio server in Claude Desktop or Cursor. Confirm the
+three tools appear and that `sign_action` returns a credential.
+
+## 5. Only after all of the above
+
+- [ ] Publish to PyPI under your account.
+- [ ] Open the PR to `modelcontextprotocol/servers` adding the `vouch` entry.
+- [ ] List it in the official MCP server registry.
+
+Naming note: the main `vouch-protocol` package also installs a `vouch-mcp`
+console script pointing at the same entry point. If you install both into one
+environment the script names collide. Recommended: this standalone package is
+the canonical distribution of the server; depend on it directly.

--- a/packages/vouch-mcp/pyproject.toml
+++ b/packages/vouch-mcp/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-mcp"
+version = "0.2.0"
+description = "Model Context Protocol server that issues and verifies Vouch Credentials to authorize AI agent tool calls."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["mcp", "vouch", "ai-agents", "verifiable-credentials", "identity", "eddsa-jcs-2022"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Security :: Cryptography",
+]
+dependencies = ["vouch-protocol[mcp]>=1.6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[project.scripts]
+vouch-mcp = "vouch_mcp:main"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-mcp/server.json
+++ b/packages/vouch-mcp/server.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "name": "io.github.vouch-protocol/vouch-mcp",
+  "description": "Issue and verify W3C Verifiable Credentials (eddsa-jcs-2022, optional post-quantum) so AI agents can cryptographically authorize the actions they take.",
+  "status": "active",
+  "repository": {
+    "url": "https://github.com/vouch-protocol/vouch",
+    "source": "github"
+  },
+  "version": "0.2.0",
+  "packages": [
+    {
+      "registry_type": "pypi",
+      "identifier": "vouch-mcp",
+      "version": "0.2.0",
+      "transport": { "type": "stdio" },
+      "environment_variables": [
+        {
+          "name": "VOUCH_PRIVATE_KEY",
+          "description": "The agent's private signing key as a JWK JSON string. Held only in this server process, never in the LLM's context.",
+          "is_required": true,
+          "is_secret": true
+        },
+        {
+          "name": "VOUCH_DID",
+          "description": "The agent's DID, e.g. did:web:agent.example.com",
+          "is_required": true
+        },
+        {
+          "name": "VOUCH_MCP_TRANSPORT",
+          "description": "Transport to serve: 'stdio' (default), 'http' (Streamable HTTP), or 'sse'.",
+          "is_required": false
+        },
+        {
+          "name": "VOUCH_MCP_HOST",
+          "description": "Bind host when VOUCH_MCP_TRANSPORT=http (default 127.0.0.1).",
+          "is_required": false
+        },
+        {
+          "name": "VOUCH_MCP_PORT",
+          "description": "Bind port when VOUCH_MCP_TRANSPORT=http (default 8080).",
+          "is_required": false
+        }
+      ]
+    }
+  ]
+}

--- a/packages/vouch-mcp/src/vouch_mcp/__init__.py
+++ b/packages/vouch-mcp/src/vouch_mcp/__init__.py
@@ -1,0 +1,16 @@
+"""vouch-mcp: an MCP server that issues Vouch Credentials for agent tool calls.
+
+This is a thin distribution that wraps ``vouch.integrations.mcp.server``
+(built on the official MCP SDK / FastMCP). It exists so the server can be
+installed and listed on its own (PyPI, the MCP server registry) while the
+implementation stays single-sourced in the vouch-protocol package.
+
+Run:
+    pip install vouch-mcp
+    VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
+"""
+
+from vouch.integrations.mcp.server import main, mcp
+
+__all__ = ["main", "mcp"]
+__version__ = "0.2.0"

--- a/packages/vouch-mcp/tests/test_smoke.py
+++ b/packages/vouch-mcp/tests/test_smoke.py
@@ -1,0 +1,59 @@
+"""Smoke tests for the vouch-mcp package.
+
+These prove the package imports, the server object is the official FastMCP
+type with the expected tools registered, and the server's signing path
+produces a credential that verifies.
+"""
+
+import asyncio
+import json
+import os
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Verifier, generate_identity
+
+
+def test_package_exports():
+    import vouch_mcp
+
+    assert callable(vouch_mcp.main)
+    assert type(vouch_mcp.mcp).__name__ == "FastMCP"
+
+
+def test_registered_tool_names():
+    import vouch_mcp
+
+    tools = asyncio.run(vouch_mcp.mcp.list_tools())
+    names = {t.name for t in tools}
+    assert {
+        "sign_action",
+        "verify_credential",
+        "create_session",
+        "check_revocation",
+        "get_identity",
+    } <= names
+
+
+def test_sign_and_verify_roundtrip():
+    kp = generate_identity("agent.example.com")
+    os.environ["VOUCH_PRIVATE_KEY"] = kp.private_key_jwk
+    os.environ["VOUCH_DID"] = kp.did
+
+    from vouch.autosign import reset_default_signer
+
+    reset_default_signer()
+
+    from vouch.integrations.mcp import server
+
+    out = server.sign_action("read", "https://api.example.com", "customer:123")
+    cred = json.loads(out)
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+    pub = Ed25519PublicKey.from_public_bytes(base64url_decode(json.loads(kp.public_key_jwk)["x"]))
+    ok, _ = Verifier.verify_credential(cred, public_key=pub)
+    assert ok is True
+
+    verdict = server.verify_credential(out, public_key=None)
+    assert "VERIFIED" in verdict or "REJECTED" in verdict

--- a/vouch/integrations/mcp/__init__.py
+++ b/vouch/integrations/mcp/__init__.py
@@ -1,5 +1,5 @@
-"""Vouch MCP Server integration."""
+"""Vouch MCP Server integration (built on the official MCP SDK / FastMCP)."""
 
-from .server import VouchMCPServer, main
+from .server import main, mcp
 
-__all__ = ["VouchMCPServer", "main"]
+__all__ = ["main", "mcp"]

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -1,264 +1,266 @@
 """
-Vouch Protocol MCP Server - Model Context Protocol integration.
+Vouch Protocol MCP Server.
 
-Provides a Standard-IO based MCP server for Claude Desktop, Cursor, and other
-MCP-compatible clients.
+A Model Context Protocol server, built on the official MCP Python SDK
+(FastMCP), that lets MCP-compatible clients (Claude Desktop, Cursor, agent
+frameworks in any language) both *issue* and *verify* Vouch Credentials.
+
+Relationship to ``vouch.autosign``:
+
+    ``autosign`` is the in-process, Python-native path: it wraps a tool so
+    every call is signed deterministically, before the tool body runs, with
+    no LLM cooperation. This MCP server is the out-of-process, cross-language
+    path: any MCP client calls ``sign_action`` / ``verify_credential`` over
+    the wire, and the private key stays in this server's process, never in
+    the model's context. Both share one signing primitive: ``sign_intent``.
+
+Tools:
+    sign_action        Issue a credential authorizing one action (PQC optional).
+    verify_credential  Verify a credential someone else presented.
+    create_session     Issue a trust-decaying session voucher (Heartbeat).
+    check_revocation   Check a credential's BitstringStatusList entry.
+    get_identity       Return this agent's DID.
+
+Run (stdio, for Claude Desktop / Cursor):
+    VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
+
+Run (Streamable HTTP, for remote / hosted use):
+    VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
+        VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
 """
 
-import sys
+from __future__ import annotations
+
 import json
-import logging
 import os
-from typing import Optional, Dict, Any
+from typing import Optional
 
-from vouch import Signer
+try:
+    from mcp.server.fastmcp import FastMCP
+except ImportError as exc:  # pragma: no cover
+    raise SystemExit(
+        "The Vouch MCP server requires the MCP SDK. Install it with:\n"
+        "    pip install 'vouch-protocol[mcp]'\n"
+        "or\n"
+        "    pip install mcp\n"
+        f"(import error: {exc})"
+    )
+
+from vouch.autosign import resolve_signer, sign_intent
 
 
-logging.basicConfig(level=logging.INFO, stream=sys.stderr)
-logger = logging.getLogger(__name__)
+mcp = FastMCP(
+    "vouch",
+    host=os.getenv("VOUCH_MCP_HOST", "127.0.0.1"),
+    port=int(os.getenv("VOUCH_MCP_PORT", "8080")),
+)
 
 
-class VouchMCPServer:
+@mcp.tool()
+def sign_action(
+    action: str,
+    target: str,
+    resource: Optional[str] = None,
+    post_quantum: bool = False,
+) -> str:
+    """Issue a Vouch Credential authorizing a single sensitive action.
+
+    Call this before any authenticated request to an external service. The
+    returned credential binds this agent's identity to this exact action and
+    resource, so a downstream service can confirm the call was authorized.
+
+    Args:
+        action: The verb, e.g. 'read', 'write', 'execute', 'send'.
+        target: The service or URL being called.
+        resource: The specific object, e.g. 'customer:123'. Defaults to target.
+        post_quantum: If true, sign under the hybrid post-quantum profile
+            (hybrid-eddsa-mldsa44-jcs-2026) for regulated deployments.
+            Requires the server to have 'vouch-protocol[pq]' installed.
+
+    Returns:
+        A compact JSON Vouch Credential to attach as a 'Vouch-Credential' header.
     """
-    MCP Server providing Vouch identity signing capabilities.
+    signer = resolve_signer()
+    if signer is None:
+        return (
+            "Error: no Vouch identity configured. Set VOUCH_PRIVATE_KEY and "
+            "VOUCH_DID, or run 'vouch init'."
+        )
+    resolved_resource = resource or target
+    try:
+        if post_quantum:
+            credential = signer.sign_credential_hybrid(
+                {"action": action, "target": target, "resource": resolved_resource}
+            )
+        else:
+            credential = sign_intent(
+                action,
+                target=target,
+                resource=resolved_resource,
+                signer=signer,
+                publish=False,
+            )
+        return json.dumps(credential, separators=(",", ":"))
+    except Exception as e:
+        return f"Error issuing Vouch Credential: {e}"
 
-    Exposes tools for AI agents to generate cryptographic Vouch-Tokens
-    for authentication with external services.
+
+@mcp.tool()
+def verify_credential(credential_json: str, public_key: Optional[str] = None) -> str:
+    """Verify a Vouch Credential that another agent or service presented.
+
+    This is the receiving side: given a credential (the JSON another party's
+    sign_action produced), confirm the signature, validity window, and intent
+    binding. Any MCP client can call this without installing an SDK.
+
+    Args:
+        credential_json: The credential as a JSON string.
+        public_key: Optional Multikey public key of the issuer. If omitted,
+            the issuer's DID is resolved to fetch its key.
+
+    Returns:
+        A human-readable verdict: the issuer DID and authorized intent when
+        valid, or a rejection reason.
     """
+    from vouch import Verifier
 
-    def __init__(self):
-        self._signer: Optional[Signer] = None
-        self._did: Optional[str] = None
-        self._auto_sign = os.getenv("VOUCH_AUTO_SIGN", "").lower() in ("true", "1", "yes")
-        self._session_token: Optional[str] = None
-        self._load_credentials()
+    try:
+        credential = json.loads(credential_json)
+    except json.JSONDecodeError as e:
+        return f"REJECTED: not valid JSON ({e})"
 
-    def _load_credentials(self) -> None:
-        """Load signing credentials from environment."""
-        private_key = os.getenv("VOUCH_PRIVATE_KEY")
-        did = os.getenv("VOUCH_DID")
+    try:
+        is_valid, passport = Verifier.verify_credential(credential, public_key=public_key)
+    except Exception as e:
+        return f"REJECTED: verification error ({e})"
 
-        if private_key and did:
-            try:
-                self._signer = Signer(private_key=private_key, did=did)
-                self._did = did
-                mode = "(Auto-Sign ON)" if self._auto_sign else ""
-                logger.info(f"Vouch MCP Server initialized with DID: {did} {mode}")
-            except Exception as e:
-                logger.error(f"Failed to initialize signer: {e}")
-        else:
-            logger.warning("VOUCH_PRIVATE_KEY or VOUCH_DID not set")
+    if not is_valid or passport is None:
+        return "REJECTED: signature, validity window, or schema check failed."
 
-    def _get_tools_list(self) -> list:
-        """Return the list of available tools."""
-        tools = [
-            {
-                "name": "sign_action",
-                "description": "Generate a cryptographic Vouch-Token to sign a sensitive action. Use this before making authenticated API calls.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "intent": {
-                            "type": "string",
-                            "description": "What action are you taking? (e.g., 'read_email', 'send_payment', 'access_database')",
-                        },
-                        "target": {
-                            "type": "string",
-                            "description": "Optional: The target service or resource",
-                        },
-                    },
-                    "required": ["intent"],
-                },
-            },
-            {
-                "name": "get_identity",
-                "description": "Get the current agent's DID (Decentralized Identifier)",
-                "inputSchema": {"type": "object", "properties": {}},
-            },
-            {
-                "name": "create_session",
-                "description": "Create a session token valid for multiple actions. Reduces need to sign each action individually.",
-                "inputSchema": {
-                    "type": "object",
-                    "properties": {
-                        "purpose": {
-                            "type": "string",
-                            "description": "What is this session for? (e.g., 'calendar_access', 'email_management')",
-                        },
-                    },
-                    "required": ["purpose"],
-                },
-            },
-        ]
-        return tools
-
-    def process_request(self, line: str) -> Optional[Dict[str, Any]]:
-        """Process an incoming MCP request."""
-        try:
-            request = json.loads(line.strip())
-            request_id = request.get("id")
-            method = request.get("method")
-
-            # Handle initialize
-            if method == "initialize":
-                return {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "result": {
-                        "protocolVersion": "2024-11-05",
-                        "capabilities": {"tools": {}},
-                        "serverInfo": {"name": "vouch-mcp-server", "version": "1.1.3"},
-                    },
-                }
-
-            # Handle tools/list
-            if method == "tools/list":
-                return {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "result": {"tools": self._get_tools_list()},
-                }
-
-            # Handle tools/call
-            if method == "tools/call":
-                params = request.get("params", {})
-                tool_name = params.get("name")
-                arguments = params.get("arguments", {})
-
-                return self._handle_tool_call(request_id, tool_name, arguments)
-
-            # Unknown method
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": {"code": -32601, "message": f"Method not found: {method}"},
-            }
-
-        except json.JSONDecodeError as e:
-            logger.error(f"Invalid JSON: {e}")
-            return None
-        except Exception as e:
-            logger.error(f"Request processing error: {e}")
-            return {"jsonrpc": "2.0", "id": None, "error": {"code": -32603, "message": str(e)}}
-
-    def _handle_tool_call(
-        self, request_id: Any, tool_name: str, arguments: Dict[str, Any]
-    ) -> Dict[str, Any]:
-        """Handle a tool call request."""
-
-        if tool_name == "sign_action":
-            if not self._signer:
-                return {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "error": {
-                        "code": -32603,
-                        "message": "VOUCH_PRIVATE_KEY and VOUCH_DID must be set in environment",
-                    },
-                }
-
-            intent = arguments.get("intent", "")
-            target = arguments.get("target", "")
-
-            try:
-                payload = {"intent": intent}
-                if target:
-                    payload["target"] = target
-
-                token = self._signer.sign(payload)
-
-                return {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "result": {
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": f"Vouch-Token: {token}\n\nAdd this as a header: 'Vouch-Token: {token}'",
-                            }
-                        ]
-                    },
-                }
-            except Exception as e:
-                return {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "error": {"code": -32603, "message": f"Signing failed: {e}"},
-                }
-
-        elif tool_name == "get_identity":
-            did = self._did or "Not configured"
-            auto_sign_status = "ON" if self._auto_sign else "OFF"
-            session_status = "Active" if self._session_token else "None"
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "result": {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"Agent DID: {did}\nAuto-Sign: {auto_sign_status}\nSession: {session_status}",
-                        }
-                    ]
-                },
-            }
-
-        elif tool_name == "create_session":
-            if not self._signer:
-                return {
-                    "jsonrpc": "2.0",
-                    "id": request_id,
-                    "error": {"code": -32603, "message": "Vouch identity not configured"},
-                }
-
-            purpose = arguments.get("purpose", "general")
-            import time
-
-            session_payload = {
-                "type": "session",
-                "purpose": purpose,
-                "created_at": int(time.time()),
-                "valid_for": "1 hour",
-            }
-            self._session_token = self._signer.sign(session_payload)
-
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "result": {
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"✅ Session created for: {purpose}\n\nSession-Token: {self._session_token}\n\nUse this token for subsequent actions. No need to sign each one individually.",
-                        }
-                    ]
-                },
-            }
-
-        else:
-            return {
-                "jsonrpc": "2.0",
-                "id": request_id,
-                "error": {"code": -32602, "message": f"Unknown tool: {tool_name}"},
-            }
-
-    def run(self) -> None:
-        """Run the MCP server loop."""
-        logger.info("Vouch MCP Server starting...")
-
-        for line in sys.stdin:
-            if not line.strip():
-                continue
-
-            response = self.process_request(line)
-            if response:
-                print(json.dumps(response), flush=True)
+    intent = getattr(passport, "intent", {}) or {}
+    issuer = getattr(passport, "iss", None) or getattr(passport, "sub", "(unknown)")
+    return (
+        "VERIFIED\n"
+        f"  issuer:   {issuer}\n"
+        f"  action:   {intent.get('action')}\n"
+        f"  target:   {intent.get('target')}\n"
+        f"  resource: {intent.get('resource')}"
+    )
 
 
-def main():
-    """Entry point for the MCP server."""
-    server = VouchMCPServer()
-    server.run()
+@mcp.tool()
+def create_session(
+    purpose: str,
+    valid_seconds: int = 3600,
+    decay_lambda: float = 0.0005,
+    initial_trust: float = 1.0,
+) -> str:
+    """Issue a trust-decaying session voucher (Heartbeat Protocol).
+
+    Unlike a plain long-lived credential, a session voucher carries a trust
+    value that decays over time (Trust Entropy). A verifier recomputes the
+    current trust with compute_trust_at and can refuse a high-stakes action
+    once trust falls below a threshold, unless the session is refreshed.
+
+    Args:
+        purpose: What the session is for, e.g. 'calendar_access'.
+        valid_seconds: Voucher lifetime in seconds (default 3600).
+        decay_lambda: Trust decay rate per second (default 0.0005).
+        initial_trust: Starting trust in [0, 1] (default 1.0).
+
+    Returns:
+        A compact JSON session voucher with an eddsa-jcs-2022 proof.
+    """
+    signer = resolve_signer()
+    if signer is None:
+        return (
+            "Error: no Vouch identity configured. Set VOUCH_PRIVATE_KEY and "
+            "VOUCH_DID, or run 'vouch init'."
+        )
+    try:
+        from vouch import data_integrity
+        from vouch.vc import build_session_voucher
+
+        voucher = build_session_voucher(
+            subject_did=signer.did,
+            validator_dids=[signer.did],
+            decay_lambda=decay_lambda,
+            initial_trust=initial_trust,
+            max_ttl_seconds=valid_seconds,
+            scope=[purpose],
+            valid_seconds=valid_seconds,
+        )
+        proof = data_integrity.build_proof(
+            voucher,
+            private_key=signer._raw_priv,
+            verification_method=signer.verification_method_id(),
+        )
+        voucher["proof"] = proof
+        return json.dumps(voucher, separators=(",", ":"))
+    except Exception as e:
+        return f"Error creating session: {e}"
+
+
+@mcp.tool()
+def check_revocation(credential_json: str) -> str:
+    """Check whether a credential has been revoked via its status list.
+
+    Reads the credential's BitstringStatusList entry (credentialStatus),
+    fetches the referenced status list, and reports whether the bit is set.
+
+    Args:
+        credential_json: The credential as a JSON string.
+
+    Returns:
+        'ACTIVE', 'REVOKED', or a note that the credential is not individually
+        revocable (no credentialStatus attached).
+    """
+    try:
+        credential = json.loads(credential_json)
+    except json.JSONDecodeError as e:
+        return f"Error: not valid JSON ({e})"
+
+    status = credential.get("credentialStatus")
+    if not status:
+        return "NOT REVOCABLE: credential has no credentialStatus entry."
+
+    try:
+        from vouch import StatusListFetcher, verify_status
+
+        fetcher = StatusListFetcher(cache_ttl_seconds=300)
+        status_credential = fetcher.get(status["statusListCredential"])
+        revoked = verify_status(
+            credential_status=status,
+            status_list_credential=status_credential,
+        )
+        return "REVOKED" if revoked else "ACTIVE"
+    except Exception as e:
+        return f"Error checking revocation: {e}"
+
+
+@mcp.tool()
+def get_identity() -> str:
+    """Return this agent's DID (Decentralized Identifier)."""
+    signer = resolve_signer()
+    if signer is None:
+        return "No Vouch identity configured. Set VOUCH_DID or run 'vouch init'."
+    return f"Agent DID: {signer.did}"
+
+
+def main() -> None:
+    """Entry point. Transport is selected by VOUCH_MCP_TRANSPORT.
+
+    - 'stdio' (default): for local clients like Claude Desktop and Cursor.
+    - 'http' / 'streamable-http': for remote / hosted deployments.
+    - 'sse': legacy Server-Sent Events transport.
+    """
+    transport = os.getenv("VOUCH_MCP_TRANSPORT", "stdio").lower().replace("_", "-")
+    if transport in ("http", "streamable-http"):
+        mcp.run(transport="streamable-http")
+    elif transport == "sse":
+        mcp.run(transport="sse")
+    else:
+        mcp.run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes `vouch-mcp` a complete Model Context Protocol server that any MCP client
can use to both issue and verify Vouch Credentials.

Signing goes through the same `vouch.autosign` `sign_intent` primitive the
in-process integrations use, so there is one signing path with two front doors:
deterministic in-process signing (`autosign`) and cross-language, key-isolated
signing over MCP. Because MCP runs the server in its own process, the private
key stays out of the model's context.

Tools:

- `sign_action` with a `post_quantum` toggle for the hybrid-eddsa-mldsa44-jcs-2026 profile.
- `verify_credential`: verify a credential another agent or service presented, so signing and verifying can live in different frameworks and still interoperate.
- `create_session`: a trust-decaying session voucher (Heartbeat Protocol).
- `check_revocation`: read a credential's BitstringStatusList entry.
- `get_identity`.

Transport: Streamable HTTP alongside stdio, selected by `VOUCH_MCP_TRANSPORT`.

Packaging: the standalone `vouch-mcp` package with a `server.json` manifest for
the MCP registry, plus a cross-framework guide for LangChain, CrewAI, AutoGen,
Google ADK, Vertex AI, AutoGPT, n8n, and Hasura.

Credentials carry an `eddsa-jcs-2022` Data Integrity proof. Package smoke tests
cover the registered tools and a sign-then-verify roundtrip.
