### PR TITLE
TypeScript SDK: cross-device fleet and root recovery

### DIFF
--- a/packages/sdk-ts/src/fleet.ts
+++ b/packages/sdk-ts/src/fleet.ts
@@ -1,0 +1,219 @@
+/**
+ * Cross-device identity by per-device keys and delegation (the OSS path).
+ *
+ * The private key never travels. Each device mints its OWN key locally, and the
+ * user's root identity delegates scoped, time-bound, revocable authority to that
+ * device's DID. A device signs its actions with its own key, chained under the
+ * root grant. Losing a device means revoking one delegation, not rotating the
+ * whole identity, and no key is ever copied between devices.
+ *
+ * Mirrors the Python vouch.fleet module. Built on the existing Signer/Verifier;
+ * the credential wire format is unchanged.
+ */
+
+import * as crypto from 'crypto';
+
+import { Signer } from './signer';
+import type { CredentialPassport, CredentialVerificationResult } from './types';
+import type { VouchCredential } from './vc';
+import { verify } from './verifier';
+
+type RootLike = Signer | { signer: Signer };
+
+function rootSigner(root: RootLike): Signer {
+  if (root instanceof Signer) return root;
+  if (root && typeof (root as { signer?: unknown }).signer === 'object') {
+    return (root as { signer: Signer }).signer;
+  }
+  throw new TypeError('enrollDevice requires a Signer or an Agent as the root');
+}
+
+export interface EnrollDeviceOptions {
+  deviceDid: string;
+  action: string;
+  target: string;
+  resource: string;
+  validSeconds?: number;
+  reputationScore?: number;
+}
+
+/**
+ * Issue a delegation grant from the root identity to a device's DID. Hand the
+ * grant to the device; it signs actions with `parentCredential` set to it.
+ */
+export async function enrollDevice(
+  root: RootLike,
+  opts: EnrollDeviceOptions
+): Promise<VouchCredential> {
+  const signer = rootSigner(root);
+  return signer.signCredential({
+    intent: {
+      action: opts.action,
+      target: opts.target,
+      resource: opts.resource,
+      delegatee: opts.deviceDid,
+    },
+    validSeconds: opts.validSeconds ?? 86400,
+    reputationScore: opts.reputationScore,
+  });
+}
+
+export interface FleetResult {
+  ok: boolean;
+  leaf?: CredentialPassport;
+  rootDid?: string;
+  reason?: string;
+}
+
+export interface VerifyDelegatedChainOptions {
+  trustedRoots?: Record<string, crypto.KeyObject | string | Record<string, unknown>>;
+  allowDidResolution?: boolean;
+  revoked?: Iterable<string> | ((id: string) => boolean);
+  requireAction?: string;
+  requireTarget?: string;
+  requireResource?: string;
+  clockSkewSeconds?: number;
+}
+
+/**
+ * Verify a delegation chain from a trusted root down to a leaf action. The
+ * `credentials` array is ordered root-first: [rootGrant, ...grants, leafAction].
+ */
+export async function verifyDelegatedChain(
+  credentials: Array<VouchCredential | Record<string, unknown>>,
+  opts: VerifyDelegatedChainOptions = {}
+): Promise<FleetResult> {
+  if (!credentials || credentials.length === 0) {
+    return { ok: false, reason: 'empty chain' };
+  }
+  const trustedRoots = opts.trustedRoots ?? {};
+  const isRevoked = revocationOracle(opts.revoked);
+  const skew = opts.clockSkewSeconds ?? 30;
+
+  const passports: CredentialPassport[] = [];
+  for (let index = 0; index < credentials.length; index++) {
+    const cred = credentials[index];
+    const issuer = issuerOf(cred);
+    if (!issuer) return { ok: false, reason: `credential ${index} has no issuer` };
+
+    const key = trustedRoots[issuer];
+    if (index === 0 && key === undefined) {
+      return { ok: false, reason: `root issuer ${issuer} is not in trustedRoots` };
+    }
+
+    const result: CredentialVerificationResult = await verify(cred, key, {
+      clockSkewSeconds: skew,
+    });
+    if (!result.isValid || !result.passport) {
+      return { ok: false, reason: `credential ${index} failed verification` };
+    }
+
+    if (isRevoked(result.passport.issuer)) {
+      return { ok: false, reason: `credential ${index} issuer ${result.passport.issuer} is revoked` };
+    }
+    if (result.passport.credentialId && isRevoked(result.passport.credentialId)) {
+      return { ok: false, reason: `credential ${index} (${result.passport.credentialId}) is revoked` };
+    }
+    passports.push(result.passport);
+  }
+
+  for (let i = 0; i < passports.length - 1; i++) {
+    const parent = passports[i];
+    const child = passports[i + 1];
+
+    const delegatee = (parent.intent as Record<string, unknown>)?.delegatee as string | undefined;
+    if (!delegatee) {
+      return { ok: false, reason: `link ${i} (grant by ${parent.issuer}) names no delegatee` };
+    }
+    if (isRevoked(delegatee)) {
+      return { ok: false, reason: `link ${i}: delegatee ${delegatee} is revoked` };
+    }
+    if (child.issuer !== delegatee) {
+      return {
+        ok: false,
+        reason: `link ${i}: child issuer ${child.issuer} is not the delegatee ${delegatee}`,
+      };
+    }
+
+    const parentResource = parent.resource ?? '';
+    const childResource = child.resource ?? '';
+    if (parentResource && childResource && !isSubResource(childResource, parentResource)) {
+      return {
+        ok: false,
+        reason: `link ${i}: resource ${childResource} is not within the granted ${parentResource}`,
+      };
+    }
+
+    if (!windowWithin(child, parent)) {
+      return { ok: false, reason: `link ${i}: child validity is outside the grant window` };
+    }
+  }
+
+  const leaf = passports[passports.length - 1];
+  const checks: Array<[string, string | undefined, unknown]> = [
+    ['action', opts.requireAction, leaf.action],
+    ['target', opts.requireTarget, leaf.target],
+    ['resource', opts.requireResource, leaf.resource],
+  ];
+  for (const [field, expected, actual] of checks) {
+    if (expected !== undefined && actual !== expected) {
+      return { ok: false, leaf, reason: `leaf intent.${field} != ${expected}` };
+    }
+  }
+
+  return { ok: true, leaf, rootDid: passports[0].issuer };
+}
+
+/**
+ * A small in-memory record of a root's enrolled and revoked devices. Pass
+ * `isRevoked` straight to verifyDelegatedChain, or back it with your own store.
+ */
+export class DeviceRegistry {
+  private enrolled = new Map<string, VouchCredential | undefined>();
+  private revokedSet = new Set<string>();
+
+  enroll(deviceDid: string, grant?: VouchCredential): void {
+    this.enrolled.set(deviceDid, grant);
+    this.revokedSet.delete(deviceDid);
+  }
+
+  revoke(deviceDid: string): void {
+    this.revokedSet.add(deviceDid);
+  }
+
+  isRevoked = (identifier: string): boolean => this.revokedSet.has(identifier);
+
+  activeDevices(): string[] {
+    return [...this.enrolled.keys()].filter((d) => !this.revokedSet.has(d));
+  }
+}
+
+function revocationOracle(
+  revoked: Iterable<string> | ((id: string) => boolean) | undefined
+): (id: string) => boolean {
+  if (revoked === undefined) return () => false;
+  if (typeof revoked === 'function') return revoked;
+  const set = new Set(revoked);
+  return (id) => set.has(id);
+}
+
+function issuerOf(cred: VouchCredential | Record<string, unknown>): string | null {
+  const issuer = (cred as Record<string, unknown>).issuer;
+  if (Array.isArray(issuer)) return (issuer[0] as string) ?? null;
+  return (issuer as string) ?? null;
+}
+
+function isSubResource(child: string, parent: string): boolean {
+  if (child === parent) return true;
+  const trimmed = parent.replace(/\/+$/, '');
+  return child.startsWith(trimmed + '/');
+}
+
+function windowWithin(child: CredentialPassport, parent: CredentialPassport): boolean {
+  const cFrom = Date.parse(child.validFrom);
+  const cUntil = Date.parse(child.validUntil);
+  const pFrom = Date.parse(parent.validFrom);
+  const pUntil = Date.parse(parent.validUntil);
+  if ([cFrom, cUntil, pFrom, pUntil].some((n) => Number.isNaN(n))) return false;
+  return cFrom >= pFrom && cUntil <= pUntil;
+}

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -46,6 +46,19 @@ export {
   resolveDefaultStore,
 } from './keystore';
 export type { KeyStore, StoredIdentity } from './keystore';
+export { enrollDevice, verifyDelegatedChain, DeviceRegistry } from './fleet';
+export type {
+  EnrollDeviceOptions,
+  FleetResult,
+  VerifyDelegatedChainOptions,
+} from './fleet';
+export {
+  splitSecret,
+  combineShares,
+  splitIdentity,
+  recoverIdentity,
+} from './recovery';
+export type { SplitOptions, RecoveredIdentity } from './recovery';
 
 export type {
   Passport,

--- a/packages/sdk-ts/src/recovery.ts
+++ b/packages/sdk-ts/src/recovery.ts
@@ -1,0 +1,174 @@
+/**
+ * Root-identity recovery by Shamir secret sharing (the OSS recovery path).
+ *
+ * Splits a root's Ed25519 seed into n shares so any threshold reconstruct it and
+ * fewer reveal nothing. Hand the shares to guardians or separate locations, and
+ * gather a threshold only during a deliberate recovery. This is the recovery and
+ * escrow primitive (the seed is reconstructed at recovery time); it is distinct
+ * from threshold signing, where the key is never reassembled.
+ *
+ * Mirrors the Python vouch.recovery module. Textbook Shamir over GF(2^8).
+ */
+
+import * as crypto from 'crypto';
+
+// ---------------------------------------------------------------------------
+// GF(2^8) arithmetic (AES field, reducing polynomial 0x11b)
+// ---------------------------------------------------------------------------
+
+const EXP = new Uint8Array(512);
+const LOG = new Uint8Array(256);
+
+(function initTables() {
+  // 3 (not 2) is a primitive element of GF(2^8) under 0x11b, so powers of 3
+  // cycle through all 255 non-zero elements. Multiply by 3 = (x*2) XOR x.
+  let x = 1;
+  for (let i = 0; i < 255; i++) {
+    EXP[i] = x;
+    LOG[x] = i;
+    let x2 = x << 1;
+    if (x2 & 0x100) x2 ^= 0x11b;
+    x = x2 ^ x;
+  }
+  for (let i = 255; i < 512; i++) EXP[i] = EXP[i - 255];
+})();
+
+function gfMul(a: number, b: number): number {
+  if (a === 0 || b === 0) return 0;
+  return EXP[LOG[a] + LOG[b]];
+}
+
+function gfInv(a: number): number {
+  if (a === 0) throw new Error('no inverse for 0 in GF(2^8)');
+  return EXP[255 - LOG[a]];
+}
+
+function evalPoly(coeffs: number[], x: number): number {
+  let result = 0;
+  for (let i = coeffs.length - 1; i >= 0; i--) {
+    result = gfMul(result, x) ^ coeffs[i];
+  }
+  return result;
+}
+
+function interpolateAtZero(points: Array<[number, number]>): number {
+  let result = 0;
+  for (let i = 0; i < points.length; i++) {
+    const [xi, yi] = points[i];
+    let num = 1;
+    let den = 1;
+    for (let j = 0; j < points.length; j++) {
+      if (i === j) continue;
+      const xj = points[j][0];
+      num = gfMul(num, xj); // (0 - xj) == xj in GF(2^8)
+      den = gfMul(den, xi ^ xj); // (xi - xj) == xi ^ xj
+    }
+    result ^= gfMul(yi, gfMul(num, gfInv(den)));
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Byte-level split / combine
+// ---------------------------------------------------------------------------
+
+export interface SplitOptions {
+  threshold: number;
+  shares: number;
+}
+
+/** Split `secret` into `shares` pieces; any `threshold` reconstruct it. */
+export function splitSecret(secret: Uint8Array, opts: SplitOptions): Uint8Array[] {
+  if (!secret || secret.length === 0) throw new Error('secret must be non-empty bytes');
+  const { threshold, shares } = opts;
+  if (!(2 <= threshold && threshold <= shares && shares <= 255)) {
+    throw new Error('require 2 <= threshold <= shares <= 255');
+  }
+  const out: number[][] = [];
+  for (let x = 1; x <= shares; x++) out.push([x]);
+  for (const byte of secret) {
+    const coeffs = [byte];
+    for (let k = 1; k < threshold; k++) coeffs.push(crypto.randomInt(256));
+    for (let i = 0; i < shares; i++) {
+      out[i].push(evalPoly(coeffs, i + 1));
+    }
+  }
+  return out.map((s) => Uint8Array.from(s));
+}
+
+/** Reconstruct a secret from `threshold` (or more) shares. */
+export function combineShares(shares: Uint8Array[]): Uint8Array {
+  if (!shares || shares.length < 2) throw new Error('need at least 2 shares');
+  const xs: number[] = [];
+  const bodies: Uint8Array[] = [];
+  for (const s of shares) {
+    if (s.length < 2) throw new Error('malformed share');
+    xs.push(s[0]);
+    bodies.push(s.subarray(1));
+  }
+  if (new Set(xs).size !== xs.length) throw new Error('shares must have distinct indices');
+  const length = bodies[0].length;
+  if (bodies.some((b) => b.length !== length)) {
+    throw new Error('shares have inconsistent length');
+  }
+  const secret = new Uint8Array(length);
+  for (let j = 0; j < length; j++) {
+    const points: Array<[number, number]> = xs.map((x, k) => [x, bodies[k][j]]);
+    secret[j] = interpolateAtZero(points);
+  }
+  return secret;
+}
+
+// ---------------------------------------------------------------------------
+// Vouch identity recovery
+// ---------------------------------------------------------------------------
+
+const ED25519_PKCS8_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+
+function seedFromPrivateJwk(privateKeyJwk: string): Uint8Array {
+  const data = JSON.parse(privateKeyJwk) as { kty?: string; crv?: string; d?: string };
+  if (data.kty !== 'OKP' || data.crv !== 'Ed25519' || !data.d) {
+    throw new Error("expected an Ed25519 private JWK with a 'd' seed");
+  }
+  return base64UrlDecode(data.d);
+}
+
+/** Split a root identity's Ed25519 seed into base64 recovery shares. */
+export function splitIdentity(
+  keypair: { privateKeyJwk: string } | string,
+  opts: SplitOptions
+): string[] {
+  const privateKeyJwk = typeof keypair === 'string' ? keypair : keypair.privateKeyJwk;
+  const seed = seedFromPrivateJwk(privateKeyJwk);
+  return splitSecret(seed, opts).map((s) => Buffer.from(s).toString('base64'));
+}
+
+export interface RecoveredIdentity {
+  privateKeyJwk: string;
+  publicKeyJwk: string;
+  did: string | null;
+}
+
+/** Recover a root identity from `threshold` base64 recovery shares. */
+export function recoverIdentity(shares: string[], opts?: { did?: string }): RecoveredIdentity {
+  const raw = shares.map((s) => new Uint8Array(Buffer.from(s, 'base64')));
+  const seed = combineShares(raw);
+  if (seed.length !== 32) {
+    throw new Error('recovered seed is not 32 bytes; wrong or too few shares');
+  }
+  const der = Buffer.concat([ED25519_PKCS8_PREFIX, Buffer.from(seed)]);
+  const priv = crypto.createPrivateKey({ key: der, format: 'der', type: 'pkcs8' });
+  const pub = crypto.createPublicKey(priv);
+  const privJwk = priv.export({ format: 'jwk' });
+  const pubJwk = pub.export({ format: 'jwk' });
+  return {
+    privateKeyJwk: JSON.stringify(privJwk),
+    publicKeyJwk: JSON.stringify(pubJwk),
+    did: opts?.did ?? null,
+  };
+}
+
+function base64UrlDecode(s: string): Uint8Array {
+  const padded = s.replace(/-/g, '+').replace(/_/g, '/').padEnd(s.length + ((4 - (s.length % 4)) % 4), '=');
+  return new Uint8Array(Buffer.from(padded, 'base64'));
+}

--- a/packages/sdk-ts/tests/fleet-recovery.test.ts
+++ b/packages/sdk-ts/tests/fleet-recovery.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for cross-device identity (fleet) and root recovery (Shamir) in the
+ * TypeScript SDK. Mirrors the Python tests/test_fleet.py and test_recovery.py.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Agent,
+  DeviceRegistry,
+  Signer,
+  Verifier,
+  combineShares,
+  enrollDevice,
+  generateIdentity,
+  recoverIdentity,
+  splitIdentity,
+  splitSecret,
+  verifyDelegatedChain,
+} from '../src';
+
+async function rootAndDevice() {
+  const root = await Agent.create('root.example', { persist: false });
+  const device = await Agent.create(undefined, { persist: false }); // did:key
+  return { root, device };
+}
+
+async function signedChain(root: Agent, device: Agent) {
+  const grant = await enrollDevice(root, {
+    deviceDid: device.did,
+    action: 'charge',
+    target: 'api.bank',
+    resource: 'https://api.bank/invoices',
+  });
+  const action = await device.sign({
+    action: 'charge',
+    target: 'api.bank',
+    resource: 'https://api.bank/invoices/42',
+    parentCredential: grant,
+  });
+  return { grant, action };
+}
+
+describe('fleet: per-device delegation', () => {
+  test('enroll and verify chain', async () => {
+    const { root, device } = await rootAndDevice();
+    const { grant, action } = await signedChain(root, device);
+    const result = await verifyDelegatedChain([grant, action], {
+      trustedRoots: { [root.did]: root.publicKeyJwk },
+    });
+    expect(result.ok).toBe(true);
+    expect(result.rootDid).toBe(root.did);
+    expect(result.leaf?.issuer).toBe(device.did);
+  });
+
+  test('untrusted root rejected', async () => {
+    const { root, device } = await rootAndDevice();
+    const { grant, action } = await signedChain(root, device);
+    const result = await verifyDelegatedChain([grant, action], { trustedRoots: {} });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('trustedRoots');
+  });
+
+  test('wrong device issuer rejected', async () => {
+    const { root, device } = await rootAndDevice();
+    const grant = await enrollDevice(root, {
+      deviceDid: device.did,
+      action: 'charge',
+      target: 'api.bank',
+      resource: 'https://api.bank/invoices',
+    });
+    const impostor = await Agent.create(undefined, { persist: false });
+    const action = await impostor.sign({
+      action: 'charge',
+      target: 'api.bank',
+      resource: 'https://api.bank/invoices/42',
+      parentCredential: grant,
+    });
+    const result = await verifyDelegatedChain([grant, action], {
+      trustedRoots: { [root.did]: root.publicKeyJwk },
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('delegatee');
+  });
+
+  test('tampered action rejected', async () => {
+    const { root, device } = await rootAndDevice();
+    const { grant, action } = await signedChain(root, device);
+    (action.credentialSubject.intent as Record<string, unknown>).resource =
+      'https://api.bank/invoices/evil';
+    const result = await verifyDelegatedChain([grant, action], {
+      trustedRoots: { [root.did]: root.publicKeyJwk },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  test('leaf intent policy', async () => {
+    const { root, device } = await rootAndDevice();
+    const { grant, action } = await signedChain(root, device);
+    const roots = { [root.did]: root.publicKeyJwk };
+    expect((await verifyDelegatedChain([grant, action], { trustedRoots: roots, requireAction: 'charge' })).ok).toBe(true);
+    expect((await verifyDelegatedChain([grant, action], { trustedRoots: roots, requireAction: 'refund' })).ok).toBe(false);
+  });
+});
+
+describe('fleet: device revocation', () => {
+  test('revoked device DID rejected', async () => {
+    const { root, device } = await rootAndDevice();
+    const { grant, action } = await signedChain(root, device);
+    const roots = { [root.did]: root.publicKeyJwk };
+    expect((await verifyDelegatedChain([grant, action], { trustedRoots: roots })).ok).toBe(true);
+    const result = await verifyDelegatedChain([grant, action], {
+      trustedRoots: roots,
+      revoked: new Set([device.did]),
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('revoked');
+  });
+
+  test('DeviceRegistry enroll and revoke', async () => {
+    const { root, device } = await rootAndDevice();
+    const { grant, action } = await signedChain(root, device);
+    const roots = { [root.did]: root.publicKeyJwk };
+    const registry = new DeviceRegistry();
+    registry.enroll(device.did, grant);
+    expect(registry.activeDevices()).toEqual([device.did]);
+    expect((await verifyDelegatedChain([grant, action], { trustedRoots: roots, revoked: registry.isRevoked })).ok).toBe(true);
+    registry.revoke(device.did);
+    expect(registry.activeDevices()).toEqual([]);
+    expect((await verifyDelegatedChain([grant, action], { trustedRoots: roots, revoked: registry.isRevoked })).ok).toBe(false);
+  });
+});
+
+describe('recovery: Shamir', () => {
+  test('split and combine round-trip', () => {
+    const secret = crypto.randomBytes(32);
+    const shares = splitSecret(new Uint8Array(secret), { threshold: 3, shares: 5 });
+    expect(shares.length).toBe(5);
+    expect(Buffer.from(combineShares(shares.slice(0, 3))).equals(secret)).toBe(true);
+    expect(Buffer.from(combineShares([shares[0], shares[2], shares[4]])).equals(secret)).toBe(true);
+  });
+
+  test('below threshold does not reveal', () => {
+    const secret = crypto.randomBytes(32);
+    const shares = splitSecret(new Uint8Array(secret), { threshold: 3, shares: 5 });
+    expect(Buffer.from(combineShares(shares.slice(0, 2))).equals(secret)).toBe(false);
+  });
+
+  test('split and recover identity signs identically', async () => {
+    const keys = await generateIdentity('root.example');
+    const shares = splitIdentity(keys, { threshold: 2, shares: 3 });
+    expect(shares.length).toBe(3);
+    const recovered = recoverIdentity(shares.slice(0, 2), { did: keys.did! });
+    expect(recovered.did).toBe(keys.did);
+    expect(recovered.publicKeyJwk).toBe(keys.publicKeyJwk);
+    // The recovered key is the original: a credential it signs verifies against
+    // the ORIGINAL public key.
+    const signer = new Signer({ privateKey: recovered.privateKeyJwk, did: keys.did! });
+    const cred = await signer.signCredential({ action: 'read', target: 't', resource: 'https://x/y' });
+    const { isValid } = await Verifier.verifyCredential(cred, keys.publicKeyJwk);
+    expect(isValid).toBe(true);
+  });
+
+  test('invalid parameters throw', () => {
+    expect(() => splitSecret(new Uint8Array(), { threshold: 2, shares: 3 })).toThrow();
+    expect(() => splitSecret(new Uint8Array([1]), { threshold: 1, shares: 3 })).toThrow();
+    expect(() => splitSecret(new Uint8Array([1]), { threshold: 4, shares: 3 })).toThrow();
+  });
+});


### PR DESCRIPTION
Ports the cross-device custody helpers to the TypeScript SDK, matching the Python surface. The credential wire format is unchanged; these build on the existing Signer and Verifier.

What it adds:
- enrollDevice(root, {deviceDid, action, target, resource}): the root authorizes a device's DID for a scope and returns the grant. The device signs actions with parentCredential set to it.
- verifyDelegatedChain([grant, action], {trustedRoots}): verifies the whole chain back to a trusted root. It checks every Data Integrity proof and validity window, that each step is authorized by the one before it, that the resource only narrows, that the validity windows nest, and an optional revocation oracle and leaf intent policy.
- DeviceRegistry: tracks a root's enrolled and revoked devices and exposes isRevoked to feed straight into verification.
- splitSecret / combineShares: textbook Shamir over GF(2^8).
- splitIdentity / recoverIdentity: split a root Ed25519 seed into base64 shares to hand to guardians, and rebuild the exact same key from any threshold.

Security boundary: verifyDelegatedChain anchors trust only in trustedRoots; every other link's key is resolved from trustedRoots, then did:key, then did:web. Revocation is enforced at verify time against the oracle the verifier supplies. did:key resolution authenticates self-consistency, not real-world identity. For recovery, fewer than the threshold of shares reveal nothing; the seed is reconstructed only at recovery time (do it on a trusted device), and shares carry no integrity tag so callers who need to detect a bad share should add a checksum.

Verification: 11 new tests pass (enroll and verify, untrusted root, wrong device, tampered action, intent policy, revocation and DeviceRegistry, Shamir split/combine round-trip and below-threshold, and identity split/recover that signs identically), alongside the full existing TypeScript suite.
