### PR TITLE
Document cross-device identity across the assistant and help surfaces

### DIFF
--- a/agents-and-skills/FAQ-DRAFT.md
+++ b/agents-and-skills/FAQ-DRAFT.md
@@ -33,6 +33,17 @@ signer=principal_signer)`, then `agent.tools = vouch.protect([tool], parent=gran
 The protocol enforces that the agent can only narrow the granted authority,
 never widen it.
 
+**Q: How do I use one identity across my devices without copying my private key?**
+A: Each device mints its own key locally, and your root identity delegates
+scoped authority to that device: `grant = vouch.enroll_device(root,
+device_did=device.did, action=..., target=..., resource=...)`. The device signs
+with its own key (`device.sign(..., parent_credential=grant)`), and a verifier
+ties it back to the root with `vouch.verify_delegated_chain([grant, action],
+trusted_roots={root.did: root.public_key_jwk})`. Lose a device and you revoke it
+with a `DeviceRegistry`; lose the root and you rebuild it from Shamir shares with
+`vouch.split_identity` and `vouch.recover_identity`. The private key never
+travels between devices.
+
 ---
 
 ## Sidecars (which language to run)

--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -183,6 +183,31 @@ chain backward.
 
 See `reference/delegation.md` for the construction and verification flow.
 
+### "How do I use one identity across many devices?"
+
+Each device mints its own key locally, and a root identity delegates
+scoped, time-bound authority to that device's DID. A device signs its
+actions with its own key, chained under the root grant, so the private
+key never travels between devices. `verify_delegated_chain` ties a
+device's action back to the trusted root. Lose a device and you revoke
+it; lose the root and you rebuild it from Shamir recovery shares.
+
+```python
+from vouch import Agent, enroll_device, verify_delegated_chain
+
+root = Agent("alice.example")
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(root, device_did=phone.did, action="charge",
+                      target="api.bank", resource="https://api.bank/invoices")
+action = phone.sign(action="charge", target="api.bank",
+                    resource="https://api.bank/invoices/42", parent_credential=grant)
+result = verify_delegated_chain([grant, action],
+                                trusted_roots={root.did: root.public_key_jwk})
+```
+
+See `reference/cross-device-identity.md` for enrollment, revocation, and
+recovery.
+
 ### "How do I revoke a specific credential?"
 
 BitstringStatusList: flip the bit at the credential's index, re-sign

--- a/claude-skill/skills/vouch-protocol/reference/cross-device-identity.md
+++ b/claude-skill/skills/vouch-protocol/reference/cross-device-identity.md
@@ -1,0 +1,136 @@
+# Cross-Device Identity Reference
+
+One identity across many devices, without ever copying the private key. Each
+device holds its own key; a root identity delegates scoped authority to each
+device; a verifier ties any device's action back to the trusted root. Lose a
+device and you revoke it; lose all of them and you rebuild the root from recovery
+shares.
+
+This builds directly on delegation chains (see the Delegation reference). The
+Python and TypeScript SDKs ship the helpers described here; the credential wire
+format is unchanged.
+
+## When to use it
+
+- A person or organization uses several devices (phones, laptops, smart devices)
+  and wants one identity across all of them.
+- You never want a private key to travel between devices or sit on a server.
+- You need to revoke a single lost device without rotating the whole identity.
+- You need the root identity to survive the loss of every device.
+
+## The model
+
+- Root identity: the durable anchor, kept off day-to-day devices.
+- Device identity: each device mints its OWN key locally (often a did:key). The
+  key never leaves the device.
+- Grant: the root signs a scoped, time-bound delegation to a device's DID.
+- Action: the device signs with its own key, chained under the grant.
+- Verification: a relying party checks the whole chain back to the trusted root.
+
+What moves between devices is authority (a signed grant), never key material.
+
+## Enroll a device
+
+```python
+from vouch import Agent, enroll_device
+
+root = Agent("alice.example")
+trusted_roots = {root.did: root.public_key_jwk}
+
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
+)
+```
+
+## Sign and verify
+
+```python
+from vouch import verify_delegated_chain
+
+action = phone.sign(
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/42",
+    parent_credential=grant,
+)
+
+result = verify_delegated_chain([grant, action], trusted_roots=trusted_roots)
+assert result.ok
+```
+
+`verify_delegated_chain` confirms every signature, that each step is authorized
+by the one before it (the child's issuer is the parent's delegatee), that the
+resource only narrows, and that the validity windows nest. The credentials are
+ordered root-first: `[root_grant, ...intermediate grants, leaf_action]`.
+
+## Revoke a lost device
+
+```python
+from vouch import DeviceRegistry
+
+registry = DeviceRegistry()
+registry.enroll(phone.did, grant)
+
+registry.revoke(phone.did)
+
+result = verify_delegated_chain(
+    [grant, action], trusted_roots=trusted_roots, revoked=registry.is_revoked
+)
+assert not result.ok
+```
+
+The `revoked` argument accepts a `DeviceRegistry.is_revoked` callable, a set of
+revoked DIDs or credential ids, or any `is_revoked(id) -> bool` function, so you
+can back it with your own store.
+
+## Recover the root
+
+Split the root into shares so any threshold rebuild it. Distribute the shares to
+guardians or separate locations. Fewer than the threshold reveal nothing.
+
+```python
+from vouch import split_identity, recover_identity, Signer
+
+# Splitting needs the root's key, so create the root with allow_key_export=True.
+root = Agent("alice.example", allow_key_export=True)
+shares = split_identity(root, threshold=2, shares=3)
+
+# Later, any two shares rebuild the exact same identity.
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+signer = Signer.from_keypair(recovered)
+```
+
+This is the recovery and escrow path. The seed is reconstructed only during a
+deliberate recovery, so do it on a trusted device and re-seal afterwards. It is
+distinct from threshold signing, where the key is never reassembled.
+
+## Security notes
+
+- Trust is anchored only in `trusted_roots`. The root credential's issuer must
+  appear there; other links resolve their key from that map, then did:key, then
+  did:web.
+- did:key resolution authenticates self-consistency, not real-world identity, so
+  the root anchor is what establishes trust.
+- Revocation is enforced at verify time against the oracle the verifier supplies,
+  so the relying party controls the revocation source of truth.
+- For recovery, shares carry no integrity tag, so a wrong or corrupted share
+  yields a wrong secret rather than an error; add your own checksum if you need
+  to detect a bad share.
+
+## API summary
+
+- `enroll_device(root, device_did=, action=, target=, resource=, valid_seconds=)`
+- `verify_delegated_chain(credentials, trusted_roots=, revoked=, require_action=, ...)`
+- `DeviceRegistry()` with `enroll`, `revoke`, `is_revoked`, `active_devices`
+- `split_identity(keypair, threshold=, shares=)` and `recover_identity(shares, did=)`
+- Byte-level primitives: `split_secret(secret, threshold=, shares=)` and
+  `combine_shares(shares)`
+
+The TypeScript SDK exposes the same surface with camelCase names
+(`enrollDevice`, `verifyDelegatedChain`, `DeviceRegistry`, `splitIdentity`,
+`recoverIdentity`).

--- a/gemini-gem/knowledge/cross-device-identity.md
+++ b/gemini-gem/knowledge/cross-device-identity.md
@@ -1,0 +1,136 @@
+# Cross-Device Identity Reference
+
+One identity across many devices, without ever copying the private key. Each
+device holds its own key; a root identity delegates scoped authority to each
+device; a verifier ties any device's action back to the trusted root. Lose a
+device and you revoke it; lose all of them and you rebuild the root from recovery
+shares.
+
+This builds directly on delegation chains (see the Delegation reference). The
+Python and TypeScript SDKs ship the helpers described here; the credential wire
+format is unchanged.
+
+## When to use it
+
+- A person or organization uses several devices (phones, laptops, smart devices)
+  and wants one identity across all of them.
+- You never want a private key to travel between devices or sit on a server.
+- You need to revoke a single lost device without rotating the whole identity.
+- You need the root identity to survive the loss of every device.
+
+## The model
+
+- Root identity: the durable anchor, kept off day-to-day devices.
+- Device identity: each device mints its OWN key locally (often a did:key). The
+  key never leaves the device.
+- Grant: the root signs a scoped, time-bound delegation to a device's DID.
+- Action: the device signs with its own key, chained under the grant.
+- Verification: a relying party checks the whole chain back to the trusted root.
+
+What moves between devices is authority (a signed grant), never key material.
+
+## Enroll a device
+
+```python
+from vouch import Agent, enroll_device
+
+root = Agent("alice.example")
+trusted_roots = {root.did: root.public_key_jwk}
+
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
+)
+```
+
+## Sign and verify
+
+```python
+from vouch import verify_delegated_chain
+
+action = phone.sign(
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/42",
+    parent_credential=grant,
+)
+
+result = verify_delegated_chain([grant, action], trusted_roots=trusted_roots)
+assert result.ok
+```
+
+`verify_delegated_chain` confirms every signature, that each step is authorized
+by the one before it (the child's issuer is the parent's delegatee), that the
+resource only narrows, and that the validity windows nest. The credentials are
+ordered root-first: `[root_grant, ...intermediate grants, leaf_action]`.
+
+## Revoke a lost device
+
+```python
+from vouch import DeviceRegistry
+
+registry = DeviceRegistry()
+registry.enroll(phone.did, grant)
+
+registry.revoke(phone.did)
+
+result = verify_delegated_chain(
+    [grant, action], trusted_roots=trusted_roots, revoked=registry.is_revoked
+)
+assert not result.ok
+```
+
+The `revoked` argument accepts a `DeviceRegistry.is_revoked` callable, a set of
+revoked DIDs or credential ids, or any `is_revoked(id) -> bool` function, so you
+can back it with your own store.
+
+## Recover the root
+
+Split the root into shares so any threshold rebuild it. Distribute the shares to
+guardians or separate locations. Fewer than the threshold reveal nothing.
+
+```python
+from vouch import split_identity, recover_identity, Signer
+
+# Splitting needs the root's key, so create the root with allow_key_export=True.
+root = Agent("alice.example", allow_key_export=True)
+shares = split_identity(root, threshold=2, shares=3)
+
+# Later, any two shares rebuild the exact same identity.
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+signer = Signer.from_keypair(recovered)
+```
+
+This is the recovery and escrow path. The seed is reconstructed only during a
+deliberate recovery, so do it on a trusted device and re-seal afterwards. It is
+distinct from threshold signing, where the key is never reassembled.
+
+## Security notes
+
+- Trust is anchored only in `trusted_roots`. The root credential's issuer must
+  appear there; other links resolve their key from that map, then did:key, then
+  did:web.
+- did:key resolution authenticates self-consistency, not real-world identity, so
+  the root anchor is what establishes trust.
+- Revocation is enforced at verify time against the oracle the verifier supplies,
+  so the relying party controls the revocation source of truth.
+- For recovery, shares carry no integrity tag, so a wrong or corrupted share
+  yields a wrong secret rather than an error; add your own checksum if you need
+  to detect a bad share.
+
+## API summary
+
+- `enroll_device(root, device_did=, action=, target=, resource=, valid_seconds=)`
+- `verify_delegated_chain(credentials, trusted_roots=, revoked=, require_action=, ...)`
+- `DeviceRegistry()` with `enroll`, `revoke`, `is_revoked`, `active_devices`
+- `split_identity(keypair, threshold=, shares=)` and `recover_identity(shares, did=)`
+- Byte-level primitives: `split_secret(secret, threshold=, shares=)` and
+  `combine_shares(shares)`
+
+The TypeScript SDK exposes the same surface with camelCase names
+(`enrollDevice`, `verifyDelegatedChain`, `DeviceRegistry`, `splitIdentity`,
+`recoverIdentity`).

--- a/openai-gpt/knowledge/cross-device-identity.md
+++ b/openai-gpt/knowledge/cross-device-identity.md
@@ -1,0 +1,136 @@
+# Cross-Device Identity Reference
+
+One identity across many devices, without ever copying the private key. Each
+device holds its own key; a root identity delegates scoped authority to each
+device; a verifier ties any device's action back to the trusted root. Lose a
+device and you revoke it; lose all of them and you rebuild the root from recovery
+shares.
+
+This builds directly on delegation chains (see the Delegation reference). The
+Python and TypeScript SDKs ship the helpers described here; the credential wire
+format is unchanged.
+
+## When to use it
+
+- A person or organization uses several devices (phones, laptops, smart devices)
+  and wants one identity across all of them.
+- You never want a private key to travel between devices or sit on a server.
+- You need to revoke a single lost device without rotating the whole identity.
+- You need the root identity to survive the loss of every device.
+
+## The model
+
+- Root identity: the durable anchor, kept off day-to-day devices.
+- Device identity: each device mints its OWN key locally (often a did:key). The
+  key never leaves the device.
+- Grant: the root signs a scoped, time-bound delegation to a device's DID.
+- Action: the device signs with its own key, chained under the grant.
+- Verification: a relying party checks the whole chain back to the trusted root.
+
+What moves between devices is authority (a signed grant), never key material.
+
+## Enroll a device
+
+```python
+from vouch import Agent, enroll_device
+
+root = Agent("alice.example")
+trusted_roots = {root.did: root.public_key_jwk}
+
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
+)
+```
+
+## Sign and verify
+
+```python
+from vouch import verify_delegated_chain
+
+action = phone.sign(
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/42",
+    parent_credential=grant,
+)
+
+result = verify_delegated_chain([grant, action], trusted_roots=trusted_roots)
+assert result.ok
+```
+
+`verify_delegated_chain` confirms every signature, that each step is authorized
+by the one before it (the child's issuer is the parent's delegatee), that the
+resource only narrows, and that the validity windows nest. The credentials are
+ordered root-first: `[root_grant, ...intermediate grants, leaf_action]`.
+
+## Revoke a lost device
+
+```python
+from vouch import DeviceRegistry
+
+registry = DeviceRegistry()
+registry.enroll(phone.did, grant)
+
+registry.revoke(phone.did)
+
+result = verify_delegated_chain(
+    [grant, action], trusted_roots=trusted_roots, revoked=registry.is_revoked
+)
+assert not result.ok
+```
+
+The `revoked` argument accepts a `DeviceRegistry.is_revoked` callable, a set of
+revoked DIDs or credential ids, or any `is_revoked(id) -> bool` function, so you
+can back it with your own store.
+
+## Recover the root
+
+Split the root into shares so any threshold rebuild it. Distribute the shares to
+guardians or separate locations. Fewer than the threshold reveal nothing.
+
+```python
+from vouch import split_identity, recover_identity, Signer
+
+# Splitting needs the root's key, so create the root with allow_key_export=True.
+root = Agent("alice.example", allow_key_export=True)
+shares = split_identity(root, threshold=2, shares=3)
+
+# Later, any two shares rebuild the exact same identity.
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+signer = Signer.from_keypair(recovered)
+```
+
+This is the recovery and escrow path. The seed is reconstructed only during a
+deliberate recovery, so do it on a trusted device and re-seal afterwards. It is
+distinct from threshold signing, where the key is never reassembled.
+
+## Security notes
+
+- Trust is anchored only in `trusted_roots`. The root credential's issuer must
+  appear there; other links resolve their key from that map, then did:key, then
+  did:web.
+- did:key resolution authenticates self-consistency, not real-world identity, so
+  the root anchor is what establishes trust.
+- Revocation is enforced at verify time against the oracle the verifier supplies,
+  so the relying party controls the revocation source of truth.
+- For recovery, shares carry no integrity tag, so a wrong or corrupted share
+  yields a wrong secret rather than an error; add your own checksum if you need
+  to detect a bad share.
+
+## API summary
+
+- `enroll_device(root, device_did=, action=, target=, resource=, valid_seconds=)`
+- `verify_delegated_chain(credentials, trusted_roots=, revoked=, require_action=, ...)`
+- `DeviceRegistry()` with `enroll`, `revoke`, `is_revoked`, `active_devices`
+- `split_identity(keypair, threshold=, shares=)` and `recover_identity(shares, did=)`
+- Byte-level primitives: `split_secret(secret, threshold=, shares=)` and
+  `combine_shares(shares)`
+
+The TypeScript SDK exposes the same surface with camelCase names
+(`enrollDevice`, `verifyDelegatedChain`, `DeviceRegistry`, `splitIdentity`,
+`recoverIdentity`).

--- a/website-agent/backend/knowledge/cross-device-identity.md
+++ b/website-agent/backend/knowledge/cross-device-identity.md
@@ -1,0 +1,136 @@
+# Cross-Device Identity Reference
+
+One identity across many devices, without ever copying the private key. Each
+device holds its own key; a root identity delegates scoped authority to each
+device; a verifier ties any device's action back to the trusted root. Lose a
+device and you revoke it; lose all of them and you rebuild the root from recovery
+shares.
+
+This builds directly on delegation chains (see the Delegation reference). The
+Python and TypeScript SDKs ship the helpers described here; the credential wire
+format is unchanged.
+
+## When to use it
+
+- A person or organization uses several devices (phones, laptops, smart devices)
+  and wants one identity across all of them.
+- You never want a private key to travel between devices or sit on a server.
+- You need to revoke a single lost device without rotating the whole identity.
+- You need the root identity to survive the loss of every device.
+
+## The model
+
+- Root identity: the durable anchor, kept off day-to-day devices.
+- Device identity: each device mints its OWN key locally (often a did:key). The
+  key never leaves the device.
+- Grant: the root signs a scoped, time-bound delegation to a device's DID.
+- Action: the device signs with its own key, chained under the grant.
+- Verification: a relying party checks the whole chain back to the trusted root.
+
+What moves between devices is authority (a signed grant), never key material.
+
+## Enroll a device
+
+```python
+from vouch import Agent, enroll_device
+
+root = Agent("alice.example")
+trusted_roots = {root.did: root.public_key_jwk}
+
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
+)
+```
+
+## Sign and verify
+
+```python
+from vouch import verify_delegated_chain
+
+action = phone.sign(
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices/42",
+    parent_credential=grant,
+)
+
+result = verify_delegated_chain([grant, action], trusted_roots=trusted_roots)
+assert result.ok
+```
+
+`verify_delegated_chain` confirms every signature, that each step is authorized
+by the one before it (the child's issuer is the parent's delegatee), that the
+resource only narrows, and that the validity windows nest. The credentials are
+ordered root-first: `[root_grant, ...intermediate grants, leaf_action]`.
+
+## Revoke a lost device
+
+```python
+from vouch import DeviceRegistry
+
+registry = DeviceRegistry()
+registry.enroll(phone.did, grant)
+
+registry.revoke(phone.did)
+
+result = verify_delegated_chain(
+    [grant, action], trusted_roots=trusted_roots, revoked=registry.is_revoked
+)
+assert not result.ok
+```
+
+The `revoked` argument accepts a `DeviceRegistry.is_revoked` callable, a set of
+revoked DIDs or credential ids, or any `is_revoked(id) -> bool` function, so you
+can back it with your own store.
+
+## Recover the root
+
+Split the root into shares so any threshold rebuild it. Distribute the shares to
+guardians or separate locations. Fewer than the threshold reveal nothing.
+
+```python
+from vouch import split_identity, recover_identity, Signer
+
+# Splitting needs the root's key, so create the root with allow_key_export=True.
+root = Agent("alice.example", allow_key_export=True)
+shares = split_identity(root, threshold=2, shares=3)
+
+# Later, any two shares rebuild the exact same identity.
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+signer = Signer.from_keypair(recovered)
+```
+
+This is the recovery and escrow path. The seed is reconstructed only during a
+deliberate recovery, so do it on a trusted device and re-seal afterwards. It is
+distinct from threshold signing, where the key is never reassembled.
+
+## Security notes
+
+- Trust is anchored only in `trusted_roots`. The root credential's issuer must
+  appear there; other links resolve their key from that map, then did:key, then
+  did:web.
+- did:key resolution authenticates self-consistency, not real-world identity, so
+  the root anchor is what establishes trust.
+- Revocation is enforced at verify time against the oracle the verifier supplies,
+  so the relying party controls the revocation source of truth.
+- For recovery, shares carry no integrity tag, so a wrong or corrupted share
+  yields a wrong secret rather than an error; add your own checksum if you need
+  to detect a bad share.
+
+## API summary
+
+- `enroll_device(root, device_did=, action=, target=, resource=, valid_seconds=)`
+- `verify_delegated_chain(credentials, trusted_roots=, revoked=, require_action=, ...)`
+- `DeviceRegistry()` with `enroll`, `revoke`, `is_revoked`, `active_devices`
+- `split_identity(keypair, threshold=, shares=)` and `recover_identity(shares, did=)`
+- Byte-level primitives: `split_secret(secret, threshold=, shares=)` and
+  `combine_shares(shares)`
+
+The TypeScript SDK exposes the same surface with camelCase names
+(`enrollDevice`, `verifyDelegatedChain`, `DeviceRegistry`, `splitIdentity`,
+`recoverIdentity`).

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -818,6 +818,26 @@ The verifier walks every link, validates signatures, and confirms resource subse
         meta: 'Specification §9 Delegation Chains',
       },
       {
+        q: 'How do I use one identity across my devices without copying my private key?',
+        a: `Each device makes its own key and keeps it local. Your root identity signs a scoped grant for each device, and the device signs its actions with its own key, chained under that grant. A verifier ties any action back to the trusted root. The private key never travels between devices.
+
+\`\`\`python
+from vouch import Agent, enroll_device, verify_delegated_chain
+
+root = Agent("alice.example")
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(root, device_did=phone.did, action="charge",
+                      target="api.bank", resource="https://api.bank/invoices")
+action = phone.sign(action="charge", target="api.bank",
+                    resource="https://api.bank/invoices/42", parent_credential=grant)
+result = verify_delegated_chain([grant, action],
+                                trusted_roots={root.did: root.public_key_jwk})
+\`\`\`
+
+Lose a device and you revoke it with a \`DeviceRegistry\`; lose the root and you rebuild it from a threshold of Shamir shares with \`split_identity\` and \`recover_identity\`. The TypeScript SDK exposes the same helpers.`,
+        meta: 'Cross-device identity',
+      },
+      {
         q: 'How do I make a credential revocable later?',
         a: `Attach a status entry when you issue it. That way, if you ever need to revoke it, you just flip a bit on a published list. Allocate an index from your status list, then pass the entry as \`credential_status\` to \`sign_credential\` so the proof covers it:
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -750,6 +750,85 @@ result = await verifier.verify_delegation_chain([principal_link, agent_link, act
 The verifier walks every link, validates each signature, and confirms resource narrowing.
 `,
       },
+      {
+        id: 'cross-device-identity',
+        title: 'One Identity Across Your Devices',
+        summary: 'Use the same identity on many devices without ever copying your private key: per-device keys, delegation, revocation, and recovery.',
+        body: `
+## The idea
+
+Each device makes its own key and keeps it local. Your root identity signs a scoped permission slip (a delegation grant) for each device. A verifier ties any device's action back to your trusted root. Lose a device and you revoke it; lose all of them and you rebuild the root from recovery shares. What moves between devices is authority, never key material.
+
+## Enroll a device
+
+Each device mints its own key. The root delegates a scope to that device's DID.
+
+\`\`\`python
+from vouch import Agent, enroll_device
+
+root = Agent("alice.example")
+trusted_roots = {root.did: root.public_key_jwk}
+
+phone = Agent()  # a did:key minted on the phone
+grant = enroll_device(
+    root,
+    device_did=phone.did,
+    action="charge",
+    target="api.bank",
+    resource="https://api.bank/invoices",
+)
+\`\`\`
+
+## Sign and verify
+
+The device signs with its own key, chained under the grant. A verifier checks the whole chain back to the trusted root.
+
+\`\`\`python
+from vouch import verify_delegated_chain
+
+action = phone.sign(
+    action="charge", target="api.bank",
+    resource="https://api.bank/invoices/42", parent_credential=grant,
+)
+result = verify_delegated_chain([grant, action], trusted_roots=trusted_roots)
+assert result.ok
+\`\`\`
+
+## Revoke a lost device
+
+Track devices with a \`DeviceRegistry\` and revoke one when it is lost. Its actions stop verifying; other devices are unaffected.
+
+\`\`\`python
+from vouch import DeviceRegistry
+
+registry = DeviceRegistry()
+registry.enroll(phone.did, grant)
+registry.revoke(phone.did)
+
+result = verify_delegated_chain(
+    [grant, action], trusted_roots=trusted_roots, revoked=registry.is_revoked
+)
+assert not result.ok
+\`\`\`
+
+## Recover the root
+
+Split the root into shares so any threshold rebuild it. Distribute the shares to guardians or separate locations. Fewer than the threshold reveal nothing.
+
+\`\`\`python
+from vouch import split_identity, recover_identity, Signer
+
+# Splitting needs the root's key, so create the root with allow_key_export=True.
+root = Agent("alice.example", allow_key_export=True)
+shares = split_identity(root, threshold=2, shares=3)
+
+recovered = recover_identity([shares[0], shares[2]], did=root.did)
+signer = Signer.from_keypair(recovered)
+\`\`\`
+
+The TypeScript SDK exposes the same helpers with camelCase names. See the runnable example in \`examples/cross_device_identity.py\`.
+`,
+      },
     ],
   },
 


### PR DESCRIPTION
Documents the cross-device identity feature across the assistant and help surfaces, using the same content everywhere.

What it adds:
- A cross-device identity reference (per-device keys, delegation, revocation, and Shamir recovery) in the shared knowledge base, with an identical copy in all four knowledge directories that back the site assistant, the Claude skill, the OpenAI GPT, and the Gemini gem.
- A matching section in the Claude skill guide (SKILL.md) that points to the new reference.
- A FAQ entry on the site (faq-data.ts) and in the draft FAQ.
- A help article on the site (help-data.ts) walking through enroll, sign, verify, revoke, and recover.

The content mirrors the runnable example and guide (examples/cross_device_identity.py, docs/cross-device-identity.md). No code changes; documentation only.
