### PR TITLE
refactor(mcp): rename the sign_action tool to sign

### DIFF
--- a/examples/mcp-vouch/README.md
+++ b/examples/mcp-vouch/README.md
@@ -1,8 +1,8 @@
 # Using Vouch Protocol from any framework, over MCP
 
 `vouch-mcp` is a Model Context Protocol server. Any MCP-capable agent framework
-can connect to it and gain two tools: `sign_action` (authorize an action with a
-Verifiable Credential) and `verify_credential` (check one someone else
+can connect to it and gain two tools: `sign` (authorize an action with a
+Verifiable Credential) and `verify` (check one someone else
 presented), plus `create_session`, `check_revocation`, and `get_identity`.
 
 The payoff: you do not need a bespoke Vouch connector per framework. You run one
@@ -48,7 +48,7 @@ client = MultiServerMCPClient({
               "env": {"VOUCH_DID": "did:web:agent.example.com",
                       "VOUCH_PRIVATE_KEY": "<jwk>"}}
 })
-tools = await client.get_tools()          # sign_action, verify_credential, ...
+tools = await client.get_tools()          # sign, verify, ...
 
 from langgraph.prebuilt import create_react_agent
 agent = create_react_agent(model, tools)
@@ -78,7 +78,7 @@ params = StdioServerParams(command="vouch-mcp",
     env={"VOUCH_DID": "did:web:agent.example.com", "VOUCH_PRIVATE_KEY": "<jwk>"})
 
 async with McpWorkbench(params) as workbench:
-    ...  # pass workbench to an AssistantAgent; it can call sign_action
+    ...  # pass workbench to an AssistantAgent; it can call sign
 ```
 
 ## Google ADK: `MCPToolset`
@@ -98,13 +98,13 @@ agent = LlmAgent(model="gemini-2.0-flash", name="claims_agent", tools=[toolset])
 
 Vertex reaches MCP through ADK (above) when you deploy on Agent Engine, or you
 can bridge the `vouch-mcp` tool schema into Gemini function-calling. Either way
-the model calls `sign_action`; the credential is minted in the server process.
+the model calls `sign`; the credential is minted in the server process.
 
 ## AutoGPT
 
 AutoGPT's platform consumes MCP servers as tool providers. Register `vouch-mcp`
 in the block/tool configuration with the same `command` + `env`, and the agent
-gains `sign_action` / `verify_credential` as callable blocks.
+gains `sign` / `verify` as callable blocks.
 
 ## n8n: MCP Client Tool node
 
@@ -117,30 +117,30 @@ Environment: VOUCH_DID=did:web:agent.example.com
              VOUCH_PRIVATE_KEY=<jwk>
 ```
 
-Then any workflow can call `sign_action` before an outbound HTTP node and attach
+Then any workflow can call `sign` before an outbound HTTP node and attach
 the returned credential as a `Vouch-Credential` header.
 
 ## Hasura: verify at the gateway (the receiving side)
 
 Hasura is not an MCP client; it is where you enforce the credential. Have your
-webhook authorizer call `verify_credential` (via the same MCP server, or the
+webhook authorizer call `verify` (via the same MCP server, or the
 `vouch` SDK directly) and reject requests whose credential is missing, invalid,
 or out of scope:
 
 ```yaml
 # hasura config: authorization webhook that runs Vouch verification
 authorization_webhook:
-  url: https://your-verifier.example.com/verify   # calls Verifier.verify_credential
+  url: https://your-verifier.example.com/verify   # calls Verifier.verify
   timeout: 5
 ```
 
 ## The two-sided demo
 
-The point of `verify_credential` is that signing and verifying can live in
+The point of `verify` is that signing and verifying can live in
 different frameworks and still interoperate:
 
-1. A CrewAI agent calls `sign_action("submit_claim", ...)` and gets a credential.
-2. A LangGraph service receives it and calls `verify_credential(...)`, which
+1. A CrewAI agent calls `sign("submit_claim", ...)` and gets a credential.
+2. A LangGraph service receives it and calls `verify(...)`, which
    confirms the issuer DID and the exact authorized intent, or rejects it.
 
 Same credential, two frameworks, one protocol.

--- a/packages/vouch-mcp/README.md
+++ b/packages/vouch-mcp/README.md
@@ -23,7 +23,7 @@ Vouch gives you two front doors onto one signing primitive:
   LLM cooperation. Best when your agent is Python and you want zero-effort,
   can't-forget signing.
 - **`vouch-mcp`** (this package): the out-of-process, cross-language path. Any
-  MCP client in any language calls `sign_action` / `verify_credential` over the
+  MCP client in any language calls `sign` / `verify` over the
   wire, and the key is isolated in the server process. Best for non-Python
   agents, key isolation, or exposing verification as a shared service.
 
@@ -81,13 +81,13 @@ VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
 
 | Tool | What it does |
 |---|---|
-| `sign_action(action, target, resource, post_quantum=False)` | Issue a credential authorizing one action, bound to that exact resource. Set `post_quantum=True` for the `hybrid-eddsa-mldsa44-jcs-2026` profile. |
-| `verify_credential(credential_json, public_key=None)` | Verify a credential another agent or service presented. Any MCP client can verify without installing an SDK. |
+| `sign(action, target, resource, post_quantum=False)` | Issue a credential authorizing one action, bound to that exact resource. Set `post_quantum=True` for the `hybrid-eddsa-mldsa44-jcs-2026` profile. |
+| `verify(credential_json, public_key=None)` | Verify a credential another agent or service presented. Any MCP client can verify without installing an SDK. |
 | `create_session(purpose, valid_seconds, decay_lambda, initial_trust)` | Issue a trust-decaying session voucher (Heartbeat Protocol). |
 | `check_revocation(credential_json)` | Check a credential's `BitstringStatusList` entry: `ACTIVE`, `REVOKED`, or not individually revocable. |
 | `get_identity()` | Return the agent's DID. |
 
-## Why `verify_credential` matters
+## Why `verify` matters
 
 Signing proves *you* acted. Verifying is how *everyone else* benefits: any
 MCP-capable agent, in any framework, can confirm another agent's credential with

--- a/packages/vouch-mcp/VERIFY.md
+++ b/packages/vouch-mcp/VERIFY.md
@@ -20,7 +20,7 @@ pytest packages/vouch-mcp/tests -q
 ```
 
 Expect: 3 passed. They check the package exports, that the FastMCP server has
-`sign_action` / `create_session` / `get_identity` registered, and that the
+`sign` / `create_session` / `get_identity` registered, and that the
 issued credential is `eddsa-jcs-2022` and verifies.
 
 ## 3. Build the distribution
@@ -41,7 +41,7 @@ python -c "from vouch import generate_identity; print(generate_identity().privat
 
 Set that as `VOUCH_PRIVATE_KEY` and a DID as `VOUCH_DID`, then register the
 `vouch-mcp` command as an stdio server in Claude Desktop or Cursor. Confirm the
-three tools appear and that `sign_action` returns a credential.
+tools appear and that `sign` returns a credential.
 
 ## 5. Only after all of the above
 

--- a/packages/vouch-mcp/tests/test_smoke.py
+++ b/packages/vouch-mcp/tests/test_smoke.py
@@ -28,7 +28,7 @@ def test_registered_tool_names():
     tools = asyncio.run(vouch_mcp.mcp.list_tools())
     names = {t.name for t in tools}
     assert {
-        "sign_action",
+        "sign",
         "verify",
         "create_session",
         "check_revocation",
@@ -47,7 +47,7 @@ def test_sign_and_verify_roundtrip():
 
     from vouch.integrations.mcp import server
 
-    out = server.sign_action("read", "https://api.example.com", "customer:123")
+    out = server.sign("read", "https://api.example.com", "customer:123")
     cred = json.loads(out)
     assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
 

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -10,12 +10,12 @@ Relationship to ``vouch.autosign``:
     ``autosign`` is the in-process, Python-native path: it wraps a tool so
     every call is signed deterministically, before the tool body runs, with
     no LLM cooperation. This MCP server is the out-of-process, cross-language
-    path: any MCP client calls ``sign_action`` / ``verify`` over
+    path: any MCP client calls ``sign`` / ``verify`` over
     the wire, and the private key stays in this server's process, never in
     the model's context. Both share one signing primitive: ``sign_intent``.
 
 Tools:
-    sign_action        Issue a credential authorizing one action (PQC optional).
+    sign        Issue a credential authorizing one action (PQC optional).
     verify  Verify a credential someone else presented.
     create_session     Issue a trust-decaying session voucher (Heartbeat).
     check_revocation   Check a credential's BitstringStatusList entry.
@@ -57,7 +57,7 @@ mcp = FastMCP(
 
 
 @mcp.tool()
-def sign_action(
+def sign(
     action: str,
     target: str,
     resource: Optional[str] = None,
@@ -110,7 +110,7 @@ def verify(credential_json: str, public_key: Optional[str] = None) -> str:
     """Verify a Vouch Credential that another agent or service presented.
 
     This is the receiving side: given a credential (the JSON another party's
-    sign_action produced), confirm the signature, validity window, and intent
+    sign produced), confirm the signature, validity window, and intent
     binding. Any MCP client can call this without installing an SDK.
 
     Args:


### PR DESCRIPTION
Renames the MCP server's `sign_action` tool to `sign`, matching the SDK's
`Signer.sign()`. The `verify_credential` tool already became `verify` when the
sign/verify SDK rename landed (that pass ran over the Python sources).

Also updates the `vouch-mcp` package README, the cross-framework examples guide,
and the verification notes to the new tool names. Registered tools are now
`sign`, `verify`, `create_session`, `check_revocation`, and `get_identity`.
