### PR TITLE
chore(release): v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,19 @@ All notable changes to Vouch Protocol will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [2.0.0] - 2026-07-05
+
+### Changed (BREAKING)
+
+- Renamed the credential API to `sign` / `verify` across every SDK and the Rust core. `Signer.sign_credential` is now `Signer.sign`, `Verifier.verify_credential` is now `Verifier.verify`, and `sign_credential_hybrid` is now `sign_hybrid`. The same rename applies in the TypeScript, Swift, JVM, .NET, C++, and Go SDKs, and in the C ABI (`vouch_sign_credential` becomes `vouch_sign`, `vouch_verify_credential` becomes `vouch_verify`).
+
+### Removed (BREAKING)
+
+- Removed the legacy v0.x JWS credential path (`Signer.sign()` returning a JWS token, and the JWS `Verifier.verify()` / `check_vouch()`). Credentials are W3C Verifiable Credentials with `eddsa-jcs-2022` Data Integrity proofs.
 
 ### Added
+
+- `vouch-mcp`: a Model Context Protocol server that lets any MCP client issue and verify Vouch Credentials (`sign`, `verify`, `create_session`, `check_revocation`, `get_identity`), over stdio or Streamable HTTP, with an optional post-quantum profile.
 
 #### Robotics: living trust, revocation, and accountable safety record
 

--- a/core/uniffi/Cargo.lock
+++ b/core/uniffi/Cargo.lock
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-core"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1370,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-core-uniffi"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "base64",
  "serde_json",

--- a/core/uniffi/Cargo.toml
+++ b/core/uniffi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vouch-core-uniffi"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Ramprasad Anandam Gaddam"]
 description = "Vouch Protocol core: UniFFI bindings (Swift, Kotlin) and C-FFI over the canonical vouch-core crate. One byte-exact implementation for native and mobile SDKs."

--- a/core/vouch-core/Cargo.toml
+++ b/core/vouch-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vouch-core"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Ramprasad Anandam Gaddam"]
 description = "Vouch Protocol canonical core: JCS canonicalization, Ed25519 + ML-DSA proofs, did:key/multikey, Data Integrity (eddsa-jcs-2022), credentials, delegation, revocation. One byte-exact implementation shared by every language SDK via WASM and UniFFI/C-FFI."

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vouch-core-wasm"
-version = "0.1.0"
+version = "2.0.0"
 edition = "2021"
 authors = ["Ramprasad Anandam Gaddam"]
 description = "Vouch Protocol core, WASM build (browser + Node): JCS canonicalization, Ed25519, did:key/multikey, Data Integrity (eddsa-jcs-2022), credentials, delegation, dual-proof ML-DSA-44, and BitstringStatusList revocation. Thin wasm-bindgen wrapper over the canonical vouch-core crate."

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
  "name": "@vouch-protocol-official/sdk",
- "version": "1.1.0",
+ "version": "2.0.0",
  "description": "Official TypeScript SDK for Vouch Protocol. Verifiable Credentials with Data Integrity proofs (eddsa-jcs-2022), Multikey verification methods, optional hybrid post-quantum profile (Ed25519 + ML-DSA-44), plus a daemon client for delegating signing operations.",
  "keywords": [
   "vouch",

--- a/packages/vouch-mcp/pyproject.toml
+++ b/packages/vouch-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-mcp"
-version = "0.2.0"
+version = "2.0.0"
 description = "Model Context Protocol server that issues and verifies Vouch Credentials to authorize AI agent tool calls."
 readme = "README.md"
 requires-python = ">=3.9"
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Topic :: Security :: Cryptography",
 ]
-dependencies = ["vouch-protocol[mcp]>=1.6.0"]
+dependencies = ["vouch-protocol[mcp]>=2.0.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]

--- a/packages/vouch-mcp/server.json
+++ b/packages/vouch-mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vouch-protocol/vouch",
     "source": "github"
   },
-  "version": "0.2.0",
+  "version": "2.0.0",
   "packages": [
     {
       "registry_type": "pypi",
       "identifier": "vouch-mcp",
-      "version": "0.2.0",
+      "version": "2.0.0",
       "transport": { "type": "stdio" },
       "environment_variables": [
         {

--- a/packages/vouch-mcp/src/vouch_mcp/__init__.py
+++ b/packages/vouch-mcp/src/vouch_mcp/__init__.py
@@ -13,4 +13,4 @@ Run:
 from vouch.integrations.mcp.server import main, mcp
 
 __all__ = ["main", "mcp"]
-__version__ = "0.2.0"
+__version__ = "2.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "1.6.3"
+version = "2.0.0"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/dotnet/VouchCore/VouchCore.csproj
+++ b/sdks/dotnet/VouchCore/VouchCore.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>VouchProtocol.Core</AssemblyName>
 
     <PackageId>VouchProtocol.Core</PackageId>
-    <Version>0.1.0</Version>
+    <Version>2.0.0</Version>
     <Authors>Ramprasad Anandam Gaddam</Authors>
     <Company>Vouch Protocol</Company>
     <Product>Vouch Protocol Core</Product>

--- a/sdks/jvm/build.gradle.kts
+++ b/sdks/jvm/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.vouchprotocol"
-version = "0.1.0"
+version = "2.0.0"
 description = "Vouch Protocol JVM SDK (Kotlin + Java) over the canonical Rust core via JNA / UniFFI."
 
 repositories { mavenCentral() }


### PR DESCRIPTION
Release v2.0.0. Bumps vouch-protocol to 2.0.0, the TypeScript SDK to 2.0.0, and the Rust core crates to 0.2.0 for the breaking credential-API rename and the removal of the legacy JWS path, and points vouch-mcp at vouch-protocol[mcp]>=2.0.0. Adds the 2.0.0 CHANGELOG entry. Publishing is tag-triggered after merge.