### PR TITLE
Add Reasoned Action Proofs: bind a justification to each agent action

### DIFF
--- a/examples/reasoned_action_demo.py
+++ b/examples/reasoned_action_demo.py
@@ -1,0 +1,141 @@
+"""
+Reasoned Action Proofs: bind an agent's justification to the action it takes.
+
+Vouch proves *who* acted and *under what authority*. This demo adds the *why*: the
+agent states a structured justification, anchors every reason to a real artifact,
+commits it to a neutral escrow BEFORE acting, and signs an action credential that
+carries the commitment. An auditor can then prove the reasoning was not fabricated
+and not rewritten after the fact.
+
+Run:
+    python examples/reasoned_action_demo.py
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from vouch import Signer, generate_identity
+from vouch.reasoning import (
+    LocalEscrow,
+    build_justification,
+    evidence_anchor,
+    justification_digest,
+    sign_reasoned_action,
+    verify_justification,
+    verify_reasoned_action,
+)
+
+
+def main() -> None:
+    # Three parties: the controller who delegated, the agent, and a neutral escrow.
+    controller_kp = generate_identity(domain="controller.example.com")
+    controller = Signer(private_key=controller_kp.private_key_jwk, did=controller_kp.did)
+
+    agent_kp = generate_identity(domain="agent.example.com")
+    agent = Signer(private_key=agent_kp.private_key_jwk, did=agent_kp.did)
+
+    escrow_kp = generate_identity(domain="escrow.example.com")
+    escrow = LocalEscrow(Signer(private_key=escrow_kp.private_key_jwk, did=escrow_kp.did))
+
+    # Real artifacts the agent is entitled to cite, each content-addressed.
+    delegation_link = controller.sign(
+        intent={"action": "delete", "target": "filesystem", "resource": "/tmp/*"}
+    )
+    user_message = {
+        "from": "did:web:alice.example",
+        "text": "please clean up the temp cache in /tmp",
+    }
+
+    # 1) The agent states WHY, anchoring each reason to an artifact by its hash.
+    intent = {"action": "delete", "target": "/tmp/cache", "resource": "/tmp/cache/*"}
+    justification = build_justification(
+        intent,
+        [
+            evidence_anchor(
+                "user requested cleanup of /tmp",
+                ref="msg:conversation/c-42/turn-3",
+                evidence=user_message,
+                anchor_type="user_message",
+            ),
+            evidence_anchor(
+                "delegation authorizes deleting /tmp/*",
+                ref="cred:" + delegation_link["id"],
+                evidence=delegation_link,
+                anchor_type="delegation",
+            ),
+        ],
+        commitment_level=3,
+    )
+
+    # 2) Commit the justification to escrow BEFORE acting (escrow sees only the digest).
+    committed_at = datetime.now(timezone.utc)
+    receipt = escrow.deposit(
+        agent_did=agent.get_did(),
+        committed_digest=justification_digest(justification),
+        deposited_at=committed_at,
+    )
+
+    # 3) Execute: the action credential carries the commitment + the escrow receipt.
+    action = sign_reasoned_action(
+        agent,
+        intent=intent,
+        justification=justification,
+        escrow_receipt=receipt,
+        valid_from=committed_at + timedelta(seconds=1),
+    )
+    print("action credential id: ", action["id"])
+    print(
+        "commitment digest:    ",
+        action["credentialSubject"]["justification"]["commitment"]["digest"][:20],
+        "...",
+    )
+
+    # ---- Auditor, after the fact ----
+    ok, subject = verify_reasoned_action(
+        action,
+        agent_kp.public_key_jwk,
+        escrow_public_key=escrow_kp.public_key_jwk,
+        require_escrow=True,
+    )
+    print("\naction verifies?      ", ok, "(proof valid, escrowed before execution)")
+
+    # Resolve the cited artifacts and confirm the reasoning is genuine.
+    resolver = {
+        "msg:conversation/c-42/turn-3": user_message,
+        "cred:" + delegation_link["id"]: delegation_link,
+    }
+    good, reason = verify_justification(justification, subject, resolver=resolver.get)
+    print("justification genuine?", good, "(every reason resolves and hashes match)")
+
+    # ---- Two attacks this defeats ----
+    print("\nAttacks:")
+
+    # A) Fabricate a reason with no real artifact behind it.
+    forged = build_justification(
+        intent,
+        [
+            evidence_anchor(
+                "the CFO approved this by phone", ref="call:none", evidence={"fake": True}
+            )
+        ],
+    )
+    # The forged justification does not match the committed digest...
+    _, r1 = verify_justification(forged, subject, resolver=resolver.get)
+    print("  fabricated reason:  rejected ->", r1)
+
+    # B) Rewrite the justification after acting (target /etc/passwd instead).
+    rewritten = build_justification(
+        {"action": "delete", "target": "/etc/passwd", "resource": "/etc/*"},
+        justification["evidenceAnchors"],
+    )
+    _, r2 = verify_justification(rewritten, subject, resolver=resolver.get)
+    print("  post-hoc rewrite:   rejected ->", r2)
+
+    print(
+        "\nResidual: a capable deceiver can still write a plausible reason anchored to\n"
+        "real evidence. This PRICES deception (a false justification is provable\n"
+        "perjury on the record); semantic quorum and behavioral bonds raise the price."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_reasoning.py
+++ b/tests/test_reasoning.py
@@ -1,0 +1,279 @@
+"""Tests for Reasoned Action Proofs (justification bound to the action)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.reasoning import (
+    ESCROW_RECEIPT_TYPE,
+    REASON_ESCROW_AFTER_EXECUTION,
+    REASON_ESCROW_DIGEST_MISMATCH,
+    REASON_EVIDENCE_HASH_MISMATCH,
+    REASON_EVIDENCE_UNRESOLVED,
+    REASON_INVALID_PROOF,
+    REASON_JUSTIFICATION_DIGEST_MISMATCH,
+    REASON_MISSING_ESCROW,
+    REASON_UNANCHORED_CLAIM,
+    REASONED_ACTION_TYPE,
+    LocalEscrow,
+    ReasonedActionError,
+    artifact_digest,
+    build_escrow_receipt,
+    build_justification,
+    check_reasoned_action,
+    evidence_anchor,
+    justification_digest,
+    sign_reasoned_action,
+    verify_escrow_receipt,
+    verify_justification,
+    verify_reasoned_action,
+)
+
+
+def _identity(domain: str = "agent.example.com"):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+USER_MSG = {"from": "did:web:alice.example", "text": "clean up /tmp"}
+INTENT = {"action": "delete", "target": "/tmp/cache", "resource": "/tmp/cache/*"}
+
+
+def _justification():
+    return build_justification(
+        INTENT,
+        [
+            evidence_anchor(
+                "user asked", ref="msg:1", evidence=USER_MSG, anchor_type="user_message"
+            ),
+        ],
+        commitment_level=3,
+    )
+
+
+def _resolver():
+    return {"msg:1": USER_MSG}.get
+
+
+class TestEvidenceAnchor:
+    def test_hash_from_evidence(self):
+        a = evidence_anchor("c", ref="r", evidence=USER_MSG)
+        assert a["evidenceHash"] == artifact_digest(USER_MSG)
+        assert a["claim"] == "c" and a["ref"] == "r"
+
+    def test_explicit_hash(self):
+        h = artifact_digest(USER_MSG)
+        a = evidence_anchor("c", ref="r", evidence_hash=h)
+        assert a["evidenceHash"] == h
+
+    def test_requires_evidence_or_hash(self):
+        with pytest.raises(ReasonedActionError):
+            evidence_anchor("c", ref="r")
+
+    def test_artifact_digest_str_and_dict_differ(self):
+        assert artifact_digest("hello") != artifact_digest({"x": "hello"})
+
+
+class TestJustification:
+    def test_digest_is_deterministic(self):
+        j1, j2 = _justification(), _justification()
+        assert justification_digest(j1) == justification_digest(j2)
+
+    def test_digest_changes_with_intent(self):
+        j = _justification()
+        other = build_justification(
+            {"action": "delete", "target": "/etc/passwd", "resource": "/etc/*"},
+            j["evidenceAnchors"],
+        )
+        assert justification_digest(j) != justification_digest(other)
+
+    def test_empty_anchors_rejected(self):
+        with pytest.raises(ReasonedActionError):
+            build_justification(INTENT, [])
+
+    def test_intent_must_have_action_target(self):
+        with pytest.raises(ReasonedActionError):
+            build_justification({"action": "delete"}, [evidence_anchor("c", ref="r", evidence={})])
+
+
+class TestEscrowReceipt:
+    def test_build_and_verify(self):
+        kp, escrow_signer = _identity("escrow.example.com")
+        digest = justification_digest(_justification())
+        receipt = build_escrow_receipt(
+            escrow_signer, agent_did="did:web:agent", committed_digest=digest
+        )
+        assert ESCROW_RECEIPT_TYPE in receipt["type"]
+        ok, subject = verify_escrow_receipt(receipt, kp.public_key_jwk)
+        assert ok is True
+        assert subject["committedDigest"] == digest
+
+    def test_wrong_key_fails(self):
+        _, escrow_signer = _identity("escrow.example.com")
+        other_kp, _ = _identity("other.example.com")
+        receipt = build_escrow_receipt(escrow_signer, agent_did="a", committed_digest="ux")
+        ok, _ = verify_escrow_receipt(receipt, other_kp.public_key_jwk)
+        assert ok is False
+
+    def test_local_escrow_wrapper(self):
+        kp, escrow_signer = _identity("escrow.example.com")
+        escrow = LocalEscrow(escrow_signer)
+        receipt = escrow.deposit(agent_did="did:web:agent", committed_digest="uabc")
+        ok, subject = verify_escrow_receipt(receipt, kp.public_key_jwk)
+        assert ok and subject["committedDigest"] == "uabc"
+
+
+class TestReasonedAction:
+    def test_sign_and_verify_full_flow(self):
+        agent_kp, agent = _identity("agent.example.com")
+        escrow_kp, escrow_signer = _identity("escrow.example.com")
+        just = _justification()
+        committed = datetime.now(timezone.utc)
+        receipt = build_escrow_receipt(
+            escrow_signer,
+            agent_did=agent.get_did(),
+            committed_digest=justification_digest(just),
+            deposited_at=committed,
+        )
+        cred = sign_reasoned_action(
+            agent,
+            intent=INTENT,
+            justification=just,
+            escrow_receipt=receipt,
+            valid_from=committed + timedelta(seconds=1),
+        )
+        assert REASONED_ACTION_TYPE in cred["type"]
+        assert (
+            check_reasoned_action(
+                cred,
+                agent_kp.public_key_jwk,
+                escrow_public_key=escrow_kp.public_key_jwk,
+                require_escrow=True,
+            )
+            is None
+        )
+        ok, subject = verify_reasoned_action(
+            cred,
+            agent_kp.public_key_jwk,
+            escrow_public_key=escrow_kp.public_key_jwk,
+        )
+        assert ok and subject["intent"] == INTENT
+
+    def test_justification_resolves(self):
+        agent_kp, agent = _identity()
+        just = _justification()
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=just)
+        _, subject = verify_reasoned_action(cred, agent_kp.public_key_jwk)
+        ok, reason = verify_justification(just, subject, resolver=_resolver())
+        assert ok is True and reason is None
+
+    def test_tampered_credential_fails(self):
+        agent_kp, agent = _identity()
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=_justification())
+        cred["credentialSubject"]["intent"]["target"] = "/etc/passwd"
+        assert check_reasoned_action(cred, agent_kp.public_key_jwk) == REASON_INVALID_PROOF
+
+    def test_require_escrow_without_receipt(self):
+        agent_kp, agent = _identity()
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=_justification())
+        assert (
+            check_reasoned_action(cred, agent_kp.public_key_jwk, require_escrow=True)
+            == REASON_MISSING_ESCROW
+        )
+
+    def test_escrow_after_execution_rejected(self):
+        agent_kp, agent = _identity("agent.example.com")
+        escrow_kp, escrow_signer = _identity("escrow.example.com")
+        just = _justification()
+        executed = datetime.now(timezone.utc)
+        # Deposit AFTER execution: temporal ordering violated.
+        receipt = build_escrow_receipt(
+            escrow_signer,
+            agent_did=agent.get_did(),
+            committed_digest=justification_digest(just),
+            deposited_at=executed + timedelta(seconds=5),
+        )
+        cred = sign_reasoned_action(
+            agent,
+            intent=INTENT,
+            justification=just,
+            escrow_receipt=receipt,
+            valid_from=executed,
+        )
+        assert (
+            check_reasoned_action(
+                cred,
+                agent_kp.public_key_jwk,
+                escrow_public_key=escrow_kp.public_key_jwk,
+            )
+            == REASON_ESCROW_AFTER_EXECUTION
+        )
+
+    def test_escrow_digest_mismatch_rejected(self):
+        agent_kp, agent = _identity("agent.example.com")
+        escrow_kp, escrow_signer = _identity("escrow.example.com")
+        just = _justification()
+        receipt = build_escrow_receipt(
+            escrow_signer,
+            agent_did=agent.get_did(),
+            committed_digest="udifferent",
+        )
+        cred = sign_reasoned_action(
+            agent, intent=INTENT, justification=just, escrow_receipt=receipt
+        )
+        assert (
+            check_reasoned_action(
+                cred,
+                agent_kp.public_key_jwk,
+                escrow_public_key=escrow_kp.public_key_jwk,
+            )
+            == REASON_ESCROW_DIGEST_MISMATCH
+        )
+
+
+class TestAttacksDefeated:
+    def test_fabricated_evidence_rejected(self):
+        agent_kp, agent = _identity()
+        just = _justification()
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=just)
+        _, subject = verify_reasoned_action(cred, agent_kp.public_key_jwk)
+        # A justification whose anchor points at a non-resolvable artifact.
+        forged = build_justification(
+            INTENT, [evidence_anchor("cfo approved", ref="call:none", evidence={"fake": True})]
+        )
+        ok, reason = verify_justification(forged, subject, resolver=_resolver())
+        # Fails first on digest mismatch (it is not what was committed).
+        assert ok is False and reason == REASON_JUSTIFICATION_DIGEST_MISMATCH
+
+    def test_unresolvable_evidence_on_matching_digest(self):
+        # Commit a justification whose evidence cannot later be resolved.
+        agent_kp, agent = _identity()
+        bad = build_justification(
+            INTENT, [evidence_anchor("ghost", ref="ghost:1", evidence={"x": 1})]
+        )
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=bad)
+        _, subject = verify_reasoned_action(cred, agent_kp.public_key_jwk)
+        ok, reason = verify_justification(bad, subject, resolver={}.get)
+        assert ok is False and reason == REASON_EVIDENCE_UNRESOLVED
+
+    def test_evidence_hash_mismatch(self):
+        agent_kp, agent = _identity()
+        just = _justification()
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=just)
+        _, subject = verify_reasoned_action(cred, agent_kp.public_key_jwk)
+        # Resolver returns a DIFFERENT artifact than the one hashed at commit.
+        ok, reason = verify_justification(just, subject, resolver={"msg:1": {"tampered": True}}.get)
+        assert ok is False and reason == REASON_EVIDENCE_HASH_MISMATCH
+
+    def test_post_hoc_rewrite_rejected(self):
+        agent_kp, agent = _identity()
+        just = _justification()
+        cred = sign_reasoned_action(agent, intent=INTENT, justification=just)
+        _, subject = verify_reasoned_action(cred, agent_kp.public_key_jwk)
+        rewritten = build_justification(
+            {"action": "delete", "target": "/etc/passwd", "resource": "/etc/*"},
+            just["evidenceAnchors"],
+        )
+        ok, reason = verify_justification(rewritten, subject, resolver=_resolver())
+        assert ok is False and reason == REASON_JUSTIFICATION_DIGEST_MISMATCH

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -268,6 +268,25 @@ def __getattr__(name):
         from . import liveness_conformance
 
         return getattr(liveness_conformance, name)
+    # Reasoned Action Proofs (justification bound to the action, PAD-017/071)
+    elif name in (
+        "ReasonedActionError",
+        "REASONED_ACTION_TYPE",
+        "evidence_anchor",
+        "build_justification",
+        "justification_digest",
+        "artifact_digest",
+        "build_escrow_receipt",
+        "verify_escrow_receipt",
+        "LocalEscrow",
+        "sign_reasoned_action",
+        "check_reasoned_action",
+        "verify_reasoned_action",
+        "verify_justification",
+    ):
+        from . import reasoning
+
+        return getattr(reasoning, name)
     # Reputation receipts and aggregation (evidence-backed reputation)
     elif name in (
         "ReceiptError",
@@ -483,6 +502,20 @@ __all__ = [
     "should_revoke",
     "revocation_entry",
     "CONFORMANCE_RECEIPT_TYPE",
+    # Reasoned Action Proofs (justification bound to the action)
+    "ReasonedActionError",
+    "REASONED_ACTION_TYPE",
+    "evidence_anchor",
+    "build_justification",
+    "justification_digest",
+    "artifact_digest",
+    "build_escrow_receipt",
+    "verify_escrow_receipt",
+    "LocalEscrow",
+    "sign_reasoned_action",
+    "check_reasoned_action",
+    "verify_reasoned_action",
+    "verify_justification",
     # Reputation receipts and aggregation
     "ReceiptError",
     "Signal",

--- a/vouch/reasoning.py
+++ b/vouch/reasoning.py
@@ -1,0 +1,502 @@
+"""
+Reasoned Action Proofs: bind an agent's justification to the action it takes.
+
+Vouch answers *who* acted and *under what authority*. A standard credential says
+nothing about *why* the agent did it. After an incident, "was this a bug or
+deliberate misuse?" is unanswerable, which blocks liability, insurance, and
+regulatory audit.
+
+This module adds the missing "why" layer without pretending to read the agent's
+mind. Before executing, an agent states a structured **justification**: the intent
+plus a set of **evidence anchors**, each a claim tied to a real artifact (a
+delegation link, a user message, a retrieved document) by that artifact's hash.
+The justification is committed by digest, optionally deposited with a neutral
+**escrow** that timestamps it, and the executed action credential carries the
+commitment. Three properties then hold:
+
+  - No fabrication. Each reason names an artifact; a verifier re-resolves the
+    artifact and checks its hash. "The user told me to" fails if no such message
+    exists or its hash does not match.
+  - No post-hoc rewrite. The action credential carries the justification digest.
+    A justification presented later must recompute to that same digest.
+  - Committed before execution. When escrow is used, the receipt's deposit time
+    must not be after the action's execution time, so reasoning cannot be
+    invented after seeing the outcome.
+
+This does not make deception impossible: a capable deceiver can still write a
+plausible reason anchored to real evidence. What it does is put the agent on the
+record, so a false justification is provable perjury with downstream cost. It is
+the on-protocol form of prior-art disclosures PAD-017 (evidence-anchored
+reasoning, sealed-verdict escrow) and PAD-071 (commit-before-outcome), and it
+composes with them and with the rest of Vouch: everything here is an ordinary
+``eddsa-jcs-2022`` Verifiable Credential and verifies across the language SDKs.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from . import data_integrity
+from .jcs import canonicalize
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+
+REASONED_ACTION_TYPE = "ReasonedActionCredential"
+ESCROW_RECEIPT_TYPE = "JustificationEscrowReceipt"
+
+JUSTIFICATION_ALGORITHM = "sha-256-jcs"
+
+# Structured verification reasons (stable strings, mirrored by the SDKs).
+REASON_INVALID_PROOF = "invalid_proof"
+REASON_NOT_REASONED_ACTION = "not_reasoned_action"
+REASON_MISSING_COMMITMENT = "missing_commitment"
+REASON_MISSING_ESCROW = "missing_escrow"
+REASON_ESCROW_INVALID = "escrow_receipt_invalid"
+REASON_ESCROW_DIGEST_MISMATCH = "escrow_digest_mismatch"
+REASON_ESCROW_AFTER_EXECUTION = "escrow_after_execution"
+REASON_JUSTIFICATION_DIGEST_MISMATCH = "justification_digest_mismatch"
+REASON_EVIDENCE_UNRESOLVED = "evidence_unresolved"
+REASON_EVIDENCE_HASH_MISMATCH = "evidence_hash_mismatch"
+REASON_UNANCHORED_CLAIM = "unanchored_claim"
+
+
+class ReasonedActionError(Exception):
+    """Raised on malformed reasoned-action input."""
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers (kept local so the module stands alone, matching
+# vouch.accountability)
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(s: str) -> datetime:
+    try:
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError) as exc:
+        raise ReasonedActionError(f"malformed timestamp: {s!r}") from exc
+
+
+def _mb64(b: bytes) -> str:
+    return "u" + base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise ReasonedActionError("signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+def _artifact_bytes(artifact: Any) -> bytes:
+    """Canonical bytes of an evidence artifact, for content addressing."""
+    if isinstance(artifact, (bytes, bytearray)):
+        return bytes(artifact)
+    if isinstance(artifact, str):
+        return artifact.encode("utf-8")
+    if isinstance(artifact, dict):
+        return canonicalize(artifact)
+    raise ReasonedActionError("evidence artifact must be a dict, str, or bytes")
+
+
+def artifact_digest(artifact: Any) -> str:
+    """Multibase SHA-256 of an evidence artifact."""
+    return _mb64(hashlib.sha256(_artifact_bytes(artifact)).digest())
+
+
+# ---------------------------------------------------------------------------
+# Justification: the structured "why", anchored to real evidence
+# ---------------------------------------------------------------------------
+
+
+def evidence_anchor(
+    claim: str,
+    ref: str,
+    *,
+    evidence: Any = None,
+    evidence_hash: Optional[str] = None,
+    anchor_type: str = "artifact",
+) -> Dict[str, Any]:
+    """
+    Build one evidence anchor: a claim tied to a verifiable artifact.
+
+    Args:
+        claim: The assertion the agent is making (e.g. "user requested cleanup").
+        ref: A resolvable reference to the artifact (a URN, a URL, a message id,
+            a delegation-chain locator) the verifier will re-fetch.
+        evidence: The artifact itself; its hash is computed and stored. Supply
+            this OR ``evidence_hash``.
+        evidence_hash: A precomputed multibase SHA-256 of the artifact, when the
+            artifact is large or already content-addressed.
+        anchor_type: Free-form label (``artifact``, ``user_message``,
+            ``delegation``, ``retrieval``, ``policy``, ...).
+
+    Returns:
+        An anchor dict with ``type``, ``claim``, ``ref``, and ``evidenceHash``.
+    """
+    if not claim or not ref:
+        raise ReasonedActionError("an evidence anchor needs a claim and a ref")
+    if evidence_hash is None:
+        if evidence is None:
+            raise ReasonedActionError("supply evidence or evidence_hash for the anchor")
+        evidence_hash = artifact_digest(evidence)
+    return {"type": anchor_type, "claim": claim, "ref": ref, "evidenceHash": evidence_hash}
+
+
+def build_justification(
+    intent: Dict[str, Any],
+    anchors: List[Dict[str, Any]],
+    *,
+    commitment_level: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Assemble a justification: the intent plus its evidence anchors.
+
+    Args:
+        intent: The action being justified. Must carry at least ``action`` and
+            ``target`` (``resource`` recommended, matching the action credential).
+        anchors: Evidence anchors from :func:`evidence_anchor`. At least one is
+            required; an empty set is an unanchored justification, which
+            :func:`verify_justification` rejects.
+        commitment_level: Optional impact level (0..4, per PAD-017 adaptive
+            commitment depth) recorded alongside the justification.
+    """
+    if not isinstance(intent, dict) or not intent.get("action") or not intent.get("target"):
+        raise ReasonedActionError("intent must be a dict with at least action and target")
+    if not anchors:
+        raise ReasonedActionError("a justification needs at least one evidence anchor")
+    justification: Dict[str, Any] = {"intent": dict(intent), "evidenceAnchors": list(anchors)}
+    if commitment_level is not None:
+        justification["commitmentLevel"] = int(commitment_level)
+    return justification
+
+
+def justification_digest(justification: Dict[str, Any]) -> str:
+    """Multibase SHA-256 over the JCS-canonical justification."""
+    if not isinstance(justification, dict):
+        raise ReasonedActionError("justification must be a JSON object")
+    return _mb64(hashlib.sha256(canonicalize(justification)).digest())
+
+
+# ---------------------------------------------------------------------------
+# Escrow: a neutral timestamp that fixes the commitment before execution
+# ---------------------------------------------------------------------------
+
+
+def build_escrow_receipt(
+    escrow_signer: Any,
+    *,
+    agent_did: str,
+    committed_digest: str,
+    deposited_at: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a signed ``JustificationEscrowReceipt`` fixing a commitment in time.
+
+    The escrow sees only the justification *digest*, never the plaintext, so an
+    agent's reasoning stays private while its commitment time is witnessed by a
+    party distinct from the agent. In production this is a hosted escrow service or
+    a transparency log; :class:`LocalEscrow` is the reference local stand-in.
+    """
+    deposited = (deposited_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    receipt: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", ESCROW_RECEIPT_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": escrow_signer.get_did(),
+        "validFrom": _iso(deposited),
+        "credentialSubject": {
+            "agent": agent_did,
+            "committedDigest": committed_digest,
+            "depositedAt": _iso(deposited),
+        },
+    }
+    return _attach_proof(receipt, escrow_signer)
+
+
+def verify_escrow_receipt(
+    receipt: Dict[str, Any],
+    escrow_public_key: Any,
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Verify an escrow receipt's proof and structure. Returns (ok, subject)."""
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if ESCROW_RECEIPT_TYPE not in _type_list(receipt):
+        return False, None
+    resolved = (
+        _coerce_ed25519_public_key(escrow_public_key) if escrow_public_key is not None else None
+    )
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(receipt, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+    subject = receipt.get("credentialSubject") or {}
+    if not subject.get("committedDigest") or not subject.get("depositedAt"):
+        return False, None
+    return True, subject
+
+
+class LocalEscrow:
+    """
+    Reference local escrow: wraps an escrow Signer and issues receipts.
+
+    Suitable for tests, demos, and self-hosted single-party deployments. A hosted,
+    multi-party, retention-managed escrow is a managed-deployment concern; the
+    receipt format it issues is identical, so callers verify both the same way.
+    """
+
+    def __init__(self, escrow_signer: Any):
+        self._signer = escrow_signer
+
+    @property
+    def did(self) -> str:
+        return self._signer.get_did()
+
+    def deposit(
+        self,
+        *,
+        agent_did: str,
+        committed_digest: str,
+        deposited_at: Optional[datetime] = None,
+    ) -> Dict[str, Any]:
+        return build_escrow_receipt(
+            self._signer,
+            agent_did=agent_did,
+            committed_digest=committed_digest,
+            deposited_at=deposited_at,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Reasoned action credential: the executed action, carrying its commitment
+# ---------------------------------------------------------------------------
+
+
+def sign_reasoned_action(
+    signer: Any,
+    *,
+    intent: Dict[str, Any],
+    justification: Dict[str, Any],
+    escrow_receipt: Optional[Dict[str, Any]] = None,
+    include_reasoning: bool = True,
+    valid_from: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a ``ReasonedActionCredential``: the action bound to its justification.
+
+    The credential subject carries the ``intent`` and a ``justification`` block
+    holding the commitment digest, the optional commitment level, the optional
+    escrow receipt, and (unless ``include_reasoning`` is False) the evidence
+    anchors themselves. The digest always covers the full justification, so
+    withholding the anchors for privacy does not weaken the binding: they can be
+    revealed later and checked against the digest.
+
+    Args:
+        signer: The acting agent's ``Signer``.
+        intent: The action taken. Should match ``justification["intent"]``.
+        justification: The object from :func:`build_justification`.
+        escrow_receipt: A receipt from :func:`build_escrow_receipt`, proving the
+            commitment was fixed before this action. Recommended for consequential
+            actions; verifiers can require it.
+        include_reasoning: If False, publish only the digest (private reasoning),
+            revealing anchors out of band at audit time.
+        valid_from: Execution time (defaults to now, UTC). Must not precede the
+            escrow deposit when a receipt is attached.
+        credential_id: Optional credential id (defaults to a ``urn:uuid``).
+    """
+    if not isinstance(intent, dict) or not intent.get("action") or not intent.get("target"):
+        raise ReasonedActionError("intent must be a dict with at least action and target")
+
+    digest = justification_digest(justification)
+    executed = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+
+    jblock: Dict[str, Any] = {
+        "commitment": {"algorithm": JUSTIFICATION_ALGORITHM, "digest": digest},
+    }
+    if "commitmentLevel" in justification:
+        jblock["commitmentLevel"] = justification["commitmentLevel"]
+    if escrow_receipt is not None:
+        jblock["escrowReceipt"] = escrow_receipt
+    if include_reasoning:
+        jblock["evidenceAnchors"] = list(justification.get("evidenceAnchors", []))
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", REASONED_ACTION_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": signer.get_did(),
+        "validFrom": _iso(executed),
+        "credentialSubject": {"intent": dict(intent), "justification": jblock},
+    }
+    return _attach_proof(credential, signer)
+
+
+def check_reasoned_action(
+    credential: Dict[str, Any],
+    public_key: Any,
+    *,
+    escrow_public_key: Any = None,
+    require_escrow: bool = False,
+) -> Optional[str]:
+    """
+    Verify a reasoned-action credential; return None on success or a structured
+    reason string on failure (one of the ``REASON_*`` constants).
+
+    Checks the agent's proof, the presence of a commitment, and, when an escrow
+    receipt is attached, the receipt's own proof, that its committed digest equals
+    the credential's commitment, and that the deposit time is not after execution
+    (commit-before-execute). Set ``require_escrow`` to reject actions with no
+    escrow receipt.
+
+    This does not resolve evidence anchors; that needs the artifacts and is done by
+    :func:`verify_justification` with a resolver.
+    """
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if REASONED_ACTION_TYPE not in _type_list(credential):
+        return REASON_NOT_REASONED_ACTION
+
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return REASON_INVALID_PROOF
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return REASON_INVALID_PROOF
+    except ValueError:
+        return REASON_INVALID_PROOF
+
+    subject = credential.get("credentialSubject") or {}
+    jblock = subject.get("justification") or {}
+    commitment = jblock.get("commitment") or {}
+    if not commitment.get("digest"):
+        return REASON_MISSING_COMMITMENT
+
+    receipt = jblock.get("escrowReceipt")
+    if receipt is None:
+        return REASON_MISSING_ESCROW if require_escrow else None
+
+    ok, rsubject = verify_escrow_receipt(receipt, escrow_public_key)
+    if not ok:
+        return REASON_ESCROW_INVALID
+    if rsubject.get("committedDigest") != commitment.get("digest"):
+        return REASON_ESCROW_DIGEST_MISMATCH
+
+    deposited = _parse_iso(rsubject["depositedAt"])
+    executed = _parse_iso(credential.get("validFrom", ""))
+    if deposited > executed:
+        return REASON_ESCROW_AFTER_EXECUTION
+    return None
+
+
+def verify_reasoned_action(
+    credential: Dict[str, Any],
+    public_key: Any,
+    *,
+    escrow_public_key: Any = None,
+    require_escrow: bool = False,
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """
+    Convenience wrapper over :func:`check_reasoned_action` returning
+    ``(ok, credentialSubject)`` in the style of the rest of the SDK.
+    """
+    reason = check_reasoned_action(
+        credential,
+        public_key,
+        escrow_public_key=escrow_public_key,
+        require_escrow=require_escrow,
+    )
+    if reason is not None:
+        return False, None
+    return True, credential.get("credentialSubject") or {}
+
+
+def verify_justification(
+    presented_justification: Dict[str, Any],
+    credential_subject: Dict[str, Any],
+    *,
+    resolver: Callable[[str], Any],
+) -> Tuple[bool, Optional[str]]:
+    """
+    Check a revealed justification against a verified credential's commitment.
+
+    Confirms (1) the presented justification recomputes to the committed digest
+    (no post-hoc rewrite) and (2) every evidence anchor resolves via ``resolver``
+    and its artifact hashes to the recorded value (no fabricated evidence).
+
+    Args:
+        presented_justification: The full justification the agent now discloses.
+        credential_subject: The ``credentialSubject`` returned by
+            :func:`verify_reasoned_action`.
+        resolver: A callable mapping an anchor ``ref`` to its artifact (dict, str,
+            or bytes), or None if it cannot be resolved.
+
+    Returns:
+        ``(True, None)`` on success, else ``(False, reason)``.
+    """
+    commitment = (credential_subject.get("justification") or {}).get("commitment") or {}
+    committed = commitment.get("digest")
+    if not committed:
+        return False, REASON_MISSING_COMMITMENT
+
+    if justification_digest(presented_justification) != committed:
+        return False, REASON_JUSTIFICATION_DIGEST_MISMATCH
+
+    anchors = presented_justification.get("evidenceAnchors") or []
+    if not anchors:
+        return False, REASON_UNANCHORED_CLAIM
+    for anchor in anchors:
+        ref = anchor.get("ref")
+        artifact = resolver(ref) if ref is not None else None
+        if artifact is None:
+            return False, REASON_EVIDENCE_UNRESOLVED
+        try:
+            if artifact_digest(artifact) != anchor.get("evidenceHash"):
+                return False, REASON_EVIDENCE_HASH_MISMATCH
+        except ReasonedActionError:
+            return False, REASON_EVIDENCE_HASH_MISMATCH
+    return True, None
+
+
+def _type_list(credential: Dict[str, Any]) -> list:
+    t = credential.get("type") or []
+    return [t] if isinstance(t, str) else list(t)
+
+
+__all__ = [
+    "ReasonedActionError",
+    "REASONED_ACTION_TYPE",
+    "ESCROW_RECEIPT_TYPE",
+    "JUSTIFICATION_ALGORITHM",
+    "artifact_digest",
+    "evidence_anchor",
+    "build_justification",
+    "justification_digest",
+    "build_escrow_receipt",
+    "verify_escrow_receipt",
+    "LocalEscrow",
+    "sign_reasoned_action",
+    "check_reasoned_action",
+    "verify_reasoned_action",
+    "verify_justification",
+]


### PR DESCRIPTION
Adds a `vouch.reasoning` module for Reasoned Action Proofs: an agent states a structured justification for an action, anchors each reason to a real artifact by that artifact's hash, commits it to a neutral escrow before executing, and carries the commitment in the signed action credential.

A verifier can then confirm the reasoning was not fabricated (each anchor must resolve and hash-match), was not rewritten after the fact (the justification must recompute to the committed digest), and was committed before execution.

The module reuses the shared eddsa-jcs-2022 Data Integrity path and JCS canonicalization, so the credentials verify across the language SDKs, and it composes with the existing accountability and delegation primitives. It realizes the approach disclosed in PAD-017 and PAD-071.

Includes a runnable example (`examples/reasoned_action_demo.py`) and a test suite (`tests/test_reasoning.py`).
