### PR TITLE
Publish PAD-085 and PAD-086: accountable autonomy for actions inside the envelope

### DIFF
--- a/docs/disclosures/PAD-085-two-phase-deliberated-execution.md
+++ b/docs/disclosures/PAD-085-two-phase-deliberated-execution.md
@@ -1,0 +1,281 @@
+# PAD-085: Two-Phase Deliberated Execution of Irreversible Agent Actions with Signed Veto Window
+
+**Identifier:** PAD-085
+**Title:** Method for Two-Phase Deliberated Execution of Consequential Autonomous Agent Actions, in Which an Intent Is Committed and Broadcast Before Execution, a Challenge Window Must Provably Elapse, and Any Authorized Party May Block Execution With a Separately-Signed Veto Bound to the Committed Intent
+**Publication Date:** July 5, 2026
+**Prior Art Effective Date:** July 5, 2026
+**Status:** Public Disclosure (Defensive Publication)
+**Category:** AI Safety / Agent Governance / Irreversible-Action Containment / Human Oversight / Verifiable Credentials
+**Author:** Ramprasad Anandam Gaddam
+**License:** Apache 2.0
+**Related:** PAD-016 (Heartbeat), PAD-017 (Proof of Reasoning), PAD-020 (Ratchet Lock), PAD-021 (Graduated Autonomy), PAD-047 (VDF Rate-Limiting), PAD-071 (Commit-Before-Outcome), PAD-086 (Executable Caveats)
+
+---
+
+## 1. Abstract
+
+A method for gating an autonomous agent's consequential and irreversible
+actions behind a mandatory two-phase, deliberated execution sequence. In the
+first phase the agent issues and broadcasts a signed **Intent Credential** that
+names the proposed action, its reversibility class, a challenge window, and the
+set of parties authorized to object. Execution is structurally impossible until
+the challenge window has provably elapsed. In the second phase the agent issues
+an **Execute Credential** that references the prior intent and carries evidence
+that the window elapsed and no valid veto was recorded; a verifier rejects any
+Execute Credential minted before the window closes or in the presence of a valid
+veto. During the window any authorized party may issue a separately-signed
+**Veto Credential** bound to the committed intent's digest, which any verifier
+treats as a hard block.
+
+The protected property is prevention rather than detection: unlike audit
+logging, reasoning capture, or post-hoc reputation, this mechanism interposes a
+deliberation delay and a third-party objection channel before an irreversible
+effect occurs, while imposing zero delay on actions classified as reversible.
+
+Key elements:
+
+- **Reversibility-graded execution.** The required deliberation latency is a
+  function of a declared reversibility class, not a flat policy. Reversible
+  actions execute immediately; only irreversible or high-blast-radius classes
+  enter the two-phase sequence.
+- **Commit-before-execute ordering.** The intent is fixed by a signed credential
+  whose `created` time and action digest are bound together, so the executed
+  action cannot differ from the announced one and cannot be executed earlier
+  than the window permits.
+- **Provable window elapse without a trusted clock (optional).** The window may
+  be evidenced by signed wall-clock timestamps or, where no clock authority is
+  trusted, by a Verifiable Delay Function output (PAD-047) proving the minimum
+  time could not have been skipped.
+- **Separated veto authority.** The parties who may block execution are named in
+  the intent and are structurally distinct from the acting agent, so the actor
+  cannot both propose and unilaterally clear its own irreversible act.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Authorization does not bound harm inside the envelope
+
+An agent operating strictly within a valid, attenuated delegation may still take
+an authorized action that is catastrophic and irreversible: wiring funds,
+deleting a production dataset, publishing to an external channel, or actuating a
+physical effector. Identity, delegation, reasoning capture, and reputation all
+answer questions after the effect. None interposes a controllable pause before
+an effect that cannot be undone.
+
+### 2.2 Detection is inadequate for irreversible effects
+
+For reversible actions, detect-and-remediate suffices: the effect can be rolled
+back. For irreversible actions it does not: by the time an audit log, reasoning
+trace, or reputation update is examined, the funds are gone and the data is
+destroyed. The one class of action where a control must act before the effect is
+exactly the class no existing agent-trust mechanism gates.
+
+### 2.3 Human-oversight mandates need a machine-checkable hook
+
+Regulatory regimes increasingly require that a human be able to intervene before
+a consequential automated decision takes effect (for example, EU AI Act Article
+14 human oversight). A blanket human-in-the-loop on every action is impractical
+at machine speed and scale. What is needed is a mechanism that applies the pause
+only to the actions that warrant it, makes the pause and the intervention
+cryptographically verifiable after the fact, and works across vendors and
+services rather than inside one platform.
+
+### 2.4 Self-cleared delays are not delays
+
+A pause the acting agent can shorten, skip, or clear by itself is not a control.
+Any deliberation mechanism must make the elapse of the window and the absence of
+an objection verifiable by an independent party, and must place the objection
+authority in different hands than the actor.
+
+---
+
+## 3. The Novel Mechanism
+
+### 3.1 Reversibility classification
+
+Each action is assigned a reversibility class, derived from verifier-side policy
+and from caveats in the delegation chain (PAD-086), never self-asserted by the
+acting agent. Classes map to a minimum deliberation window:
+
+| Class | Example | Minimum window |
+|---|---|---|
+| `reversible` | read, idempotent write to a versioned store | 0 (immediate) |
+| `reversible-costly` | send an internal message, mutate a cache | short, policy-set |
+| `irreversible-financial` | transfer funds, place an order | policy-set, typically minutes to hours |
+| `irreversible-destructive` | delete without backup, revoke access | policy-set |
+| `irreversible-external` | publish, email an outside party, actuate | policy-set |
+
+### 3.2 Phase one: Intent Credential
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2"],
+  "type": ["VerifiableCredential", "VouchIntentCredential"],
+  "issuer": "did:web:agent.example",
+  "credentialSubject": {
+    "intent": { "action": "transfer_funds", "target": "acct:vendor-1", "resource": "usd:5000" },
+    "actionDigest": { "algorithm": "sha-256-jcs", "digest": "u<multibase>" },
+    "reversibilityClass": "irreversible-financial",
+    "challengeWindow": {
+      "minSeconds": 900,
+      "opensAt": "2026-07-05T10:00:00Z",
+      "vetoAuthorities": ["did:web:controller.example", "did:web:risk.example"],
+      "broadcast": ["log://transparency.example/agent-actions", "mcp://controller.example/inbox"]
+    }
+  },
+  "proof": { "type": "DataIntegrityProof", "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+The `actionDigest` is the JCS-canonical SHA-256 of the exact action object, so
+the later executed action must be byte-identical to the announced one. The
+credential is broadcast to the named channels at issuance.
+
+### 3.3 Phase two: Execute Credential
+
+After the window closes, and if no valid veto exists, the agent issues:
+
+```json
+{
+  "type": ["VerifiableCredential", "VouchExecuteCredential"],
+  "credentialSubject": {
+    "intentRef": "urn:vouch:intent:...",
+    "intentDigest": { "algorithm": "sha-256-jcs", "digest": "u<multibase>" },
+    "windowEvidence": {
+      "mode": "timestamp",
+      "closedAt": "2026-07-05T10:15:00Z",
+      "vdfProof": null
+    },
+    "vetoStatus": "none"
+  },
+  "proof": { "...eddsa-jcs-2022 or dual-proof...": "..." }
+}
+```
+
+### 3.4 Phase (any time in window): Veto Credential
+
+```json
+{
+  "type": ["VerifiableCredential", "VouchVetoCredential"],
+  "issuer": "did:web:controller.example",
+  "credentialSubject": {
+    "intentDigest": { "algorithm": "sha-256-jcs", "digest": "u<multibase>" },
+    "decision": "block",
+    "reason": "amount exceeds unattended threshold pending review"
+  },
+  "proof": { "...": "..." }
+}
+```
+
+### 3.5 Verifier algorithm
+
+A verifier presented with an Execute Credential accepts the action only if all
+of the following hold, and otherwise emits the named structured reason:
+
+1. The referenced Intent Credential verifies and its `actionDigest` equals the
+   digest of the action now being executed. (`intent_mismatch`)
+2. The issuer of the Execute Credential is the issuer of the intent, under a
+   still-valid delegation. (`unauthorized_executor`)
+3. The window evidence proves at least `minSeconds` elapsed after `opensAt`:
+   either signed `closedAt` minus `opensAt` is at least `minSeconds`, or a valid
+   VDF proof of the target duration. An execute time inside the window is
+   rejected. (`challenge_window_not_elapsed`)
+4. No Veto Credential signed by any listed `vetoAuthority` and bound to this
+   `intentDigest` has been observed on the broadcast channels. (`vetoed`)
+
+### 3.6 Structured reasons
+
+`challenge_window_not_elapsed`, `vetoed`, `intent_mismatch`,
+`unauthorized_executor`, `reversibility_class_understated`. These compose with
+the delegation verifier's reasons and the caveat reasons of PAD-086.
+
+---
+
+## 4. Prior Art Differentiation
+
+Two-phase commit, maker-checker approval, time-locks, and change-control windows
+are all established. This disclosure does not claim those general ideas. What is
+differentiated is their composition into a credential-native, cross-verifier,
+reversibility-graded deliberation control for autonomous agents:
+
+- **Versus PAD-047 (VDF rate-limiting).** PAD-047 enforces a minimum interval
+  between an agent's own successive high-stakes actions to stop runaway loops.
+  PAD-085 enforces a deliberation delay and third-party objection channel before
+  a single irreversible action, with a signed veto path. PAD-085 may use a VDF as
+  one way to evidence its window, but its subject is deliberation and veto, not
+  self-rate-limiting.
+- **Versus PAD-017 (Proof of Reasoning).** PAD-017 escalates audit depth by
+  impact and captures why an action was taken; it is detective. PAD-085 withholds
+  execution for a window and admits a blocking veto; it is preventive. They
+  compose: the intent can carry PAD-017 justification, and the window is when a
+  reviewer reads it.
+- **Versus PAD-020 and PAD-021 (Ratchet Lock, Graduated Autonomy).** Those bound
+  what capabilities an agent may acquire or hold. PAD-085 gates the timing and
+  clearance of exercising a capability the agent already holds.
+- **Versus PAD-071 (Commit-Before-Outcome).** PAD-071 commits a verdict before
+  its outcome is known, for track-record integrity. PAD-085 commits an intent
+  before its execution, for pre-effect intervention. Same commit-before
+  discipline, different protected event.
+- **Versus platform maker-checker and cloud change windows.** Those are siloed
+  inside one service or IAM system and gate human or service-account actions.
+  PAD-085 is a portable credential any counterparty verifier can check before
+  transacting, spans services, and binds the veto authority cryptographically
+  rather than by platform role.
+- **Versus a plain signed timestamp delay.** A self-signed delay the agent can
+  backdate is not a control. PAD-085 requires independently-verifiable window
+  evidence (signed third-party close or VDF) and a separated veto authority.
+
+---
+
+## 5. Technical Implementation
+
+The method is realized using the protocol's shared `eddsa-jcs-2022` Data
+Integrity proofs (with the hybrid Ed25519 + ML-DSA-44 dual-proof profile
+available for long-retention deployments) and RFC 8785 JCS canonicalization, so
+the Intent, Execute, and Veto credentials verify byte-identically across the
+language SDKs. The action and intent digests are SHA-256 over the JCS canonical
+form. The optional VDF window mode reuses the Verifiable Delay Function primitive
+of PAD-047; the broadcast transport is caller-selected and vendor-neutral. The
+verifier evaluates the four-step algorithm of section 3.5 offline against the
+presented credentials.
+
+---
+
+## 6. Claims Summary
+
+1. A method for gating an autonomous agent's action behind a two-phase sequence
+   in which a signed intent credential naming the action, its reversibility
+   class, a challenge window, and authorized objectors is committed and
+   broadcast, and a signed execute credential referencing that intent is
+   required before the action takes effect.
+2. The method of claim 1 wherein a verifier rejects the execute credential
+   unless evidence proves the challenge window elapsed, so execution cannot be
+   performed earlier than the deliberation delay permits.
+3. The method of claim 2 wherein the window elapse is evidenced by a Verifiable
+   Delay Function output, so the delay is enforceable without trust in any clock
+   authority.
+4. The method of claim 1 wherein any party named as an objector may issue a
+   separately-signed veto credential bound to the committed intent digest, which
+   a verifier treats as a hard block, and wherein the objector set is
+   structurally distinct from the acting agent.
+5. The method of claim 1 wherein the required deliberation delay is a function of
+   a reversibility class derived from verifier policy and delegation-chain
+   caveats rather than self-asserted by the agent, so a reversible action incurs
+   no delay and an understated class is a detectable violation.
+6. The method of claim 1 wherein the executed action must be byte-identical to
+   the committed action digest, so an agent cannot announce one action and
+   execute another.
+7. The method of claim 1 wherein the credentials use canonicalization and
+   signature primitives shared across language SDKs, so the intent, veto, and
+   execution verify cross-language and compose with delegation, reasoning, and
+   accountability credentials of the same protocol.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/PAD-086-executable-caveats-delegation-chains.md
+++ b/docs/disclosures/PAD-086-executable-caveats-delegation-chains.md
@@ -1,0 +1,266 @@
+# PAD-086: Deterministic Executable Caveats Embedded in Object-Capability Delegation Chains for Autonomous Agents
+
+**Identifier:** PAD-086
+**Title:** Method for Embedding Deterministic, Fuel-Bounded Executable Caveats in Attenuatable Object-Capability Delegation Chains, Such That Every Downstream Verifier Must Evaluate Each Accumulated Caveat Against a Proposed Action and No Descendant May Remove an Ancestor's Caveat
+**Publication Date:** July 5, 2026
+**Prior Art Effective Date:** July 5, 2026
+**Status:** Public Disclosure (Defensive Publication)
+**Category:** Agent Authorization / Object Capabilities / Delegation / Policy Enforcement / Verifiable Credentials
+**Author:** Ramprasad Anandam Gaddam
+**License:** Apache 2.0
+**Related:** PAD-002 (Chain of Custody Delegation), PAD-010 (Semantic Consent Signing), PAD-012 (Executable Usage Covenants in Media), PAD-056 (Allow-List Bounded Signing), PAD-066 (Physical Capability Scope Attenuation), PAD-085 (Two-Phase Deliberated Execution)
+
+---
+
+## 1. Abstract
+
+A method for attaching **deterministic executable caveats** to the links of an
+attenuatable object-capability delegation chain used by autonomous agents. A
+caveat is a sandboxed, fuel-bounded predicate (for example a WebAssembly module)
+that receives a defined context describing a proposed action and returns allow or
+deny. Caveats **accumulate down the chain**: each delegated link may add caveats,
+but a link's caveat set always includes every ancestor's caveats, and no
+descendant can remove or weaken an ancestor's caveat because the caveat set is
+part of the signed link. At verification time, a verifier presented with a
+proposed action MUST evaluate every accumulated caveat and reject the action if
+any denies, in addition to the existing static attenuation checks (action,
+target, resource, time, rate, policy).
+
+This turns the delegation envelope from a set of static narrowing fields into
+live, portable, conditional authority that travels with the capability. It lets a
+grantor express conditions that no static field can, such as "only during a
+declared incident," "only if the invoice references an approved purchase order,"
+or "never two disbursements to the same payee within one hour," while preserving
+the object-capability guarantees that delegation only ever attenuates and that
+verification is offline and byte-identical across implementations.
+
+Determinism is mandatory: the caveat runtime has no clock, no randomness, no
+network or filesystem, a pinned numeric profile, and a fuel limit, so the same
+(caveat, context) pair yields the same result on every verifier, and evaluation
+cost is bounded by verifier-side budgets.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Static attenuation cannot express conditional authority
+
+An attenuatable delegation model narrows authority along fixed axes: which
+action, which target, which resource, valid-from and valid-until, a rate ceiling,
+a policy label. Real grants are conditional in ways these axes cannot capture.
+"You may approve refunds, but only for orders that shipped, and never above the
+customer's lifetime spend" is not expressible as a narrowing of static fields. A
+grantor forced to choose between granting too much or nothing at all will grant
+too much, and the confused-deputy and over-privilege failures follow.
+
+### 2.2 Out-of-band policy defeats offline verifiability and portability
+
+The usual workaround is to keep the real policy in a central service the verifier
+calls at check time. This defeats the two properties that make object-capability
+delegation valuable: a capability should be verifiable offline by any
+counterparty, and it should be portable across services without a shared policy
+backend. It also reintroduces a trusted third party and a runtime dependency in
+the hot path of every authorization.
+
+### 2.3 Attached policy that a holder can drop is not enforcement
+
+If conditional policy is attached to a capability but a downstream holder can
+strip it before re-delegating or presenting the capability, the condition is
+advisory, not enforced. Any conditional-authority mechanism for delegation must
+guarantee that conditions can only be added down a chain and never removed, and
+that a verifier is obligated to evaluate them rather than free to ignore them.
+
+### 2.4 Non-deterministic policy code breaks cross-verifier agreement
+
+If the attached policy can read a clock, draw randomness, perform I/O, or depend
+on platform-specific floating point, two honest verifiers can reach different
+decisions on the same capability and action. For a credential meant to verify
+byte-identically across independent language implementations, policy evaluation
+must be perfectly deterministic and its cost must be bounded so a malicious caveat
+cannot mount a denial-of-service against the verifier.
+
+---
+
+## 3. The Novel Mechanism
+
+### 3.1 Caveat structure on a delegation link
+
+Each delegation link may carry a `caveats` array. Each caveat pins the exact
+module to run and the shape of the context it will receive:
+
+```json
+{
+  "delegation": {
+    "parent": "urn:vouch:cap:...",
+    "attenuation": { "action": "refund", "target": "store:eu", "resource": "usd:<=200" },
+    "caveats": [
+      {
+        "id": "cav-shipped-only",
+        "runtime": "wasm-caveat-1",
+        "moduleHash": { "algorithm": "sha-256", "digest": "u<multibase>" },
+        "contextSchema": "u<multibase-of-schema>",
+        "fuelLimit": 2000000,
+        "onDeny": "caveat_denied:shipped-only"
+      }
+    ]
+  }
+}
+```
+
+The `caveats` array is inside the signed link, so it is covered by the link's
+Data Integrity proof.
+
+### 3.2 Accumulation and non-removal
+
+The effective caveat set of a link is the union of its own caveats and the
+effective caveat set of its parent. A builder may add caveats when delegating; it
+cannot emit a link whose effective set omits any ancestor caveat. Because each
+ancestor link is itself signed and referenced, a verifier reconstructs the full
+accumulated set from the chain and detects any attempt to present a chain with a
+missing ancestor caveat as a broken or non-attenuating chain (reusing the
+attenuation verifier's `capability_not_attenuated` machinery).
+
+### 3.3 Deterministic caveat runtime
+
+A conforming caveat runtime guarantees:
+
+- No ambient authority: no clock, no randomness, no network, no filesystem, no
+  environment. All inputs arrive in the context object.
+- A pinned numeric profile (no nondeterministic floating point; integer and
+  fixed-point only, or a specified deterministic float mode).
+- A fuel meter: execution halts at `fuelLimit`, and halting counts as deny with
+  reason `caveat_fuel_exhausted`.
+- Module identity pinned by `moduleHash`; a verifier that lacks the module or
+  computes a different hash rejects with `caveat_module_unavailable`.
+
+The context object is assembled by the verifier from the proposed action, the
+delegation chain, and any verifier-supplied evidence declared in `contextSchema`
+(for example an incident flag or a set of approved purchase-order ids). The
+caveat sees only what the schema admits, so the facts it can consider, and
+therefore its limits, are explicit.
+
+### 3.4 Verifier obligation and budgets
+
+A verifier evaluating a proposed action against a capability MUST:
+
+1. Perform the existing static attenuation checks (action, target, resource,
+   time, rate, policy).
+2. Assemble the context per each caveat's `contextSchema`.
+3. Evaluate every caveat in the effective set; if any returns deny or exhausts
+   fuel, reject the action with that caveat's `onDeny` reason.
+4. Enforce a verifier-side budget (total fuel across all caveats, maximum caveat
+   count) and emit `verifier_budget_exceeded` if exceeded, consistent with the
+   optional budget model used for chain depth and verification time.
+
+### 3.5 Structured reasons
+
+`caveat_denied:<id>`, `caveat_fuel_exhausted`, `caveat_module_unavailable`,
+`caveat_context_unsatisfiable`, `verifier_budget_exceeded`. These compose with
+the delegation attenuation reasons and the deliberation reasons of PAD-085.
+
+### 3.6 Standard caveat library
+
+A small set of audited, widely-useful caveats is provided so most grantors never
+write custom modules: time-of-day and calendar windows, per-window rate and count
+ceilings, value ceilings and running-total ceilings, membership tests against a
+context-supplied allow list, and an incident-flag gate. Custom caveats are the
+escape hatch, not the common path.
+
+---
+
+## 4. Prior Art Differentiation
+
+Caveats on capabilities are not new. Macaroons (Birgisson et al., 2014)
+introduced caveats; Biscuit tokens carry offline-attenuable Datalog caveats;
+ZCAP-LD (Authorization Capabilities for Linked Data) carries JSON caveats on
+delegatable capabilities. This disclosure does not claim caveats-on-capabilities
+in general. What is differentiated is the specific composition:
+
+- **Versus Macaroons and Biscuit.** Macaroon caveats are predicates over request
+  context, typically first-party string predicates or third-party discharge;
+  Biscuit uses a Datalog engine. This method uses a general deterministic,
+  fuel-bounded WebAssembly predicate with a pinned numeric profile and a
+  verifier-assembled typed context, so arbitrary conditional logic is expressible
+  while cross-verifier byte-identical agreement and denial-of-service-bounded cost
+  are guaranteed. Neither Macaroons nor Biscuit target multi-language
+  byte-identical Verifiable Credential verification or an explicit fuel and budget
+  cost model as the design center.
+- **Versus ZCAP-LD caveats.** ZCAP-LD caveats are declarative data interpreted by
+  an invoker-specific handler; there is no standard executable evaluation model
+  and no guarantee two verifiers evaluate a caveat identically. This method pins
+  the module by hash and mandates a deterministic runtime and universal verifier
+  obligation, so evaluation is portable and reproducible rather than
+  handler-defined.
+- **Versus PAD-012 (executable covenants in media).** PAD-012 embeds executable
+  usage policy in a C2PA media manifest to govern downstream use of content. This
+  method embeds executable caveats in an object-capability delegation chain to
+  govern an agent's authority to act, with down-chain accumulation, non-removal,
+  and mandatory verifier evaluation as first-class properties absent from the
+  media-covenant setting.
+- **Versus PAD-056 (allow-list bounded signing) and static policy labels.** Those
+  bound authority to an enumerated set fixed at configuration time. This method
+  evaluates a predicate over runtime action context, so authority can be
+  conditional on facts not known at grant time.
+- **Versus calling a policy service (OPA/Rego, XACML PDP) at check time.** Those
+  require an online trusted decision point and a shared policy backend. This method
+  keeps evaluation offline and self-contained in the capability, preserving
+  object-capability portability and removing the runtime trusted third party.
+- **Object-capability lineage.** Consistent with the delegation layer being
+  object capabilities (zcaps) rather than claim-style Verifiable Credentials, this
+  method places conditional authority in the capability itself and preserves the
+  invariant that delegation only ever attenuates: a caveat can only further
+  restrict, never broaden.
+
+---
+
+## 5. Technical Implementation
+
+The method is realized alongside the protocol's existing capability-attenuation
+verification, adding a `caveats` extension evaluated by a conforming WebAssembly
+caveat runtime with a pinned numeric profile, together with a standard caveat
+library and shared cross-language interop vectors that prove byte-identical
+allow/deny across the language implementations. Caveat modules are pinned by
+SHA-256; the context is JCS-canonical. The signed link, including its caveat set,
+uses the shared `eddsa-jcs-2022` Data Integrity path, so the accumulated caveats
+verify offline with no runtime policy service.
+
+---
+
+## 6. Claims Summary
+
+1. A method for attaching to a link of an attenuatable object-capability
+   delegation chain one or more caveats, each being a deterministic fuel-bounded
+   executable predicate pinned by a hash of its module, such that a verifier
+   evaluating a proposed action against the capability must evaluate every caveat
+   and reject the action if any denies.
+2. The method of claim 1 wherein the effective caveat set of a link is the union
+   of its own caveats and its parent's effective set, and the set is part of the
+   signed link, so a descendant can add but never remove or weaken an ancestor's
+   caveat.
+3. The method of claim 1 wherein the caveat runtime has no clock, randomness, or
+   input-output beyond a verifier-assembled typed context and a pinned numeric
+   profile, so the same caveat and context yield an identical result on every
+   independent verifier implementation.
+4. The method of claim 1 wherein each caveat carries a fuel limit and the verifier
+   enforces a total budget across caveats, and fuel exhaustion or budget excess is
+   treated as denial with a named reason, bounding verifier cost against a
+   malicious caveat.
+5. The method of claim 1 wherein the context supplied to a caveat is constrained
+   by a schema declared on the caveat, so the facts a caveat can consider are
+   explicit and signed.
+6. The method of claim 1 wherein a library of audited standard caveats (time
+   windows, rate and count ceilings, value and running-total ceilings, allow-list
+   membership, incident gate) is provided so conditional authority is expressible
+   without authoring custom modules.
+7. The method of claim 1 wherein the caveats compose with static attenuation
+   checks and with a two-phase deliberated-execution control, and the capability
+   verifies offline without a runtime policy service.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented, to prevent patenting by any party and to keep them available to the
+open Vouch Protocol ecosystem.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -92,6 +92,36 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-082](./PAD-082-portable-agent-identity-fork-detection.md) | Fork Detection for a Portable Agent Identity via Embodiment Time-Overlap | 2026-07-04 | Published |
 | [PAD-083](./PAD-083-physical-custody-handoff-chain.md) | Physical Custody Handoff Chain Across Human and Robot Actors | 2026-07-05 | Published |
 | [PAD-084](./PAD-084-custody-condition-localization.md) | Localizing a Physical State Change to a Custody Hop via Handoff Condition Attestation | 2026-07-05 | Published |
+| [PAD-085](./PAD-085-two-phase-deliberated-execution.md) | Two-Phase Deliberated Execution of Irreversible Agent Actions with Signed Veto Window | 2026-07-05 | Published |
+| [PAD-086](./PAD-086-executable-caveats-delegation-chains.md) | Deterministic Executable Caveats Embedded in Object-Capability Delegation Chains | 2026-07-05 | Published |
+
+
+## July 5, 2026: Accountable Autonomy for Actions Inside the Envelope (PAD-085, PAD-086)
+
+Two disclosures that move accountability past the point where an action is merely
+authorized, toward controlling what an already-authorized agent may do.
+
+- **PAD-085** gates an agent's consequential, irreversible actions behind a
+  two-phase deliberated sequence: a signed intent is committed and broadcast with
+  a challenge window and a named set of objectors, the window must provably elapse
+  (by signed timestamp or a Verifiable Delay Function), and any authorized party
+  may block execution with a separately-signed veto bound to the committed intent.
+  Reversible actions pay no delay. It is a preventive control, acting before an
+  irreversible effect rather than auditing it afterward, and it gives regulatory
+  human-oversight mandates a machine-checkable hook.
+- **PAD-086** attaches deterministic, fuel-bounded executable caveats to the links
+  of an object-capability delegation chain. Caveats accumulate down the chain and
+  cannot be removed by any descendant, every verifier is obligated to evaluate
+  each accumulated caveat against a proposed action, and the pinned, side-effect-
+  free runtime keeps evaluation offline and byte-identical across implementations.
+  It turns the static delegation envelope into live, portable conditional
+  authority ("only for shipped orders," "only during an incident") while
+  preserving the object-capability invariant that delegation only ever attenuates.
+
+Both build on the same `eddsa-jcs-2022` credentials and JCS canonicalization as
+the rest of Vouch, so they verify across the language SDKs and compose with the
+delegation, reasoning, and commit-before-outcome primitives (PAD-002, PAD-017,
+PAD-047, PAD-071).
 
 
 ## July 5, 2026: Physical Custody Handoff (PAD-083, PAD-084)


### PR DESCRIPTION
Publishes two defensive prior-art disclosures under Apache 2.0, both built on the same eddsa-jcs-2022 credentials and JCS canonicalization as the rest of Vouch.

**PAD-085 — Two-Phase Deliberated Execution.** Gates an agent's consequential, irreversible actions behind a two-phase sequence: a signed intent is committed and broadcast with a challenge window and a named set of objectors, the window must provably elapse (by signed timestamp or a Verifiable Delay Function), and any authorized party may block execution with a separately-signed veto bound to the committed intent. Reversible actions pay no delay. It is a preventive control, acting before an irreversible effect rather than auditing it afterward, and gives regulatory human-oversight requirements a machine-checkable hook.

**PAD-086 — Deterministic Executable Caveats in Delegation Chains.** Attaches deterministic, fuel-bounded executable caveats to the links of an object-capability delegation chain. Caveats accumulate down the chain and cannot be removed by any descendant, every verifier is obligated to evaluate each accumulated caveat against a proposed action, and the pinned, side-effect-free runtime keeps evaluation offline and byte-identical across implementations. This turns the static delegation envelope into portable conditional authority while preserving the invariant that delegation only ever attenuates.

Adds both disclosure files and registers them in the disclosures index.
