### PR TITLE
Add Proof of Deliberation: two-phase deliberated execution

### DIFF
--- a/examples/deliberation_demo.py
+++ b/examples/deliberation_demo.py
@@ -1,0 +1,89 @@
+"""
+Proof of Deliberation: make an agent wait, and let a human veto, before it does
+something irreversible.
+
+The one preventive control in Vouch: a reversible action runs instantly, but an
+irreversible one (wiring funds) must announce its intent, wait out a challenge
+window, and survive any veto before a verifier will accept it. The agent cannot
+shorten the window and cannot clear its own veto.
+
+Run:
+    python examples/deliberation_demo.py
+"""
+
+from datetime import datetime, timedelta, timezone
+
+from vouch import Signer, generate_identity
+from vouch.deliberation import (
+    CLASS_IRREVERSIBLE_FINANCIAL,
+    CLASS_REVERSIBLE,
+    check_execution,
+    commit_intent,
+    execute,
+    requires_window,
+    veto_intent,
+)
+
+WIRE = {"action": "transfer_funds", "target": "acct:vendor-1", "resource": "usd:5000"}
+
+
+def main() -> None:
+    agent_kp = generate_identity(domain="agent.example.com")
+    agent = Signer(private_key=agent_kp.private_key_jwk, did=agent_kp.did)
+    controller_kp = generate_identity(domain="controller.example.com")
+    controller = Signer(private_key=controller_kp.private_key_jwk, did=controller_kp.did)
+
+    # A) Reversible action: no ceremony, runs immediately.
+    print("A) read a cache entry  (reversible)")
+    print("   requires a deliberation window?", requires_window(CLASS_REVERSIBLE), "-> runs now\n")
+
+    # The window for the irreversible wire: 15 minutes, controller may veto.
+    opened = datetime.now(timezone.utc)
+    intent = commit_intent(
+        agent,
+        intent=WIRE,
+        reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL,
+        min_seconds=900,
+        veto_authorities=[controller.get_did()],
+        broadcast=["log://transparency.example/agent-actions"],
+        opens_at=opened,
+    )
+    print("B) wire $5000  (irreversible-financial)")
+    print(
+        "   intent committed, window closes 15 min after",
+        intent["credentialSubject"]["challengeWindow"]["opensAt"],
+    )
+
+    # B1) Agent tries to execute 1 minute in -> too early.
+    early = execute(agent, intent_credential=intent, closed_at=opened + timedelta(minutes=1))
+    r = check_execution(early, intent, agent_kp.public_key_jwk)
+    print("   execute after 1 min:      rejected ->", r)
+
+    # B2) Controller vetoes during the window -> blocked even after the window.
+    veto_cred = veto_intent(
+        controller, intent_credential=intent, reason="over unattended threshold"
+    )
+    after = execute(agent, intent_credential=intent, closed_at=opened + timedelta(minutes=20))
+    r = check_execution(
+        after,
+        intent,
+        agent_kp.public_key_jwk,
+        vetoes=[veto_cred],
+        veto_public_keys={controller.get_did(): controller_kp.public_key_jwk},
+    )
+    print("   execute after veto:       rejected ->", r)
+
+    # B3) Clean run: window elapsed, no veto.
+    clean = execute(agent, intent_credential=intent, closed_at=opened + timedelta(minutes=16))
+    r = check_execution(clean, intent, agent_kp.public_key_jwk, vetoes=[], veto_public_keys={})
+    print("   execute after 16 min, no veto:", "ACCEPTED" if r is None else f"rejected -> {r}")
+
+    print(
+        "\nThe verifier, not the agent, decides when the money can move. The agent\n"
+        "cannot shorten the window (elapse is checked) and cannot clear its own veto\n"
+        "(the veto authority is a different DID). Reversible actions pay no delay."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_deliberation.py
+++ b/tests/test_deliberation.py
@@ -1,0 +1,179 @@
+"""Tests for Proof of Deliberation (two-phase deliberated execution)."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.deliberation import (
+    CLASS_IRREVERSIBLE_FINANCIAL,
+    CLASS_REVERSIBLE,
+    EXECUTE_TYPE,
+    INTENT_TYPE,
+    REASON_INTENT_MISMATCH,
+    REASON_INVALID_PROOF,
+    REASON_UNAUTHORIZED_EXECUTOR,
+    REASON_VETOED,
+    REASON_WINDOW_NOT_ELAPSED,
+    VETO_TYPE,
+    DeliberationError,
+    action_digest,
+    check_execution,
+    commit_intent,
+    execute,
+    requires_window,
+    veto_intent,
+    verify_execution,
+    verify_intent,
+)
+
+WIRE = {"action": "transfer_funds", "target": "acct:vendor-1", "resource": "usd:5000"}
+
+
+def _identity(domain="agent.example.com"):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+def _committed(agent, controller_did, opened, min_seconds=900):
+    return commit_intent(
+        agent,
+        intent=WIRE,
+        reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL,
+        min_seconds=min_seconds,
+        veto_authorities=[controller_did],
+        opens_at=opened,
+    )
+
+
+class TestClasses:
+    def test_reversible_needs_no_window(self):
+        assert requires_window(CLASS_REVERSIBLE) is False
+        assert requires_window(CLASS_IRREVERSIBLE_FINANCIAL) is True
+
+    def test_irreversible_requires_positive_window(self):
+        _, agent = _identity()
+        with pytest.raises(DeliberationError):
+            commit_intent(
+                agent, intent=WIRE, reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL, min_seconds=0
+            )
+
+    def test_unknown_class_rejected(self):
+        _, agent = _identity()
+        with pytest.raises(DeliberationError):
+            commit_intent(agent, intent=WIRE, reversibility_class="whatever", min_seconds=10)
+
+    def test_intent_needs_action_target(self):
+        _, agent = _identity()
+        with pytest.raises(DeliberationError):
+            commit_intent(agent, intent={"action": "x"}, reversibility_class=CLASS_REVERSIBLE)
+
+
+class TestIntentAndVeto:
+    def test_commit_and_verify_intent(self):
+        akp, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        intent = _committed(agent, ctrl.get_did(), datetime.now(timezone.utc))
+        assert INTENT_TYPE in intent["type"]
+        ok, subject = verify_intent(intent, akp.public_key_jwk)
+        assert ok and subject["actionDigest"]["digest"] == action_digest(WIRE)
+
+    def test_veto_binds_to_intent(self):
+        _, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        intent = _committed(agent, ctrl.get_did(), datetime.now(timezone.utc))
+        veto = veto_intent(ctrl, intent_credential=intent, reason="no")
+        assert VETO_TYPE in veto["type"]
+        assert veto["credentialSubject"]["intentDigest"]["digest"] == action_digest(WIRE)
+
+
+class TestExecution:
+    def test_clean_window_accepted(self):
+        akp, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)
+        ex = execute(agent, intent_credential=intent, closed_at=opened + timedelta(seconds=901))
+        assert EXECUTE_TYPE in ex["type"]
+        assert check_execution(ex, intent, akp.public_key_jwk) is None
+        ok, subject = verify_execution(ex, intent, akp.public_key_jwk)
+        assert ok and subject["intent"] == WIRE
+
+    def test_execute_too_early_rejected(self):
+        akp, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)
+        ex = execute(agent, intent_credential=intent, closed_at=opened + timedelta(seconds=60))
+        assert check_execution(ex, intent, akp.public_key_jwk) == REASON_WINDOW_NOT_ELAPSED
+
+    def test_veto_blocks_even_after_window(self):
+        akp, agent = _identity()
+        ckp, ctrl = _identity("controller.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)
+        veto = veto_intent(ctrl, intent_credential=intent, reason="over threshold")
+        ex = execute(agent, intent_credential=intent, closed_at=opened + timedelta(seconds=1200))
+        reason = check_execution(
+            ex,
+            intent,
+            akp.public_key_jwk,
+            vetoes=[veto],
+            veto_public_keys={ctrl.get_did(): ckp.public_key_jwk},
+        )
+        assert reason == REASON_VETOED
+
+    def test_veto_from_unlisted_authority_ignored(self):
+        akp, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        rkp, rogue = _identity("rogue.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)  # only ctrl may veto
+        rogue_veto = veto_intent(rogue, intent_credential=intent, reason="I object")
+        ex = execute(agent, intent_credential=intent, closed_at=opened + timedelta(seconds=1000))
+        reason = check_execution(
+            ex,
+            intent,
+            akp.public_key_jwk,
+            vetoes=[rogue_veto],
+            veto_public_keys={rogue.get_did(): rkp.public_key_jwk},
+        )
+        assert reason is None  # rogue is not in vetoAuthorities
+
+    def test_unauthorized_executor_rejected(self):
+        akp, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        bkp, bob = _identity("bob.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)
+        # Bob (not the intent issuer) signs an execute for the same intent.
+        ex = execute(bob, intent_credential=intent, closed_at=opened + timedelta(seconds=1000))
+        assert check_execution(ex, intent, bkp.public_key_jwk) == REASON_UNAUTHORIZED_EXECUTOR
+
+    def test_tampered_action_rejected(self):
+        akp, agent = _identity()
+        _, ctrl = _identity("controller.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)
+        ex = execute(agent, intent_credential=intent, closed_at=opened + timedelta(seconds=1000))
+        # Re-sign an execute whose embedded intent was changed to a bigger amount.
+        ex["credentialSubject"]["intent"] = {
+            "action": "transfer_funds",
+            "target": "acct:vendor-1",
+            "resource": "usd:999999",
+        }
+        from vouch import data_integrity  # noqa: PLC0415
+
+        ex["proof"] = data_integrity.build_proof(
+            ex, agent._raw_priv, agent.verification_method_id()
+        )
+        assert check_execution(ex, intent, akp.public_key_jwk) == REASON_INTENT_MISMATCH
+
+    def test_wrong_executor_key_fails_proof(self):
+        akp, agent = _identity()
+        okp, _ = _identity("other.example.com")
+        _, ctrl = _identity("controller.example.com")
+        opened = datetime.now(timezone.utc)
+        intent = _committed(agent, ctrl.get_did(), opened)
+        ex = execute(agent, intent_credential=intent, closed_at=opened + timedelta(seconds=1000))
+        assert check_execution(ex, intent, okp.public_key_jwk) == REASON_INVALID_PROOF

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -287,6 +287,29 @@ def __getattr__(name):
         from . import reasoning
 
         return getattr(reasoning, name)
+    # Proof of Deliberation (two-phase deliberated execution, PAD-085)
+    elif name in (
+        "DeliberationError",
+        "INTENT_TYPE",
+        "EXECUTE_TYPE",
+        "VETO_TYPE",
+        "CLASS_REVERSIBLE",
+        "CLASS_REVERSIBLE_COSTLY",
+        "CLASS_IRREVERSIBLE_FINANCIAL",
+        "CLASS_IRREVERSIBLE_DESTRUCTIVE",
+        "CLASS_IRREVERSIBLE_EXTERNAL",
+        "action_digest",
+        "requires_window",
+        "commit_intent",
+        "verify_intent",
+        "veto_intent",
+        "execute",
+        "check_execution",
+        "verify_execution",
+    ):
+        from . import deliberation
+
+        return getattr(deliberation, name)
     # Reputation receipts and aggregation (evidence-backed reputation)
     elif name in (
         "ReceiptError",
@@ -516,6 +539,22 @@ __all__ = [
     "check_reasoned_action",
     "verify_reasoned_action",
     "verify_justification",
+    # Proof of Deliberation (two-phase deliberated execution)
+    "DeliberationError",
+    "INTENT_TYPE",
+    "EXECUTE_TYPE",
+    "VETO_TYPE",
+    "CLASS_REVERSIBLE",
+    "CLASS_REVERSIBLE_COSTLY",
+    "CLASS_IRREVERSIBLE_FINANCIAL",
+    "CLASS_IRREVERSIBLE_DESTRUCTIVE",
+    "CLASS_IRREVERSIBLE_EXTERNAL",
+    "commit_intent",
+    "verify_intent",
+    "veto_intent",
+    "execute",
+    "check_execution",
+    "verify_execution",
     # Reputation receipts and aggregation
     "ReceiptError",
     "Signal",

--- a/vouch/deliberation.py
+++ b/vouch/deliberation.py
@@ -1,0 +1,457 @@
+"""
+Proof of Deliberation: gate irreversible agent actions behind a challenge window.
+
+Identity, delegation, reasoning, and reputation all answer questions *after* an
+action takes effect. For a reversible action that is enough: the effect can be
+rolled back. For an *irreversible* one (wiring funds, deleting without backup,
+publishing, actuating) it is not, and by the time an audit log is read the money
+is already gone.
+
+This module adds the one preventive control in the accountable-autonomy set. A
+consequential action runs in two phases:
+
+  1. commit_intent  -> the agent signs and broadcasts a VouchIntentCredential
+     naming the action, its reversibility class, a challenge window, and the
+     parties allowed to object. The exact action is fixed by a digest.
+  2. execute        -> only after the window has provably elapsed, and only if no
+     valid veto exists, the agent signs a VouchExecuteCredential that a verifier
+     will accept.
+
+During the window any named authority may veto_intent, producing a
+VouchVetoCredential bound to the committed intent that any verifier treats as a
+hard block. The verifier, not the agent, decides when the action may proceed: the
+agent cannot shorten the window (elapse is checked) and cannot clear its own veto
+(the veto authority is a separate DID). Reversible actions pay no delay.
+
+Everything here is an ordinary ``eddsa-jcs-2022`` Verifiable Credential, so the
+intent, veto, and execution verify across the language SDKs and compose with the
+delegation, reasoning, and accountability primitives. This is the on-protocol
+form of the method disclosed in PAD-085.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+from . import data_integrity
+from .jcs import canonicalize
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+
+INTENT_TYPE = "VouchIntentCredential"
+EXECUTE_TYPE = "VouchExecuteCredential"
+VETO_TYPE = "VouchVetoCredential"
+
+DIGEST_ALGORITHM = "sha-256-jcs"
+
+# Reversibility classes. Those in REVERSIBLE_CLASSES need no deliberation window;
+# the rest require one before they may execute.
+CLASS_REVERSIBLE = "reversible"
+CLASS_REVERSIBLE_COSTLY = "reversible-costly"
+CLASS_IRREVERSIBLE_FINANCIAL = "irreversible-financial"
+CLASS_IRREVERSIBLE_DESTRUCTIVE = "irreversible-destructive"
+CLASS_IRREVERSIBLE_EXTERNAL = "irreversible-external"
+
+REVERSIBLE_CLASSES = frozenset({CLASS_REVERSIBLE, CLASS_REVERSIBLE_COSTLY})
+IRREVERSIBLE_CLASSES = frozenset(
+    {
+        CLASS_IRREVERSIBLE_FINANCIAL,
+        CLASS_IRREVERSIBLE_DESTRUCTIVE,
+        CLASS_IRREVERSIBLE_EXTERNAL,
+    }
+)
+KNOWN_CLASSES = REVERSIBLE_CLASSES | IRREVERSIBLE_CLASSES
+
+# Structured verification reasons (stable strings, mirrored by the SDKs).
+REASON_INVALID_PROOF = "invalid_proof"
+REASON_NOT_EXECUTE = "not_execute_credential"
+REASON_INTENT_MISMATCH = "intent_mismatch"
+REASON_UNAUTHORIZED_EXECUTOR = "unauthorized_executor"
+REASON_WINDOW_NOT_ELAPSED = "challenge_window_not_elapsed"
+REASON_VETOED = "vetoed"
+
+
+class DeliberationError(Exception):
+    """Raised on malformed deliberation input."""
+
+
+# ---------------------------------------------------------------------------
+# Low-level helpers (kept local so the module stands alone, matching
+# vouch.accountability and vouch.reasoning)
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(s: str) -> datetime:
+    try:
+        return datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError) as exc:
+        raise DeliberationError(f"malformed timestamp: {s!r}") from exc
+
+
+def _mb64(b: bytes) -> str:
+    return "u" + base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise DeliberationError("signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+def _type_list(credential: Dict[str, Any]) -> list:
+    t = credential.get("type") or []
+    return [t] if isinstance(t, str) else list(t)
+
+
+def action_digest(intent: Dict[str, Any]) -> str:
+    """Multibase SHA-256 over the JCS-canonical action, so the executed action
+    must be byte-identical to the announced one."""
+    if not isinstance(intent, dict):
+        raise DeliberationError("intent must be a JSON object")
+    return _mb64(hashlib.sha256(canonicalize(intent)).digest())
+
+
+def requires_window(reversibility_class: str) -> bool:
+    """True if the class must deliberate before executing."""
+    return reversibility_class not in REVERSIBLE_CLASSES
+
+
+# ---------------------------------------------------------------------------
+# Phase one: the Intent Credential
+# ---------------------------------------------------------------------------
+
+
+def commit_intent(
+    signer: Any,
+    *,
+    intent: Dict[str, Any],
+    reversibility_class: str,
+    min_seconds: int = 0,
+    veto_authorities: Optional[Iterable[str]] = None,
+    broadcast: Optional[Iterable[str]] = None,
+    opens_at: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a ``VouchIntentCredential`` announcing an action before it executes.
+
+    The credential fixes the exact action by digest and declares a challenge
+    window: how long a verifier must wait (``min_seconds``), when it opens, which
+    DIDs may object (``veto_authorities``), and where the intent is broadcast.
+    Broadcast the returned credential to those channels so objectors can see it.
+
+    Args:
+        signer: The acting agent's ``Signer``.
+        intent: The action to be taken (``action``/``target``/``resource``).
+        reversibility_class: One of the module's class constants. Irreversible
+            classes require ``min_seconds > 0``.
+        min_seconds: Minimum deliberation window, in seconds.
+        veto_authorities: DIDs permitted to block execution during the window.
+        broadcast: Opaque channel locators the intent is published to.
+        opens_at: Window open time (defaults to now, UTC).
+        credential_id: Optional credential id (defaults to a ``urn:uuid``).
+    """
+    if not isinstance(intent, dict) or not intent.get("action") or not intent.get("target"):
+        raise DeliberationError("intent must be a dict with at least action and target")
+    if reversibility_class not in KNOWN_CLASSES:
+        raise DeliberationError(f"unknown reversibility class: {reversibility_class!r}")
+    if requires_window(reversibility_class) and min_seconds <= 0:
+        raise DeliberationError(
+            f"class {reversibility_class!r} is irreversible and requires min_seconds > 0"
+        )
+
+    opened = (opens_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    window: Dict[str, Any] = {
+        "minSeconds": int(min_seconds),
+        "opensAt": _iso(opened),
+        "vetoAuthorities": list(veto_authorities or []),
+    }
+    if broadcast:
+        window["broadcast"] = list(broadcast)
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", INTENT_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": signer.get_did(),
+        "validFrom": _iso(opened),
+        "credentialSubject": {
+            "intent": dict(intent),
+            "actionDigest": {"algorithm": DIGEST_ALGORITHM, "digest": action_digest(intent)},
+            "reversibilityClass": reversibility_class,
+            "challengeWindow": window,
+        },
+    }
+    return _attach_proof(credential, signer)
+
+
+def verify_intent(
+    credential: Dict[str, Any], public_key: Any
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Verify an intent credential's proof and structure. Returns (ok, subject)."""
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if INTENT_TYPE not in _type_list(credential):
+        return False, None
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+    subject = credential.get("credentialSubject") or {}
+    if not (subject.get("actionDigest") or {}).get("digest"):
+        return False, None
+    return True, subject
+
+
+# ---------------------------------------------------------------------------
+# The Veto Credential (issued during the window by an authorized objector)
+# ---------------------------------------------------------------------------
+
+
+def veto_intent(
+    veto_signer: Any,
+    *,
+    intent_credential: Dict[str, Any],
+    reason: str = "",
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a ``VouchVetoCredential`` blocking a committed intent.
+
+    Signed by an objector (whose DID should appear in the intent's
+    ``vetoAuthorities``), it binds to the intent's action digest so a verifier can
+    match it to exactly this intent.
+    """
+    subject = intent_credential.get("credentialSubject") or {}
+    digest = (subject.get("actionDigest") or {}).get("digest")
+    if not digest:
+        raise DeliberationError("intent credential has no action digest to veto")
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", VETO_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": veto_signer.get_did(),
+        "validFrom": _iso(datetime.now(timezone.utc)),
+        "credentialSubject": {
+            "intentDigest": {"algorithm": DIGEST_ALGORITHM, "digest": digest},
+            "decision": "block",
+            "reason": reason,
+        },
+    }
+    return _attach_proof(credential, veto_signer)
+
+
+def _veto_blocks(
+    veto: Dict[str, Any],
+    intent_digest: str,
+    veto_authorities: Iterable[str],
+    veto_public_keys: Dict[str, Any],
+) -> bool:
+    """A veto blocks iff it verifies under a listed authority's key, decides
+    'block', and binds to this intent's digest."""
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if VETO_TYPE not in _type_list(veto):
+        return False
+    issuer = veto.get("issuer")
+    if issuer not in set(veto_authorities):
+        return False
+    key = veto_public_keys.get(issuer)
+    resolved = _coerce_ed25519_public_key(key) if key is not None else None
+    if resolved is None:
+        return False
+    try:
+        if not data_integrity.verify_proof(veto, resolved):
+            return False
+    except ValueError:
+        return False
+    subject = veto.get("credentialSubject") or {}
+    if subject.get("decision") != "block":
+        return False
+    return (subject.get("intentDigest") or {}).get("digest") == intent_digest
+
+
+# ---------------------------------------------------------------------------
+# Phase two: the Execute Credential
+# ---------------------------------------------------------------------------
+
+
+def execute(
+    signer: Any,
+    *,
+    intent_credential: Dict[str, Any],
+    closed_at: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Issue a ``VouchExecuteCredential`` for a committed intent after its window.
+
+    ``closed_at`` records when the window is claimed to have closed; a verifier
+    rejects it if that is earlier than ``opensAt + minSeconds``. The credential
+    references the intent and repeats its digest, so the executed action is bound
+    to exactly what was announced.
+    """
+    subject = intent_credential.get("credentialSubject") or {}
+    digest = (subject.get("actionDigest") or {}).get("digest")
+    if not digest:
+        raise DeliberationError("intent credential has no action digest")
+
+    closed = (closed_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", EXECUTE_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": signer.get_did(),
+        "validFrom": _iso(closed),
+        "credentialSubject": {
+            "intentRef": intent_credential.get("id"),
+            "intentDigest": {"algorithm": DIGEST_ALGORITHM, "digest": digest},
+            "intent": dict(subject.get("intent") or {}),
+            "windowEvidence": {"mode": "timestamp", "closedAt": _iso(closed)},
+        },
+    }
+    return _attach_proof(credential, signer)
+
+
+def check_execution(
+    execute_credential: Dict[str, Any],
+    intent_credential: Dict[str, Any],
+    executor_public_key: Any,
+    *,
+    intent_public_key: Any = None,
+    vetoes: Optional[List[Dict[str, Any]]] = None,
+    veto_public_keys: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    """
+    Verify a two-phase execution; return None on success or a structured reason.
+
+    Checks the executor's proof, that the executed action matches the committed
+    intent digest, that the executor is the intent's issuer, that the challenge
+    window has provably elapsed, and that no valid veto from a listed authority
+    blocks it. Pass ``intent_public_key`` to also verify the intent's own proof,
+    and ``vetoes`` plus ``veto_public_keys`` (issuer DID -> key) to enforce vetoes.
+    """
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if EXECUTE_TYPE not in _type_list(execute_credential):
+        return REASON_NOT_EXECUTE
+
+    resolved = (
+        _coerce_ed25519_public_key(executor_public_key) if executor_public_key is not None else None
+    )
+    if resolved is None:
+        return REASON_INVALID_PROOF
+    try:
+        if not data_integrity.verify_proof(execute_credential, resolved):
+            return REASON_INVALID_PROOF
+    except ValueError:
+        return REASON_INVALID_PROOF
+
+    if intent_public_key is not None:
+        ok, _ = verify_intent(intent_credential, intent_public_key)
+        if not ok:
+            return REASON_INVALID_PROOF
+
+    esub = execute_credential.get("credentialSubject") or {}
+    isub = intent_credential.get("credentialSubject") or {}
+    intent_digest = (isub.get("actionDigest") or {}).get("digest")
+    exec_digest = (esub.get("intentDigest") or {}).get("digest")
+
+    # The executed action must be byte-identical to the committed one.
+    if not intent_digest or exec_digest != intent_digest:
+        return REASON_INTENT_MISMATCH
+    if "intent" in esub and action_digest(esub["intent"]) != intent_digest:
+        return REASON_INTENT_MISMATCH
+
+    # Only the intent's issuer may execute it.
+    if execute_credential.get("issuer") != intent_credential.get("issuer"):
+        return REASON_UNAUTHORIZED_EXECUTOR
+
+    # The window must provably have elapsed.
+    window = isub.get("challengeWindow") or {}
+    min_seconds = int(window.get("minSeconds", 0))
+    opened = _parse_iso(window.get("opensAt", ""))
+    closed = _parse_iso((esub.get("windowEvidence") or {}).get("closedAt", ""))
+    if (closed - opened).total_seconds() < min_seconds:
+        return REASON_WINDOW_NOT_ELAPSED
+
+    # No valid veto from a listed authority may bind to this intent.
+    authorities = window.get("vetoAuthorities") or []
+    if vetoes and authorities:
+        keys = veto_public_keys or {}
+        for v in vetoes:
+            if _veto_blocks(v, intent_digest, authorities, keys):
+                return REASON_VETOED
+
+    return None
+
+
+def verify_execution(
+    execute_credential: Dict[str, Any],
+    intent_credential: Dict[str, Any],
+    executor_public_key: Any,
+    *,
+    intent_public_key: Any = None,
+    vetoes: Optional[List[Dict[str, Any]]] = None,
+    veto_public_keys: Optional[Dict[str, Any]] = None,
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """
+    Convenience wrapper over :func:`check_execution` returning
+    ``(ok, credentialSubject)`` in the style of the rest of the SDK.
+    """
+    reason = check_execution(
+        execute_credential,
+        intent_credential,
+        executor_public_key,
+        intent_public_key=intent_public_key,
+        vetoes=vetoes,
+        veto_public_keys=veto_public_keys,
+    )
+    if reason is not None:
+        return False, None
+    return True, execute_credential.get("credentialSubject") or {}
+
+
+__all__ = [
+    "DeliberationError",
+    "INTENT_TYPE",
+    "EXECUTE_TYPE",
+    "VETO_TYPE",
+    "CLASS_REVERSIBLE",
+    "CLASS_REVERSIBLE_COSTLY",
+    "CLASS_IRREVERSIBLE_FINANCIAL",
+    "CLASS_IRREVERSIBLE_DESTRUCTIVE",
+    "CLASS_IRREVERSIBLE_EXTERNAL",
+    "REVERSIBLE_CLASSES",
+    "IRREVERSIBLE_CLASSES",
+    "action_digest",
+    "requires_window",
+    "commit_intent",
+    "verify_intent",
+    "veto_intent",
+    "execute",
+    "check_execution",
+    "verify_execution",
+]


### PR DESCRIPTION
Adds a `vouch.deliberation` module implementing two-phase deliberated execution, the one preventive control in the accountable-autonomy set.

An agent commits a signed `VouchIntentCredential` naming the action, its reversibility class, a challenge window, and the DIDs allowed to object. It may only execute after a verifier confirms the challenge window elapsed and no authorized veto was recorded. Any listed authority can issue a signed `VouchVetoCredential` that binds to the committed intent and blocks execution.

The executed action must be byte-identical to the committed one, the executor must be the intent's issuer, and the window elapse is checked by the verifier, so the agent cannot shorten the window or clear its own veto. Reversible actions run with no delay. All three credentials use the shared eddsa-jcs-2022 path and verify across the language SDKs.

Realizes the method disclosed in PAD-085. Includes a runnable example (`examples/deliberation_demo.py`) and a test suite (`tests/test_deliberation.py`).
