### PR TITLE
Update vouch-mcp server.json to the current registry schema

### DIFF
--- a/packages/vouch-mcp/server.json
+++ b/packages/vouch-mcp/server.json
@@ -1,7 +1,7 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-07-09/server.schema.json",
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.vouch-protocol/vouch-mcp",
-  "description": "Issue and verify W3C Verifiable Credentials (eddsa-jcs-2022, optional post-quantum) so AI agents can cryptographically authorize the actions they take.",
+  "description": "Sign and verify W3C Verifiable Credentials so AI agents can cryptographically authorize actions.",
   "status": "active",
   "repository": {
     "url": "https://github.com/vouch-protocol/vouch",
@@ -10,36 +10,36 @@
   "version": "2.0.0",
   "packages": [
     {
-      "registry_type": "pypi",
+      "registryType": "pypi",
       "identifier": "vouch-mcp",
       "version": "2.0.0",
       "transport": { "type": "stdio" },
-      "environment_variables": [
+      "environmentVariables": [
         {
           "name": "VOUCH_PRIVATE_KEY",
-          "description": "The agent's private signing key as a JWK JSON string. Held only in this server process, never in the LLM's context.",
-          "is_required": true,
-          "is_secret": true
+          "description": "The agent's signing key as a JWK JSON string, held only in this server process.",
+          "isRequired": true,
+          "isSecret": true
         },
         {
           "name": "VOUCH_DID",
           "description": "The agent's DID, e.g. did:web:agent.example.com",
-          "is_required": true
+          "isRequired": true
         },
         {
           "name": "VOUCH_MCP_TRANSPORT",
           "description": "Transport to serve: 'stdio' (default), 'http' (Streamable HTTP), or 'sse'.",
-          "is_required": false
+          "isRequired": false
         },
         {
           "name": "VOUCH_MCP_HOST",
           "description": "Bind host when VOUCH_MCP_TRANSPORT=http (default 127.0.0.1).",
-          "is_required": false
+          "isRequired": false
         },
         {
           "name": "VOUCH_MCP_PORT",
           "description": "Bind port when VOUCH_MCP_TRANSPORT=http (default 8080).",
-          "is_required": false
+          "isRequired": false
         }
       ]
     }


### PR DESCRIPTION
Updates the MCP registry metadata for vouch-mcp to the 2025-12-11 server schema. Renames the package fields to their current camelCase form (registryType, environmentVariables, isRequired, isSecret) and shortens the description to fit the registry's 100-character limit. This is the form the registry accepts when publishing io.github.vouch-protocol/vouch-mcp.
