### PR TITLE
Add MCP registry ownership marker and release vouch-mcp 2.0.1

### DIFF
--- a/packages/vouch-mcp/README.md
+++ b/packages/vouch-mcp/README.md
@@ -102,3 +102,9 @@ discovered and installed like any other MCP server.
 ## License
 
 Apache-2.0.
+
+## MCP registry
+
+This server is listed in the Model Context Protocol registry.
+
+mcp-name: io.github.vouch-protocol/vouch-mcp

--- a/packages/vouch-mcp/pyproject.toml
+++ b/packages/vouch-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-mcp"
-version = "2.0.0"
+version = "2.0.1"
 description = "Model Context Protocol server that issues and verifies Vouch Credentials to authorize AI agent tool calls."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/vouch-mcp/server.json
+++ b/packages/vouch-mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vouch-protocol/vouch",
     "source": "github"
   },
-  "version": "2.0.0",
+  "version": "2.0.1",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "vouch-mcp",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/packages/vouch-mcp/src/vouch_mcp/__init__.py
+++ b/packages/vouch-mcp/src/vouch_mcp/__init__.py
@@ -13,4 +13,4 @@ Run:
 from vouch.integrations.mcp.server import main, mcp
 
 __all__ = ["main", "mcp"]
-__version__ = "2.0.0"
+__version__ = "2.0.1"


### PR DESCRIPTION
Add MCP registry ownership marker and release vouch-mcp 2.0.1

Add the mcp-name marker to the vouch-mcp README so the Model Context
Protocol registry can confirm ownership of the PyPI package, and bump
the package to 2.0.1 across pyproject.toml, the module, and server.json
so the published metadata matches.

Signed-off-by: Ramprasad Gaddam <groups.rampy1@gmail.com>

Vouch-DID: did:vouch:be434c6279c0
