### PR TITLE
Add an interactive demos page under Support

### DIFF
--- a/website/src/app/demos/DemosClient.tsx
+++ b/website/src/app/demos/DemosClient.tsx
@@ -1,0 +1,301 @@
+'use client';
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Interactive demos for the three accountable-autonomy runtime primitives that
+ * ship in the SDK: Reasoned Action Proofs (PAD-085 companion, vouch.reasoning),
+ * Proof of Deliberation (PAD-085, vouch.deliberation), and Executable Caveats
+ * (PAD-086, vouch.caveats). Styled with the site's parchment/burgundy/serif
+ * system so it reads as part of the document, light and dark.
+ *
+ * Semantic colours are demo-local: burgundy (the brand) doubles as deny/veto,
+ * a parchment-harmonised green marks allow. Both read on either theme.
+ */
+
+const ALLOW = '#3f7d55';
+const DENY = 'rgb(var(--color-burgundy))';
+
+function useReducedMotion() {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const m = window.matchMedia('(prefers-reduced-motion: reduce)');
+    setReduced(m.matches);
+    const h = () => setReduced(m.matches);
+    m.addEventListener('change', h);
+    return () => m.removeEventListener('change', h);
+  }, []);
+  return reduced;
+}
+
+/* ------------------------------------------------------------------ */
+/* Section II — The Deliberation (vouch.deliberation)                  */
+/* ------------------------------------------------------------------ */
+
+type DelibState = 'idle' | 'running' | 'executed' | 'blocked';
+
+function Deliberation() {
+  const reduced = useReducedMotion();
+  const WINDOW_MS = 7000;
+  const [state, setState] = useState<DelibState>('idle');
+  const [progress, setProgress] = useState(0); // 0..1
+  const [log, setLog] = useState<React.ReactNode[]>([]);
+  const [toast, setToast] = useState<string | null>(null);
+  const raf = useRef<number | null>(null);
+  const start = useRef<number>(0);
+  const toastTimer = useRef<number | null>(null);
+
+  const push = useCallback((node: React.ReactNode) => setLog((l) => [...l, node]), []);
+  const flash = useCallback((msg: string) => {
+    setToast(msg);
+    if (toastTimer.current) window.clearTimeout(toastTimer.current);
+    toastTimer.current = window.setTimeout(() => setToast(null), 1900);
+  }, []);
+
+  const stop = () => { if (raf.current) cancelAnimationFrame(raf.current); raf.current = null; };
+  useEffect(() => stop, []);
+
+  const minsLeft = (p: number) => {
+    const s = Math.ceil((1 - p) * 15 * 60);
+    return `${String(Math.floor(s / 60)).padStart(2, '0')}:${String(s % 60).padStart(2, '0')}`;
+  };
+
+  const tick = useCallback((now: number) => {
+    const p = Math.min(1, (now - start.current) / WINDOW_MS);
+    setProgress(p);
+    if (p >= 1) {
+      setState('executed');
+      push(<span><span className="k">t+15:00</span>  window closed · <b style={{ color: ALLOW }}>no veto</b></span>);
+      push(<span style={{ color: ALLOW }}>✓ EXECUTE accepted</span>);
+      return;
+    }
+    raf.current = requestAnimationFrame(tick);
+  }, [push]);
+
+  const commit = () => {
+    setLog([]); setProgress(0); setState('running');
+    push(<span><b style={{ color: DENY }}>INTENT</b> transfer_funds · usd:5000 → acct:vendor-1</span>);
+    push(<span className="k">class irreversible-financial · window 900s · veto→ did:web:controller</span>);
+    if (reduced) { setProgress(0.45); return; }
+    start.current = performance.now();
+    raf.current = requestAnimationFrame(tick);
+  };
+  const force = () => {
+    push(<span><span className="k">t+00:31</span>  agent tries to execute early</span>);
+    push(<span style={{ color: DENY }}>✕ rejected · challenge_window_not_elapsed</span>);
+    flash('rejected · challenge_window_not_elapsed');
+  };
+  const veto = () => {
+    stop(); setState('blocked');
+    push(<span><b style={{ color: DENY }}>VETO</b> signed by did:web:controller · over unattended threshold</span>);
+    push(<span style={{ color: DENY }}>✕ EXECUTE rejected · vetoed</span>);
+  };
+  const reset = () => { stop(); setState('idle'); setProgress(0); setLog([]); };
+
+  const pct = (progress * 100).toFixed(1);
+  return (
+    <div className="grid md:grid-cols-2 gap-8 items-start">
+      <div>
+        <div className="flex items-center justify-between mb-4">
+          <span className="font-serif text-[1.05rem]">Agent wants to <span className="text-burgundy font-semibold">wire $5,000</span></span>
+          <button className="demo-chip" onClick={() => flash('reversible · executed instantly')}>read cache · reversible</button>
+        </div>
+        <div className="border border-dashed border-rule px-6 py-8 flex flex-col items-center gap-4 text-center min-h-[240px] justify-center">
+          {state === 'executed' ? (
+            <div className="demo-stamp" style={{ color: ALLOW, borderColor: ALLOW }}>✓ EXECUTED</div>
+          ) : state === 'blocked' ? (
+            <div className="demo-stamp" style={{ color: DENY, borderColor: DENY }}>⦸ BLOCKED</div>
+          ) : (
+            <div className="demo-ring" style={{ ['--p' as string]: pct, ['--arc' as string]: DENY }}>
+              <div className="demo-ring-face">
+                <span className="font-mono text-[1.5rem] tabular-nums">{state === 'running' ? minsLeft(progress) : '15:00'}</span>
+                <small className="eyebrow-faint block mt-1">window</small>
+              </div>
+            </div>
+          )}
+          <p className="text-ink-soft text-[0.9rem] max-w-[42ch] leading-relaxed">
+            {state === 'idle' && <>Commit the intent to broadcast what the agent wants and start a 15-minute window (compressed to a few seconds). You are the controller.</>}
+            {state === 'running' && <>Intent is broadcast and the clock is running. Wait it out, or veto.</>}
+            {state === 'executed' && <>Window elapsed with no veto. The verifier accepts the execute credential.</>}
+            {state === 'blocked' && <>The controller signed a veto bound to this intent. Every verifier now rejects the execute.</>}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-3 mt-5">
+          <button className="btn-primary" onClick={commit} disabled={state === 'running'}>Commit intent</button>
+          <button className="demo-btn" onClick={force} disabled={state !== 'running'}>Force execute now</button>
+          <button className="demo-btn demo-veto" onClick={veto} disabled={state !== 'running'}>Veto</button>
+          <button className="demo-btn ml-auto" onClick={reset}>Reset</button>
+        </div>
+      </div>
+      <div>
+        <div className="eyebrow-faint mb-2">Signed action ledger</div>
+        <div className="demo-ledger">
+          {log.length === 0 ? <div className="k">— idle —</div> : log.map((l, i) => <div key={i} className="demo-line">{l}</div>)}
+        </div>
+      </div>
+      {toast && <div className="demo-toast">{toast}</div>}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Section III — The Envelope (vouch.caveats)                          */
+/* ------------------------------------------------------------------ */
+
+function Envelope() {
+  const [amount, setAmount] = useState(120);
+  const [hour, setHour] = useState(11);
+  const [shipped, setShipped] = useState(true);
+  const [drop, setDrop] = useState(false);
+
+  let deny: string | null = null;
+  let reason = '';
+  if (drop) { deny = 'root'; reason = 'unrooted_capability'; }
+  else if (!shipped) { deny = 'shipped'; reason = 'caveat_denied:shipped-only'; }
+  else if (amount > 200) { deny = 'ceiling'; reason = 'caveat_denied:amount≤200'; }
+  else if (!(hour >= 9 && hour < 17)) { deny = 'hours'; reason = 'caveat_denied:business-hours'; }
+  const allow = deny === null;
+
+  const chip = (key: string, label: string) => {
+    const blocked = deny === key;
+    const dropped = drop && key === 'shipped';
+    return (
+      <span className={`demo-cav${blocked ? ' blocked' : ''}${dropped ? ' dropped' : ''}`}>{label}</span>
+    );
+  };
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-stretch gap-0">
+        <div className="demo-hop">
+          <div className="eyebrow-faint">Root · grantor</div>
+          <div className="font-serif font-semibold text-[1.05rem] mt-1">CEO</div>
+          <div className="mt-2">{chip('shipped', 'shipped-only')}</div>
+        </div>
+        <div className="self-center font-mono text-ink-faint px-2">→</div>
+        <div className="demo-hop">
+          <div className="eyebrow-faint">delegate</div>
+          <div className="font-serif font-semibold text-[1.05rem] mt-1">Manager</div>
+          <div className="mt-2">{chip('ceiling', 'amount ≤ $200')}{chip('hours', 'business-hours')}</div>
+        </div>
+        <div className="self-center font-mono text-ink-faint px-2">→</div>
+        <div className="demo-hop">
+          <div className="eyebrow-faint">holder · acts</div>
+          <div className="font-serif font-semibold text-[1.05rem] mt-1">Refund Agent</div>
+          <div className="eyebrow-faint mt-3">issues a refund</div>
+        </div>
+      </div>
+
+      <div className="grid gap-4 mt-7 max-w-prose-wide">
+        <label className="demo-ctl">
+          <span>refund amount</span>
+          <input type="range" min={0} max={600} step={10} value={amount} onChange={(e) => setAmount(+e.target.value)} />
+          <output>${amount}</output>
+        </label>
+        <label className="demo-ctl">
+          <span>time of day</span>
+          <input type="range" min={0} max={23} step={1} value={hour} onChange={(e) => setHour(+e.target.value)} />
+          <output>{String(hour).padStart(2, '0')}:00</output>
+        </label>
+        <div className="flex flex-wrap gap-x-8 gap-y-2">
+          <label className="demo-switch"><input type="checkbox" checked={shipped} onChange={(e) => setShipped(e.target.checked)} /> order has shipped</label>
+          <label className="demo-switch"><input type="checkbox" checked={drop} onChange={(e) => setDrop(e.target.checked)} /> agent hides the CEO&apos;s rule</label>
+        </div>
+      </div>
+
+      <div className="demo-verdict mt-6" style={{ borderColor: allow ? ALLOW : DENY }}>
+        <span className="demo-badge" style={{ color: allow ? ALLOW : DENY, borderColor: allow ? ALLOW : DENY }}>
+          {allow ? 'ALLOW' : 'DENY'}
+        </span>
+        <span className="font-mono text-[0.85rem] text-ink-soft">
+          {allow ? 'All three accumulated caveats pass. Verified offline, no policy server.'
+            : deny === 'root' ? <>Chain no longer roots at the CEO → <b className="text-ink">{reason}</b>. You can&apos;t shed an ancestor&apos;s caveat by hiding a hop.</>
+            : <>Blocked by a caveat from {deny === 'shipped' ? 'the CEO, two hops up' : 'the Manager'} → <b className="text-ink">{reason}</b></>}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Section I — Reasoned Action (vouch.reasoning)                       */
+/* ------------------------------------------------------------------ */
+
+function ReasonedAction() {
+  const [mode, setMode] = useState<'honest' | 'fabricate' | 'rewrite'>('honest');
+  const verdicts = {
+    honest: { ok: true, reason: 'every reason resolves and hashes match', label: 'ACCEPTED' },
+    fabricate: { ok: false, reason: 'evidence_unresolved · "the CFO approved by phone" resolves to nothing', label: 'REJECTED' },
+    rewrite: { ok: false, reason: 'justification_digest_mismatch · rewritten after the escrow commit', label: 'REJECTED' },
+  } as const;
+  const v = verdicts[mode];
+  return (
+    <div className="grid md:grid-cols-2 gap-8 items-start">
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          Before acting, the agent states <em>why</em>, ties each reason to a real artifact by its hash, and escrows the
+          justification <b className="text-ink">before</b> it executes. An auditor can then prove the reasoning was neither
+          fabricated nor rewritten after the fact.
+        </p>
+        <div className="eyebrow-faint mb-2">Try it as the agent</div>
+        <div className="flex flex-col gap-2">
+          <button className={`demo-radio${mode === 'honest' ? ' on' : ''}`} onClick={() => setMode('honest')}>Cite the real user request + delegation</button>
+          <button className={`demo-radio${mode === 'fabricate' ? ' on' : ''}`} onClick={() => setMode('fabricate')}>Fabricate a reason (&ldquo;the CFO approved by phone&rdquo;)</button>
+          <button className={`demo-radio${mode === 'rewrite' ? ' on' : ''}`} onClick={() => setMode('rewrite')}>Rewrite the justification after acting</button>
+        </div>
+      </div>
+      <div>
+        <div className="demo-ledger" style={{ minHeight: '150px' }}>
+          <div className="demo-line"><span className="k">intent</span> delete · /tmp/cache/*</div>
+          <div className="demo-line"><span className="k">reason</span> {mode === 'fabricate' ? 'CFO approved by phone → call:none' : mode === 'rewrite' ? 'user asked → (digest changed)' : 'user asked to clean /tmp → msg:c-42'}</div>
+          <div className="demo-line"><span className="k">escrowed</span> before execution ✓</div>
+        </div>
+        <div className="demo-verdict mt-4" style={{ borderColor: v.ok ? ALLOW : DENY }}>
+          <span className="demo-badge" style={{ color: v.ok ? ALLOW : DENY, borderColor: v.ok ? ALLOW : DENY }}>{v.label}</span>
+          <span className="font-mono text-[0.85rem] text-ink-soft">{v.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+
+export default function DemosClient() {
+  return (
+    <>
+      <section id="reasoned-action" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ I</span>
+            <h2>Reasoned action</h2>
+          </div>
+          <p className="eyebrow mb-6">Every action states why — and can&apos;t lie about it · vouch.reasoning</p>
+          <ReasonedAction />
+        </div>
+      </section>
+
+      <section id="deliberation" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ II</span>
+            <h2>The deliberation</h2>
+          </div>
+          <p className="eyebrow mb-6">Irreversible actions wait, and you can veto · vouch.deliberation</p>
+          <Deliberation />
+        </div>
+      </section>
+
+      <section id="caveats" className="scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ III</span>
+            <h2>The envelope</h2>
+          </div>
+          <p className="eyebrow mb-6">A rule the CEO sets binds an agent two hops down · vouch.caveats</p>
+          <Envelope />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/website/src/app/demos/page.tsx
+++ b/website/src/app/demos/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from 'next';
+import DemosClient from './DemosClient';
+
+export const metadata: Metadata = {
+  title: 'Interactive demos',
+  description:
+    'See Vouch Protocol’s accountable-autonomy controls run in the browser: an agent that must state why before it acts, an irreversible action you can veto during a live challenge window, and a delegation chain whose caveats block an out-of-envelope action two hops down.',
+};
+
+export default function DemosPage() {
+  return (
+    <>
+      <section className="border-b border-rule">
+        <div className="container-wide py-16 md:py-20">
+          <div className="eyebrow mb-5">Support · Interactive demos</div>
+          <h1 className="font-serif font-semibold text-ink leading-[1.1] tracking-tight mb-5 text-[clamp(2rem,4.2vw,3rem)]">
+            Watch an agent get stopped.
+          </h1>
+          <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-prose">
+            You can&apos;t read an AI agent&apos;s mind, and you can&apos;t pre-approve every action it invents. So Vouch does
+            what every institution has always done with authorized actors: it makes each action state its reason, slows
+            down the irreversible ones, and keeps a veto. All three run below, on real credential shapes.
+          </p>
+          <p className="footnote mt-5">
+            Every verdict here mirrors the shipped SDK modules
+            {' '}<code className="font-mono text-[0.85em]">vouch.reasoning</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.deliberation</code>, and
+            {' '}<code className="font-mono text-[0.85em]">vouch.caveats</code>. Disclosed as PAD-085 and PAD-086.
+          </p>
+        </div>
+      </section>
+
+      <DemosClient />
+
+      <section>
+        <div className="container-wide py-16">
+          <div className="border-l-2 border-burgundy bg-burgundy/[0.03] px-5 py-4 max-w-prose-wide">
+            <p className="text-ink-soft text-[0.95rem] leading-relaxed">
+              <strong className="text-ink">Run it yourself.</strong> Each demo maps to a runnable example in the repo:
+              {' '}<code className="font-mono text-[0.85em]">examples/reasoned_action_demo.py</code>,
+              {' '}<code className="font-mono text-[0.85em]">examples/deliberation_demo.py</code>, and
+              {' '}<code className="font-mono text-[0.85em]">examples/caveats_demo.py</code>. See the{' '}
+              <a href="/help/" className="prose-link">guides</a> for the full walkthrough.
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -155,7 +155,10 @@ The credential format for these renewals ships today (it is called SessionVouche
         q: 'What is a delegation chain?',
         a: `A chain of permission slips that tracks "who let whom do what." Imagine you tell your assistant "please book my flight." Your assistant tells an AI travel agent "please find flights." The travel agent tells a payment agent "please charge this card." Three steps, three permission grants.
 
-A Vouch delegation chain captures all three steps cryptographically. Each step narrows the permission (the travel agent can find flights but not, say, sell your house). At the end, anyone looking at the action can walk the chain backward to the human who started it. "The AI did it" becomes "Person X delegated to assistant Y who delegated to agent Z, and here is each signed step." Real accountability.`,
+A Vouch delegation chain captures all three steps cryptographically. Each step narrows the permission (the travel agent can find flights but not, say, sell your house). At the end, anyone looking at the action can walk the chain backward to the human who started it. "The AI did it" becomes "Person X delegated to assistant Y who delegated to agent Z, and here is each signed step." Real accountability.
+
+Beyond narrowing static fields, a link can carry executable caveats: live conditions ("only for shipped orders", "under the customer's lifetime spend", "business hours only") that accumulate down the chain and that no downstream holder can drop. Try it in the interactive demo, where a rule the CEO sets still blocks an agent two hops away.`,
+        helpLinks: [{ label: 'See it: the delegation-envelope demo', href: '/demos/#caveats' }],
       },
       {
         q: 'Can Vouch prove an agent has a track record it cannot fake?',

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -298,3 +298,63 @@
   nav, footer { display: none; }
   pre, code { background: #f5f5f5 !important; color: black !important; }
 }
+
+/* ------------------------------------------------------------------ */
+/* Interactive demos (/demos). Namespaced `demo-*`, built on the theme */
+/* tokens so they adapt to light and dark automatically.               */
+/* ------------------------------------------------------------------ */
+.demo-ring{ --p:0; width:132px; height:132px; border-radius:50%; display:grid; place-items:center;
+  position:relative; background:conic-gradient(var(--arc) calc(var(--p)*1%), rgb(var(--color-parchment-deep)) 0); }
+.demo-ring-face{ position:relative; z-index:1; width:104px; height:104px; border-radius:50%;
+  background:rgb(var(--color-parchment)); display:flex; flex-direction:column; align-items:center; justify-content:center; }
+.demo-stamp{ font-family:var(--font-mono,"JetBrains Mono",monospace); font-weight:700; letter-spacing:.04em;
+  font-size:1.7rem; padding:.5rem 1.1rem; border:2px solid; border-radius:2px; transform:rotate(-3deg); }
+
+.demo-ledger{ font-family:"JetBrains Mono",ui-monospace,monospace; font-size:.78rem; line-height:1.5;
+  background:rgb(var(--color-code-bg)); color:rgb(var(--color-code-fg)); border:1px solid rgb(var(--color-code-bg));
+  padding:.9rem 1rem; min-height:230px; max-height:260px; overflow:auto; }
+.demo-line{ padding:.18rem 0; border-bottom:1px solid rgb(var(--color-code-fg) / .12); }
+.demo-line:last-child{ border-bottom:0; }
+.demo-ledger .k{ color:rgb(var(--color-code-fg) / .5); }
+
+.demo-btn,.demo-chip{ font-family:"JetBrains Mono",monospace; font-size:.72rem; letter-spacing:.1em; text-transform:uppercase;
+  border:1px solid rgb(var(--color-ink-faint)); background:transparent; color:rgb(var(--color-ink)); padding:.7rem 1.1rem;
+  cursor:pointer; transition:.15s; }
+.demo-chip{ padding:.45rem .8rem; font-size:.66rem; }
+.demo-btn:hover,.demo-chip:hover{ border-color:rgb(var(--color-burgundy)); color:rgb(var(--color-burgundy)); }
+.demo-btn:disabled{ opacity:.38; cursor:not-allowed; }
+.demo-veto{ border-color:rgb(var(--color-burgundy) / .55); color:rgb(var(--color-burgundy)); }
+.demo-veto:hover{ background:rgb(var(--color-burgundy) / .08); }
+.demo-btn:focus-visible,.demo-chip:focus-visible,.demo-radio:focus-visible{ outline:2px solid rgb(var(--color-burgundy)); outline-offset:2px; }
+
+.demo-hop{ flex:1; min-width:150px; border:1px solid rgb(var(--color-rule)); background:rgb(var(--color-parchment-warm)); padding:.9rem 1rem; }
+.demo-cav{ display:inline-block; font-family:"JetBrains Mono",monospace; font-size:.68rem; padding:.25rem .6rem;
+  border:1px solid rgb(var(--color-burgundy) / .5); color:rgb(var(--color-burgundy)); background:rgb(var(--color-burgundy) / .06);
+  border-radius:999px; margin:.35rem .35rem 0 0; }
+.demo-cav.blocked{ background:rgb(var(--color-burgundy) / .16); box-shadow:0 0 0 3px rgb(var(--color-burgundy) / .12); font-weight:600; }
+.demo-cav.dropped{ opacity:.4; text-decoration:line-through; border-style:dashed; }
+
+.demo-ctl{ display:grid; grid-template-columns:120px 1fr 74px; align-items:center; gap:.9rem; }
+.demo-ctl span{ font-family:"JetBrains Mono",monospace; font-size:.72rem; color:rgb(var(--color-ink-soft)); }
+.demo-ctl output{ font-family:"JetBrains Mono",monospace; font-size:.85rem; color:rgb(var(--color-burgundy)); text-align:right; font-variant-numeric:tabular-nums; }
+.demo-ctl input[type=range]{ width:100%; accent-color:rgb(var(--color-burgundy)); }
+.demo-switch{ display:inline-flex; align-items:center; gap:.5rem; font-family:"JetBrains Mono",monospace; font-size:.72rem;
+  color:rgb(var(--color-ink-soft)); cursor:pointer; }
+.demo-switch input{ accent-color:rgb(var(--color-burgundy)); width:15px; height:15px; }
+
+.demo-verdict{ display:flex; align-items:center; gap:.9rem; padding:1rem 1.1rem; border:1px solid rgb(var(--color-rule));
+  background:rgb(var(--color-parchment-warm)); }
+.demo-badge{ font-family:"JetBrains Mono",monospace; font-weight:700; font-size:.82rem; letter-spacing:.06em;
+  padding:.4rem .75rem; border:1px solid; white-space:nowrap; }
+
+.demo-radio{ text-align:left; font-family:"JetBrains Mono",monospace; font-size:.75rem; border:1px solid rgb(var(--color-rule));
+  background:transparent; color:rgb(var(--color-ink-soft)); padding:.65rem .85rem; cursor:pointer; transition:.15s; }
+.demo-radio:hover{ border-color:rgb(var(--color-burgundy) / .5); }
+.demo-radio.on{ border-color:rgb(var(--color-burgundy)); color:rgb(var(--color-ink)); background:rgb(var(--color-burgundy) / .06); }
+
+.demo-toast{ position:fixed; left:50%; bottom:1.5rem; transform:translateX(-50%); z-index:60;
+  font-family:"JetBrains Mono",monospace; font-size:.78rem; background:rgb(var(--color-code-bg)); color:rgb(var(--color-parchment));
+  border:1px solid rgb(var(--color-burgundy)); padding:.65rem 1rem; }
+
+@media (max-width:640px){ .demo-ctl{ grid-template-columns:96px 1fr 60px; } }
+@media (prefers-reduced-motion:reduce){ .demo-stamp{ transform:none; } }

--- a/website/src/app/support/page.tsx
+++ b/website/src/app/support/page.tsx
@@ -36,6 +36,12 @@ const PRIMARY: Channel[] = [
     body: 'Long-form guides for quickstarts, deployment, cross-language verification, robotics, and integrations, each with runnable code.',
     cta: { label: 'Open the guides', href: '/help/' },
   },
+  {
+    eyebrow: 'For seeing it work',
+    title: 'Interactive demos',
+    body: 'Run the accountable-autonomy controls in your browser: an agent that must state why before it acts, an irreversible action you can veto during a live challenge window, and a delegation chain whose caveats block an out-of-envelope action two hops down.',
+    cta: { label: 'Open the demos', href: '/demos/' },
+  },
 ];
 
 // The other channels, in order. The standards mailing list comes last.
@@ -122,7 +128,7 @@ export default function SupportPage() {
             <span className="num">§ I</span>
             <h2>Start here</h2>
           </div>
-          <div className="grid md:grid-cols-3 gap-10">
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-10">
             {PRIMARY.map((channel) => (
               <ChannelCard key={channel.title} channel={channel} />
             ))}

--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -16,6 +16,7 @@ const LINKS = [
 
 // Secondary destinations, folded into a "More" dropdown so the nav centre stays lean.
 const MORE = [
+    { href: '/demos/', label: 'Demos' },
     { href: '/blog/', label: 'Blog' },
     { href: '/agent-trust-index/', label: 'Index' },
     { href: '/conformance/', label: 'Conformance' },


### PR DESCRIPTION
Adds a `/demos` page under Support that runs the three accountable-autonomy controls live in the browser, styled entirely in the site's parchment, burgundy, and serif system (light and dark), on real credential shapes:

- **Reasoned action** (`vouch.reasoning`) — the agent states why before acting; a fabricated reason or a post-hoc rewrite is rejected.
- **The deliberation** (`vouch.deliberation`) — an irreversible wire runs a challenge window you can veto. Force-executing early is rejected (`challenge_window_not_elapsed`), a veto blocks it (`vetoed`), and a clean window executes.
- **The envelope** (`vouch.caveats`) — a CEO → Manager → Agent chain whose accumulated caveats allow or deny a refund. The CEO's rule binds the agent two hops down, and hiding a hop lands on `unrooted_capability`.

Wires the page into the Support "Start here" grid and the More nav menu, and deep-links the delegation-chain FAQ answer to the envelope demo. Each demo maps to a runnable example in the repo (`examples/reasoned_action_demo.py`, `examples/deliberation_demo.py`, `examples/caveats_demo.py`).
