### PR TITLE
ci: keep the welcome workflow on first-interaction v1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,9 @@ updates:
       - "github-actions"
     commit-message:
       prefix: "ci"
+    ignore:
+      # first-interaction v2+ renamed its inputs (repo_token/issue_message/
+      # pr_message) and breaks the welcome workflow, which pins v1 on purpose.
+      # Stay on v1 until the workflow is migrated to the newer input names.
+      - dependency-name: "actions/first-interaction"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
Dependabot keeps bumping `actions/first-interaction` from v1 to v3, and v3 renamed its inputs, so the welcome greeter fails on every new PR. This tells Dependabot to ignore major-version bumps for that action so it stays on v1, where the workflow inputs are correct.
