### PR TITLE
feat: LangGraph and Goose integrations, plus the A2A package

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,10 @@ Vouch is not one tool, it is a set of them. Here is the whole map.
 ### Framework integrations (new in v1.6.2)
 Standalone packages that drop Vouch into the agent framework you already use. Each one issues a verifiable credential for a tool call, with optional delegation back to a human principal.
 - **`vouch-langchain`** a LangChain tool that signs each tool call before it leaves the agent.
+- **`vouch-langgraph`** signs LangGraph tool calls and graph nodes, so a signed trail runs across the whole graph.
 - **`vouch-crewai`** a CrewAI tool, with supervisor-to-worker delegation that can only narrow authority, never widen it.
 - **`vouch-a2a`** binds an A2A (Agent2Agent) Agent Card to a Vouch identity, so two agents can verify each other before they collaborate.
+- **`vouch-goose`** registers the Vouch MCP server as an extension for Block's Goose agent, so a Goose session can sign and verify out of the box.
 - **`vouch-mlflow`** signs an MLflow model artifact at registration time, bound to a content digest so any change to the weights breaks the signature.
 - **`vouch-safetensors`** embeds a credential in a `.safetensors` header, complementary to OpenSSF Model Signing, so a model carries who produced it.
 

--- a/packages/vouch-a2a/README.md
+++ b/packages/vouch-a2a/README.md
@@ -1,0 +1,55 @@
+# vouch-a2a
+
+Bind [A2A](https://a2a-protocol.org/) (Agent2Agent) Agent Cards to a
+[Vouch](https://vouch-protocol.com) identity, so two agents can establish trust
+before they collaborate.
+
+A2A standardized how agents discover and talk to each other through Agent Cards.
+It does not, by itself, prove who stands behind an agent. `vouch-a2a` attaches a
+W3C Verifiable Credential (`eddsa-jcs-2022` Data Integrity proof) to the card,
+optionally with a delegation chain back to the human or org that operates the
+agent. A verifier can then refuse an unsigned or impostor peer.
+
+## Install
+
+```bash
+pip install vouch-a2a
+```
+
+## Sign an Agent Card
+
+```python
+from vouch import Signer
+from vouch_a2a import sign_agent_card
+
+signer = Signer(private_key=PRIV_JWK, did="did:web:agents.acme.com")
+
+card = {
+    "name": "BillingAgent",
+    "url": "https://agents.acme.com/billing",
+    "version": "1.0.0",
+    "capabilities": {"streaming": True},
+    "skills": [{"id": "invoice", "name": "Create invoice"}],
+}
+
+signed_card = sign_agent_card(signer, card)          # adds a 'vouchCredential' field
+# Optionally bind to an org principal:
+# signed_card = sign_agent_card(signer, card, parent_credential=org_principal_cred)
+```
+
+## Verify a peer's card
+
+```python
+from vouch_a2a import verify_agent_card
+
+ok, passport = verify_agent_card(peer_card, public_key=peer_pubkey)
+if not ok:
+    raise PermissionError("Refusing to collaborate with an unverified agent")
+```
+
+The credential binds to the card's `url` (the stable agent identity). The input
+card is never mutated; `sign_agent_card` returns a copy.
+
+## License
+
+Apache-2.0.

--- a/packages/vouch-a2a/VERIFY.md
+++ b/packages/vouch-a2a/VERIFY.md
@@ -1,0 +1,45 @@
+# vouch-a2a: your verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-a2a-test && source /tmp/vouch-a2a-test/bin/activate
+pip install -e packages/vouch-a2a   # pulls vouch-protocol
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-a2a/tests -q
+```
+
+Expect: 4 passed. They check exports, sign-and-verify of an Agent Card, that an
+unsigned card fails closed, and that a delegation chain on a card verifies.
+
+## 3. Real A2A card (recommended)
+
+Take an actual Agent Card from your A2A deployment, sign it with
+`sign_agent_card`, serve it, and confirm a peer using `verify_agent_card`
+accepts it and rejects a tampered or unsigned one.
+
+## 4. Build
+
+```bash
+pip install build && python -m build packages/vouch-a2a
+unzip -l packages/vouch-a2a/dist/*.whl   # confirm only vouch_a2a is packaged
+```
+
+## 5. Only after the above
+
+- [ ] Publish to PyPI under your account.
+- [ ] Open a proposal/issue on `a2aproject/A2A` for an optional signed-identity
+      extension on Agent Cards, citing this package as the reference.
+- [ ] List the agent in the A2A directory once signed.
+
+Design note: v0.1 binds the credential to the card's `url` (stable agent
+identity), not a hash of the full card, so routine capability/skill updates do
+not invalidate it. If you want tamper-evidence of the whole card, we can add an
+optional content-digest binding in a later version.

--- a/packages/vouch-a2a/pyproject.toml
+++ b/packages/vouch-a2a/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-a2a"
+version = "0.1.0"
+description = "Bind A2A (Agent2Agent) Agent Cards to a Vouch identity for verifiable agent-to-agent trust."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["a2a", "agent2agent", "vouch", "ai-agents", "verifiable-credentials", "identity"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Security :: Cryptography",
+]
+dependencies = ["vouch-protocol>=1.6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-a2a/src/vouch_a2a/__init__.py
+++ b/packages/vouch-a2a/src/vouch_a2a/__init__.py
@@ -1,0 +1,11 @@
+"""vouch-a2a: bind A2A Agent Cards to a Vouch identity.
+
+Thin distribution wrapping vouch.integrations.a2a. It exists so the A2A binding
+can be installed and listed on its own while the implementation stays
+single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.a2a import VOUCH_CARD_FIELD, sign_agent_card, verify_agent_card
+
+__all__ = ["sign_agent_card", "verify_agent_card", "VOUCH_CARD_FIELD"]
+__version__ = "0.1.0"

--- a/packages/vouch-a2a/tests/test_smoke.py
+++ b/packages/vouch-a2a/tests/test_smoke.py
@@ -1,0 +1,69 @@
+"""Smoke tests for the vouch-a2a package."""
+
+import os
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwcrypto.common import base64url_decode
+import json
+
+from vouch import Signer, generate_identity
+
+
+def _pub(kp):
+    return Ed25519PublicKey.from_public_bytes(base64url_decode(json.loads(kp.public_key_jwk)["x"]))
+
+
+def test_package_exports():
+    import vouch_a2a
+
+    assert vouch_a2a.sign_agent_card is not None
+    assert vouch_a2a.verify_agent_card is not None
+
+
+def test_sign_and_verify_card():
+    from vouch_a2a import sign_agent_card, verify_agent_card, VOUCH_CARD_FIELD
+
+    kp = generate_identity()
+    signer = Signer(private_key=kp.private_key_jwk, did="did:web:agents.acme.com")
+
+    card = {"name": "BillingAgent", "url": "https://agents.acme.com/billing", "version": "1.0.0"}
+    signed = sign_agent_card(signer, card)
+
+    # input not mutated, credential added on the copy
+    assert VOUCH_CARD_FIELD not in card
+    assert VOUCH_CARD_FIELD in signed
+    assert signed[VOUCH_CARD_FIELD]["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+    ok, passport = verify_agent_card(signed, public_key=_pub(kp))
+    assert ok is True
+
+
+def test_unsigned_card_fails_closed():
+    from vouch_a2a import verify_agent_card
+
+    ok, passport = verify_agent_card({"name": "NoCred"}, public_key=None)
+    assert ok is False
+    assert passport is None
+
+
+def test_delegation_chain_on_card():
+    from vouch_a2a import sign_agent_card, verify_agent_card
+
+    org_kp = generate_identity()
+    agent_kp = generate_identity()
+    org = Signer(private_key=org_kp.private_key_jwk, did="did:web:acme.com")
+    agent = Signer(private_key=agent_kp.private_key_jwk, did="did:web:agents.acme.com")
+
+    # org issues a broad operate authority; agent narrows it onto its own card
+    parent = org.sign(
+        intent={
+            "action": "operate",
+            "target": "https://agents.acme.com",
+            "resource": "a2a:agent-card",
+        }
+    )
+    card = {"name": "BillingAgent", "url": "https://agents.acme.com/billing"}
+    signed = sign_agent_card(agent, card, parent_credential=parent)
+
+    ok, _ = verify_agent_card(signed, public_key=_pub(agent_kp))
+    assert ok is True

--- a/packages/vouch-goose/README.md
+++ b/packages/vouch-goose/README.md
@@ -1,0 +1,56 @@
+# vouch-goose
+
+Make Block's [Goose](https://github.com/block/goose) agent Vouch-aware. Goose
+runs its tools from MCP servers registered as extensions, and Vouch ships an MCP
+server (`vouch-mcp`), so this package registers that server as a Goose extension.
+Then any Goose session can create an identity, sign and verify credentials, scan
+for leaked keys, and decode DIDs.
+
+## Install
+
+```bash
+pip install vouch-goose      # pulls vouch-mcp
+```
+
+## One command to wire it in
+
+```bash
+vouch-goose
+```
+
+This adds a `vouch` extension to `~/.config/goose/config.yaml`, creating the file
+if needed and leaving your other extensions untouched. Start Goose and the Vouch
+tools are available.
+
+Options:
+
+```bash
+vouch-goose --config /path/to/config.yaml   # a non-default Goose config
+vouch-goose --name my-vouch                 # a different extension name
+vouch-goose --keep-existing                 # do not overwrite an existing entry
+```
+
+## Or wire it in from Python
+
+```python
+from vouch.integrations.goose import install, extension_config
+
+install()                 # writes the extension into the Goose config
+extension_config()        # the config entry, if you would rather merge it yourself
+```
+
+## What it writes
+
+```yaml
+extensions:
+  vouch:
+    enabled: true
+    type: stdio
+    cmd: vouch-mcp
+    args: []
+    timeout: 300
+```
+
+## License
+
+Apache-2.0. Part of the [Vouch Protocol](https://github.com/vouch-protocol/vouch).

--- a/packages/vouch-goose/VERIFY.md
+++ b/packages/vouch-goose/VERIFY.md
@@ -1,0 +1,37 @@
+# vouch-goose: verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-goose-test && source /tmp/vouch-goose-test/bin/activate
+pip install -e packages/vouch-goose   # pulls vouch-protocol and vouch-mcp
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest pyyaml
+pytest packages/vouch-goose/tests -q
+```
+
+Expect: 5 passed. They check exports, the extension config shape, that install
+creates the file and registers the extension, that it preserves existing config,
+and that `--keep-existing` leaves an existing entry intact.
+
+## 3. Real Goose (recommended)
+
+```bash
+vouch-goose
+```
+
+Confirm a `vouch` extension appears under `extensions:` in
+`~/.config/goose/config.yaml`, then start Goose and check the Vouch tools are
+listed and callable.
+
+## 4. Build
+
+```bash
+python -m build packages/vouch-goose
+```

--- a/packages/vouch-goose/pyproject.toml
+++ b/packages/vouch-goose/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-goose"
+version = "0.1.0"
+description = "Register the vouch-mcp server as an extension for Block's Goose agent."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["goose", "block", "mcp", "vouch", "ai-agents", "verifiable-credentials", "identity"]
+dependencies = ["vouch-protocol[goose]>=1.6.0", "vouch-mcp>=1.6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.scripts]
+vouch-goose = "vouch.integrations.goose:_main"
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-goose/src/vouch_goose/__init__.py
+++ b/packages/vouch-goose/src/vouch_goose/__init__.py
@@ -1,0 +1,17 @@
+"""vouch-goose: make Block's Goose agent Vouch-aware.
+
+Thin distribution wrapping ``vouch.integrations.goose``. It registers the
+vouch-mcp server as a Goose extension so Goose can create identities, sign, and
+verify through the same MCP tools every other client uses. The implementation
+stays single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.goose import (
+    EXTENSION_NAME,
+    extension_config,
+    goose_config_path,
+    install,
+)
+
+__all__ = ["install", "extension_config", "goose_config_path", "EXTENSION_NAME"]
+__version__ = "0.1.0"

--- a/packages/vouch-goose/tests/test_smoke.py
+++ b/packages/vouch-goose/tests/test_smoke.py
@@ -1,0 +1,68 @@
+"""Smoke tests for the vouch-goose package."""
+
+import pytest
+
+
+def test_package_exports():
+    import vouch_goose
+
+    assert vouch_goose.install is not None
+    assert vouch_goose.extension_config is not None
+    assert vouch_goose.goose_config_path is not None
+
+
+def test_extension_config_shape():
+    from vouch_goose import extension_config
+
+    cfg = extension_config()
+
+    assert cfg["type"] == "stdio"
+    assert cfg["cmd"] == "vouch-mcp"
+    assert cfg["enabled"] is True
+    assert cfg["args"] == []
+    assert cfg["timeout"] == 300
+
+
+def test_install_creates_file_and_registers(tmp_path):
+    pytest.importorskip("yaml")
+    import yaml
+
+    from vouch_goose import install
+
+    cfg = tmp_path / "sub" / "config.yaml"
+    path = install(config_path=cfg)
+
+    assert path.exists()
+    data = yaml.safe_load(path.read_text())
+    assert data["extensions"]["vouch"]["type"] == "stdio"
+    assert data["extensions"]["vouch"]["cmd"] == "vouch-mcp"
+
+
+def test_install_preserves_existing(tmp_path):
+    pytest.importorskip("yaml")
+    import yaml
+
+    from vouch_goose import install
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("GOOSE_MODEL: gpt\nextensions:\n  other:\n    type: stdio\n    cmd: foo\n")
+    install(config_path=cfg)
+
+    data = yaml.safe_load(cfg.read_text())
+    assert data["extensions"]["vouch"]["cmd"] == "vouch-mcp"
+    assert data["extensions"]["other"]["cmd"] == "foo"  # preserved
+    assert data["GOOSE_MODEL"] == "gpt"  # preserved
+
+
+def test_install_keep_existing(tmp_path):
+    pytest.importorskip("yaml")
+    import yaml
+
+    from vouch_goose import install
+
+    cfg = tmp_path / "config.yaml"
+    cfg.write_text("extensions:\n  vouch:\n    type: stdio\n    cmd: custom-vouch-mcp\n")
+    install(config_path=cfg, overwrite=False)
+
+    data = yaml.safe_load(cfg.read_text())
+    assert data["extensions"]["vouch"]["cmd"] == "custom-vouch-mcp"  # left intact

--- a/packages/vouch-langgraph/README.md
+++ b/packages/vouch-langgraph/README.md
@@ -1,0 +1,53 @@
+# vouch-langgraph
+
+Sign every LangGraph tool call and graph node with a Vouch Credential, so an
+agent's actions carry a verifiable record of who ran them and on whose authority.
+
+LangGraph tools are LangChain tools, so tool-level signing is shared with the
+LangChain integration. On top of that, `sign_node` signs each node step, giving
+a signed trail across the whole graph.
+
+## Install
+
+```bash
+pip install vouch-langgraph
+```
+
+## Sign the tools
+
+```python
+from langgraph.prebuilt import create_react_agent
+from vouch.integrations.langgraph import protect
+
+agent = create_react_agent(llm, tools=protect([search, send_email]))
+```
+
+Every tool call is now signed in Python before it runs.
+
+## Sign each node
+
+```python
+from vouch.integrations.langgraph import sign_node
+
+@sign_node
+def plan(state):
+    ...
+
+@sign_node(action="charge_card")
+def bill(state):
+    ...
+```
+
+Each node step issues its own credential. Verify anywhere with
+`vouch.Verifier.verify_credential`, or read the latest with
+`vouch.autosign.current_credential`.
+
+## Identity
+
+`protect` and `sign_node` use the ambient Vouch identity, or a `signer=` you
+pass in. Provision one with `vouch init --yes`, or construct a `Signer`
+directly. See the [Vouch Protocol docs](https://vouch-protocol.com).
+
+## License
+
+Apache-2.0. Part of the [Vouch Protocol](https://github.com/vouch-protocol/vouch).

--- a/packages/vouch-langgraph/VERIFY.md
+++ b/packages/vouch-langgraph/VERIFY.md
@@ -1,0 +1,33 @@
+# vouch-langgraph: verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-langgraph-test && source /tmp/vouch-langgraph-test/bin/activate
+pip install -e packages/vouch-langgraph   # pulls vouch-protocol
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-langgraph/tests -q
+```
+
+Expect: 4 passed. They check exports, that a protected tool call is signed,
+that a signed node issues a credential, and that a bare node still runs when no
+identity is resolved.
+
+## 3. Real graph (recommended)
+
+Wrap the tools in an actual LangGraph agent with `protect([...])`, decorate a
+node with `@sign_node`, run the graph, and confirm `current_credential()`
+returns a credential that `Verifier.verify_credential` accepts.
+
+## 4. Build
+
+```bash
+python -m build packages/vouch-langgraph
+```

--- a/packages/vouch-langgraph/pyproject.toml
+++ b/packages/vouch-langgraph/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-langgraph"
+version = "0.1.0"
+description = "Sign LangGraph tool calls and graph nodes with Vouch Credentials."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["langgraph", "langchain", "vouch", "ai-agents", "verifiable-credentials", "identity"]
+dependencies = ["vouch-protocol[langgraph]>=1.6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-langgraph/src/vouch_langgraph/__init__.py
+++ b/packages/vouch-langgraph/src/vouch_langgraph/__init__.py
@@ -1,0 +1,11 @@
+"""vouch-langgraph: sign LangGraph tool calls and graph nodes with Vouch.
+
+Thin distribution wrapping ``vouch.integrations.langgraph``. It exists so the
+integration can be installed and listed on its own while the implementation
+stays single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.langgraph import protect, sign_node
+
+__all__ = ["protect", "sign_node"]
+__version__ = "0.1.0"

--- a/packages/vouch-langgraph/tests/test_smoke.py
+++ b/packages/vouch-langgraph/tests/test_smoke.py
@@ -1,0 +1,61 @@
+"""Smoke tests for the vouch-langgraph package."""
+
+from vouch import Signer, generate_identity
+from vouch.autosign import current_credential
+
+
+def _signer():
+    kp = generate_identity()
+    return Signer(private_key=kp.private_key_jwk, did="did:web:agent.example")
+
+
+def test_package_exports():
+    import vouch_langgraph
+
+    assert vouch_langgraph.protect is not None
+    assert vouch_langgraph.sign_node is not None
+
+
+def test_protect_signs_plain_callable():
+    from vouch_langgraph import protect
+
+    signer = _signer()
+
+    def search(q: str) -> str:
+        return f"results for {q}"
+
+    wrapped = protect([search], signer=signer)[0]
+    out = wrapped("hello")
+
+    assert out == "results for hello"
+    cred = current_credential()
+    assert cred is not None
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+
+def test_sign_node_signs_each_step():
+    from vouch_langgraph import sign_node
+
+    signer = _signer()
+
+    @sign_node(action="plan", signer=signer)
+    def plan(state: dict) -> dict:
+        return {**state, "planned": True}
+
+    result = plan({"x": 1})
+
+    assert result["planned"] is True
+    cred = current_credential()
+    assert cred is not None
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+
+def test_sign_node_bare_decorator_runs():
+    from vouch_langgraph import sign_node
+
+    @sign_node
+    def step(state: dict) -> dict:
+        return {**state, "seen": True}
+
+    # No signer resolved here, so the step runs unsigned but still returns.
+    assert step({"x": 1})["seen"] is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
 # Framework integrations
 langchain = ["langchain>=0.1.0"]
 crewai = ["crewai>=0.1.0"]
+langgraph = ["langgraph>=0.1.0"]
+goose = ["pyyaml>=6.0"]
 autogen = ["pyautogen>=0.2.0"]
 mcp = ["mcp>=0.1.0"]
 vertex = ["google-cloud-aiplatform>=1.0.0"]
@@ -107,7 +109,7 @@ dev = [
 
 # All optional dependencies
 all = [
-    "vouch-protocol[langchain,crewai,autogen,mcp,vertex,streamlit,server,enterprise,tracing,dev]"
+    "vouch-protocol[langchain,crewai,langgraph,goose,autogen,mcp,vertex,streamlit,server,enterprise,tracing,dev]"
 ]
 
 [project.urls]

--- a/vouch/integrations/a2a.py
+++ b/vouch/integrations/a2a.py
@@ -1,0 +1,81 @@
+"""
+Vouch Protocol A2A (Agent2Agent) Integration.
+
+Bind an A2A Agent Card to a Vouch identity so two agents can establish trust
+before they collaborate. The signed card carries a Vouch Credential
+(eddsa-jcs-2022 Data Integrity proof) that proves which principal operates the
+agent, optionally through a delegation chain to an accountable human or org.
+
+A2A standardized how agents discover and talk to each other via Agent Cards.
+It does not, on its own, prove who stands behind an agent. This module adds
+that proof as an optional, additive field on the card, so a verifier can refuse
+an unsigned or impostor peer.
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any, Dict, Optional, Tuple
+
+from vouch import Signer, Verifier
+
+# The additive field carrying the Vouch Credential on an Agent Card.
+VOUCH_CARD_FIELD = "vouchCredential"
+
+
+def sign_agent_card(
+    signer: Signer,
+    card: Dict[str, Any],
+    *,
+    parent_credential: Optional[Dict[str, Any]] = None,
+    hybrid: bool = False,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Return a copy of an A2A Agent Card with a Vouch Credential attached.
+
+    The credential binds to the card's ``url`` (the stable agent identity), and
+    when ``parent_credential`` is supplied, extends a delegation chain so the
+    agent's authority traces back to an accountable principal.
+
+    Args:
+        signer: The operating agent or principal's Signer.
+        card: An A2A Agent Card as a dict (name, url, version, capabilities, ...).
+        parent_credential: Optional parent credential to extend (delegation).
+        hybrid: Issue under the post-quantum hybrid profile when True.
+        valid_seconds: Optional validity window override.
+
+    Returns:
+        A new card dict with a ``vouchCredential`` field. The input is not mutated.
+    """
+    url = card.get("url") or card.get("name") or "a2a:agent"
+    intent = {"action": "operate", "target": url, "resource": "a2a:agent-card"}
+    issue = signer.sign_hybrid if hybrid else signer.sign
+    credential = issue(
+        intent=intent,
+        parent_credential=parent_credential,
+        valid_seconds=valid_seconds,
+    )
+    signed = copy.deepcopy(card)
+    signed[VOUCH_CARD_FIELD] = credential
+    return signed
+
+
+def verify_agent_card(
+    card: Dict[str, Any],
+    public_key: Optional[Any] = None,
+) -> Tuple[bool, Optional[Any]]:
+    """Verify the Vouch Credential embedded in an A2A Agent Card.
+
+    Args:
+        card: An Agent Card that may carry a ``vouchCredential`` field.
+        public_key: The operating agent's public key (Ed25519PublicKey or
+            Multikey string). If None, only structural and temporal checks run.
+
+    Returns:
+        An ``(is_valid, passport)`` tuple. Returns ``(False, None)`` when no
+        credential is present.
+    """
+    credential = card.get(VOUCH_CARD_FIELD)
+    if not credential:
+        return False, None
+    return Verifier.verify(credential, public_key=public_key)

--- a/vouch/integrations/goose.py
+++ b/vouch/integrations/goose.py
@@ -1,0 +1,132 @@
+"""
+Vouch Protocol Goose (Block) Integration.
+
+Goose is an MCP client: its tools come from MCP servers registered as
+"extensions" in ``~/.config/goose/config.yaml``. Vouch already ships an MCP
+server (the ``vouch-mcp`` package), so making Goose Vouch-aware means
+registering that server as a Goose extension. Then any Goose session can create
+an identity, sign and verify credentials, scan for leaked keys, and decode DIDs
+through the same tools every other MCP client uses.
+
+:func:`extension_config` returns the config entry, and :func:`install` merges it
+into the Goose config file, creating it if needed and leaving everything else
+untouched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+__all__ = ["EXTENSION_NAME", "goose_config_path", "extension_config", "install"]
+
+EXTENSION_NAME = "vouch"
+
+
+def goose_config_path() -> Path:
+    """Return the Goose config file path, honoring ``XDG_CONFIG_HOME``."""
+    base = os.environ.get("XDG_CONFIG_HOME")
+    root = Path(base) if base else Path.home() / ".config"
+    return root / "goose" / "config.yaml"
+
+
+def extension_config(
+    *,
+    cmd: str = "vouch-mcp",
+    args: Optional[List[str]] = None,
+    timeout: int = 300,
+) -> Dict[str, Any]:
+    """Return the Goose config entry that runs vouch-mcp as a stdio extension.
+
+    The shape matches Goose's stdio extension schema: ``enabled``, ``type``,
+    ``cmd``, ``args``, and ``timeout``.
+    """
+    return {
+        "enabled": True,
+        "type": "stdio",
+        "cmd": cmd,
+        "args": list(args or []),
+        "timeout": timeout,
+    }
+
+
+def install(
+    *,
+    name: str = EXTENSION_NAME,
+    config_path: Optional[Path] = None,
+    cmd: str = "vouch-mcp",
+    args: Optional[List[str]] = None,
+    timeout: int = 300,
+    overwrite: bool = True,
+) -> Path:
+    """Register vouch-mcp as a Goose extension in the Goose config file.
+
+    Merges an ``extensions.<name>`` entry into ``~/.config/goose/config.yaml``
+    (or ``config_path``), creating the file and parent directories if needed and
+    preserving any existing extensions and settings. Returns the path written.
+
+    Set ``overwrite=False`` to leave an existing entry of the same name intact.
+    """
+    yaml = _require_yaml()
+    path = Path(config_path) if config_path else goose_config_path()
+
+    data: Dict[str, Any] = {}
+    if path.exists():
+        loaded = yaml.safe_load(path.read_text()) or {}
+        if isinstance(loaded, dict):
+            data = loaded
+
+    extensions = data.get("extensions")
+    if not isinstance(extensions, dict):
+        extensions = {}
+    if name in extensions and not overwrite:
+        return path
+
+    extensions[name] = extension_config(cmd=cmd, args=args, timeout=timeout)
+    data["extensions"] = extensions
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(data, sort_keys=False))
+    return path
+
+
+def _require_yaml():
+    try:
+        import yaml  # type: ignore
+
+        return yaml
+    except ImportError as e:  # pragma: no cover - optional dep
+        raise RuntimeError(
+            "PyYAML is required to edit the Goose config. Install it with: pip install pyyaml"
+        ) from e
+
+
+def _main() -> int:
+    """Entry point for the ``vouch-goose`` command."""
+    parser = argparse.ArgumentParser(
+        prog="vouch-goose",
+        description="Register the vouch-mcp server as a Goose extension.",
+    )
+    parser.add_argument(
+        "--config", help="Path to the Goose config.yaml (default: ~/.config/goose/config.yaml)"
+    )
+    parser.add_argument("--name", default=EXTENSION_NAME, help="Extension name to use in Goose")
+    parser.add_argument("--cmd", default="vouch-mcp", help="Command Goose runs for the extension")
+    parser.add_argument(
+        "--keep-existing",
+        action="store_true",
+        help="Do not overwrite an existing entry of the same name",
+    )
+    ns = parser.parse_args()
+
+    path = install(
+        name=ns.name,
+        config_path=Path(ns.config) if ns.config else None,
+        cmd=ns.cmd,
+        overwrite=not ns.keep_existing,
+    )
+    print(f"Registered Goose extension '{ns.name}' (cmd: {ns.cmd}) in {path}")
+    print("Start Goose and the Vouch tools are available.")
+    return 0

--- a/vouch/integrations/langgraph.py
+++ b/vouch/integrations/langgraph.py
@@ -1,0 +1,87 @@
+"""
+Vouch Protocol LangGraph Integration.
+
+LangGraph builds agent workflows as graphs. The tool calls inside a graph run
+through the same LangChain tool objects, so tool-level signing is shared with
+the LangChain integration: wrap the tools you hand to a ToolNode or to
+``create_react_agent`` and every tool call is signed before it runs.
+
+On top of that, :func:`sign_node` wraps a graph node (a ``state -> state``
+callable) so each node step issues its own Vouch Credential, giving a signed
+trail across the whole graph rather than only at the leaf tools.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import Any, Callable, List, Optional, Sequence
+
+from vouch import Signer
+from vouch.autosign import sign_intent
+from vouch.integrations.langchain import protect as _protect_tools
+
+__all__ = ["protect", "sign_node"]
+
+
+def protect(
+    tools: Sequence[Any],
+    *,
+    signer: Optional[Signer] = None,
+    **signed_kwargs: Any,
+) -> List[Any]:
+    """Sign-wrap the tools handed to a ToolNode or ``create_react_agent``.
+
+    LangGraph tools are LangChain tools (or plain callables), so this delegates
+    to the LangChain integration. Every tool call is signed before it runs.
+
+    Example::
+
+        from langgraph.prebuilt import create_react_agent
+        from vouch.integrations.langgraph import protect
+
+        agent = create_react_agent(llm, tools=protect([search, send_email]))
+    """
+    return _protect_tools(tools, signer=signer, **signed_kwargs)
+
+
+def sign_node(
+    fn: Optional[Callable[..., Any]] = None,
+    *,
+    signer: Optional[Signer] = None,
+    action: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Wrap a LangGraph node so each execution issues a Vouch Credential.
+
+    Use as a decorator on a node callable (``state -> state``). The credential
+    records the node running, under the node's function name unless ``action``
+    is given. The node runs whether or not an identity is resolved; when none
+    is, signing is skipped and the step proceeds unsigned.
+
+    Example::
+
+        @sign_node
+        def plan(state): ...
+
+        @sign_node(action="charge_card")
+        def bill(state): ...
+    """
+
+    def decorate(func: Callable[..., Any]) -> Callable[..., Any]:
+        node_action = action or getattr(func, "__name__", "node")
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            sign_intent(
+                node_action,
+                target="langgraph:node",
+                resource="langgraph:node",
+                signer=signer,
+            )
+            return func(*args, **kwargs)
+
+        wrapper.__vouch_signed__ = True
+        return wrapper
+
+    if fn is not None:
+        return decorate(fn)
+    return decorate


### PR DESCRIPTION
Adds two new framework integrations and brings the A2A package to main. Each is a thin `packages/vouch-<name>` distribution over an implementation module in `vouch/integrations`, so the code stays single-sourced.

- **`vouch-langgraph`** signs LangGraph work. `protect([...])` wraps the tools handed to a `ToolNode` or `create_react_agent` (LangGraph tools are LangChain tools, so this reuses the shared signing core), and `@sign_node` signs each graph node, giving a signed trail across the whole graph.
- **`vouch-goose`** makes Block's Goose agent Vouch-aware. Goose loads its tools from MCP servers, and Vouch already ships one (`vouch-mcp`), so `vouch-goose` registers it as a Goose extension. One command, `vouch-goose`, writes the entry into `~/.config/goose/config.yaml`, creating the file if needed and leaving other extensions untouched.
- **`vouch-a2a`** signs and verifies A2A (Agent2Agent) Agent Cards, so two agents can check who stands behind each other before they collaborate, with optional delegation back to an accountable principal.

Also wires the `langgraph` and `goose` optional-dependency extras, adds the `vouch-goose` console script, and lists the new packages in the README. Each package carries its own smoke tests and a VERIFY checklist.
