### PR TITLE
Add interactive robotics demos for access, fusion, and wear

### DIFF
--- a/website/src/app/demos/robotics/RoboticsDemos.module.css
+++ b/website/src/app/demos/robotics/RoboticsDemos.module.css
@@ -1,0 +1,177 @@
+/*
+ * Component-scoped styles for the robotics interactive demos. Scoped as a CSS
+ * module so nothing here collides with the site-wide demo classes. Colors come
+ * from the shared theme variables, so this reads as part of the document on
+ * both light and dark themes.
+ */
+
+.demo {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 2rem;
+  align-items: start;
+}
+@media (min-width: 768px) {
+  .demo {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.radio {
+  text-align: left;
+  border: 1px solid rgb(var(--color-rule));
+  background: transparent;
+  color: rgb(var(--color-ink-soft));
+  padding: 0.6rem 0.85rem;
+  font-size: 0.92rem;
+  line-height: 1.35;
+  cursor: pointer;
+  transition: border-color 0.15s ease, background 0.15s ease, color 0.15s ease;
+}
+.radio:hover {
+  border-color: rgb(var(--color-burgundy));
+}
+.radio.on {
+  border-color: rgb(var(--color-burgundy));
+  background: rgba(var(--color-burgundy), 0.05);
+  color: rgb(var(--color-ink));
+}
+
+.stage {
+  border: 1px dashed rgb(var(--color-rule));
+  padding: 1.4rem;
+  min-height: 260px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.card {
+  border: 1px solid rgb(var(--color-rule));
+  padding: 0.75rem 0.9rem;
+  background: rgba(var(--color-parchment-deep), 0.35);
+}
+.cardLabel {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgb(var(--color-ink-faint));
+  margin-bottom: 0.3rem;
+}
+.mono {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.82rem;
+  color: rgb(var(--color-ink-soft));
+  word-break: break-word;
+}
+
+.verdict {
+  margin-top: auto;
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  border-top: 1px solid rgb(var(--color-rule));
+  padding-top: 0.9rem;
+}
+.badge {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.78rem;
+  font-weight: 600;
+  border: 1px solid;
+  padding: 0.2rem 0.55rem;
+  white-space: nowrap;
+}
+.reason {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.8rem;
+  color: rgb(var(--color-ink-soft));
+}
+
+/* Fusion: sensor frames flowing into a fused output. */
+.flow {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+.frame {
+  border: 1px solid rgb(var(--color-rule));
+  padding: 0.4rem 0.6rem;
+  font-size: 0.78rem;
+  color: rgb(var(--color-ink-soft));
+  transition: opacity 0.25s ease, border-color 0.25s ease;
+}
+.frame.dropped {
+  opacity: 0.3;
+  text-decoration: line-through;
+  border-style: dashed;
+}
+.arrow {
+  color: rgb(var(--color-ink-faint));
+  font-size: 1.1rem;
+}
+.world {
+  border: 1px solid rgb(var(--color-burgundy));
+  padding: 0.4rem 0.7rem;
+  font-size: 0.82rem;
+  color: rgb(var(--color-ink));
+  font-weight: 600;
+}
+.world.tampered {
+  border-style: dashed;
+}
+
+/* Wear: the shrinking envelope. */
+.sliderRow {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  margin-top: 0.4rem;
+}
+.slider {
+  flex: 1;
+  accent-color: rgb(var(--color-burgundy));
+}
+.wearVal {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 0.9rem;
+  color: rgb(var(--color-ink));
+  min-width: 3.2rem;
+  text-align: right;
+}
+.capRow {
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+}
+.cap {
+  display: grid;
+  grid-template-columns: 8.5rem 1fr 4.5rem;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.82rem;
+  color: rgb(var(--color-ink-soft));
+}
+.track {
+  position: relative;
+  height: 0.7rem;
+  background: rgba(var(--color-rule), 0.6);
+  overflow: hidden;
+}
+.fill {
+  position: absolute;
+  inset: 0 auto 0 0;
+  background: rgb(var(--color-burgundy));
+  transition: width 0.2s ease;
+}
+.capNum {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  text-align: right;
+  color: rgb(var(--color-ink));
+}

--- a/website/src/app/demos/robotics/RoboticsDemos.tsx
+++ b/website/src/app/demos/robotics/RoboticsDemos.tsx
@@ -1,0 +1,278 @@
+'use client';
+
+import React, { useState } from 'react';
+
+import styles from './RoboticsDemos.module.css';
+
+/**
+ * Interactive demos for the three robotics capabilities shipped alongside this
+ * page: infrastructure access (vouch.robotics.access), fused-sensor provenance
+ * (vouch.robotics.fusion), and wear and degradation (vouch.robotics.wear). Each
+ * mirrors the real credential shapes and the real verification logic, rendered
+ * as an on-brand illustration rather than a live signature so it runs with no
+ * network call. Burgundy doubles as refuse, a parchment-harmonized green marks
+ * allow, and both read on either theme.
+ */
+
+const ALLOW = '#3f7d55';
+const DENY = 'rgb(var(--color-burgundy))';
+
+/* ------------------------------------------------------------------ */
+/* Access: an operator grant plus a robot request, authorized offline. */
+/* ------------------------------------------------------------------ */
+
+type AccessScenario = 'open' | 'admin' | 'expired' | 'other';
+
+const ACCESS_SCENARIOS: Array<{ id: AccessScenario; label: string }> = [
+  { id: 'open', label: 'Robot A asks to open door-3, inside the window' },
+  { id: 'admin', label: 'Robot A asks to unlock_admin on door-3' },
+  { id: 'expired', label: 'Robot A asks to open door-3 after the window closes' },
+  { id: 'other', label: 'A different robot presents Robot A’s grant' },
+];
+
+function Access() {
+  const [scenario, setScenario] = useState<AccessScenario>('open');
+
+  const request = {
+    open: { robot: 'did:web:robot-a', op: 'open', when: 't+05:00' },
+    admin: { robot: 'did:web:robot-a', op: 'unlock_admin', when: 't+05:00' },
+    expired: { robot: 'did:web:robot-a', op: 'open', when: 't+02:00:00' },
+    other: { robot: 'did:web:robot-b', op: 'open', when: 't+05:00' },
+  }[scenario];
+
+  const verdict = {
+    open: { ok: true, reason: 'authorized' },
+    admin: { ok: false, reason: 'operation not permitted by the grant' },
+    expired: { ok: false, reason: 'grant invalid or out of window' },
+    other: { ok: false, reason: 'grant and request name different robots' },
+  }[scenario];
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          The facility operator signs an access grant naming the resource, the operations it permits, an optional zone,
+          and a time window. The robot signs a request for one operation. The door authorizes it offline, with no call to
+          a server.
+        </p>
+        <div className="eyebrow-faint mb-2">Choose what the robot asks for</div>
+        <div className={styles.controls}>
+          {ACCESS_SCENARIOS.map((s) => (
+            <button
+              key={s.id}
+              className={`${styles.radio}${scenario === s.id ? ' ' + styles.on : ''}`}
+              onClick={() => setScenario(s.id)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Operator grant (signed)</div>
+          <div className={styles.mono}>
+            robot: did:web:robot-a
+            <br />
+            resource: door-3 · operations: [open, close] · zone: cell-3
+            <br />
+            window: t0 &rarr; t0 + 3600s
+          </div>
+        </div>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Robot request (signed)</div>
+          <div className={styles.mono}>
+            robot: {request.robot}
+            <br />
+            resource: door-3 · operation: {request.op} · at: {request.when}
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: verdict.ok ? ALLOW : DENY, borderColor: verdict.ok ? ALLOW : DENY }}>
+            {verdict.ok ? '✓ AUTHORIZED' : '✕ REFUSED'}
+          </span>
+          <span className={styles.reason}>{verdict.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Fusion: input frames bound to a fused world model.                  */
+/* ------------------------------------------------------------------ */
+
+type FusionScenario = 'honest' | 'tamper' | 'drop';
+
+const FUSION_SCENARIOS: Array<{ id: FusionScenario; label: string }> = [
+  { id: 'honest', label: 'Fuse three signed frames into the world model' },
+  { id: 'tamper', label: 'Alter the fused output after signing' },
+  { id: 'drop', label: 'Fuse from an input the robot never recorded' },
+];
+
+function Fusion() {
+  const [scenario, setScenario] = useState<FusionScenario>('honest');
+
+  const verdict = {
+    honest: { ok: true, reason: 'verified · digest and inputs match' },
+    tamper: { ok: false, reason: 'fused output hash does not match' },
+    drop: { ok: false, reason: 'input frame not in the perception log' },
+  }[scenario];
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          A robot fuses camera, lidar, and radar into one world model and acts on that. The attestation binds the fused
+          output to the exact set of input frame hashes and the fusion method, so a manipulated result or a dropped input
+          is detectable.
+        </p>
+        <div className="eyebrow-faint mb-2">Try it as the robot</div>
+        <div className={styles.controls}>
+          {FUSION_SCENARIOS.map((s) => (
+            <button
+              key={s.id}
+              className={`${styles.radio}${scenario === s.id ? ' ' + styles.on : ''}`}
+              onClick={() => setScenario(s.id)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.flow}>
+          <span className={styles.frame}>camera</span>
+          <span className={styles.frame}>lidar</span>
+          <span className={`${styles.frame}${scenario === 'drop' ? ' ' + styles.dropped : ''}`}>radar</span>
+          <span className={styles.arrow}>&rarr;</span>
+          <span className={`${styles.world}${scenario === 'tamper' ? ' ' + styles.tampered : ''}`}>world model</span>
+        </div>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Fused attestation (signed)</div>
+          <div className={styles.mono}>
+            method: occupancy-grid-v1
+            <br />
+            inputs: [uCAM, uLID, {scenario === 'drop' ? 'uPHANTOM' : 'uRAD'}]
+            <br />
+            inputsDigest: uaDpZB… · outputHash: {scenario === 'tamper' ? 'u-ALTERED…' : 'u-IyAz…'}
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: verdict.ok ? ALLOW : DENY, borderColor: verdict.ok ? ALLOW : DENY }}>
+            {verdict.ok ? '✓ VERIFIED' : '✕ DETECTED'}
+          </span>
+          <span className={styles.reason}>{verdict.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Wear: the capability envelope shrinks with the attested wear level. */
+/* ------------------------------------------------------------------ */
+
+const BASE_CAPS: Array<{ key: string; label: string; base: number; unit: string }> = [
+  { key: 'force', label: 'max force', base: 80, unit: 'N' },
+  { key: 'speed', label: 'max speed', base: 1.5, unit: 'm/s' },
+  { key: 'near', label: 'near humans', base: 0.25, unit: 'm/s' },
+];
+
+function Wear() {
+  const [wear, setWear] = useState(25);
+  const factor = 1 - wear / 100;
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          A robot signs its own wear level, bound to its identity and hash-linked over time. A deterministic rule scales
+          its force and speed caps down by that level, and the narrowed scope is a valid attenuation of the original, so a
+          worn robot stays inside a tighter, verifiable envelope than the limit it shipped with.
+        </p>
+        <div className="eyebrow-faint mb-2">Drag the attested wear level</div>
+        <div className={styles.sliderRow}>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={wear}
+            onChange={(e) => setWear(Number(e.target.value))}
+            className={styles.slider}
+            aria-label="wear level"
+          />
+          <span className={styles.wearVal}>{wear}%</span>
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Narrowed capability scope</div>
+          <div className={styles.capRow}>
+            {BASE_CAPS.map((c) => {
+              const now = c.base * factor;
+              return (
+                <div key={c.key} className={styles.cap}>
+                  <span>{c.label}</span>
+                  <span className={styles.track}>
+                    <span className={styles.fill} style={{ width: `${factor * 100}%` }} />
+                  </span>
+                  <span className={styles.capNum}>
+                    {Number(now.toFixed(3))} {c.unit}
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: ALLOW, borderColor: ALLOW }}>
+            {'✓ VALID ATTENUATION'}
+          </span>
+          <span className={styles.reason}>every cap is at or below the original</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+
+export default function RoboticsDemos() {
+  return (
+    <>
+      <section id="access" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ I</span>
+            <h2>Infrastructure access</h2>
+          </div>
+          <p className="eyebrow mb-6">A robot opens a door with a grant the door checks offline · vouch.robotics.access</p>
+          <Access />
+        </div>
+      </section>
+
+      <section id="fusion" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ II</span>
+            <h2>Fused-sensor provenance</h2>
+          </div>
+          <p className="eyebrow mb-6">The world model a robot acts on is bound to the frames that made it · vouch.robotics.fusion</p>
+          <Fusion />
+        </div>
+      </section>
+
+      <section id="wear" className="scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ III</span>
+            <h2>Wear and degradation</h2>
+          </div>
+          <p className="eyebrow mb-6">A worn robot narrows its own envelope, verifiably · vouch.robotics.wear</p>
+          <Wear />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/website/src/app/demos/robotics/page.tsx
+++ b/website/src/app/demos/robotics/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from 'next';
+
+import RoboticsDemos from './RoboticsDemos';
+
+export const metadata: Metadata = {
+  title: 'Robotics interactive demos',
+  description:
+    'See Vouch Protocol robotics controls run in the browser: a robot that opens a door with a grant the door authorizes offline, a fused world model bound to the exact sensor frames that made it, and a worn robot that narrows its own force and speed envelope as it degrades.',
+};
+
+export default function RoboticsDemosPage() {
+  return (
+    <>
+      <section className="border-b border-rule">
+        <div className="container-wide py-16 md:py-20">
+          <div className="eyebrow mb-5">Support · Robotics demos</div>
+          <h1 className="font-serif font-semibold text-ink leading-[1.1] tracking-tight mb-5 text-[clamp(2rem,4.2vw,3rem)]">
+            Watch a robot stay in bounds.
+          </h1>
+          <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-prose">
+            A robot acts in the physical world, so the questions get sharper: what is it allowed to touch, is the world it
+            sees real, and is it still fit to do the job. Vouch answers each with a credential the robot or the resource
+            can check on the spot. Three of them run below, on the real credential shapes.
+          </p>
+          <p className="footnote mt-5">
+            Every verdict here mirrors the shipped SDK modules
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.access</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.fusion</code>, and
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.wear</code>. Disclosed as PAD-087 through PAD-092.
+          </p>
+        </div>
+      </section>
+
+      <RoboticsDemos />
+
+      <section>
+        <div className="container-wide py-16">
+          <div className="border-l-2 border-burgundy bg-burgundy/[0.03] px-5 py-4 max-w-prose">
+            <p className="text-ink-soft text-[0.95rem] leading-relaxed">
+              <strong className="text-ink">Build it yourself.</strong> Each demo maps to the same functions the SDK ships
+              in Python, TypeScript, Go, and the Rust core:
+              {' '}<code className="font-mono text-[0.85em]">authorize_access</code>,
+              {' '}<code className="font-mono text-[0.85em]">verify_fused_attestation</code>, and
+              {' '}<code className="font-mono text-[0.85em]">attenuate_for_wear</code>. See the{' '}
+              <a href="/robotics/" className="prose-link">robotics overview</a> and the{' '}
+              <a href="/help/" className="prose-link">guides</a> for the full walkthrough.
+            </p>
+          </div>
+        </div>
+      </section>
+    </>
+  );
+}


### PR DESCRIPTION
This adds an interactive demos page for the robotics capabilities, at /demos/robotics.

Three demos run in the browser on the real credential shapes, with no network call:

- Infrastructure access: an operator grant and a robot request, plus the door's offline authorize decision, so you can watch it allow the permitted operation and refuse an operation the grant does not cover, a request after the window closes, or a request from a different robot.
- Fused-sensor provenance: three sensor frames fused into a world model, with a control to alter the fused output or drop an input so the attestation check catches it.
- Wear and degradation: a wear slider that scales the force and speed caps down and shows the narrowed scope stays a valid attenuation of the original.

Each demo maps to the shipped SDK functions authorize_access, verify_fused_attestation, and attenuate_for_wear. The page reuses the site design system and keeps its own component-scoped styles, so it sits alongside the existing demos page without touching it.
