### PR TITLE
Add a one-command end to end agent authorization demo

### DIFF
--- a/demo/e2e/README.md
+++ b/demo/e2e/README.md
@@ -1,0 +1,59 @@
+# End to end agent authorization demo
+
+One command shows an AI agent authorizing real actions with Vouch Protocol,
+with the private key held in a separate signing sidecar and the agent code
+carrying a single line of Vouch.
+
+```bash
+python demo/e2e/run_demo.py
+```
+
+No API keys and no network. The agent logic is deterministic so the
+cryptographic pipeline is the only thing on display.
+
+## What it demonstrates
+
+1. An identity is minted for the agent.
+2. The private key goes to a separate signing sidecar, the published
+   `vouch-mcp` server, and stays in that process. The agent never holds it.
+3. The agent decides on an action and signs that intent through the sidecar
+   over the Model Context Protocol.
+4. A bank verifies the credential and enforces the exact intent binding.
+5. A replayed credential aimed at a different account is rejected.
+6. The same flow runs under the post-quantum profile.
+7. A trust-decaying session voucher (Heartbeat Protocol) is issued.
+
+## The point: where the code lives
+
+The files are split by role so the integration cost is visible on its own.
+
+| File | Role | Vouch code |
+| --- | --- | --- |
+| `agent.py` | the AI agent's business logic | one call: `sidecar.sign(...)` |
+| `vouch_sidecar.py` | the MCP client to the signing sidecar | the whole integration surface, written once |
+| `bank.py` | the receiving service | verify, then check the intent binding |
+| `run_demo.py` | the orchestrator that runs the scenes | mints the identity, starts the sidecar |
+
+The agent process cannot leak the key, because it never receives it. It holds
+one `VouchSidecar` handle and nothing else. A prompt-injected model in the agent
+cannot exfiltrate a secret it does not have.
+
+## Turning this into a real framework agent
+
+The agent here is framework-agnostic on purpose. To drive it with a real LLM
+agent (LangChain, CrewAI, AutoGen, Google ADK, Vertex AI, n8n), wrap the single
+`sidecar.sign` call as a tool the framework can invoke. The per-framework glue
+lives in [`examples/05_integrations/`](../../examples/05_integrations/).
+
+## The sidecar
+
+The sidecar is the published `vouch-mcp` server, run here as a child process:
+
+```
+python -m vouch.integrations.mcp.server
+```
+
+with `VOUCH_PRIVATE_KEY` and `VOUCH_DID` in its environment. In production it is
+`pip install vouch-mcp` and runs on its own, over stdio for local clients or
+Streamable HTTP for hosted use. It exposes `sign`, `verify`, `create_session`,
+`check_revocation`, and `get_identity`.

--- a/demo/e2e/README.md
+++ b/demo/e2e/README.md
@@ -38,12 +38,53 @@ The agent process cannot leak the key, because it never receives it. It holds
 one `VouchSidecar` handle and nothing else. A prompt-injected model in the agent
 cannot exfiltrate a secret it does not have.
 
+## Use the sidecar from your own MCP client
+
+The demo launches the sidecar as a child process so it runs in one command. In a
+real setup you install it once and register it with your MCP client, the same
+way you add any other server. There is a ready-to-edit config next to this file,
+[`mcp_client_config.json`](mcp_client_config.json):
+
+```json
+{
+  "mcpServers": {
+    "vouch": {
+      "command": "vouch-mcp",
+      "env": {
+        "VOUCH_DID": "did:web:your-agent.example.com",
+        "VOUCH_PRIVATE_KEY": "PASTE_YOUR_PRIVATE_KEY_JWK_JSON_STRING"
+      }
+    }
+  }
+}
+```
+
+Install the server with `pip install vouch-mcp`, then drop that block into your
+Claude Desktop or Cursor config. To get real values for the two env vars:
+
+```python
+from vouch import generate_identity
+kp = generate_identity("your-agent.example.com")
+print(kp.did)              # -> VOUCH_DID
+print(kp.private_key_jwk)  # -> VOUCH_PRIVATE_KEY
+```
+
+Once it is registered, your agent has `sign`, `verify`, `create_session`,
+`check_revocation`, and `get_identity` as ordinary MCP tools, and the key stays
+in the server process.
+
 ## Turning this into a real framework agent
 
 The agent here is framework-agnostic on purpose. To drive it with a real LLM
-agent (LangChain, CrewAI, AutoGen, Google ADK, Vertex AI, n8n), wrap the single
-`sidecar.sign` call as a tool the framework can invoke. The per-framework glue
-lives in [`examples/05_integrations/`](../../examples/05_integrations/).
+agent, wrap the single `sidecar.sign` call as a tool the framework can invoke.
+One server serves every framework through its standard MCP client, so there is
+no per-framework Vouch connector to maintain:
+
+- [`examples/mcp-vouch/`](../../examples/mcp-vouch/) wires the same `vouch-mcp`
+  server into LangChain, LangGraph, CrewAI, AutoGen, Google ADK, Vertex AI,
+  AutoGPT, n8n, and Hasura, each through that framework's own MCP client.
+- [`examples/05_integrations/`](../../examples/05_integrations/) has the
+  per-framework agent scripts if you want a full runnable agent for one stack.
 
 ## The sidecar
 

--- a/demo/e2e/agent.py
+++ b/demo/e2e/agent.py
@@ -1,0 +1,58 @@
+"""The AI agent part: business logic that decides what to do.
+
+This module is deliberately framework-agnostic so the Vouch integration cost is
+visible in isolation. The agent decides on an action using whatever logic you
+like (an LLM, a planner, a rule). Then it asks the sidecar to sign that intent
+and attaches the returned credential to its outbound request.
+
+Count the Vouch-specific lines here: there is exactly one call, ``sidecar.sign``.
+Nothing else in an agent has to change. To make this a real LangChain, CrewAI,
+or Google ADK agent, wrap that one call as a tool the framework can invoke;
+``examples/05_integrations/`` shows the per-framework glue.
+
+The private key is never in this module. It cannot be: the agent only ever
+holds a VouchSidecar handle.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from vouch_sidecar import VouchSidecar
+
+# The service this agent calls. In a real deployment this is your bank, CRM,
+# database gateway, or any API that wants proof of who authorized the call.
+BANK_API = "api.bank.example.com"
+
+
+async def make_payment(
+    sidecar: VouchSidecar,
+    amount: int,
+    to_account: str,
+    post_quantum: bool = False,
+) -> Dict[str, Any]:
+    """Decide to move money, then authorize it with a signed intent.
+
+    Returns the outbound request the agent would send to the bank, with the
+    Vouch Credential attached.
+    """
+    # ---- agent business logic (no Vouch here) --------------------------------
+    resource = f"account:{to_account}"
+    plan = f"transfer ${amount} to {resource}"
+
+    # ---- the one Vouch line: sign this exact intent in the sidecar -----------
+    credential = await sidecar.sign(
+        action="transfer",
+        target=BANK_API,
+        resource=resource,
+        post_quantum=post_quantum,
+    )
+
+    # ---- send the request, credential attached as a header -------------------
+    return {
+        "plan": plan,
+        "action": "transfer",
+        "amount": amount,
+        "requested_resource": resource,
+        "vouch_credential": credential,
+    }

--- a/demo/e2e/bank.py
+++ b/demo/e2e/bank.py
@@ -1,0 +1,66 @@
+"""The receiving service: verifies the credential and enforces the binding.
+
+This is the other party. It never trusts the request fields on their own. It
+verifies the attached Vouch Credential, then checks that the action it is about
+to perform matches the exact intent that was authorized. A valid signature on
+``account:123`` does not authorize a transfer to ``account:999``.
+
+The bank does not need the sidecar or the private key. It only needs the
+agent's public key, which it holds the way any service holds a trusted key: in
+its own trust registry. Here we pass it in directly.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Tuple
+
+from vouch import Verifier
+
+
+@dataclass
+class Bank:
+    """A service that accepts an action only if the credential authorizes it."""
+
+    trusted_did: str
+    trusted_public_key_jwk: str
+
+    def handle(self, request: Dict[str, Any]) -> Tuple[bool, str]:
+        """Return (accepted, reason) for one incoming request."""
+        credential_json = request.get("vouch_credential", "")
+        try:
+            credential = json.loads(credential_json)
+        except (json.JSONDecodeError, TypeError):
+            return False, "no valid Vouch Credential attached"
+
+        # 1. Is the credential genuine, unexpired, and from a key we trust?
+        is_valid, passport = Verifier.verify(
+            credential, public_key=self.trusted_public_key_jwk
+        )
+        if not is_valid or passport is None:
+            return False, "credential failed signature or validity check"
+
+        issuer = getattr(passport, "iss", None) or getattr(passport, "sub", None)
+        if issuer != self.trusted_did:
+            return False, f"issuer {issuer} is not our trusted agent"
+
+        # 2. Does the credential authorize *this exact* action? This is the
+        #    step that catches a swapped or replayed request.
+        intent = getattr(passport, "intent", {}) or {}
+        authorized_resource = intent.get("resource")
+        requested_resource = request.get("requested_resource")
+        if authorized_resource != requested_resource:
+            return (
+                False,
+                f"credential authorizes {authorized_resource}, "
+                f"but the request targets {requested_resource}",
+            )
+        if intent.get("action") != request.get("action"):
+            return (
+                False,
+                f"credential authorizes '{intent.get('action')}', "
+                f"but the request is '{request.get('action')}'",
+            )
+
+        return True, f"authorized by {issuer} for {authorized_resource}"

--- a/demo/e2e/bank.py
+++ b/demo/e2e/bank.py
@@ -35,9 +35,7 @@ class Bank:
             return False, "no valid Vouch Credential attached"
 
         # 1. Is the credential genuine, unexpired, and from a key we trust?
-        is_valid, passport = Verifier.verify(
-            credential, public_key=self.trusted_public_key_jwk
-        )
+        is_valid, passport = Verifier.verify(credential, public_key=self.trusted_public_key_jwk)
         if not is_valid or passport is None:
             return False, "credential failed signature or validity check"
 

--- a/demo/e2e/mcp_client_config.json
+++ b/demo/e2e/mcp_client_config.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "vouch": {
+      "command": "vouch-mcp",
+      "env": {
+        "VOUCH_DID": "did:web:your-agent.example.com",
+        "VOUCH_PRIVATE_KEY": "PASTE_YOUR_PRIVATE_KEY_JWK_JSON_STRING"
+      }
+    }
+  }
+}

--- a/demo/e2e/run_demo.py
+++ b/demo/e2e/run_demo.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""One command end to end: an AI agent authorizes real actions with Vouch.
+
+    python demo/e2e/run_demo.py
+
+What it shows, in one process tree:
+
+  1. An identity is minted for the agent.
+  2. The private key is handed to a *separate* signing sidecar (the published
+     vouch-mcp server) and stays there. The agent process never holds it.
+  3. The agent decides on an action and signs that intent through the sidecar
+     over MCP. One line of Vouch code in the agent.
+  4. A bank verifies the credential and enforces the exact intent binding.
+  5. A replayed credential aimed at a different account is rejected.
+  6. The same flow runs under the post-quantum profile.
+  7. A trust-decaying session voucher (Heartbeat Protocol) is issued.
+
+No API keys and no network are required. The agent logic is deterministic so
+the cryptographic pipeline is the only thing on display. To drive it with a
+real LLM agent (LangChain, CrewAI, Google ADK), wrap the single sidecar.sign
+call as a tool; examples/05_integrations/ has the per-framework glue.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+
+# Run against the repo's vouch package (and make the sidecar child do the same),
+# rather than any older copy installed in site-packages. This also lets the
+# sibling role modules import each other from any working directory.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
+sys.path.insert(0, _REPO_ROOT)
+sys.path.insert(0, _HERE)
+os.environ["PYTHONPATH"] = os.pathsep.join(
+    p for p in (_REPO_ROOT, os.environ.get("PYTHONPATH", "")) if p
+)
+
+from agent import BANK_API, make_payment  # noqa: E402
+from bank import Bank  # noqa: E402
+from vouch.keys import generate_identity  # noqa: E402
+from vouch_sidecar import VouchSidecar  # noqa: E402
+
+
+# ---- tiny terminal styling ---------------------------------------------------
+
+_USE_COLOR = sys.stdout.isatty() and not os.getenv("NO_COLOR")
+
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _USE_COLOR else text
+
+
+def cyan(t: str) -> str:
+    return _c("36", t)
+
+
+def green(t: str) -> str:
+    return _c("32", t)
+
+
+def red(t: str) -> str:
+    return _c("31", t)
+
+
+def yellow(t: str) -> str:
+    return _c("33", t)
+
+
+def dim(t: str) -> str:
+    return _c("2", t)
+
+
+def scene(title: str) -> None:
+    print()
+    print(cyan("━━━ " + title + " ━━━"))
+
+
+def verdict(accepted: bool, reason: str) -> None:
+    if accepted:
+        print(green("  ACCEPTED: ") + reason)
+    else:
+        print(red("  REJECTED: ") + reason)
+
+
+async def main() -> int:
+    print(cyan("╔══════════════════════════════════════════════════════════╗"))
+    print(cyan("║   Vouch Protocol: end to end agent authorization demo    ║"))
+    print(cyan("╚══════════════════════════════════════════════════════════╝"))
+
+    # -- Setup: the operator mints an identity for the agent. ------------------
+    scene("1. Mint the agent's identity")
+    kp = generate_identity(domain="acme-payments.agent.example")
+    print("  DID: " + yellow(kp.did))
+    print(dim("  The private key is about to go to the sidecar process only."))
+    print(dim("  The agent code below never receives it."))
+
+    # -- The bank knows the agent's public key (its trust registry). -----------
+    bank = Bank(trusted_did=kp.did, trusted_public_key_jwk=kp.public_key_jwk)
+
+    # -- Start the sidecar. The key lives in its environment, nowhere else. ----
+    async with VouchSidecar(kp.private_key_jwk, kp.did) as sidecar:
+        scene("2. The signing sidecar is running (separate process)")
+        print("  " + await sidecar.get_identity())
+        print(dim("  Key holder: the vouch-mcp child process. Not the agent."))
+
+        # -- Scene 3: an authorized payment. -----------------------------------
+        scene("3. Agent signs an intent and the bank verifies it")
+        request = await make_payment(sidecar, amount=500, to_account="123")
+        print("  agent plan:   " + request["plan"])
+        print(dim("  target:       " + BANK_API))
+        print(dim("  credential:   " + request["vouch_credential"][:72] + " ..."))
+        verdict(*bank.handle(request))
+
+        # -- Scene 4: replay the credential against a different account. -------
+        scene("4. An attacker replays that credential to redirect the funds")
+        stolen = dict(request)
+        stolen["requested_resource"] = "account:999"
+        print(dim("  same valid credential, but the request now targets account:999"))
+        verdict(*bank.handle(stolen))
+        print(dim("  The signature is genuine. The intent binding still blocks it."))
+
+        # -- Scene 5: post-quantum profile. ------------------------------------
+        scene("5. The same flow under the post-quantum profile")
+        pq = await make_payment(sidecar, amount=500, to_account="123", post_quantum=True)
+        cred = pq["vouch_credential"]
+        if cred.lstrip().startswith("{"):
+            doc = json.loads(cred)
+            proof = doc.get("proof", {})
+            intent = doc.get("credentialSubject", {}).get("intent", {})
+            binding_ok = intent.get("resource") == pq["requested_resource"]
+            print("  cryptosuite:  " + yellow(proof.get("cryptosuite", "unknown")))
+            print("  signature:    " + str(len(proof.get("proofValue", "")))
+                  + " base58 chars (Ed25519 and ML-DSA-44 composite)")
+            print("  binding:      " + (green("intact") if binding_ok else red("mismatch")))
+            print(dim("  One flag switched the whole flow to quantum-safe signing."))
+            print(dim("  A verifier completes hybrid checks with the issuer's ML-DSA"))
+            print(dim("  key, published in its DID document alongside the Ed25519 key."))
+        else:
+            print(yellow("  skipped: ") + "install 'vouch-protocol[pq]' to sign hybrid PQ.")
+            print(dim("  detail: " + cred.strip().splitlines()[0]))
+
+        # -- Scene 6: a trust-decaying session voucher (Heartbeat). ------------
+        scene("6. A trust-decaying session voucher (Heartbeat Protocol)")
+        voucher_json = await sidecar.create_session("payments_session", valid_seconds=3600)
+        if voucher_json.lstrip().startswith("{"):
+            voucher = json.loads(voucher_json)
+            subject = voucher.get("credentialSubject", {})
+            print("  purpose:      payments_session")
+            print("  initial trust: " + str(subject.get("initialTrust", subject.get("trust", "1.0"))))
+            print(dim("  trust decays over time; a verifier can refuse once it drops."))
+        else:
+            print(dim("  " + voucher_json.strip().splitlines()[0]))
+
+    # -- Summary: the point of the whole thing. --------------------------------
+    scene("What just happened")
+    print("  " + green("Key isolation:  ") + "the private key stayed in the sidecar process.")
+    print("  " + green("Agent tax:      ") + "one line of Vouch code in the agent (sidecar.sign).")
+    print("  " + green("Binding:        ") + "a genuine credential cannot be redirected.")
+    print("  " + green("Future proof:   ") + "post-quantum is one flag; heartbeat is one call.")
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/demo/e2e/run_demo.py
+++ b/demo/e2e/run_demo.py
@@ -133,8 +133,11 @@ async def main() -> int:
             intent = doc.get("credentialSubject", {}).get("intent", {})
             binding_ok = intent.get("resource") == pq["requested_resource"]
             print("  cryptosuite:  " + yellow(proof.get("cryptosuite", "unknown")))
-            print("  signature:    " + str(len(proof.get("proofValue", "")))
-                  + " base58 chars (Ed25519 and ML-DSA-44 composite)")
+            print(
+                "  signature:    "
+                + str(len(proof.get("proofValue", "")))
+                + " base58 chars (Ed25519 and ML-DSA-44 composite)"
+            )
             print("  binding:      " + (green("intact") if binding_ok else red("mismatch")))
             print(dim("  One flag switched the whole flow to quantum-safe signing."))
             print(dim("  A verifier completes hybrid checks with the issuer's ML-DSA"))
@@ -150,7 +153,9 @@ async def main() -> int:
             voucher = json.loads(voucher_json)
             subject = voucher.get("credentialSubject", {})
             print("  purpose:      payments_session")
-            print("  initial trust: " + str(subject.get("initialTrust", subject.get("trust", "1.0"))))
+            print(
+                "  initial trust: " + str(subject.get("initialTrust", subject.get("trust", "1.0")))
+            )
             print(dim("  trust decays over time; a verifier can refuse once it drops."))
         else:
             print(dim("  " + voucher_json.strip().splitlines()[0]))

--- a/demo/e2e/vouch_sidecar.py
+++ b/demo/e2e/vouch_sidecar.py
@@ -1,0 +1,118 @@
+"""The Vouch part: a thin MCP client to the signing sidecar.
+
+This is the *entire* integration surface an agent needs. The agent process
+never imports a private key, never touches signing code, and never links the
+Vouch SDK. It holds one handle to this sidecar and calls ``sign`` / ``verify``
+over the Model Context Protocol.
+
+The sidecar itself is the published ``vouch-mcp`` server, run as a separate
+child process. The private key is placed in that child's environment and stays
+there. A prompt-injected model in the agent process cannot exfiltrate a key it
+never holds.
+
+Everything below is protocol plumbing you write once. Compare its size to
+``agent.py`` to see the real integration cost.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import AsyncExitStack
+from typing import Optional
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+class VouchSidecar:
+    """An async handle to a Vouch signing sidecar spoken to over MCP (stdio).
+
+    Use as an async context manager. On enter it launches the ``vouch-mcp``
+    server as a child process with the private key in *that* process's
+    environment, then opens an MCP session to it.
+    """
+
+    def __init__(self, private_key_jwk: str, did: str) -> None:
+        # These are handed to the child process only. The agent code that
+        # imports this class receives a VouchSidecar instance, never these.
+        self._private_key_jwk = private_key_jwk
+        self._did = did
+        self._stack: Optional[AsyncExitStack] = None
+        self._session: Optional[ClientSession] = None
+
+    async def __aenter__(self) -> "VouchSidecar":
+        # The key lives only in the child's env. We inherit the parent env so
+        # the child can find Python and the vouch package, then add the secret.
+        child_env = {
+            **os.environ,
+            "VOUCH_PRIVATE_KEY": self._private_key_jwk,
+            "VOUCH_DID": self._did,
+        }
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-m", "vouch.integrations.mcp.server"],
+            env=child_env,
+        )
+        self._stack = AsyncExitStack()
+        # Send the child's server logs to nowhere so the demo output stays clean.
+        errlog = open(os.devnull, "w")
+        self._stack.callback(errlog.close)
+        read, write = await self._stack.enter_async_context(
+            stdio_client(params, errlog=errlog)
+        )
+        self._session = await self._stack.enter_async_context(
+            ClientSession(read, write)
+        )
+        await self._session.initialize()
+        return self
+
+    async def __aexit__(self, *exc: object) -> None:
+        if self._stack is not None:
+            await self._stack.aclose()
+            self._stack = None
+            self._session = None
+
+    async def _call(self, tool: str, **args: object) -> str:
+        assert self._session is not None, "sidecar not started"
+        result = await self._session.call_tool(tool, args)
+        parts = getattr(result, "content", None) or []
+        for part in parts:
+            text = getattr(part, "text", None)
+            if text is not None:
+                return text
+        return str(result)
+
+    # ---- the four calls an agent actually makes ------------------------------
+
+    async def get_identity(self) -> str:
+        """This agent's DID, per the sidecar."""
+        return await self._call("get_identity")
+
+    async def sign(
+        self,
+        action: str,
+        target: str,
+        resource: Optional[str] = None,
+        post_quantum: bool = False,
+    ) -> str:
+        """Sign one intent. Returns a Vouch Credential as compact JSON."""
+        args: dict = {"action": action, "target": target}
+        if resource is not None:
+            args["resource"] = resource
+        if post_quantum:
+            args["post_quantum"] = True
+        return await self._call("sign", **args)
+
+    async def verify(self, credential_json: str, public_key: Optional[str] = None) -> str:
+        """Verify a credential someone presented. Returns a readable verdict."""
+        args: dict = {"credential_json": credential_json}
+        if public_key is not None:
+            args["public_key"] = public_key
+        return await self._call("verify", **args)
+
+    async def create_session(self, purpose: str, valid_seconds: int = 3600) -> str:
+        """Issue a trust-decaying session voucher (Heartbeat Protocol)."""
+        return await self._call(
+            "create_session", purpose=purpose, valid_seconds=valid_seconds
+        )

--- a/demo/e2e/vouch_sidecar.py
+++ b/demo/e2e/vouch_sidecar.py
@@ -58,12 +58,8 @@ class VouchSidecar:
         # Send the child's server logs to nowhere so the demo output stays clean.
         errlog = open(os.devnull, "w")
         self._stack.callback(errlog.close)
-        read, write = await self._stack.enter_async_context(
-            stdio_client(params, errlog=errlog)
-        )
-        self._session = await self._stack.enter_async_context(
-            ClientSession(read, write)
-        )
+        read, write = await self._stack.enter_async_context(stdio_client(params, errlog=errlog))
+        self._session = await self._stack.enter_async_context(ClientSession(read, write))
         await self._session.initialize()
         return self
 
@@ -113,6 +109,4 @@ class VouchSidecar:
 
     async def create_session(self, purpose: str, valid_seconds: int = 3600) -> str:
         """Issue a trust-decaying session voucher (Heartbeat Protocol)."""
-        return await self._call(
-            "create_session", purpose=purpose, valid_seconds=valid_seconds
-        )
+        return await self._call("create_session", purpose=purpose, valid_seconds=valid_seconds)


### PR DESCRIPTION
A single command runs an AI agent that authorizes real actions with Vouch Protocol. The private key is held in a separate signing sidecar, the published vouch-mcp server, and the agent carries one line of Vouch code.

The demo lives in demo/e2e/, split by role so the integration cost is visible on its own: the agent calls sidecar.sign once, the sidecar holds the key in its own process, and a bank verifies the credential and enforces the intent binding. The scenes cover an authorized payment, a rejected credential replay, the post-quantum profile, and a trust-decaying session voucher. It needs no API keys and no network.

For MCP developers it ships a drop-in mcpServers config that registers vouch-mcp with Claude Desktop or Cursor, and it points to examples/mcp-vouch for wiring the same server into LangChain, LangGraph, CrewAI, AutoGen, Google ADK, Vertex AI, AutoGPT, n8n, and Hasura through each framework's standard MCP client.
