### PR TITLE
Align SDK examples and the agent backend with the current sign/verify API

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -84,12 +84,11 @@ Then run `vouch` with no arguments for a short menu (sign git commits, or create
 Three-line Python:
 
 ```python
-from vouch import generate_identity, Signer, build_vouch_credential
+from vouch import generate_identity, Signer
 
 keys = generate_identity("agent.example.com")  # returns a KeyPair
 signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
-credential = build_vouch_credential(
-    issuer_did="did:web:agent.example.com",
+signed = signer.sign(
     intent={
         "action": "submit_claim",
         "target": "claim:HC-001",
@@ -97,7 +96,6 @@ credential = build_vouch_credential(
     },
     valid_seconds=300,
 )
-signed = signer.sign(credential)
 ```
 
 The `signed` dict is a full Verifiable Credential with a Data Integrity
@@ -215,14 +213,13 @@ the BitstringStatusListCredential, and republish. Verifiers fetch the
 list and check the bit.
 
 ```python
-from vouch import StatusList, build_status_list_entry, build_vouch_credential
+from vouch import StatusList, build_status_list_entry
 
 status_list = StatusList(status_list_id="https://issuer.example/status/1")
 index = status_list.allocate_index()
 
 # Attach to credential at issuance
-credential = build_vouch_credential(
-    issuer_did="did:web:issuer.example",
+signed = signer.sign(
     intent={...},
     credential_status=build_status_list_entry(
         status_list_credential="https://issuer.example/status/1",

--- a/claude-skill/skills/vouch-protocol/reference/python-sdk.md
+++ b/claude-skill/skills/vouch-protocol/reference/python-sdk.md
@@ -34,17 +34,15 @@ signer = Signer(private_key=stored_private_key_jwk, did="did:web:agent.example.c
 ## Credential issuance
 
 ```python
-from vouch import build_vouch_credential
-
-credential = build_vouch_credential(
-    issuer_did="did:web:agent.example.com",
+# sign() builds and signs in one step. The issuer DID comes from the signer.
+signed = signer.sign(
     intent={
         "action": "submit_claim",     # required
         "target": "claim:HC-001",      # required
         "resource": "https://insurance.example.com/claims/HC-001",  # required
     },
     valid_seconds=300,                 # default 300 (5 minutes)
-    reputation_score=85,               # optional, [0, 100]
+    reputation_score=90,               # optional, issuer's reputation assertion
     delegation_chain=[...],            # optional, list of prior links
     credential_status={                # optional, BitstringStatusList entry
         "id": "...#42",
@@ -54,9 +52,6 @@ credential = build_vouch_credential(
         "statusListCredential": "https://issuer.example/status/1",
     },
 )
-
-# Sign it
-signed = signer.sign(credential)
 # signed is a dict ready to JSON-serialize and send
 ```
 

--- a/claude-skill/skills/vouch-protocol/reference/revocation.md
+++ b/claude-skill/skills/vouch-protocol/reference/revocation.md
@@ -44,7 +44,6 @@ Maintain a single `StatusList` per status purpose (revocation, or optionally sus
 from vouch import (
     generate_identity, Signer, StatusList, FilesystemStatusListStore,
     build_status_list_credential, build_status_list_entry,
-    build_vouch_credential,
 )
 
 # Load or create the status list
@@ -64,15 +63,13 @@ signer = Signer(private_key=issuer_keys.private_key_jwk, did=issuer_keys.did)
 index = status_list.allocate_index()
 store.save(status_list)  # persist the cursor
 
-credential = build_vouch_credential(
-    issuer_did="did:web:issuer.example",
+signed_credential = signer.sign(
     intent={"action": "...", "target": "...", "resource": "..."},
     credential_status=build_status_list_entry(
         status_list_credential="https://issuer.example/status/1",
         status_list_index=index,
     ),
 )
-signed_credential = signer.sign(credential)
 ```
 
 #### Revoke later

--- a/claude-skill/skills/vouch-protocol/reference/troubleshooting.md
+++ b/claude-skill/skills/vouch-protocol/reference/troubleshooting.md
@@ -31,10 +31,10 @@ The credential's `intent` is missing one of `action`, `target`, or
 
 ```python
 # Wrong:
-build_vouch_credential(issuer_did="...", intent={"action": "submit"})
+signer.sign(intent={"action": "submit"})
 
 # Right:
-build_vouch_credential(issuer_did="...", intent={
+signer.sign(intent={
     "action": "submit_claim",
     "target": "claim:HC-001",
     "resource": "https://insurance.example.com/claims/HC-001",

--- a/gemini-gem/knowledge/post-quantum.md
+++ b/gemini-gem/knowledge/post-quantum.md
@@ -106,10 +106,14 @@ pip install 'vouch-protocol[pq]'
 ```
 
 ```python
-from vouch import Signer, build_vouch_credential
+from vouch import Signer
 
 signer = Signer.from_did_with_hybrid("did:web:agent.example.com")
-signed = signer.sign_hybrid(build_vouch_credential(...))
+signed = signer.sign_hybrid(intent={
+    "action": "submit_claim",
+    "target": "claim:HC-001",
+    "resource": "https://insurance.example.com/claims/HC-001",
+})
 ```
 
 ### TypeScript

--- a/gemini-gem/knowledge/revocation.md
+++ b/gemini-gem/knowledge/revocation.md
@@ -44,7 +44,6 @@ Maintain a single `StatusList` per status purpose (revocation, or optionally sus
 from vouch import (
     Signer, StatusList, FilesystemStatusListStore,
     build_status_list_credential, build_status_list_entry,
-    build_vouch_credential,
 )
 
 # Load or create the status list
@@ -63,15 +62,13 @@ signer = Signer.from_did("did:web:issuer.example")
 index = status_list.allocate_index()
 store.save(status_list)  # persist the cursor
 
-credential = build_vouch_credential(
-    issuer_did="did:web:issuer.example",
+signed_credential = signer.sign(
     intent={"action": "...", "target": "...", "resource": "..."},
     credential_status=build_status_list_entry(
         status_list_credential="https://issuer.example/status/1",
         status_list_index=index,
     ),
 )
-signed_credential = signer.sign(credential)
 ```
 
 #### Revoke later

--- a/gemini-gem/knowledge/troubleshooting.md
+++ b/gemini-gem/knowledge/troubleshooting.md
@@ -31,10 +31,10 @@ The credential's `intent` is missing one of `action`, `target`, or
 
 ```python
 # Wrong:
-build_vouch_credential(issuer_did="...", intent={"action": "submit"})
+signer.sign(intent={"action": "submit"})
 
 # Right:
-build_vouch_credential(issuer_did="...", intent={
+signer.sign(intent={
     "action": "submit_claim",
     "target": "claim:HC-001",
     "resource": "https://insurance.example.com/claims/HC-001",

--- a/openai-gpt/knowledge/post-quantum.md
+++ b/openai-gpt/knowledge/post-quantum.md
@@ -106,10 +106,14 @@ pip install 'vouch-protocol[pq]'
 ```
 
 ```python
-from vouch import Signer, build_vouch_credential
+from vouch import Signer
 
 signer = Signer.from_did_with_hybrid("did:web:agent.example.com")
-signed = signer.sign_hybrid(build_vouch_credential(...))
+signed = signer.sign_hybrid(intent={
+    "action": "submit_claim",
+    "target": "claim:HC-001",
+    "resource": "https://insurance.example.com/claims/HC-001",
+})
 ```
 
 ### TypeScript

--- a/openai-gpt/knowledge/revocation.md
+++ b/openai-gpt/knowledge/revocation.md
@@ -44,7 +44,6 @@ Maintain a single `StatusList` per status purpose (revocation, or optionally sus
 from vouch import (
     Signer, StatusList, FilesystemStatusListStore,
     build_status_list_credential, build_status_list_entry,
-    build_vouch_credential,
 )
 
 # Load or create the status list
@@ -63,15 +62,13 @@ signer = Signer.from_did("did:web:issuer.example")
 index = status_list.allocate_index()
 store.save(status_list)  # persist the cursor
 
-credential = build_vouch_credential(
-    issuer_did="did:web:issuer.example",
+signed_credential = signer.sign(
     intent={"action": "...", "target": "...", "resource": "..."},
     credential_status=build_status_list_entry(
         status_list_credential="https://issuer.example/status/1",
         status_list_index=index,
     ),
 )
-signed_credential = signer.sign(credential)
 ```
 
 #### Revoke later

--- a/openai-gpt/knowledge/troubleshooting.md
+++ b/openai-gpt/knowledge/troubleshooting.md
@@ -31,10 +31,10 @@ The credential's `intent` is missing one of `action`, `target`, or
 
 ```python
 # Wrong:
-build_vouch_credential(issuer_did="...", intent={"action": "submit"})
+signer.sign(intent={"action": "submit"})
 
 # Right:
-build_vouch_credential(issuer_did="...", intent={
+signer.sign(intent={
     "action": "submit_claim",
     "target": "claim:HC-001",
     "resource": "https://insurance.example.com/claims/HC-001",

--- a/website-agent/backend/knowledge/post-quantum.md
+++ b/website-agent/backend/knowledge/post-quantum.md
@@ -106,10 +106,14 @@ pip install 'vouch-protocol[pq]'
 ```
 
 ```python
-from vouch import Signer, build_vouch_credential
+from vouch import Signer
 
 signer = Signer.from_did_with_hybrid("did:web:agent.example.com")
-signed = signer.sign_hybrid(build_vouch_credential(...))
+signed = signer.sign_hybrid(intent={
+    "action": "submit_claim",
+    "target": "claim:HC-001",
+    "resource": "https://insurance.example.com/claims/HC-001",
+})
 ```
 
 ### TypeScript

--- a/website-agent/backend/knowledge/revocation.md
+++ b/website-agent/backend/knowledge/revocation.md
@@ -44,7 +44,6 @@ Maintain a single `StatusList` per status purpose (revocation, or optionally sus
 from vouch import (
     Signer, StatusList, FilesystemStatusListStore,
     build_status_list_credential, build_status_list_entry,
-    build_vouch_credential,
 )
 
 # Load or create the status list
@@ -63,15 +62,13 @@ signer = Signer.from_did("did:web:issuer.example")
 index = status_list.allocate_index()
 store.save(status_list)  # persist the cursor
 
-credential = build_vouch_credential(
-    issuer_did="did:web:issuer.example",
+signed_credential = signer.sign(
     intent={"action": "...", "target": "...", "resource": "..."},
     credential_status=build_status_list_entry(
         status_list_credential="https://issuer.example/status/1",
         status_list_index=index,
     ),
 )
-signed_credential = signer.sign(credential)
 ```
 
 #### Revoke later

--- a/website-agent/backend/knowledge/troubleshooting.md
+++ b/website-agent/backend/knowledge/troubleshooting.md
@@ -31,10 +31,10 @@ The credential's `intent` is missing one of `action`, `target`, or
 
 ```python
 # Wrong:
-build_vouch_credential(issuer_did="...", intent={"action": "submit"})
+signer.sign(intent={"action": "submit"})
 
 # Right:
-build_vouch_credential(issuer_did="...", intent={
+signer.sign(intent={
     "action": "submit_claim",
     "target": "claim:HC-001",
     "resource": "https://insurance.example.com/claims/HC-001",

--- a/website-agent/backend/vouch_agent/llm.py
+++ b/website-agent/backend/vouch_agent/llm.py
@@ -92,7 +92,7 @@ from vouch import Signer
 
 Correct version of the same:
 ```python
-from vouch import Signer, build_vouch_credential, Verifier
+from vouch import Signer, Verifier
 
 signer = Signer.generate(did="did:web:agent.example.com")
 ```


### PR DESCRIPTION
Brings the knowledge base, the Claude skill reference, and the website-agent backend to the current signing API. `Signer.sign` and `Signer.sign_hybrid` build and sign an intent in one step, and `Verifier.verify` returns the `(is_valid, passport)` tuple. Each example now uses these method names and their keyword arguments (`valid_seconds`, `reputation_score`, `delegation_chain`, `credential_status`, `parent_credential`).
