### PR TITLE
Add a provenance section to the interactive demos

### DIFF
--- a/website/src/app/demos/DemosClient.tsx
+++ b/website/src/app/demos/DemosClient.tsx
@@ -260,6 +260,49 @@ function ReasonedAction() {
 }
 
 /* ------------------------------------------------------------------ */
+/* Section IV — Inference provenance (vouch.provenance)                */
+/* ------------------------------------------------------------------ */
+
+function Provenance() {
+  const [mode, setMode] = useState<'sound' | 'substitute' | 'swap'>('sound');
+  const verdicts = {
+    sound: { ok: true, reason: 'context reproduces and the replay byte-matches', label: 'MATCH' },
+    substitute: { ok: false, reason: 'context_root_mismatch · a retrieved source was swapped', label: 'MISMATCH' },
+    swap: { ok: false, reason: 'weights_mismatch · a different model claims this output', label: 'MISMATCH' },
+  } as const;
+  const v = verdicts[mode];
+  return (
+    <div className="grid md:grid-cols-2 gap-8 items-start">
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          The agent binds its output to a fingerprint of the <b className="text-ink">model</b> and a Merkle root over the
+          <b className="text-ink"> context</b> it was grounded in. An auditor can re-fetch the sources to reproduce the
+          root, and re-run the model on the same seed to byte-compare the output.
+        </p>
+        <div className="eyebrow-faint mb-2">Try it as the auditor</div>
+        <div className="flex flex-col gap-2">
+          <button className={`demo-radio${mode === 'sound' ? ' on' : ''}`} onClick={() => setMode('sound')}>Re-fetch the same sources, re-run the same model</button>
+          <button className={`demo-radio${mode === 'substitute' ? ' on' : ''}`} onClick={() => setMode('substitute')}>Substitute a retrieved source</button>
+          <button className={`demo-radio${mode === 'swap' ? ' on' : ''}`} onClick={() => setMode('swap')}>Swap in a different model</button>
+        </div>
+      </div>
+      <div>
+        <div className="demo-ledger" style={{ minHeight: '150px' }}>
+          <div className="demo-line"><span className="k">output</span> approve_refund · A-1007 · usd:120</div>
+          <div className="demo-line"><span className="k">contextRoot</span> {mode === 'substitute' ? 'uRniQ… recomputes ✗' : 'uRniQ… reproduces ✓'}</div>
+          <div className="demo-line"><span className="k">model</span> {mode === 'swap' ? 'llama-3-8b · hash ✗' : 'llama-3-8b · weightsHash ✓'}</div>
+          <div className="demo-line"><span className="k">sampler</span> seed 42 · temp 0.0</div>
+        </div>
+        <div className="demo-verdict mt-4" style={{ borderColor: v.ok ? ALLOW : DENY }}>
+          <span className="demo-badge" style={{ color: v.ok ? ALLOW : DENY, borderColor: v.ok ? ALLOW : DENY }}>{v.label}</span>
+          <span className="font-mono text-[0.85rem] text-ink-soft">{v.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 
 export default function DemosClient() {
   return (
@@ -286,7 +329,7 @@ export default function DemosClient() {
         </div>
       </section>
 
-      <section id="caveats" className="scroll-mt-24">
+      <section id="caveats" className="border-b border-rule scroll-mt-24">
         <div className="container-wide py-16">
           <div className="section-heading">
             <span className="num">§ III</span>
@@ -294,6 +337,17 @@ export default function DemosClient() {
           </div>
           <p className="eyebrow mb-6">A rule the CEO sets binds an agent two hops down · vouch.caveats</p>
           <Envelope />
+        </div>
+      </section>
+
+      <section id="provenance" className="scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ IV</span>
+            <h2>The provenance</h2>
+          </div>
+          <p className="eyebrow mb-6">Prove the output came from this model on this context · vouch.provenance</p>
+          <Provenance />
         </div>
       </section>
     </>

--- a/website/src/app/demos/page.tsx
+++ b/website/src/app/demos/page.tsx
@@ -25,7 +25,8 @@ export default function DemosPage() {
             Every verdict here mirrors the shipped SDK modules
             {' '}<code className="font-mono text-[0.85em]">vouch.reasoning</code>,
             {' '}<code className="font-mono text-[0.85em]">vouch.deliberation</code>, and
-            {' '}<code className="font-mono text-[0.85em]">vouch.caveats</code>. Disclosed as PAD-085 and PAD-086.
+            {' '}<code className="font-mono text-[0.85em]">vouch.caveats</code>, and
+            {' '}<code className="font-mono text-[0.85em]">vouch.provenance</code>. Disclosed as PAD-043, PAD-045, PAD-085, and PAD-086.
           </p>
         </div>
       </section>

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -283,7 +283,7 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
       {
         q: 'Can I prove what model and safety policy a robot ran, even after an OTA update?',
         a: `Yes, via a \`ModelProvenanceAttestation\` recording the model name, weights hash, safety policy, and config hash. On an over-the-air update the robot re-signs a new attestation with a \`supersedes\` link to the previous one, forming a tamper-evident chain you can walk to answer "what was running at any past time."`,
-        helpLinks: [{ label: 'Provenance guide', href: '/help/#robotics-provenance' }],
+        helpLinks: [{ label: 'Provenance guide', href: '/help/#robotics-provenance' }, { label: 'See it: reproduce and replay a decision', href: '/demos/#provenance' }],
         meta: 'Shipped - vouch.robotics.provenance, PAD-065',
       },
       {


### PR DESCRIPTION
Adds a fourth section (`/demos/#provenance`) to the interactive demos for inference provenance, matching the `vouch.provenance` module.

As the auditor, you can re-fetch the same sources and re-run the same model (**MATCH**), substitute a retrieved source (`context_root_mismatch`), or swap in a different model (`weights_mismatch`), and watch the verdict flip. Styled in the site's parchment/burgundy/serif system like the other three.

Also updates the demos hero footnote to include `vouch.provenance` (PAD-043, PAD-045), and deep-links the "Can I prove what model and safety policy a robot ran?" FAQ answer to the new section.

Pairs with the `vouch.provenance` SDK module.
