### PR TITLE
Add action transparency: an append-only RFC 6962 log of agent actions

### DIFF
--- a/examples/transparency_demo.py
+++ b/examples/transparency_demo.py
@@ -1,0 +1,76 @@
+"""
+Action Transparency: an append-only log that can't hide or rewrite an action.
+
+Consequential actions are submitted to a public Merkle log. The log signs its
+size and root (a Signed Tree Head). Anyone can then demand proof that a specific
+action is in the log, and that an older tree head is a strict prefix of a newer
+one, so the log cannot quietly drop or rewrite history.
+
+Run:
+    python examples/transparency_demo.py
+"""
+
+from vouch import Signer, generate_identity
+from vouch.transparency import (
+    TransparencyLog,
+    check_consistency,
+    check_inclusion,
+    sign_tree_head,
+)
+
+
+def main() -> None:
+    log_kp = generate_identity(domain="log.example.com")
+    log_op = Signer(private_key=log_kp.private_key_jwk, did=log_kp.did)
+
+    log = TransparencyLog()
+    actions = [
+        {"agent": "did:web:agent-a", "action": "transfer_funds", "amount": "usd:5000"},
+        {"agent": "did:web:agent-b", "action": "publish", "target": "blog"},
+        {"agent": "did:web:agent-a", "action": "delete", "target": "db:staging-3"},
+    ]
+    for a in actions:
+        log.append(a)
+
+    old_sth = sign_tree_head(log_op, log)
+    print("logged", old_sth["credentialSubject"]["treeSize"], "actions")
+    print("root:", old_sth["credentialSubject"]["rootHash"][:22], "...")
+
+    # A verifier demands proof that a specific action is in the log.
+    proof = log.inclusion_proof(0)
+    ok = check_inclusion(actions[0], 0, old_sth, proof, log_public_key=log_kp.public_key_jwk)
+    print("\nwire $5000 is in the log?    ", "yes" if ok is None else f"no ({ok})")
+
+    # An action that was never submitted cannot be proven in.
+    r = check_inclusion({"agent": "did:web:rogue", "action": "exfiltrate"}, 0, old_sth, proof)
+    print("a never-logged action proves in?", "no ·", r)
+
+    # The log grows. A monitor checks the new head is a prefix of the old one.
+    for a in [{"agent": "did:web:agent-c", "action": "email", "target": "vendor"}]:
+        log.append(a)
+    new_sth = sign_tree_head(log_op, log)
+    cproof = log.consistency_proof(3)
+    r = check_consistency(old_sth, new_sth, cproof, log_public_key=log_kp.public_key_jwk)
+    print("\nlog appended-only (no rewrite)?", "yes" if r is None else f"no ({r})")
+
+    # Now the log tries to REWRITE history: rebuild with entry 0 changed.
+    forged = TransparencyLog()
+    forged.append(
+        {"agent": "did:web:agent-a", "action": "transfer_funds", "amount": "usd:50"}
+    )  # was 5000
+    for a in actions[1:] + [{"agent": "did:web:agent-c", "action": "email", "target": "vendor"}]:
+        forged.append(a)
+    forged_sth = sign_tree_head(log_op, forged)
+    r = check_consistency(old_sth, forged_sth, forged.consistency_proof(3))
+    print("log rewrote an old entry?      ", "detected ·", r)
+
+    print(
+        "\nPublishing every action in an append-only log makes an omitted or altered\n"
+        "action impossible to hide: inclusion proofs stop silent omission, consistency\n"
+        "proofs stop history rewriting, and a monitor comparing tree heads across\n"
+        "observers catches a split view."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_transparency.py
+++ b/tests/test_transparency.py
@@ -1,0 +1,224 @@
+"""Tests for Action Transparency (append-only RFC 6962 Merkle log)."""
+
+import pytest
+
+from vouch import Signer, generate_identity
+from vouch.transparency import (
+    REASON_CONSISTENCY_FAILED,
+    REASON_INCLUSION_FAILED,
+    REASON_INVALID_STH,
+    REASON_TREE_SHRANK,
+    SIGNED_TREE_HEAD_TYPE,
+    TransparencyError,
+    TransparencyLog,
+    check_consistency,
+    check_inclusion,
+    consistency_proof,
+    entry_digest,
+    inclusion_proof,
+    merkle_tree_hash,
+    sign_tree_head,
+    verify_consistency,
+    verify_inclusion,
+    verify_tree_head,
+)
+
+MAXN = 33
+
+
+def _entries(n):
+    return [entry_digest({"action": "a", "i": i}) for i in range(n)]
+
+
+def _identity(domain="log.example.com"):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestTreeHash:
+    def test_single_leaf_is_leaf_hash(self):
+        from vouch.merkle import hash_leaf
+
+        e = _entries(1)
+        assert merkle_tree_hash(e) == hash_leaf(e[0])
+
+    def test_order_sensitive(self):
+        e = _entries(4)
+        assert merkle_tree_hash(e) != merkle_tree_hash(list(reversed(e)))
+
+    def test_empty_is_hash_of_empty(self):
+        import hashlib
+
+        assert merkle_tree_hash([]) == hashlib.sha256(b"").digest()
+
+
+class TestInclusionExhaustive:
+    def test_every_index_every_size(self):
+        for n in range(1, MAXN):
+            e = _entries(n)
+            root = merkle_tree_hash(e)
+            for i in range(n):
+                proof = inclusion_proof(i, e)
+                assert verify_inclusion(e[i], i, n, proof, root), f"n={n} i={i}"
+
+    def test_wrong_leaf_fails(self):
+        for n in range(2, 12):
+            e = _entries(n)
+            root = merkle_tree_hash(e)
+            proof = inclusion_proof(0, e)
+            assert not verify_inclusion(e[1], 0, n, proof, root)
+
+    def test_wrong_index_fails(self):
+        e = _entries(8)
+        root = merkle_tree_hash(e)
+        proof = inclusion_proof(3, e)
+        assert not verify_inclusion(e[3], 4, 8, proof, root)
+
+    def test_tampered_proof_fails(self):
+        e = _entries(8)
+        root = merkle_tree_hash(e)
+        proof = inclusion_proof(5, e)
+        proof[0] = bytes(32)
+        assert not verify_inclusion(e[5], 5, 8, proof, root)
+
+    def test_out_of_range(self):
+        with pytest.raises(TransparencyError):
+            inclusion_proof(5, _entries(3))
+
+
+class TestConsistencyExhaustive:
+    def test_every_prefix_every_size(self):
+        for n in range(1, MAXN):
+            e = _entries(n)
+            new_root = merkle_tree_hash(e)
+            for m in range(1, n + 1):
+                proof = consistency_proof(m, e)
+                old_root = merkle_tree_hash(e[:m])
+                assert verify_consistency(m, n, proof, old_root, new_root), f"m={m} n={n}"
+
+    def test_rewritten_history_fails(self):
+        # A log that changed an old entry cannot prove consistency with the
+        # original old root.
+        for n in range(2, 14):
+            for m in range(1, n):
+                orig = _entries(n)
+                orig_old_root = merkle_tree_hash(orig[:m])
+                forked = list(orig)
+                forked[0] = entry_digest({"tampered": True})
+                proof = consistency_proof(m, forked)
+                forked_new_root = merkle_tree_hash(forked)
+                assert not verify_consistency(m, n, proof, orig_old_root, forked_new_root)
+
+    def test_equal_sizes(self):
+        e = _entries(5)
+        r = merkle_tree_hash(e)
+        assert verify_consistency(5, 5, [], r, r)
+        assert not verify_consistency(5, 5, [], r, bytes(32))
+
+    def test_tree_shrank_fails(self):
+        e = _entries(6)
+        assert not verify_consistency(6, 4, [], merkle_tree_hash(e), merkle_tree_hash(e[:4]))
+
+    def test_tampered_proof_fails(self):
+        e = _entries(10)
+        proof = consistency_proof(3, e)
+        proof[0] = bytes(32)
+        assert not verify_consistency(3, 10, proof, merkle_tree_hash(e[:3]), merkle_tree_hash(e))
+
+
+class TestLog:
+    def test_append_and_root(self):
+        log = TransparencyLog()
+        assert log.size == 0
+        log.append({"action": "x"})
+        log.append({"action": "y"})
+        assert log.size == 2
+        assert log.root() == merkle_tree_hash(
+            [entry_digest({"action": "x"}), entry_digest({"action": "y"})]
+        )
+
+    def test_log_inclusion_roundtrip(self):
+        log = TransparencyLog()
+        for i in range(9):
+            log.append({"i": i})
+        from vouch.transparency import _unmb
+
+        proof = [_unmb(p) for p in log.inclusion_proof(4)]
+        assert verify_inclusion(entry_digest({"i": 4}), 4, 9, proof, log.root())
+
+
+class TestSignedTreeHead:
+    def test_sign_and_verify(self):
+        kp, log_signer = _identity()
+        log = TransparencyLog()
+        log.append({"action": "wire"})
+        sth = sign_tree_head(log_signer, log)
+        assert SIGNED_TREE_HEAD_TYPE in sth["type"]
+        ok, subject = verify_tree_head(sth, kp.public_key_jwk)
+        assert ok and subject["treeSize"] == 1
+
+    def test_wrong_key_fails(self):
+        _, log_signer = _identity()
+        other_kp, _ = _identity("other.example.com")
+        log = TransparencyLog()
+        log.append({"a": 1})
+        sth = sign_tree_head(log_signer, log)
+        ok, _ = verify_tree_head(sth, other_kp.public_key_jwk)
+        assert ok is False
+
+
+class TestVerifierChecks:
+    def _log_with_sth(self, n):
+        kp, log_signer = _identity()
+        log = TransparencyLog()
+        actions = [{"action": "act", "i": i} for i in range(n)]
+        for a in actions:
+            log.append(a)
+        sth = sign_tree_head(log_signer, log)
+        return kp, log_signer, log, sth, actions
+
+    def test_check_inclusion_ok(self):
+        kp, _, log, sth, actions = self._log_with_sth(7)
+        proof = log.inclusion_proof(3)
+        assert check_inclusion(actions[3], 3, sth, proof, log_public_key=kp.public_key_jwk) is None
+
+    def test_action_not_in_log_rejected(self):
+        kp, _, log, sth, actions = self._log_with_sth(7)
+        proof = log.inclusion_proof(3)
+        assert check_inclusion({"action": "never_logged"}, 3, sth, proof) == REASON_INCLUSION_FAILED
+
+    def test_check_inclusion_bad_sth(self):
+        kp, _, log, sth, actions = self._log_with_sth(7)
+        other_kp, _ = _identity("other.example.com")
+        proof = log.inclusion_proof(3)
+        assert (
+            check_inclusion(actions[3], 3, sth, proof, log_public_key=other_kp.public_key_jwk)
+            == REASON_INVALID_STH
+        )
+
+    def test_check_consistency_ok(self):
+        kp, log_signer, log, old_sth, actions = self._log_with_sth(5)
+        for i in range(5, 9):
+            log.append({"action": "act", "i": i})
+        new_sth = sign_tree_head(log_signer, log)
+        proof = log.consistency_proof(5)
+        assert check_consistency(old_sth, new_sth, proof, log_public_key=kp.public_key_jwk) is None
+
+    def test_check_consistency_rewrite_rejected(self):
+        # The log rewrites an old entry, then issues a new STH: consistency breaks.
+        kp, log_signer, log, old_sth, actions = self._log_with_sth(5)
+        forked = TransparencyLog()
+        forked.append({"tampered": True})  # entry 0 changed
+        for i in range(1, 9):
+            forked.append({"action": "act", "i": i})
+        new_sth = sign_tree_head(log_signer, forked)
+        proof = forked.consistency_proof(5)
+        assert check_consistency(old_sth, new_sth, proof) == REASON_CONSISTENCY_FAILED
+
+    def test_check_consistency_shrank(self):
+        kp, log_signer, log, big_sth, actions = self._log_with_sth(6)
+        small = TransparencyLog()
+        for i in range(3):
+            small.append({"action": "act", "i": i})
+        small_sth = sign_tree_head(log_signer, small)
+        assert check_consistency(big_sth, small_sth, []) == REASON_TREE_SHRANK

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -345,6 +345,25 @@ def __getattr__(name):
         from . import provenance
 
         return getattr(provenance, name)
+    # Action transparency (append-only RFC 6962 log of agent actions)
+    elif name in (
+        "TransparencyError",
+        "SIGNED_TREE_HEAD_TYPE",
+        "TransparencyLog",
+        "entry_digest",
+        "merkle_tree_hash",
+        "inclusion_proof",
+        "verify_inclusion",
+        "consistency_proof",
+        "verify_consistency",
+        "sign_tree_head",
+        "verify_tree_head",
+        "check_inclusion",
+        "check_consistency",
+    ):
+        from . import transparency
+
+        return getattr(transparency, name)
     # Reputation receipts and aggregation (evidence-backed reputation)
     elif name in (
         "ReceiptError",
@@ -615,6 +634,20 @@ __all__ = [
     "verify_inference_provenance",
     "verify_context",
     "check_replay",
+    # Action transparency (append-only RFC 6962 log)
+    "TransparencyError",
+    "SIGNED_TREE_HEAD_TYPE",
+    "TransparencyLog",
+    "entry_digest",
+    "merkle_tree_hash",
+    "inclusion_proof",
+    "verify_inclusion",
+    "consistency_proof",
+    "verify_consistency",
+    "sign_tree_head",
+    "verify_tree_head",
+    "check_inclusion",
+    "check_consistency",
     # Reputation receipts and aggregation
     "ReceiptError",
     "Signal",

--- a/vouch/transparency.py
+++ b/vouch/transparency.py
@@ -1,0 +1,432 @@
+"""
+Action Transparency: an append-only, publicly-auditable log of agent actions.
+
+Point verification catches what one verifier sees. Certificate Transparency
+taught the harder lesson: publishing every issuance in an append-only log made
+misissuance impossible to hide, and that alone changed issuer behaviour. This
+module brings the same discipline to agent actions.
+
+Consequential action credentials are submitted to an append-only Merkle log. The
+log periodically signs a **Signed Tree Head** (its size and Merkle root) as a
+commitment to its state. A verifier can then demand:
+
+  - an **inclusion proof** that a given action is actually in the log a Signed
+    Tree Head commits to, so an action cannot be quietly kept out of the record;
+  - a **consistency proof** that an older Signed Tree Head is a strict prefix of a
+    newer one, so the log cannot rewrite or delete history, and a monitor comparing
+    tree heads across observers detects a split view.
+
+The Merkle tree follows RFC 6962 (leaf and node hashes are domain-separated via
+``vouch.merkle``'s ``hash_leaf`` and ``hash_node``), so inclusion and consistency
+proofs are compact and the roots are reproducible across implementations. This
+module ships the log mechanics and the proof verification; the anomaly-detection
+policy a monitor layers on top is deployment-specific. It is the on-protocol
+transparency layer beneath the accountable-autonomy runtime.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from . import data_integrity
+from .jcs import canonicalize
+from .merkle import hash_leaf, hash_node
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+
+SIGNED_TREE_HEAD_TYPE = "SignedTreeHead"
+
+# Structured verification reasons (stable strings, mirrored by the SDKs).
+REASON_INVALID_STH = "invalid_signed_tree_head"
+REASON_STH_MISMATCH = "sth_mismatch"
+REASON_INCLUSION_FAILED = "inclusion_failed"
+REASON_CONSISTENCY_FAILED = "consistency_failed"
+REASON_TREE_SHRANK = "tree_shrank"
+
+
+class TransparencyError(Exception):
+    """Raised on malformed transparency-log input."""
+
+
+# ---------------------------------------------------------------------------
+# Encoding + signing helpers
+# ---------------------------------------------------------------------------
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _mb(b: bytes) -> str:
+    return "u" + base64.urlsafe_b64encode(b).rstrip(b"=").decode("ascii")
+
+
+def _unmb(s: str) -> bytes:
+    if not isinstance(s, str) or not s.startswith("u"):
+        raise TransparencyError("expected multibase 'u' prefix")
+    payload = s[1:]
+    return base64.urlsafe_b64decode(payload + "=" * (-len(payload) % 4))
+
+
+def _raw_priv(signer: Any):
+    raw = getattr(signer, "_raw_priv", None)
+    if raw is None:
+        raise TransparencyError("signing requires a Signer with an Ed25519 key")
+    return raw
+
+
+def _attach_proof(credential: Dict[str, Any], signer: Any) -> Dict[str, Any]:
+    credential["proof"] = data_integrity.build_proof(
+        credential, _raw_priv(signer), signer.verification_method_id()
+    )
+    return credential
+
+
+def _type_list(credential: Dict[str, Any]) -> list:
+    t = credential.get("type") or []
+    return [t] if isinstance(t, str) else list(t)
+
+
+def _to_bytes(value: Any) -> bytes:
+    if isinstance(value, (bytes, bytearray)):
+        return bytes(value)
+    if isinstance(value, str):
+        return value.encode("utf-8")
+    if isinstance(value, dict):
+        return canonicalize(value)
+    raise TransparencyError("log entry must be a dict, str, or bytes")
+
+
+def entry_digest(value: Any) -> bytes:
+    """The 32-byte log entry for an action (SHA-256 over its canonical bytes)."""
+    return hashlib.sha256(_to_bytes(value)).digest()
+
+
+# ---------------------------------------------------------------------------
+# RFC 6962 Merkle tree hash, inclusion, and consistency
+# ---------------------------------------------------------------------------
+
+
+def _k(n: int) -> int:
+    """Largest power of two strictly less than n (n >= 2)."""
+    k = 1
+    while (k << 1) < n:
+        k <<= 1
+    return k
+
+
+def merkle_tree_hash(entries: Sequence[bytes]) -> bytes:
+    """RFC 6962 Merkle Tree Hash over an ordered list of leaf values."""
+    n = len(entries)
+    if n == 0:
+        return hashlib.sha256(b"").digest()
+    if n == 1:
+        return hash_leaf(bytes(entries[0]))
+    k = _k(n)
+    return hash_node(merkle_tree_hash(entries[:k]), merkle_tree_hash(entries[k:]))
+
+
+def inclusion_proof(index: int, entries: Sequence[bytes]) -> List[bytes]:
+    """RFC 6962 audit path proving ``entries[index]`` is in the tree."""
+    n = len(entries)
+    if not 0 <= index < n:
+        raise TransparencyError("index out of range")
+    if n == 1:
+        return []
+    k = _k(n)
+    if index < k:
+        return inclusion_proof(index, entries[:k]) + [merkle_tree_hash(entries[k:])]
+    return inclusion_proof(index - k, entries[k:]) + [merkle_tree_hash(entries[:k])]
+
+
+def verify_inclusion(
+    leaf: bytes, index: int, tree_size: int, proof: Sequence[bytes], root: bytes
+) -> bool:
+    """Verify an RFC 6962 inclusion proof: that ``leaf`` at ``index`` is in a tree
+    of ``tree_size`` with the given ``root``."""
+    if not 0 <= index < tree_size:
+        return False
+    fn, sn = index, tree_size - 1
+    r = hash_leaf(bytes(leaf))
+    for p in proof:
+        if sn == 0:
+            return False
+        if (fn & 1) or fn == sn:
+            r = hash_node(bytes(p), r)
+            if not (fn & 1):
+                while not (fn & 1) and fn != 0:
+                    fn >>= 1
+                    sn >>= 1
+        else:
+            r = hash_node(r, bytes(p))
+        fn >>= 1
+        sn >>= 1
+    return sn == 0 and r == bytes(root)
+
+
+def _subproof(m: int, entries: Sequence[bytes], b: bool) -> List[bytes]:
+    n = len(entries)
+    if m == n:
+        return [] if b else [merkle_tree_hash(entries)]
+    k = _k(n)
+    if m <= k:
+        return _subproof(m, entries[:k], b) + [merkle_tree_hash(entries[k:])]
+    return _subproof(m - k, entries[k:], False) + [merkle_tree_hash(entries[:k])]
+
+
+def consistency_proof(old_size: int, entries: Sequence[bytes]) -> List[bytes]:
+    """RFC 6962 consistency proof that the tree of ``old_size`` is a prefix of the
+    tree over all ``entries``."""
+    n = len(entries)
+    if not 0 < old_size <= n:
+        raise TransparencyError("old_size must be in (0, len(entries)]")
+    if old_size == n:
+        return []
+    return _subproof(old_size, entries, True)
+
+
+def verify_consistency(
+    old_size: int,
+    new_size: int,
+    proof: Sequence[bytes],
+    old_root: bytes,
+    new_root: bytes,
+) -> bool:
+    """Verify an RFC 6962 consistency proof: that the tree of ``old_size`` with
+    ``old_root`` is a prefix of the tree of ``new_size`` with ``new_root``."""
+    old_root, new_root = bytes(old_root), bytes(new_root)
+    if old_size > new_size:
+        return False
+    if old_size == new_size:
+        return len(proof) == 0 and old_root == new_root
+    if old_size == 0:
+        return len(proof) == 0
+
+    node, last = old_size - 1, new_size - 1
+    while node & 1:
+        node >>= 1
+        last >>= 1
+
+    proof = [bytes(p) for p in proof]
+    if old_size & (old_size - 1) == 0:  # old_size is a power of two
+        fr = sr = old_root
+        idx = 0
+    else:
+        if not proof:
+            return False
+        fr = sr = proof[0]
+        idx = 1
+
+    while node:
+        if idx >= len(proof):
+            return False
+        if node & 1:
+            p = proof[idx]
+            idx += 1
+            fr = hash_node(p, fr)
+            sr = hash_node(p, sr)
+        elif node < last:
+            p = proof[idx]
+            idx += 1
+            sr = hash_node(sr, p)
+        node >>= 1
+        last >>= 1
+
+    while last:
+        if idx >= len(proof):
+            return False
+        sr = hash_node(sr, proof[idx])
+        idx += 1
+        last >>= 1
+
+    return idx == len(proof) and fr == old_root and sr == new_root
+
+
+# ---------------------------------------------------------------------------
+# The append-only log
+# ---------------------------------------------------------------------------
+
+
+class TransparencyLog:
+    """
+    An in-memory append-only Merkle log of entry digests. A hosted log persists
+    the same structure; the wire artifacts (Signed Tree Heads and proofs) are
+    identical either way.
+    """
+
+    def __init__(self, entries: Optional[Sequence[bytes]] = None):
+        self._entries: List[bytes] = [bytes(e) for e in (entries or [])]
+
+    @property
+    def size(self) -> int:
+        return len(self._entries)
+
+    def append(self, value: Any) -> int:
+        """Append an action (its entry digest) and return its index."""
+        self._entries.append(entry_digest(value))
+        return len(self._entries) - 1
+
+    def append_digest(self, digest: bytes) -> int:
+        if len(digest) != 32:
+            raise TransparencyError("entry digest must be 32 bytes")
+        self._entries.append(bytes(digest))
+        return len(self._entries) - 1
+
+    def root(self) -> bytes:
+        return merkle_tree_hash(self._entries)
+
+    def root_multibase(self) -> str:
+        return _mb(self.root())
+
+    def inclusion_proof(self, index: int) -> List[str]:
+        return [_mb(h) for h in inclusion_proof(index, self._entries)]
+
+    def consistency_proof(self, old_size: int) -> List[str]:
+        return [_mb(h) for h in consistency_proof(old_size, self._entries)]
+
+
+# ---------------------------------------------------------------------------
+# Signed Tree Heads and verifier-side checks
+# ---------------------------------------------------------------------------
+
+
+def sign_tree_head(
+    log_signer: Any,
+    log: TransparencyLog,
+    *,
+    log_id: Optional[str] = None,
+    timestamp: Optional[datetime] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Issue a ``SignedTreeHead`` committing to the log's current size and root."""
+    issued = (timestamp or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    sth: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", SIGNED_TREE_HEAD_TYPE],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "issuer": log_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": {
+            "logId": log_id or log_signer.get_did(),
+            "treeSize": log.size,
+            "rootHash": log.root_multibase(),
+        },
+    }
+    return _attach_proof(sth, log_signer)
+
+
+def verify_tree_head(
+    sth: Dict[str, Any], log_public_key: Any
+) -> Tuple[bool, Optional[Dict[str, Any]]]:
+    """Verify a Signed Tree Head's proof and structure. Returns (ok, subject)."""
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    if SIGNED_TREE_HEAD_TYPE not in _type_list(sth):
+        return False, None
+    resolved = _coerce_ed25519_public_key(log_public_key) if log_public_key is not None else None
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(sth, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+    subject = sth.get("credentialSubject") or {}
+    if not isinstance(subject.get("treeSize"), int) or not subject.get("rootHash"):
+        return False, None
+    return True, subject
+
+
+def check_inclusion(
+    entry: Any,
+    index: int,
+    sth: Dict[str, Any],
+    proof: Sequence[str],
+    *,
+    log_public_key: Any = None,
+) -> Optional[str]:
+    """
+    Confirm an action is in the log a Signed Tree Head commits to. Returns None on
+    success or a structured reason. Pass ``log_public_key`` to also verify the STH.
+    """
+    if log_public_key is not None:
+        ok, _ = verify_tree_head(sth, log_public_key)
+        if not ok:
+            return REASON_INVALID_STH
+    subject = sth.get("credentialSubject") or {}
+    size = subject.get("treeSize")
+    root_mb = subject.get("rootHash")
+    if not isinstance(size, int) or not root_mb:
+        return REASON_INVALID_STH
+    leaf = (
+        entry_digest(entry)
+        if not (isinstance(entry, (bytes, bytearray)) and len(entry) == 32)
+        else bytes(entry)
+    )
+    try:
+        proof_bytes = [_unmb(p) for p in proof]
+        if not verify_inclusion(leaf, index, size, proof_bytes, _unmb(root_mb)):
+            return REASON_INCLUSION_FAILED
+    except TransparencyError:
+        return REASON_INCLUSION_FAILED
+    return None
+
+
+def check_consistency(
+    old_sth: Dict[str, Any],
+    new_sth: Dict[str, Any],
+    proof: Sequence[str],
+    *,
+    log_public_key: Any = None,
+) -> Optional[str]:
+    """
+    Confirm an older Signed Tree Head is a strict prefix of a newer one, so the log
+    did not rewrite or delete history. Returns None on success or a structured
+    reason. Pass ``log_public_key`` to also verify both tree heads.
+    """
+    if log_public_key is not None:
+        for h in (old_sth, new_sth):
+            ok, _ = verify_tree_head(h, log_public_key)
+            if not ok:
+                return REASON_INVALID_STH
+    o = old_sth.get("credentialSubject") or {}
+    n = new_sth.get("credentialSubject") or {}
+    old_size, new_size = o.get("treeSize"), n.get("treeSize")
+    if not isinstance(old_size, int) or not isinstance(new_size, int):
+        return REASON_INVALID_STH
+    if new_size < old_size:
+        return REASON_TREE_SHRANK
+    try:
+        if not verify_consistency(
+            old_size,
+            new_size,
+            [_unmb(p) for p in proof],
+            _unmb(o["rootHash"]),
+            _unmb(n["rootHash"]),
+        ):
+            return REASON_CONSISTENCY_FAILED
+    except (TransparencyError, KeyError):
+        return REASON_CONSISTENCY_FAILED
+    return None
+
+
+__all__ = [
+    "TransparencyError",
+    "SIGNED_TREE_HEAD_TYPE",
+    "TransparencyLog",
+    "entry_digest",
+    "merkle_tree_hash",
+    "inclusion_proof",
+    "verify_inclusion",
+    "consistency_proof",
+    "verify_consistency",
+    "sign_tree_head",
+    "verify_tree_head",
+    "check_inclusion",
+    "check_consistency",
+]


### PR DESCRIPTION
Adds a `vouch.transparency` module: an append-only, publicly-auditable log of agent actions, the same discipline Certificate Transparency brought to misissuance.

Consequential action credentials are submitted to an append-only Merkle log that signs its size and root as a **Signed Tree Head**. Then:

- a verifier can demand an **inclusion proof** that a specific action is in the log a tree head commits to (`inclusion_failed` otherwise), so an action cannot be silently omitted;
- a monitor can demand a **consistency proof** that an older tree head is a strict prefix of a newer one (`consistency_failed`, `tree_shrank` otherwise), so the log cannot rewrite or delete history, and comparing tree heads across observers catches a split view.

The tree follows RFC 6962 with domain-separated leaf and node hashes from `vouch.merkle`, so inclusion and consistency proofs are compact and reproducible across implementations; the Signed Tree Head is an `eddsa-jcs-2022` Verifiable Credential. This ships the log mechanics and proof verification; the anomaly-detection policy a monitor layers on top is left to the deployment.

Includes exhaustive proof tests (every index and prefix across many tree sizes, plus rewrite-history and shrink attacks), a runnable example (`examples/transparency_demo.py`), and a test suite (`tests/test_transparency.py`).
