### PR TITLE
Document the accountable-autonomy runtime across the FAQ, guides, knowledge base, and assistants

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -258,6 +258,20 @@ attestation = attest_outcome(
 See `reference/outcome-evidence.md`. This is the per-verdict evidence layer
 underneath the reputation engine.
 
+### "How do I bound or record what an already-authorized agent does?"
+
+The accountable-autonomy runtime is five Python SDK modules: `vouch.reasoning`
+(the agent states why before acting and cannot fabricate or rewrite it),
+`vouch.deliberation` (irreversible actions commit an intent, wait out a challenge
+window, and can be vetoed before a verifier accepts them), `vouch.caveats` (live
+conditions on a delegation link that accumulate down the chain and cannot be
+dropped by a descendant), `vouch.provenance` (bind an output to a fingerprint of
+the model weights and a Merkle root over the context, reproducible by replay), and
+`vouch.transparency` (an append-only RFC 6962 log with inclusion and consistency
+proofs so an action cannot be omitted or rewritten). See
+`reference/accountable-autonomy.md`; each has a runnable `examples/*_demo.py` and a
+live section on the interactive demos page.
+
 ### "How do I integrate Vouch with LangChain / CrewAI / MCP?"
 
 Reference implementations under `vouch/integrations/`. See

--- a/claude-skill/skills/vouch-protocol/reference/accountable-autonomy.md
+++ b/claude-skill/skills/vouch-protocol/reference/accountable-autonomy.md
@@ -1,0 +1,131 @@
+# Accountable Autonomy Reference
+
+Identity and delegation prove who acted and under what authority. They do not,
+on their own, bound what an already-authorized agent may do, slow down an
+irreversible action, prove why the agent acted, or make the record public. The
+accountable-autonomy runtime adds five Python SDK modules that do, each an
+ordinary `eddsa-jcs-2022` Verifiable Credential so it verifies across the
+language SDKs.
+
+## Reasoned Action Proofs (`vouch.reasoning`)
+
+The agent states *why* before it acts, ties each reason to a real artifact by its
+hash, and escrows the justification before executing. An auditor can then prove
+the reasoning was neither fabricated (each anchor must resolve and hash-match) nor
+rewritten after the fact (the justification must recompute to the committed
+digest), and that it was committed before execution.
+
+```python
+from vouch import Signer, generate_identity
+from vouch.reasoning import (
+    build_justification, evidence_anchor, sign_reasoned_action,
+    verify_reasoned_action, verify_justification, LocalEscrow, justification_digest,
+)
+
+k = generate_identity("agent.example.com"); agent = Signer(private_key=k.private_key_jwk, did=k.did)
+intent = {"action": "delete", "target": "/tmp/cache", "resource": "/tmp/cache/*"}
+just = build_justification(intent, [evidence_anchor("user asked", ref="msg:1", evidence={"text": "clean /tmp"})])
+cred = sign_reasoned_action(agent, intent=intent, justification=just)
+ok, subject = verify_reasoned_action(cred, k.public_key_jwk)
+good, reason = verify_justification(just, subject, resolver={"msg:1": {"text": "clean /tmp"}}.get)
+```
+
+Structured reasons: `justification_digest_mismatch`, `evidence_unresolved`,
+`evidence_hash_mismatch`, `escrow_after_execution`.
+
+## Proof of Deliberation (`vouch.deliberation`)
+
+A reversible action runs instantly. An irreversible one (wire funds, delete
+without backup, publish, actuate) must commit and broadcast a signed intent with
+a challenge window and a set of authorized objectors, wait out the window, and
+survive any veto before a verifier accepts the execute credential. The agent
+cannot shorten the window (the verifier checks the elapse) and cannot clear its
+own veto (the veto authority is a separate DID).
+
+```python
+from vouch.deliberation import (
+    commit_intent, execute, veto_intent, check_execution, CLASS_IRREVERSIBLE_FINANCIAL,
+)
+
+intent = commit_intent(agent, intent={"action": "transfer_funds", "target": "acct:v1", "resource": "usd:5000"},
+                       reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL, min_seconds=900,
+                       veto_authorities=["did:web:controller"])
+ex = execute(agent, intent_credential=intent)  # only accepted once the window has elapsed
+reason = check_execution(ex, intent, k.public_key_jwk)   # None, or challenge_window_not_elapsed / vetoed
+```
+
+Structured reasons: `challenge_window_not_elapsed`, `vetoed`, `intent_mismatch`,
+`unauthorized_executor`.
+
+## Executable Caveats (`vouch.caveats`)
+
+Delegation narrows static fields (action, target, resource, time, rate). Caveats
+add live conditions ("only for shipped orders", "under the lifetime spend",
+"business hours") attached to a delegation link. Caveats accumulate down the
+chain, no descendant can drop an ancestor's caveat (the verifier requires the
+chain to root at the grantor), and every verifier must evaluate every accumulated
+caveat. A standard caveat library evaluates identically across languages; a
+custom module-hash caveat is the escape hatch.
+
+```python
+from vouch.caveats import build_capability, verify_capability, flag_true, value_ceiling
+
+link1 = build_capability(ceo, to=mgr.get_did(), attenuation={"action": "refund"},
+                         caveats=[flag_true("shipped-only", field="shipped")])
+link2 = build_capability(mgr, to=agent.get_did(), attenuation={"action": "refund", "resource": "usd:<=200"},
+                         caveats=[value_ceiling("under-200", field="amount", limit=200)], parent=link1)
+reason = verify_capability([link1, link2], keys.get, {"shipped": True, "amount": 120}, root_issuer=ceo.get_did())
+```
+
+Structured reasons: `caveat_denied:<id>`, `unrooted_capability`, `broken_chain`,
+`verifier_budget_exceeded`.
+
+## Inference Provenance (`vouch.provenance`)
+
+Binds an output to a fingerprint of the model weights and a Merkle root over the
+context it was grounded in, plus the sampler settings. An auditor can re-fetch
+the sources to reproduce the context root (catching a fabricated or substituted
+context) and re-run the model on the same seed to byte-compare the output.
+
+```python
+from vouch.provenance import sign_inference_provenance, verify_context, check_replay, weights_hash
+
+cred = sign_inference_provenance(agent, output={"action": "approve_refund"},
+                                 model_weights_hash=weights_hash(b"...weights..."),
+                                 context_chunks=[{"source": "policy://refunds", "text": "..."}],
+                                 sampler={"seed": 42, "temperature": 0.0})
+ok, subject = verify_inference_provenance(cred, k.public_key_jwk)
+good, reason = verify_context([{"source": "policy://refunds", "text": "..."}], subject)  # context_root_mismatch on tamper
+```
+
+Structured reasons: `context_root_mismatch`, `output_mismatch`, `weights_mismatch`.
+
+## Action Transparency (`vouch.transparency`)
+
+Consequential actions are submitted to an append-only RFC 6962 Merkle log that
+signs its size and root as a Signed Tree Head. A verifier can demand an inclusion
+proof that an action is in the log; a monitor can demand a consistency proof that
+an older tree head is a strict prefix of a newer one, so the log cannot silently
+omit an action or rewrite history, and comparing tree heads across observers
+catches a split view.
+
+```python
+from vouch.transparency import TransparencyLog, sign_tree_head, check_inclusion, check_consistency
+
+log = TransparencyLog()
+i = log.append({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"})
+sth = sign_tree_head(log_operator, log)
+reason = check_inclusion({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"},
+                         i, sth, log.inclusion_proof(i), log_public_key=log_keys.public_key_jwk)
+```
+
+Structured reasons: `inclusion_failed`, `consistency_failed`, `tree_shrank`,
+`invalid_signed_tree_head`.
+
+## How they compose
+
+None of these verify an agent's mind. Together they make harm irrational and
+unhidable even for a misaligned agent: it must state a reason on the record
+(reasoning), wait out a window a human can veto (deliberation), stay inside an
+authority that cannot be broadened (caveats), against a decision that is
+reproducible (provenance), in front of a public append-only log (transparency).

--- a/claude-skill/skills/vouch-protocol/reference/overview.md
+++ b/claude-skill/skills/vouch-protocol/reference/overview.md
@@ -77,3 +77,16 @@ https://github.com/vouch-protocol/vouch
 
 - Discord: https://discord.gg/mMqx5cG9Y
 - Issues: https://github.com/vouch-protocol/vouch/issues
+
+## Accountable-autonomy runtime
+
+Five modules bound and record what an already-authorized agent does, so harm is
+hard to hide even for a misaligned agent: Reasoned Action Proofs
+(`vouch.reasoning`, the agent states why and cannot fabricate or rewrite it),
+Proof of Deliberation (`vouch.deliberation`, irreversible actions wait out a
+challenge window a human can veto), Executable Caveats (`vouch.caveats`, live
+conditions that bind every descendant of a delegation and cannot be dropped),
+Inference Provenance (`vouch.provenance`, the output is bound to the model and
+context that produced it, and is reproducible), and Action Transparency
+(`vouch.transparency`, an append-only RFC 6962 log so an action cannot be
+omitted or rewritten). See `accountable-autonomy.md`.

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -88,6 +88,14 @@ Never share user data with external sites.
   evidence (`vouch.accountability`): commit the verdict before the outcome with
   `commit_outcome`, settle it later with `attest_outcome`. Verification rejects a
   settlement timestamped before its commitment. See `outcome-evidence.md`.
+- "How do I bound or record what an already-authorized agent does?" -> The
+  accountable-autonomy runtime: `vouch.reasoning` (state why, cannot fabricate or
+  rewrite), `vouch.deliberation` (irreversible actions wait out a challenge window
+  and can be vetoed), `vouch.caveats` (live conditions that bind every descendant
+  of a delegation and cannot be dropped), `vouch.provenance` (bind an output to the
+  model and context, reproducible by replay), and `vouch.transparency` (append-only
+  RFC 6962 log with inclusion and consistency proofs). See
+  `accountable-autonomy.md`.
 - "How does agent reputation work?" -> Evidence-backed reputation: signed
   receipts (`vouch.receipts`) aggregated by a public deterministic function
   (`vouch.reputation_aggregate`) over a verified ledger (`vouch.reputation_ledger`),

--- a/gemini-gem/knowledge/accountable-autonomy.md
+++ b/gemini-gem/knowledge/accountable-autonomy.md
@@ -1,0 +1,131 @@
+# Accountable Autonomy Reference
+
+Identity and delegation prove who acted and under what authority. They do not,
+on their own, bound what an already-authorized agent may do, slow down an
+irreversible action, prove why the agent acted, or make the record public. The
+accountable-autonomy runtime adds five Python SDK modules that do, each an
+ordinary `eddsa-jcs-2022` Verifiable Credential so it verifies across the
+language SDKs.
+
+## Reasoned Action Proofs (`vouch.reasoning`)
+
+The agent states *why* before it acts, ties each reason to a real artifact by its
+hash, and escrows the justification before executing. An auditor can then prove
+the reasoning was neither fabricated (each anchor must resolve and hash-match) nor
+rewritten after the fact (the justification must recompute to the committed
+digest), and that it was committed before execution.
+
+```python
+from vouch import Signer, generate_identity
+from vouch.reasoning import (
+    build_justification, evidence_anchor, sign_reasoned_action,
+    verify_reasoned_action, verify_justification, LocalEscrow, justification_digest,
+)
+
+k = generate_identity("agent.example.com"); agent = Signer(private_key=k.private_key_jwk, did=k.did)
+intent = {"action": "delete", "target": "/tmp/cache", "resource": "/tmp/cache/*"}
+just = build_justification(intent, [evidence_anchor("user asked", ref="msg:1", evidence={"text": "clean /tmp"})])
+cred = sign_reasoned_action(agent, intent=intent, justification=just)
+ok, subject = verify_reasoned_action(cred, k.public_key_jwk)
+good, reason = verify_justification(just, subject, resolver={"msg:1": {"text": "clean /tmp"}}.get)
+```
+
+Structured reasons: `justification_digest_mismatch`, `evidence_unresolved`,
+`evidence_hash_mismatch`, `escrow_after_execution`.
+
+## Proof of Deliberation (`vouch.deliberation`)
+
+A reversible action runs instantly. An irreversible one (wire funds, delete
+without backup, publish, actuate) must commit and broadcast a signed intent with
+a challenge window and a set of authorized objectors, wait out the window, and
+survive any veto before a verifier accepts the execute credential. The agent
+cannot shorten the window (the verifier checks the elapse) and cannot clear its
+own veto (the veto authority is a separate DID).
+
+```python
+from vouch.deliberation import (
+    commit_intent, execute, veto_intent, check_execution, CLASS_IRREVERSIBLE_FINANCIAL,
+)
+
+intent = commit_intent(agent, intent={"action": "transfer_funds", "target": "acct:v1", "resource": "usd:5000"},
+                       reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL, min_seconds=900,
+                       veto_authorities=["did:web:controller"])
+ex = execute(agent, intent_credential=intent)  # only accepted once the window has elapsed
+reason = check_execution(ex, intent, k.public_key_jwk)   # None, or challenge_window_not_elapsed / vetoed
+```
+
+Structured reasons: `challenge_window_not_elapsed`, `vetoed`, `intent_mismatch`,
+`unauthorized_executor`.
+
+## Executable Caveats (`vouch.caveats`)
+
+Delegation narrows static fields (action, target, resource, time, rate). Caveats
+add live conditions ("only for shipped orders", "under the lifetime spend",
+"business hours") attached to a delegation link. Caveats accumulate down the
+chain, no descendant can drop an ancestor's caveat (the verifier requires the
+chain to root at the grantor), and every verifier must evaluate every accumulated
+caveat. A standard caveat library evaluates identically across languages; a
+custom module-hash caveat is the escape hatch.
+
+```python
+from vouch.caveats import build_capability, verify_capability, flag_true, value_ceiling
+
+link1 = build_capability(ceo, to=mgr.get_did(), attenuation={"action": "refund"},
+                         caveats=[flag_true("shipped-only", field="shipped")])
+link2 = build_capability(mgr, to=agent.get_did(), attenuation={"action": "refund", "resource": "usd:<=200"},
+                         caveats=[value_ceiling("under-200", field="amount", limit=200)], parent=link1)
+reason = verify_capability([link1, link2], keys.get, {"shipped": True, "amount": 120}, root_issuer=ceo.get_did())
+```
+
+Structured reasons: `caveat_denied:<id>`, `unrooted_capability`, `broken_chain`,
+`verifier_budget_exceeded`.
+
+## Inference Provenance (`vouch.provenance`)
+
+Binds an output to a fingerprint of the model weights and a Merkle root over the
+context it was grounded in, plus the sampler settings. An auditor can re-fetch
+the sources to reproduce the context root (catching a fabricated or substituted
+context) and re-run the model on the same seed to byte-compare the output.
+
+```python
+from vouch.provenance import sign_inference_provenance, verify_context, check_replay, weights_hash
+
+cred = sign_inference_provenance(agent, output={"action": "approve_refund"},
+                                 model_weights_hash=weights_hash(b"...weights..."),
+                                 context_chunks=[{"source": "policy://refunds", "text": "..."}],
+                                 sampler={"seed": 42, "temperature": 0.0})
+ok, subject = verify_inference_provenance(cred, k.public_key_jwk)
+good, reason = verify_context([{"source": "policy://refunds", "text": "..."}], subject)  # context_root_mismatch on tamper
+```
+
+Structured reasons: `context_root_mismatch`, `output_mismatch`, `weights_mismatch`.
+
+## Action Transparency (`vouch.transparency`)
+
+Consequential actions are submitted to an append-only RFC 6962 Merkle log that
+signs its size and root as a Signed Tree Head. A verifier can demand an inclusion
+proof that an action is in the log; a monitor can demand a consistency proof that
+an older tree head is a strict prefix of a newer one, so the log cannot silently
+omit an action or rewrite history, and comparing tree heads across observers
+catches a split view.
+
+```python
+from vouch.transparency import TransparencyLog, sign_tree_head, check_inclusion, check_consistency
+
+log = TransparencyLog()
+i = log.append({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"})
+sth = sign_tree_head(log_operator, log)
+reason = check_inclusion({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"},
+                         i, sth, log.inclusion_proof(i), log_public_key=log_keys.public_key_jwk)
+```
+
+Structured reasons: `inclusion_failed`, `consistency_failed`, `tree_shrank`,
+`invalid_signed_tree_head`.
+
+## How they compose
+
+None of these verify an agent's mind. Together they make harm irrational and
+unhidable even for a misaligned agent: it must state a reason on the record
+(reasoning), wait out a window a human can veto (deliberation), stay inside an
+authority that cannot be broadened (caveats), against a decision that is
+reproducible (provenance), in front of a public append-only log (transparency).

--- a/gemini-gem/knowledge/overview.md
+++ b/gemini-gem/knowledge/overview.md
@@ -90,3 +90,16 @@ https://github.com/vouch-protocol/vouch
 
 - Discord: https://discord.gg/mMqx5cG9Y
 - Issues: https://github.com/vouch-protocol/vouch/issues
+
+## Accountable-autonomy runtime
+
+Five modules bound and record what an already-authorized agent does, so harm is
+hard to hide even for a misaligned agent: Reasoned Action Proofs
+(`vouch.reasoning`, the agent states why and cannot fabricate or rewrite it),
+Proof of Deliberation (`vouch.deliberation`, irreversible actions wait out a
+challenge window a human can veto), Executable Caveats (`vouch.caveats`, live
+conditions that bind every descendant of a delegation and cannot be dropped),
+Inference Provenance (`vouch.provenance`, the output is bound to the model and
+context that produced it, and is reproducible), and Action Transparency
+(`vouch.transparency`, an append-only RFC 6962 log so an action cannot be
+omitted or rewritten). See `accountable-autonomy.md`.

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -89,6 +89,14 @@ been removed. See `integrations.md`.
   Outcome evidence (`vouch.accountability`): commit the verdict before the
   outcome with `commit_outcome`, settle it later with `attest_outcome`. See
   `outcome-evidence.md`.
+- "How do I bound or record what an already-authorized agent does?" -> The
+  accountable-autonomy runtime: `vouch.reasoning` (state why, cannot fabricate or
+  rewrite), `vouch.deliberation` (irreversible actions wait out a challenge window
+  and can be vetoed), `vouch.caveats` (live conditions that bind every descendant
+  of a delegation and cannot be dropped), `vouch.provenance` (bind an output to the
+  model and context that produced it, reproducible by replay), and
+  `vouch.transparency` (append-only RFC 6962 log with inclusion and consistency
+  proofs). See `accountable-autonomy.md`.
 - "How does agent reputation work, or how do I score an agent?" ->
   Evidence-backed reputation: signed receipts (`vouch.receipts`) aggregated by a
   public deterministic function (`vouch.reputation_aggregate`) over a verified

--- a/openai-gpt/knowledge/accountable-autonomy.md
+++ b/openai-gpt/knowledge/accountable-autonomy.md
@@ -1,0 +1,131 @@
+# Accountable Autonomy Reference
+
+Identity and delegation prove who acted and under what authority. They do not,
+on their own, bound what an already-authorized agent may do, slow down an
+irreversible action, prove why the agent acted, or make the record public. The
+accountable-autonomy runtime adds five Python SDK modules that do, each an
+ordinary `eddsa-jcs-2022` Verifiable Credential so it verifies across the
+language SDKs.
+
+## Reasoned Action Proofs (`vouch.reasoning`)
+
+The agent states *why* before it acts, ties each reason to a real artifact by its
+hash, and escrows the justification before executing. An auditor can then prove
+the reasoning was neither fabricated (each anchor must resolve and hash-match) nor
+rewritten after the fact (the justification must recompute to the committed
+digest), and that it was committed before execution.
+
+```python
+from vouch import Signer, generate_identity
+from vouch.reasoning import (
+    build_justification, evidence_anchor, sign_reasoned_action,
+    verify_reasoned_action, verify_justification, LocalEscrow, justification_digest,
+)
+
+k = generate_identity("agent.example.com"); agent = Signer(private_key=k.private_key_jwk, did=k.did)
+intent = {"action": "delete", "target": "/tmp/cache", "resource": "/tmp/cache/*"}
+just = build_justification(intent, [evidence_anchor("user asked", ref="msg:1", evidence={"text": "clean /tmp"})])
+cred = sign_reasoned_action(agent, intent=intent, justification=just)
+ok, subject = verify_reasoned_action(cred, k.public_key_jwk)
+good, reason = verify_justification(just, subject, resolver={"msg:1": {"text": "clean /tmp"}}.get)
+```
+
+Structured reasons: `justification_digest_mismatch`, `evidence_unresolved`,
+`evidence_hash_mismatch`, `escrow_after_execution`.
+
+## Proof of Deliberation (`vouch.deliberation`)
+
+A reversible action runs instantly. An irreversible one (wire funds, delete
+without backup, publish, actuate) must commit and broadcast a signed intent with
+a challenge window and a set of authorized objectors, wait out the window, and
+survive any veto before a verifier accepts the execute credential. The agent
+cannot shorten the window (the verifier checks the elapse) and cannot clear its
+own veto (the veto authority is a separate DID).
+
+```python
+from vouch.deliberation import (
+    commit_intent, execute, veto_intent, check_execution, CLASS_IRREVERSIBLE_FINANCIAL,
+)
+
+intent = commit_intent(agent, intent={"action": "transfer_funds", "target": "acct:v1", "resource": "usd:5000"},
+                       reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL, min_seconds=900,
+                       veto_authorities=["did:web:controller"])
+ex = execute(agent, intent_credential=intent)  # only accepted once the window has elapsed
+reason = check_execution(ex, intent, k.public_key_jwk)   # None, or challenge_window_not_elapsed / vetoed
+```
+
+Structured reasons: `challenge_window_not_elapsed`, `vetoed`, `intent_mismatch`,
+`unauthorized_executor`.
+
+## Executable Caveats (`vouch.caveats`)
+
+Delegation narrows static fields (action, target, resource, time, rate). Caveats
+add live conditions ("only for shipped orders", "under the lifetime spend",
+"business hours") attached to a delegation link. Caveats accumulate down the
+chain, no descendant can drop an ancestor's caveat (the verifier requires the
+chain to root at the grantor), and every verifier must evaluate every accumulated
+caveat. A standard caveat library evaluates identically across languages; a
+custom module-hash caveat is the escape hatch.
+
+```python
+from vouch.caveats import build_capability, verify_capability, flag_true, value_ceiling
+
+link1 = build_capability(ceo, to=mgr.get_did(), attenuation={"action": "refund"},
+                         caveats=[flag_true("shipped-only", field="shipped")])
+link2 = build_capability(mgr, to=agent.get_did(), attenuation={"action": "refund", "resource": "usd:<=200"},
+                         caveats=[value_ceiling("under-200", field="amount", limit=200)], parent=link1)
+reason = verify_capability([link1, link2], keys.get, {"shipped": True, "amount": 120}, root_issuer=ceo.get_did())
+```
+
+Structured reasons: `caveat_denied:<id>`, `unrooted_capability`, `broken_chain`,
+`verifier_budget_exceeded`.
+
+## Inference Provenance (`vouch.provenance`)
+
+Binds an output to a fingerprint of the model weights and a Merkle root over the
+context it was grounded in, plus the sampler settings. An auditor can re-fetch
+the sources to reproduce the context root (catching a fabricated or substituted
+context) and re-run the model on the same seed to byte-compare the output.
+
+```python
+from vouch.provenance import sign_inference_provenance, verify_context, check_replay, weights_hash
+
+cred = sign_inference_provenance(agent, output={"action": "approve_refund"},
+                                 model_weights_hash=weights_hash(b"...weights..."),
+                                 context_chunks=[{"source": "policy://refunds", "text": "..."}],
+                                 sampler={"seed": 42, "temperature": 0.0})
+ok, subject = verify_inference_provenance(cred, k.public_key_jwk)
+good, reason = verify_context([{"source": "policy://refunds", "text": "..."}], subject)  # context_root_mismatch on tamper
+```
+
+Structured reasons: `context_root_mismatch`, `output_mismatch`, `weights_mismatch`.
+
+## Action Transparency (`vouch.transparency`)
+
+Consequential actions are submitted to an append-only RFC 6962 Merkle log that
+signs its size and root as a Signed Tree Head. A verifier can demand an inclusion
+proof that an action is in the log; a monitor can demand a consistency proof that
+an older tree head is a strict prefix of a newer one, so the log cannot silently
+omit an action or rewrite history, and comparing tree heads across observers
+catches a split view.
+
+```python
+from vouch.transparency import TransparencyLog, sign_tree_head, check_inclusion, check_consistency
+
+log = TransparencyLog()
+i = log.append({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"})
+sth = sign_tree_head(log_operator, log)
+reason = check_inclusion({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"},
+                         i, sth, log.inclusion_proof(i), log_public_key=log_keys.public_key_jwk)
+```
+
+Structured reasons: `inclusion_failed`, `consistency_failed`, `tree_shrank`,
+`invalid_signed_tree_head`.
+
+## How they compose
+
+None of these verify an agent's mind. Together they make harm irrational and
+unhidable even for a misaligned agent: it must state a reason on the record
+(reasoning), wait out a window a human can veto (deliberation), stay inside an
+authority that cannot be broadened (caveats), against a decision that is
+reproducible (provenance), in front of a public append-only log (transparency).

--- a/openai-gpt/knowledge/overview.md
+++ b/openai-gpt/knowledge/overview.md
@@ -90,3 +90,16 @@ https://github.com/vouch-protocol/vouch
 
 - Discord: https://discord.gg/mMqx5cG9Y
 - Issues: https://github.com/vouch-protocol/vouch/issues
+
+## Accountable-autonomy runtime
+
+Five modules bound and record what an already-authorized agent does, so harm is
+hard to hide even for a misaligned agent: Reasoned Action Proofs
+(`vouch.reasoning`, the agent states why and cannot fabricate or rewrite it),
+Proof of Deliberation (`vouch.deliberation`, irreversible actions wait out a
+challenge window a human can veto), Executable Caveats (`vouch.caveats`, live
+conditions that bind every descendant of a delegation and cannot be dropped),
+Inference Provenance (`vouch.provenance`, the output is bound to the model and
+context that produced it, and is reproducible), and Action Transparency
+(`vouch.transparency`, an append-only RFC 6962 log so an action cannot be
+omitted or rewritten). See `accountable-autonomy.md`.

--- a/website-agent/backend/knowledge/accountable-autonomy.md
+++ b/website-agent/backend/knowledge/accountable-autonomy.md
@@ -1,0 +1,131 @@
+# Accountable Autonomy Reference
+
+Identity and delegation prove who acted and under what authority. They do not,
+on their own, bound what an already-authorized agent may do, slow down an
+irreversible action, prove why the agent acted, or make the record public. The
+accountable-autonomy runtime adds five Python SDK modules that do, each an
+ordinary `eddsa-jcs-2022` Verifiable Credential so it verifies across the
+language SDKs.
+
+## Reasoned Action Proofs (`vouch.reasoning`)
+
+The agent states *why* before it acts, ties each reason to a real artifact by its
+hash, and escrows the justification before executing. An auditor can then prove
+the reasoning was neither fabricated (each anchor must resolve and hash-match) nor
+rewritten after the fact (the justification must recompute to the committed
+digest), and that it was committed before execution.
+
+```python
+from vouch import Signer, generate_identity
+from vouch.reasoning import (
+    build_justification, evidence_anchor, sign_reasoned_action,
+    verify_reasoned_action, verify_justification, LocalEscrow, justification_digest,
+)
+
+k = generate_identity("agent.example.com"); agent = Signer(private_key=k.private_key_jwk, did=k.did)
+intent = {"action": "delete", "target": "/tmp/cache", "resource": "/tmp/cache/*"}
+just = build_justification(intent, [evidence_anchor("user asked", ref="msg:1", evidence={"text": "clean /tmp"})])
+cred = sign_reasoned_action(agent, intent=intent, justification=just)
+ok, subject = verify_reasoned_action(cred, k.public_key_jwk)
+good, reason = verify_justification(just, subject, resolver={"msg:1": {"text": "clean /tmp"}}.get)
+```
+
+Structured reasons: `justification_digest_mismatch`, `evidence_unresolved`,
+`evidence_hash_mismatch`, `escrow_after_execution`.
+
+## Proof of Deliberation (`vouch.deliberation`)
+
+A reversible action runs instantly. An irreversible one (wire funds, delete
+without backup, publish, actuate) must commit and broadcast a signed intent with
+a challenge window and a set of authorized objectors, wait out the window, and
+survive any veto before a verifier accepts the execute credential. The agent
+cannot shorten the window (the verifier checks the elapse) and cannot clear its
+own veto (the veto authority is a separate DID).
+
+```python
+from vouch.deliberation import (
+    commit_intent, execute, veto_intent, check_execution, CLASS_IRREVERSIBLE_FINANCIAL,
+)
+
+intent = commit_intent(agent, intent={"action": "transfer_funds", "target": "acct:v1", "resource": "usd:5000"},
+                       reversibility_class=CLASS_IRREVERSIBLE_FINANCIAL, min_seconds=900,
+                       veto_authorities=["did:web:controller"])
+ex = execute(agent, intent_credential=intent)  # only accepted once the window has elapsed
+reason = check_execution(ex, intent, k.public_key_jwk)   # None, or challenge_window_not_elapsed / vetoed
+```
+
+Structured reasons: `challenge_window_not_elapsed`, `vetoed`, `intent_mismatch`,
+`unauthorized_executor`.
+
+## Executable Caveats (`vouch.caveats`)
+
+Delegation narrows static fields (action, target, resource, time, rate). Caveats
+add live conditions ("only for shipped orders", "under the lifetime spend",
+"business hours") attached to a delegation link. Caveats accumulate down the
+chain, no descendant can drop an ancestor's caveat (the verifier requires the
+chain to root at the grantor), and every verifier must evaluate every accumulated
+caveat. A standard caveat library evaluates identically across languages; a
+custom module-hash caveat is the escape hatch.
+
+```python
+from vouch.caveats import build_capability, verify_capability, flag_true, value_ceiling
+
+link1 = build_capability(ceo, to=mgr.get_did(), attenuation={"action": "refund"},
+                         caveats=[flag_true("shipped-only", field="shipped")])
+link2 = build_capability(mgr, to=agent.get_did(), attenuation={"action": "refund", "resource": "usd:<=200"},
+                         caveats=[value_ceiling("under-200", field="amount", limit=200)], parent=link1)
+reason = verify_capability([link1, link2], keys.get, {"shipped": True, "amount": 120}, root_issuer=ceo.get_did())
+```
+
+Structured reasons: `caveat_denied:<id>`, `unrooted_capability`, `broken_chain`,
+`verifier_budget_exceeded`.
+
+## Inference Provenance (`vouch.provenance`)
+
+Binds an output to a fingerprint of the model weights and a Merkle root over the
+context it was grounded in, plus the sampler settings. An auditor can re-fetch
+the sources to reproduce the context root (catching a fabricated or substituted
+context) and re-run the model on the same seed to byte-compare the output.
+
+```python
+from vouch.provenance import sign_inference_provenance, verify_context, check_replay, weights_hash
+
+cred = sign_inference_provenance(agent, output={"action": "approve_refund"},
+                                 model_weights_hash=weights_hash(b"...weights..."),
+                                 context_chunks=[{"source": "policy://refunds", "text": "..."}],
+                                 sampler={"seed": 42, "temperature": 0.0})
+ok, subject = verify_inference_provenance(cred, k.public_key_jwk)
+good, reason = verify_context([{"source": "policy://refunds", "text": "..."}], subject)  # context_root_mismatch on tamper
+```
+
+Structured reasons: `context_root_mismatch`, `output_mismatch`, `weights_mismatch`.
+
+## Action Transparency (`vouch.transparency`)
+
+Consequential actions are submitted to an append-only RFC 6962 Merkle log that
+signs its size and root as a Signed Tree Head. A verifier can demand an inclusion
+proof that an action is in the log; a monitor can demand a consistency proof that
+an older tree head is a strict prefix of a newer one, so the log cannot silently
+omit an action or rewrite history, and comparing tree heads across observers
+catches a split view.
+
+```python
+from vouch.transparency import TransparencyLog, sign_tree_head, check_inclusion, check_consistency
+
+log = TransparencyLog()
+i = log.append({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"})
+sth = sign_tree_head(log_operator, log)
+reason = check_inclusion({"agent": "did:web:a", "action": "transfer_funds", "amount": "usd:5000"},
+                         i, sth, log.inclusion_proof(i), log_public_key=log_keys.public_key_jwk)
+```
+
+Structured reasons: `inclusion_failed`, `consistency_failed`, `tree_shrank`,
+`invalid_signed_tree_head`.
+
+## How they compose
+
+None of these verify an agent's mind. Together they make harm irrational and
+unhidable even for a misaligned agent: it must state a reason on the record
+(reasoning), wait out a window a human can veto (deliberation), stay inside an
+authority that cannot be broadened (caveats), against a decision that is
+reproducible (provenance), in front of a public append-only log (transparency).

--- a/website-agent/backend/knowledge/overview.md
+++ b/website-agent/backend/knowledge/overview.md
@@ -90,3 +90,16 @@ https://github.com/vouch-protocol/vouch
 
 - Discord: https://discord.gg/mMqx5cG9Y
 - Issues: https://github.com/vouch-protocol/vouch/issues
+
+## Accountable-autonomy runtime
+
+Five modules bound and record what an already-authorized agent does, so harm is
+hard to hide even for a misaligned agent: Reasoned Action Proofs
+(`vouch.reasoning`, the agent states why and cannot fabricate or rewrite it),
+Proof of Deliberation (`vouch.deliberation`, irreversible actions wait out a
+challenge window a human can veto), Executable Caveats (`vouch.caveats`, live
+conditions that bind every descendant of a delegation and cannot be dropped),
+Inference Provenance (`vouch.provenance`, the output is bound to the model and
+context that produced it, and is reproducible), and Action Transparency
+(`vouch.transparency`, an append-only RFC 6962 log so an action cannot be
+omitted or rewritten). See `accountable-autonomy.md`.

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -184,6 +184,47 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
   },
 
   // =====================================================================
+  // ACCOUNTABLE AUTONOMY
+  // =====================================================================
+  {
+    id: 'accountable-autonomy',
+    audience: 'Accountable autonomy',
+    title: 'Bounding and recording what an authorized agent does',
+    items: [
+      {
+        q: 'Identity proves who acted. What stops an authorized agent from doing something harmful?',
+        a: `A misaligned agent can take an action that is inside its authority and still catastrophic. Vouch does not read the agent's mind. It does what institutions have always done with authorized actors: five Python SDK modules make each action state its reason (\`vouch.reasoning\`), slow down the irreversible ones behind a veto (\`vouch.deliberation\`), stay inside an authority that cannot be broadened (\`vouch.caveats\`), come from a decision that is reproducible (\`vouch.provenance\`), and land in a public append-only log (\`vouch.transparency\`). Together they make harm hard to hide even for a misaligned agent.`,
+        helpLinks: [{ label: 'See all four in the browser', href: '/demos/' }],
+        meta: 'Shipped - vouch.reasoning, deliberation, caveats, provenance, transparency',
+      },
+      {
+        q: 'How does an agent prove why it acted, without being able to fake the reason?',
+        a: `\`vouch.reasoning\` (Reasoned Action Proofs) has the agent state its justification before acting, tie each reason to a real artifact by that artifact's hash, and escrow the justification before execution. An auditor can then prove the reasoning was not fabricated (each anchor must resolve and hash-match a real message or delegation), not rewritten after the fact (it must recompute to the committed digest), and committed before the action. It does not make deception impossible; it puts the agent on the record, so a false justification is provable.`,
+        helpLinks: [{ label: 'See it: reasoned action', href: '/demos/#reasoned-action' }],
+      },
+      {
+        q: 'Can I make an agent wait, or let a human veto, before it does something irreversible?',
+        a: `Yes, with \`vouch.deliberation\`. A reversible action runs instantly. An irreversible one (wiring funds, deleting without backup, publishing) must commit and broadcast a signed intent with a challenge window and a set of authorized objectors, wait out the window, and survive any veto before a verifier accepts it. The agent cannot shorten the window (the verifier checks the elapse) and cannot clear its own veto (the veto authority is a separate DID). This gives regulatory human-oversight requirements a machine-checkable hook.`,
+        helpLinks: [{ label: 'See it: the deliberation window', href: '/demos/#deliberation' }],
+      },
+      {
+        q: 'Can a permission carry a live condition that a sub-agent two hops down cannot drop?',
+        a: `Yes, with executable caveats (\`vouch.caveats\`). Beyond narrowing static fields, a delegation link can carry conditions ("only for shipped orders", "under the customer's lifetime spend", "business hours only"). Caveats accumulate down the chain, so a rule the grantor sets binds every descendant, and no holder in between can drop it because the verifier requires the presented chain to root at the grantor. Every verifier must evaluate every accumulated caveat, offline, with no policy server.`,
+        helpLinks: [{ label: 'See it: the delegation envelope', href: '/demos/#caveats' }],
+      },
+      {
+        q: 'Can I prove an agent output came from a specific model and context, not a hallucination?',
+        a: `\`vouch.provenance\` binds an output to a fingerprint of the model weights and a Merkle root over the context it was grounded in, plus the sampler settings. An auditor can re-fetch the sources to reproduce the context root (catching a fabricated or substituted context) and re-run the model on the same seed to byte-compare the output. It does not read the model's mind; it makes the provenance of a decision reproducible and its inputs non-repudiable, and it is the anchor point for zero-knowledge proofs of inference later.`,
+        helpLinks: [{ label: 'See it: the provenance', href: '/demos/#provenance' }],
+      },
+      {
+        q: 'How do I make agent actions publicly auditable so none can be hidden or rewritten?',
+        a: `\`vouch.transparency\` submits consequential actions to an append-only RFC 6962 Merkle log that signs its size and root as a Signed Tree Head. A verifier can demand an inclusion proof that a specific action is in the log, and a monitor can demand a consistency proof that an older tree head is a strict prefix of a newer one. So the log cannot silently omit an action or rewrite history, and comparing tree heads across observers catches a split view. It is the same discipline Certificate Transparency brought to misissuance.`,
+      },
+    ],
+  },
+
+  // =====================================================================
   // CONFORMANCE
   // =====================================================================
   {

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -1778,6 +1778,62 @@ See [PAD-016](https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures
   },
 
   // =====================================================================
+  // ACCOUNTABLE AUTONOMY: bound and record what an authorized agent does
+  // =====================================================================
+  {
+    id: 'accountable-autonomy',
+    title: 'Accountable Autonomy',
+    description:
+      'Five modules that bound and record what an already-authorized agent does: reasoned actions, deliberation windows, executable caveats, inference provenance, and an append-only transparency log.',
+    articles: [
+      {
+        id: 'accountable-autonomy-overview',
+        title: 'The Accountable-Autonomy Runtime',
+        summary:
+          'Make an authorized agent state its reason, wait out a veto, stay inside its envelope, prove its output, and land in a public log.',
+        body: `
+Identity and delegation prove who acted and under what authority. They do not, on their own, bound what an already-authorized agent may do, slow down an irreversible action, prove why the agent acted, or make the record public. Five Python SDK modules add exactly that. Each is an ordinary \`eddsa-jcs-2022\` Verifiable Credential, so it verifies across the language SDKs, and each has a runnable example in the repo and a live section on the [interactive demos](/demos/).
+
+## Reasoned Action Proofs
+
+\`vouch.reasoning\` has the agent state its justification before acting, tie each reason to a real artifact by that artifact's hash, and escrow the justification before execution. An auditor proves the reasoning was not fabricated (\`evidence_unresolved\`, \`evidence_hash_mismatch\`), not rewritten (\`justification_digest_mismatch\`), and committed before the action (\`escrow_after_execution\`).
+
+\`\`\`python
+from vouch.reasoning import build_justification, evidence_anchor, sign_reasoned_action, verify_justification
+
+just = build_justification(intent, [evidence_anchor("user asked", ref="msg:1", evidence=user_message)])
+cred = sign_reasoned_action(agent, intent=intent, justification=just)
+ok, subject = verify_reasoned_action(cred, agent_pub)
+good, reason = verify_justification(just, subject, resolver=lookup)
+\`\`\`
+
+See \`examples/reasoned_action_demo.py\` and the [reasoned-action demo](/demos/#reasoned-action).
+
+## Proof of Deliberation
+
+\`vouch.deliberation\` gates irreversible actions. The agent commits and broadcasts a signed intent with a challenge window and named objectors, waits out the window, and survives any veto before a verifier accepts the execute credential. The agent cannot shorten the window (\`challenge_window_not_elapsed\`) or clear its own veto (\`vetoed\`). Reversible actions run with no delay. See \`examples/deliberation_demo.py\` and the [deliberation demo](/demos/#deliberation).
+
+## Executable Caveats
+
+\`vouch.caveats\` attaches live conditions to a delegation link ("only for shipped orders", "under the lifetime spend", "business hours"). Caveats accumulate down the chain and cannot be dropped by a descendant (the verifier requires the chain to root at the grantor, else \`unrooted_capability\`), and every verifier must evaluate every accumulated caveat. A standard caveat library evaluates identically across languages; a custom module-hash caveat is the escape hatch. See \`examples/caveats_demo.py\` and the [caveats demo](/demos/#caveats).
+
+## Inference Provenance
+
+\`vouch.provenance\` binds an output to a fingerprint of the model weights and a Merkle root over the retrieved context, plus the sampler settings. An auditor re-fetches the sources to reproduce the context root (\`context_root_mismatch\` on a substituted context) and re-runs the model on the same seed to byte-compare the output (\`output_mismatch\`, \`weights_mismatch\`). See \`examples/provenance_demo.py\` and the [provenance demo](/demos/#provenance).
+
+## Action Transparency
+
+\`vouch.transparency\` submits consequential actions to an append-only RFC 6962 Merkle log that signs its size and root as a Signed Tree Head. A verifier demands an inclusion proof that an action is in the log (\`inclusion_failed\`), and a monitor demands a consistency proof that an older tree head is a strict prefix of a newer one (\`consistency_failed\`, \`tree_shrank\`), so the log cannot omit or rewrite an action. See \`examples/transparency_demo.py\`.
+
+## How they compose
+
+None of these verify an agent's mind. Together they make harm hard to hide even for a misaligned agent: it must state a reason on the record, wait out a window a human can veto, stay inside an authority that cannot be broadened, against a decision that is reproducible, in front of a public append-only log.
+`,
+      },
+    ],
+  },
+
+  // =====================================================================
   // AI ASSISTANTS: walkthroughs for each surface
   // =====================================================================
   {


### PR DESCRIPTION
Documents the accountable-autonomy runtime (the five shipped Python SDK modules `vouch.reasoning`, `vouch.deliberation`, `vouch.caveats`, `vouch.provenance`, and `vouch.transparency`) across every self-serve surface:

- **Knowledge base**: a new `accountable-autonomy.md` reference mirrored into all four knowledge directories (`website-agent/backend/knowledge`, `openai-gpt/knowledge`, `gemini-gem/knowledge`, `claude-skill/.../reference`), plus an accountable-autonomy note appended to each `overview.md`.
- **FAQ**: a new "Accountable autonomy" section with a question per mechanism, each deep-linking the matching interactive demo.
- **Help & Guides**: a new "Accountable Autonomy" section walking through all five modules with runnable-example references and demo links.
- **Assistants**: a pointer to the new reference in the Claude skill (`SKILL.md`), OpenAI Custom GPT, and Gemini Gem instructions.

Every mechanism maps to a runnable `examples/*_demo.py` and a live section on `/demos`. Pairs with the transparency-log PR so the transparency references land together.
