### PR TITLE
Surface the LangGraph and Goose integrations across the site, and highlight flagship robotics

### DIFF
--- a/claude-skill/README.md
+++ b/claude-skill/README.md
@@ -132,7 +132,7 @@ Same license as the main Vouch Protocol repository (Apache-2.0).
 ## Framework integration packages (coming soon, v1.6.2)
 
 Standalone, separately installable packages that wrap a specific framework:
-`vouch-langchain`, `vouch-crewai`, `vouch-mcp`, `vouch-a2a`, `vouch-mlflow`, and
+`vouch-langchain`, `vouch-langgraph`, `vouch-crewai`, `vouch-mcp`, `vouch-a2a`, `vouch-goose`, `vouch-mlflow`, and
 `vouch-safetensors`. Each issues a verifiable credential per tool call, with
 optional delegation back to a human principal. Until v1.6.2 publishes to PyPI,
 use the integrations from the main package, for example

--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -19,7 +19,7 @@ Invoke when the user:
 
 - Asks how to sign or verify agent actions cryptographically
 - Mentions Vouch by name or package (`vouch-protocol`, `@vouch-protocol-official/core-wasm`, `vouch-sidecar`)
-- Wants to add agent identity to their LangChain / CrewAI / MCP / AutoGen / Vertex AI flow
+- Wants to add agent identity to their LangChain / LangGraph / CrewAI / MCP / AutoGen / Goose / Vertex AI flow
 - Asks about Verifiable Credentials, Data Integrity proofs, or DIDs in the context of AI agents
 - Needs post-quantum signatures for regulated deployments (`hybrid-eddsa-mldsa44-jcs-2026`)
 - Is building a multi-agent system and needs delegation chains
@@ -262,6 +262,12 @@ underneath the reputation engine.
 
 Reference implementations under `vouch/integrations/`. See
 `reference/integrations.md` for the common pattern.
+
+- LangGraph: `from vouch.integrations.langgraph import protect, sign_node`, wrap
+  the tools with `protect([...])` for a `ToolNode` or `create_react_agent`, and
+  `@sign_node` signs each graph node so the whole graph carries a signed trail.
+- Goose: `pip install vouch-goose`, then run `vouch-goose` to register the Vouch
+  MCP server as a Goose extension.
 
 ### "How do I give a robot a verifiable identity, or enforce physical limits?"
 

--- a/claude-skill/skills/vouch-protocol/reference/integrations.md
+++ b/claude-skill/skills/vouch-protocol/reference/integrations.md
@@ -71,6 +71,20 @@ tools = protect([search, send_email])
 autosign()  # patches langchain_core.tools.tool (falls back to langchain.tools.tool)
 ```
 
+## LangGraph
+
+```python
+from vouch.integrations.langgraph import protect, sign_node
+
+# LangGraph tools are LangChain tools: wrap the tools for a ToolNode or create_react_agent.
+tools = protect([search, send_email])
+
+# Sign each graph node so the whole graph carries a signed trail.
+@sign_node
+def plan(state):
+    ...
+```
+
 ## AutoGen
 
 AutoGen has no global tool decorator, but it registers tools through a
@@ -251,6 +265,16 @@ vouch-mcp
 
 The server exposes tools to the connected model to mint a credential, return the
 configured DID, and create a short-lived session token.
+
+## Goose
+
+Block's Goose loads its tools from MCP servers. Vouch ships one (vouch-mcp), so
+register it as a Goose extension.
+
+```bash
+pip install vouch-goose
+vouch-goose            # writes the extension into ~/.config/goose/config.yaml
+```
 
 ## Browser and mobile
 

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -22,7 +22,7 @@ deterministic path, then show lower-level APIs only if they ask:
   afterward, no env plumbing in agent code).
 - `from vouch import protect` and `agent.tools = protect([tool_a, tool_b])` so
   every tool call is signed in Python before it runs.
-- For decorator frameworks (CrewAI, LangChain, AutoGPT, AutoGen),
+- For decorator frameworks (CrewAI, LangChain, LangGraph, AutoGPT, AutoGen),
   `<framework>.autosign()` signs every tool framework-wide.
 - Verify with `vouch.verify(credential)`, or protect an endpoint with the
   FastAPI `VouchGate` dependency.

--- a/gemini-gem/knowledge/integrations.md
+++ b/gemini-gem/knowledge/integrations.md
@@ -71,6 +71,20 @@ tools = protect([search, send_email])
 autosign()  # patches langchain_core.tools.tool (falls back to langchain.tools.tool)
 ```
 
+## LangGraph
+
+```python
+from vouch.integrations.langgraph import protect, sign_node
+
+# LangGraph tools are LangChain tools: wrap the tools for a ToolNode or create_react_agent.
+tools = protect([search, send_email])
+
+# Sign each graph node so the whole graph carries a signed trail.
+@sign_node
+def plan(state):
+    ...
+```
+
 ## AutoGen
 
 AutoGen has no global tool decorator, but it registers tools through a
@@ -251,6 +265,16 @@ vouch-mcp
 
 The server exposes tools to the connected model to mint a credential, return the
 configured DID, and create a short-lived session token.
+
+## Goose
+
+Block's Goose loads its tools from MCP servers. Vouch ships one (vouch-mcp), so
+register it as a Goose extension.
+
+```bash
+pip install vouch-goose
+vouch-goose            # writes the extension into ~/.config/goose/config.yaml
+```
 
 ## Browser and mobile
 

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -26,7 +26,7 @@ deterministic path, then show lower-level APIs only if they ask:
 - `from vouch import protect` and `agent.tools = protect([tool_a, tool_b])` so
   every tool call is signed in Python before it runs. No prompt, no reliance on
   the model calling a signing tool.
-- For decorator frameworks (CrewAI, LangChain, AutoGPT, AutoGen),
+- For decorator frameworks (CrewAI, LangChain, LangGraph, AutoGPT, AutoGen),
   `<framework>.autosign()` signs every tool framework-wide.
 - Verify in one line with `vouch.verify(credential)`, or protect a web endpoint
   with the FastAPI `VouchGate` dependency.

--- a/openai-gpt/knowledge/integrations.md
+++ b/openai-gpt/knowledge/integrations.md
@@ -71,6 +71,20 @@ tools = protect([search, send_email])
 autosign()  # patches langchain_core.tools.tool (falls back to langchain.tools.tool)
 ```
 
+## LangGraph
+
+```python
+from vouch.integrations.langgraph import protect, sign_node
+
+# LangGraph tools are LangChain tools: wrap the tools for a ToolNode or create_react_agent.
+tools = protect([search, send_email])
+
+# Sign each graph node so the whole graph carries a signed trail.
+@sign_node
+def plan(state):
+    ...
+```
+
 ## AutoGen
 
 AutoGen has no global tool decorator, but it registers tools through a
@@ -251,6 +265,16 @@ vouch-mcp
 
 The server exposes tools to the connected model to mint a credential, return the
 configured DID, and create a short-lived session token.
+
+## Goose
+
+Block's Goose loads its tools from MCP servers. Vouch ships one (vouch-mcp), so
+register it as a Goose extension.
+
+```bash
+pip install vouch-goose
+vouch-goose            # writes the extension into ~/.config/goose/config.yaml
+```
 
 ## Browser and mobile
 

--- a/website-agent/backend/knowledge/integrations.md
+++ b/website-agent/backend/knowledge/integrations.md
@@ -71,6 +71,20 @@ tools = protect([search, send_email])
 autosign()  # patches langchain_core.tools.tool (falls back to langchain.tools.tool)
 ```
 
+## LangGraph
+
+```python
+from vouch.integrations.langgraph import protect, sign_node
+
+# LangGraph tools are LangChain tools: wrap the tools for a ToolNode or create_react_agent.
+tools = protect([search, send_email])
+
+# Sign each graph node so the whole graph carries a signed trail.
+@sign_node
+def plan(state):
+    ...
+```
+
 ## AutoGen
 
 AutoGen has no global tool decorator, but it registers tools through a
@@ -251,6 +265,16 @@ vouch-mcp
 
 The server exposes tools to the connected model to mint a credential, return the
 configured DID, and create a short-lived session token.
+
+## Goose
+
+Block's Goose loads its tools from MCP servers. Vouch ships one (vouch-mcp), so
+register it as a Goose extension.
+
+```bash
+pip install vouch-goose
+vouch-goose            # writes the extension into ~/.config/goose/config.yaml
+```
 
 ## Browser and mobile
 

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -1055,6 +1055,7 @@ status_list = store.load()
         a: `Python integrations live under \`vouch/integrations/\`:
 
 - **LangChain** - tool wrapper that signs tool inputs before execution
+- **LangGraph** - signs tool calls and graph nodes across a LangGraph graph
 - **CrewAI** - tool wrapper for crew-style multi-agent flows
 - **AutoGPT** - command integration
 - **AutoGen** - tool wrapper
@@ -1065,8 +1066,9 @@ status_list = store.load()
 - **n8n** - workflow automation node
 - **Hasura** - GraphQL webhook
 - **MCP** - Model Context Protocol server
+- **Goose** - registers the Vouch MCP server as an extension for Block's Goose agent
 
-**New standalone packages in v1.6.2:** \`vouch-langchain\`, \`vouch-crewai\`, \`vouch-a2a\` (binds an A2A Agent Card to a Vouch identity), \`vouch-mlflow\` (signs a model artifact at registration time, bound to its content digest), and \`vouch-safetensors\` (embeds a credential in the model header, complementary to OpenSSF Model Signing). Each issues a verifiable credential per tool call, with optional delegation back to a human principal.
+**New standalone packages:** \`vouch-langchain\`, \`vouch-langgraph\` (signs LangGraph tool calls and graph nodes), \`vouch-crewai\`, \`vouch-a2a\` (binds an A2A Agent Card to a Vouch identity), \`vouch-goose\` (registers the Vouch MCP server as a Goose extension), \`vouch-mlflow\` (signs a model artifact at registration time, bound to its content digest), and \`vouch-safetensors\` (embeds a credential in the model header, complementary to OpenSSF Model Signing). Each issues a verifiable credential per tool call, with optional delegation back to a human principal.
 
 Examples for each are in [examples/05_integrations/](https://github.com/vouch-protocol/vouch/tree/main/examples/05_integrations).
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -1334,7 +1334,7 @@ Then point at your collector via \`OTEL_EXPORTER_OTLP_ENDPOINT\`. Verifier spans
       {
         id: 'integrations',
         title: 'Which AI Frameworks Vouch Plugs Into',
-        summary: 'Ready-made integrations for LangChain, CrewAI, AutoGPT, AutoGen, MCP, Vertex AI, and more.',
+        summary: 'Ready-made integrations for LangChain, LangGraph, CrewAI, Goose, AutoGPT, AutoGen, MCP, Vertex AI, and more.',
         body: `
 ## Python integrations
 
@@ -1343,6 +1343,7 @@ All under \`vouch/integrations/\`:
 | Framework | File | What it does |
 |---|---|---|
 | LangChain | \`langchain/tool.py\` | Wraps a LangChain Tool so its inputs are signed before execution |
+| LangGraph | \`langgraph.py\` | Signs LangGraph tool calls and graph nodes across a graph |
 | CrewAI | \`crewai/tool.py\` | Same pattern for crew-style multi-agent flows |
 | AutoGPT | \`autogpt/commands.py\` | Command integration for AutoGPT plugins |
 | AutoGen | \`autogen/tool.py\` | Tool wrapper for AutoGen conversational agents |
@@ -1353,6 +1354,7 @@ All under \`vouch/integrations/\`:
 | n8n | \`n8n.py\` | n8n workflow automation node |
 | Hasura | \`hasura/webhook.py\` | GraphQL webhook handler |
 | MCP | \`mcp/server.py\` | Reference Model Context Protocol server |
+| Goose | \`goose.py\` | Registers the Vouch MCP server as an extension for Block's Goose agent |
 | Amnesia | \`amnesia.py\` | Wraps an Amnesia egress decision in a Verifiable Credential for a replayable audit trail |
 
 End-to-end examples are at [examples/05_integrations/](https://github.com/vouch-protocol/vouch/tree/main/examples/05_integrations).

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -70,6 +70,13 @@ const FEATURES: Array<{ num: string; title: string; body: string; spec: string; 
     body: 'Agents move across hosts and clouds and rarely hold a stable domain or IP, but they always hold a key. Vouch reaches a peer by its identity, not its location. It prefers identity-first routing over UDNA (Universal DID-Native Addressing) and falls back to standard DNS and HTTPS when a peer is not on the overlay. The signed credential, liability attestations, and provenance cross the switch unchanged, so the trust properties hold whichever path the bytes take. Optional and aligned with the W3C UDNA Community Group.',
     spec: 'Hybrid Transport',
   },
+  {
+    num: 'xii.',
+    title: 'Drops Into Your Agent Framework',
+    body: "Standalone packages that sign each tool call in the stack you already use. vouch-langchain and vouch-langgraph sign tool calls and graph nodes, vouch-crewai adds supervisor-to-worker delegation that can only narrow authority, vouch-a2a binds an A2A Agent Card to a Vouch identity, and vouch-goose registers the Vouch MCP server as an extension for Block's Goose agent.",
+    spec: 'Framework integrations',
+    href: '/tools/',
+  },
 ];
 
 const LANGUAGE_TILES = [
@@ -160,8 +167,9 @@ export default function HomePage() {
             proofs, and Decentralized Identifiers, with one byte-exact core and SDKs for every major
             platform: web, mobile, JVM, .NET, and native, plus the Python, TypeScript, and Go references.
             The same credentials extend to robots and embodied agents, with hardware-rooted identity,
-            enforceable physical limits, and a tamper-evident black box. Agents can be reached by who
-            they are, not where they are.
+            enforceable physical limits, a tamper-evident black box, one accountable identity that
+            carries across robot bodies, and bounded, revocable access to physical infrastructure like
+            doors, elevators, and chargers. Agents can be reached by who they are, not where they are.
           </p>
           <div className="flex flex-wrap gap-3 items-center">
             <Link href="/faq/" className="btn-primary">Read the FAQ</Link>

--- a/website/src/app/tools/page.tsx
+++ b/website/src/app/tools/page.tsx
@@ -141,8 +141,10 @@ const GROUPS: Group[] = [
         intro: 'Standalone packages that issue a verifiable credential for each tool call, with optional delegation back to a human principal. New in v1.6.2.',
         tools: [
             { name: 'vouch-langchain', blurb: 'A LangChain tool that signs each tool call before it leaves the agent.', start: 'pip install vouch-langchain', tag: 'New' },
+            { name: 'vouch-langgraph', blurb: 'Signs LangGraph tool calls and graph nodes, so a signed trail runs across the whole graph.', start: 'pip install vouch-langgraph', tag: 'New' },
             { name: 'vouch-crewai', blurb: 'A CrewAI tool, with supervisor-to-worker delegation that can only narrow authority, never widen it.', start: 'pip install vouch-crewai', tag: 'New' },
             { name: 'vouch-a2a', blurb: 'Binds an A2A (Agent2Agent) Agent Card to a Vouch identity, so two agents can verify each other before they collaborate.', start: 'pip install vouch-a2a', tag: 'New' },
+            { name: 'vouch-goose', blurb: "Registers the Vouch MCP server as an extension for Block's Goose agent, so a Goose session can sign and verify out of the box.", start: 'pip install vouch-goose', tag: 'New' },
             { name: 'vouch-mlflow', blurb: 'Signs an MLflow model artifact at registration time, bound to a content digest so any change to the weights breaks the signature.', start: 'pip install vouch-mlflow', tag: 'New' },
             { name: 'vouch-safetensors', blurb: 'Embeds a credential in a .safetensors header, complementary to OpenSSF Model Signing, so a model carries who produced it.', start: 'pip install vouch-safetensors', tag: 'New' },
         ],


### PR DESCRIPTION
Surfaces the two new framework integrations across the site and the assistants, and lifts a couple of flagship robotics capabilities into the hero.

**Integrations (`vouch-langgraph`, `vouch-goose`)**
- Tools page: added both alongside the existing framework packages.
- FAQ and Help: added to the integration lists and the standalone-packages list, with a Help table row each.
- Home page: a new "Drops Into Your Agent Framework" card covering LangChain, LangGraph, CrewAI, A2A, and Goose.
- Assistants: added `## LangGraph` and `## Goose` sections to the knowledge base `integrations.md` (all four mirrors in sync), the Claude skill (`SKILL.md`, package list), and a LangGraph mention in the Gemini and OpenAI instructions.

**Robotics**
- The hero now names two of today's flagship capabilities: one accountable identity that carries across robot bodies, and bounded, revocable access to physical infrastructure like doors, elevators, and chargers.

The robotics page and the home page's robotics card already enumerate the full set from the robotics feature work, so those are left as they are.
