### PR TITLE
Fix the npm and crates publish workflows

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -24,13 +24,13 @@ jobs:
         working-directory: core/vouch-core
         run: |
           if [ "${{ inputs.dry_run }}" = "true" ]; then
-            cargo publish --dry-run
+            cargo publish --dry-run --allow-dirty
           else
-            cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+            cargo publish --allow-dirty --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
           fi
       - name: Publish vouch-core-uniffi
         if: ${{ inputs.dry_run != true }}
         working-directory: core/uniffi
         # vouch-core-uniffi depends on vouch-core, so it publishes second.
         # cargo waits for the just-published vouch-core to appear in the index.
-        run: cargo publish --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+        run: cargo publish --allow-dirty --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,10 +36,10 @@ jobs:
       - name: Publish sdk
         working-directory: packages/sdk-ts
         run: |
-          npm ci
+          npm install
           npm publish --access public || echo "sdk: version may already be published, continuing"
       - name: Publish api-client
         working-directory: sdks/clients/typescript
         run: |
-          npm ci
+          npm install
           npm publish --access public || echo "api-client: version may already be published, continuing"


### PR DESCRIPTION
Makes the npm and crates publish workflows succeed. The npm jobs run npm install instead of npm ci, so they no longer require a committed package-lock.json. The crates jobs pass --allow-dirty to cargo publish, so they succeed when the build leaves generated files in the working tree.