### PR TITLE
Show the PR number on each contributor card

### DIFF
--- a/website/src/app/contributors/page.tsx
+++ b/website/src/app/contributors/page.tsx
@@ -83,14 +83,22 @@ export default function ContributorsPage() {
                         <ul className="grid grid-cols-2 md:grid-cols-3 gap-4">
                             {CONTRIBUTORS.map((c) => (
                                 <li key={`${c.login}-${c.pr}`} className="bg-parchment-warm border border-rule p-4">
-                                    <Link
-                                        href={`/c/${c.login}/${c.pr}/`}
-                                        className="font-mono text-burgundy no-underline"
-                                    >
-                                        @{c.login}
-                                    </Link>
+                                    <div className="flex items-baseline justify-between gap-2">
+                                        <Link
+                                            href={`/c/${c.login}/${c.pr}/`}
+                                            className="font-mono text-burgundy no-underline"
+                                        >
+                                            @{c.login}
+                                        </Link>
+                                        <Link
+                                            href={`https://github.com/vouch-protocol/vouch/pull/${c.pr}`}
+                                            className="font-mono text-[0.8rem] text-ink-faint no-underline hover:text-burgundy"
+                                        >
+                                            #{c.pr}
+                                        </Link>
+                                    </div>
                                     <p className="text-ink-faint text-[0.85rem] mt-1 leading-snug">
-                                        {c.title ? c.title : `PR #${c.pr}`}
+                                        {c.title}
                                     </p>
                                 </li>
                             ))}

--- a/website/src/data/contributors.json
+++ b/website/src/data/contributors.json
@@ -2,7 +2,7 @@
   {
     "login": "kautilyaa",
     "pr": 37,
-    "title": "Identified and fixed the dev-setup and test failures (issue #36)"
+    "title": "Identified and fixed the dev-setup and test failures"
   },
   {
     "login": "Franflorio",


### PR DESCRIPTION
Each contributor card now shows a small PR number next to the handle, linking to the pull request. Before, only one card carried a reference (an issue number a contributor had typed into their PR title), which looked inconsistent.

The number is drawn from data every card already has, and the stray issue reference is removed from that one title so all cards read the same way.
