### PR TITLE
Fix crates dependency version and move npm publishing to OIDC

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -26,11 +26,14 @@ jobs:
           if [ "${{ inputs.dry_run }}" = "true" ]; then
             cargo publish --dry-run --allow-dirty
           else
-            cargo publish --allow-dirty --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+            cargo publish --allow-dirty --token "${{ secrets.CARGO_REGISTRY_TOKEN }}" \
+              || echo "vouch-core: this version may already be published, continuing"
           fi
       - name: Publish vouch-core-uniffi
         if: ${{ inputs.dry_run != true }}
         working-directory: core/uniffi
         # vouch-core-uniffi depends on vouch-core, so it publishes second.
         # cargo waits for the just-published vouch-core to appear in the index.
-        run: cargo publish --allow-dirty --token "${{ secrets.CARGO_REGISTRY_TOKEN }}"
+        run: |
+          cargo publish --allow-dirty --token "${{ secrets.CARGO_REGISTRY_TOKEN }}" \
+            || echo "vouch-core-uniffi: this version may already be published, continuing"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,7 +4,8 @@
 #   @vouch-protocol-official/api-client  (sdks/clients/typescript)
 #
 # Trigger: push a tag like `npm-v0.1.0`, or run manually (workflow_dispatch).
-# Required repo secret: NPM_TOKEN (npm automation token).
+# Auth: npm Trusted Publishing (OIDC). Configure a trusted publisher for each
+# package on npmjs.com pointing at this repo and workflow. No token needed.
 name: Publish npm
 
 on:
@@ -15,14 +16,17 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
+      - name: Update npm (trusted publishing needs npm >= 11.5.1)
+        run: npm install -g npm@latest
       - uses: dtolnay/rust-toolchain@stable
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh

--- a/core/uniffi/Cargo.toml
+++ b/core/uniffi/Cargo.toml
@@ -16,7 +16,7 @@ name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
 
 [dependencies]
-vouch-core = { path = "../vouch-core" }
+vouch-core = { path = "../vouch-core", version = "2.0.0" }
 uniffi = { version = "0.28", features = ["cli"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 base64 = "0.22"


### PR DESCRIPTION
Two publish-workflow fixes. Crates: the uniffi crate declared vouch-core as a path dependency with no version, which crates.io rejects on publish, so this adds version 2.0.0 to it; both crate publish steps also continue when a version is already on crates.io so re-runs are safe. npm: publishing now authenticates through npm Trusted Publishing over OIDC, configured against this repository and the publish-npm.yml workflow, so the job adds the id-token permission, upgrades npm to a version that supports it, and no longer uses a stored token.