### PR TITLE
Align the npm package versions for the 2.0.0 release

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -32,7 +32,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build the WASM core
         working-directory: core/wasm
-        run: bash build-npm.sh
+        run: bash build-npm.sh 2.0.0
       - name: Publish core-wasm
         working-directory: core/wasm/pkg
         run: |

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -86,7 +86,7 @@
  },
  "peerDependencies": {
   "@noble/post-quantum": "^0.4.0",
-  "@vouch-protocol-official/core-wasm": "^0.1.0"
+  "@vouch-protocol-official/core-wasm": "^2.0.0"
  },
  "peerDependenciesMeta": {
   "@noble/post-quantum": {
@@ -98,6 +98,7 @@
  },
  "devDependencies": {
   "@noble/post-quantum": "^0.4.0",
+  "@vouch-protocol-official/core-wasm": "^2.0.0",
   "@types/node": "^20.10.0",
   "tsup": "^8.0.0",
   "typescript": "^5.3.0",

--- a/sdks/clients/typescript/package.json
+++ b/sdks/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vouch-protocol-official/api-client",
-  "version": "0.1.0",
+  "version": "2.0.0",
   "description": "Typed HTTP client for the Vouch Protocol Bridge API (sign, verify, audio), generated from its OpenAPI spec.",
   "author": "Ramprasad Anandam Gaddam",
   "license": "Apache-2.0",


### PR DESCRIPTION
Brings the npm packages to a consistent 2.0.0. The WASM core build passes 2.0.0 so core-wasm publishes at that version instead of the build script's 0.1.0 default. The sdk package points its core-wasm peer dependency at 2.0.0 and adds it as a dev dependency so the type build resolves it. The api-client package moves from 0.1.0 to 2.0.0.