### PR TITLE
Document the Verified Contributor credential across guides and assistants

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -365,6 +365,16 @@ C++, .NET, JVM, and Swift wrappers through a `VouchRobotics` class (a
 `vouch::robotics` namespace in C++), for verifying and integrating from those
 languages. See `reference/robotics.md`.
 
+### "What is the Vouch Verified Contributor badge, and how do I get one?"
+
+Land a merged pull request on the repository and an automated workflow mints you a
+signed Vouch Verified Contributor credential: a real `eddsa-jcs-2022` Verifiable
+Credential issued by `did:web:vouch-protocol.com:contributors` and chained to the
+project root identity `did:web:vouch-protocol.com`. It publishes a certificate page
+at `vouch-protocol.com/c/<login>/<pr>`, lists the contributor at
+`vouch-protocol.com/contributors`, and comments the badge on the PR. It verifies
+like any other Vouch credential. See `reference/verified-contributor.md`.
+
 ## Decision rules
 
 - **User is just signing one credential** -> Python signer, three lines.
@@ -397,6 +407,7 @@ For depth on any topic, read the relevant file under `reference/`:
 - `reference/sidecar.md` - Identity Sidecar architecture and deployment
 - `reference/conformance.md` - Implementation conformance levels (L1-L3), the self-test runner, and the verified re-checkable badge
 - `reference/troubleshooting.md` - Common errors and fixes
+- `reference/verified-contributor.md` - The Vouch Verified Contributor credential earned on a merged PR, and how to verify it
 
 ## What this skill does NOT do
 

--- a/claude-skill/skills/vouch-protocol/reference/verified-contributor.md
+++ b/claude-skill/skills/vouch-protocol/reference/verified-contributor.md
@@ -1,0 +1,65 @@
+# Vouch Verified Contributor credential
+
+Vouch Protocol issues a signed credential to people who contribute to it.
+When you land a merged pull request on the repository, an automated
+workflow mints a Vouch Verified Contributor credential for the author of
+that pull request's commits. This is the project using its own protocol:
+the badge is a real Verifiable Credential, not a decorative image.
+
+## What you get
+
+- A certificate page at `https://vouch-protocol.com/c/<login>/<pr>`.
+- A listing on the contributors page at `https://vouch-protocol.com/contributors`.
+- A comment on your pull request with the badge, a copy-paste snippet,
+  and the full credential inline.
+
+The badge is offered, never required. Add it to your profile or site if
+you want to.
+
+## What the credential is
+
+- A Verifiable Credential signed with the `eddsa-jcs-2022` cryptosuite
+  (Ed25519 over JCS-canonicalized bytes), the same default format every
+  Vouch SDK produces.
+- Issued by `did:web:vouch-protocol.com:contributors`.
+- Chained back to the project root authority `did:web:vouch-protocol.com`
+  through a delegation, so a verifier can walk from the badge to the root
+  identity.
+- The subject is the contributor (the author of the merged commits), so
+  credit stays correct even when a maintainer relays a contribution for
+  someone else.
+
+## Verifying the badge
+
+Because it is a normal Vouch credential, anyone can verify it with the
+SDK or the hosted verifier. The issuer public key is published in the DID
+document at `https://vouch-protocol.com/contributors/did.json`. In Python:
+
+```python
+from vouch import Verifier
+
+# `credential` is the JSON from the pull request comment or the
+# certificate page; `issuer_public_jwk` is the publicKeyJwk from the
+# contributor DID document.
+is_valid, passport = Verifier.verify_credential(credential, public_key=issuer_public_jwk)
+print(is_valid, passport.subject_did)
+```
+
+The certificate page verifies the same credential against the published
+contributor DID document before it is rendered.
+
+## How it works end to end
+
+1. Your pull request merges.
+2. A workflow resolves the contributor from the commit authors, skipping
+   the maintainer and bots.
+3. It mints the credential and self-verifies it against the published DID.
+4. It publishes the certificate page and adds you to the contributors
+   list, then waits for the site to deploy.
+5. It posts the congratulatory comment on your pull request.
+
+## Links
+
+- Contributors: https://vouch-protocol.com/contributors
+- Repository: https://github.com/vouch-protocol/vouch
+- Good first issues: https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -239,6 +239,13 @@ Never share user data with external sites.
   identity mint and verify, conformance, passport, action check, and `sign_pq`, via
   a `VouchRobotics` class (a `vouch::robotics` namespace in C++). Output is
   byte-identical across languages. See `robotics.md`.
+- "What is the Vouch Verified Contributor badge, or how do I get one?" -> Land a
+  merged pull request on the repository; an automated workflow mints a signed
+  Verified Contributor credential (a real `eddsa-jcs-2022` VC issued by
+  `did:web:vouch-protocol.com:contributors`, chained to the project root identity),
+  publishes a certificate page at `vouch-protocol.com/c/<login>/<pr>`, lists the
+  contributor at `vouch-protocol.com/contributors`, and comments the badge on the
+  PR. It verifies like any other Vouch credential. See `verified-contributor.md`.
 
 ## Safety rules
 

--- a/gemini-gem/knowledge/verified-contributor.md
+++ b/gemini-gem/knowledge/verified-contributor.md
@@ -1,0 +1,65 @@
+# Vouch Verified Contributor credential
+
+Vouch Protocol issues a signed credential to people who contribute to it.
+When you land a merged pull request on the repository, an automated
+workflow mints a Vouch Verified Contributor credential for the author of
+that pull request's commits. This is the project using its own protocol:
+the badge is a real Verifiable Credential, not a decorative image.
+
+## What you get
+
+- A certificate page at `https://vouch-protocol.com/c/<login>/<pr>`.
+- A listing on the contributors page at `https://vouch-protocol.com/contributors`.
+- A comment on your pull request with the badge, a copy-paste snippet,
+  and the full credential inline.
+
+The badge is offered, never required. Add it to your profile or site if
+you want to.
+
+## What the credential is
+
+- A Verifiable Credential signed with the `eddsa-jcs-2022` cryptosuite
+  (Ed25519 over JCS-canonicalized bytes), the same default format every
+  Vouch SDK produces.
+- Issued by `did:web:vouch-protocol.com:contributors`.
+- Chained back to the project root authority `did:web:vouch-protocol.com`
+  through a delegation, so a verifier can walk from the badge to the root
+  identity.
+- The subject is the contributor (the author of the merged commits), so
+  credit stays correct even when a maintainer relays a contribution for
+  someone else.
+
+## Verifying the badge
+
+Because it is a normal Vouch credential, anyone can verify it with the
+SDK or the hosted verifier. The issuer public key is published in the DID
+document at `https://vouch-protocol.com/contributors/did.json`. In Python:
+
+```python
+from vouch import Verifier
+
+# `credential` is the JSON from the pull request comment or the
+# certificate page; `issuer_public_jwk` is the publicKeyJwk from the
+# contributor DID document.
+is_valid, passport = Verifier.verify_credential(credential, public_key=issuer_public_jwk)
+print(is_valid, passport.subject_did)
+```
+
+The certificate page verifies the same credential against the published
+contributor DID document before it is rendered.
+
+## How it works end to end
+
+1. Your pull request merges.
+2. A workflow resolves the contributor from the commit authors, skipping
+   the maintainer and bots.
+3. It mints the credential and self-verifies it against the published DID.
+4. It publishes the certificate page and adds you to the contributors
+   list, then waits for the site to deploy.
+5. It posts the congratulatory comment on your pull request.
+
+## Links
+
+- Contributors: https://vouch-protocol.com/contributors
+- Repository: https://github.com/vouch-protocol/vouch
+- Good first issues: https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -241,6 +241,13 @@ been removed. See `integrations.md`.
   identity mint and verify, conformance, passport, action check, and `sign_pq`, via
   a `VouchRobotics` class (a `vouch::robotics` namespace in C++). Output is
   byte-identical across languages. See `robotics.md`.
+- "What is the Vouch Verified Contributor badge, or how do I get one?" -> Land a
+  merged pull request on the repository; an automated workflow mints a signed
+  Verified Contributor credential (a real `eddsa-jcs-2022` VC issued by
+  `did:web:vouch-protocol.com:contributors`, chained to the project root identity),
+  publishes a certificate page at `vouch-protocol.com/c/<login>/<pr>`, lists the
+  contributor at `vouch-protocol.com/contributors`, and comments the badge on the
+  PR. It verifies like any other Vouch credential. See `verified-contributor.md`.
 
 ## Actions (if enabled)
 

--- a/openai-gpt/knowledge/verified-contributor.md
+++ b/openai-gpt/knowledge/verified-contributor.md
@@ -1,0 +1,65 @@
+# Vouch Verified Contributor credential
+
+Vouch Protocol issues a signed credential to people who contribute to it.
+When you land a merged pull request on the repository, an automated
+workflow mints a Vouch Verified Contributor credential for the author of
+that pull request's commits. This is the project using its own protocol:
+the badge is a real Verifiable Credential, not a decorative image.
+
+## What you get
+
+- A certificate page at `https://vouch-protocol.com/c/<login>/<pr>`.
+- A listing on the contributors page at `https://vouch-protocol.com/contributors`.
+- A comment on your pull request with the badge, a copy-paste snippet,
+  and the full credential inline.
+
+The badge is offered, never required. Add it to your profile or site if
+you want to.
+
+## What the credential is
+
+- A Verifiable Credential signed with the `eddsa-jcs-2022` cryptosuite
+  (Ed25519 over JCS-canonicalized bytes), the same default format every
+  Vouch SDK produces.
+- Issued by `did:web:vouch-protocol.com:contributors`.
+- Chained back to the project root authority `did:web:vouch-protocol.com`
+  through a delegation, so a verifier can walk from the badge to the root
+  identity.
+- The subject is the contributor (the author of the merged commits), so
+  credit stays correct even when a maintainer relays a contribution for
+  someone else.
+
+## Verifying the badge
+
+Because it is a normal Vouch credential, anyone can verify it with the
+SDK or the hosted verifier. The issuer public key is published in the DID
+document at `https://vouch-protocol.com/contributors/did.json`. In Python:
+
+```python
+from vouch import Verifier
+
+# `credential` is the JSON from the pull request comment or the
+# certificate page; `issuer_public_jwk` is the publicKeyJwk from the
+# contributor DID document.
+is_valid, passport = Verifier.verify_credential(credential, public_key=issuer_public_jwk)
+print(is_valid, passport.subject_did)
+```
+
+The certificate page verifies the same credential against the published
+contributor DID document before it is rendered.
+
+## How it works end to end
+
+1. Your pull request merges.
+2. A workflow resolves the contributor from the commit authors, skipping
+   the maintainer and bots.
+3. It mints the credential and self-verifies it against the published DID.
+4. It publishes the certificate page and adds you to the contributors
+   list, then waits for the site to deploy.
+5. It posts the congratulatory comment on your pull request.
+
+## Links
+
+- Contributors: https://vouch-protocol.com/contributors
+- Repository: https://github.com/vouch-protocol/vouch
+- Good first issues: https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/website-agent/backend/knowledge/verified-contributor.md
+++ b/website-agent/backend/knowledge/verified-contributor.md
@@ -1,0 +1,65 @@
+# Vouch Verified Contributor credential
+
+Vouch Protocol issues a signed credential to people who contribute to it.
+When you land a merged pull request on the repository, an automated
+workflow mints a Vouch Verified Contributor credential for the author of
+that pull request's commits. This is the project using its own protocol:
+the badge is a real Verifiable Credential, not a decorative image.
+
+## What you get
+
+- A certificate page at `https://vouch-protocol.com/c/<login>/<pr>`.
+- A listing on the contributors page at `https://vouch-protocol.com/contributors`.
+- A comment on your pull request with the badge, a copy-paste snippet,
+  and the full credential inline.
+
+The badge is offered, never required. Add it to your profile or site if
+you want to.
+
+## What the credential is
+
+- A Verifiable Credential signed with the `eddsa-jcs-2022` cryptosuite
+  (Ed25519 over JCS-canonicalized bytes), the same default format every
+  Vouch SDK produces.
+- Issued by `did:web:vouch-protocol.com:contributors`.
+- Chained back to the project root authority `did:web:vouch-protocol.com`
+  through a delegation, so a verifier can walk from the badge to the root
+  identity.
+- The subject is the contributor (the author of the merged commits), so
+  credit stays correct even when a maintainer relays a contribution for
+  someone else.
+
+## Verifying the badge
+
+Because it is a normal Vouch credential, anyone can verify it with the
+SDK or the hosted verifier. The issuer public key is published in the DID
+document at `https://vouch-protocol.com/contributors/did.json`. In Python:
+
+```python
+from vouch import Verifier
+
+# `credential` is the JSON from the pull request comment or the
+# certificate page; `issuer_public_jwk` is the publicKeyJwk from the
+# contributor DID document.
+is_valid, passport = Verifier.verify_credential(credential, public_key=issuer_public_jwk)
+print(is_valid, passport.subject_did)
+```
+
+The certificate page verifies the same credential against the published
+contributor DID document before it is rendered.
+
+## How it works end to end
+
+1. Your pull request merges.
+2. A workflow resolves the contributor from the commit authors, skipping
+   the maintainer and bots.
+3. It mints the credential and self-verifies it against the published DID.
+4. It publishes the certificate page and adds you to the contributors
+   list, then waits for the site to deploy.
+5. It posts the congratulatory comment on your pull request.
+
+## Links
+
+- Contributors: https://vouch-protocol.com/contributors
+- Repository: https://github.com/vouch-protocol/vouch
+- Good first issues: https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -1793,6 +1793,28 @@ Rule of thumb: if your auditor will ask about the sidecar, run the Go one. For e
   },
 
   // =====================================================================
+  // COMMUNITY AND CONTRIBUTING
+  // =====================================================================
+  {
+    id: 'community',
+    audience: 'Community & Contributing',
+    title: 'Contributing and the Verified Contributor badge',
+    items: [
+      {
+        q: 'How do I become a Vouch Verified Contributor?',
+        a: `Land a merged pull request on the [repository](https://github.com/vouch-protocol/vouch). When it merges, an automated workflow mints a signed Vouch Verified Contributor credential for you, publishes a certificate page at \`vouch-protocol.com/c/<your-handle>/<pr>\`, adds you to the [contributors page](https://vouch-protocol.com/contributors), and posts a comment on your pull request with the badge and the full credential.
+
+New to the project? Start with a [good first issue](https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). The badge is offered, never required.`,
+        helpLinks: [{ label: 'Become a Vouch Verified Contributor', href: '/help/#verified-contributor' }],
+      },
+      {
+        q: 'Is the contributor badge a real credential or an image?',
+        a: `It is a real Verifiable Credential, signed with the same \`eddsa-jcs-2022\` cryptosuite every Vouch SDK uses. It is issued by \`did:web:vouch-protocol.com:contributors\` and chained back to the project root identity \`did:web:vouch-protocol.com\`, so anyone can verify it with the Vouch verifier or an SDK. The subject is the author of the merged commits, so credit stays correct even when a maintainer relays a contribution for someone else.`,
+      },
+    ],
+  },
+
+  // =====================================================================
   // USING THIS SITE
   // =====================================================================
   {

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -2769,4 +2769,48 @@ Security boundary: the robot signs its wear state and derives the narrowed scope
       },
     ],
   },
+  {
+    id: 'community',
+    title: 'Community',
+    description: 'Contribute to the protocol and earn a signed Vouch Verified Contributor credential.',
+    articles: [
+      {
+        id: 'verified-contributor',
+        title: 'Become a Vouch Verified Contributor',
+        summary: 'Land a merged pull request and receive a real, signed Verified Contributor credential, published to a certificate page and the contributors list.',
+        body: `
+## What it is
+
+When you land a merged pull request on the [repository](https://github.com/vouch-protocol/vouch), an automated workflow mints a **Vouch Verified Contributor** credential for you. It is a real Verifiable Credential, not a decorative image: the project signs it with its own protocol.
+
+## What you receive
+
+- A certificate page at \`vouch-protocol.com/c/<your-handle>/<pr>\`.
+- A listing on the [contributors page](https://vouch-protocol.com/contributors).
+- A comment on your pull request with the badge, a copy-paste snippet, and the full credential inline.
+
+## The credential
+
+- Signed with the \`eddsa-jcs-2022\` cryptosuite, the same default format every Vouch SDK produces.
+- Issued by \`did:web:vouch-protocol.com:contributors\`, chained back to the project root identity \`did:web:vouch-protocol.com\`.
+- The subject is the author of the merged commits, so credit stays correct even when a maintainer relays a contribution for someone else.
+
+## Verify it
+
+Because it is a normal Vouch credential, anyone can verify it with the SDK or the hosted verifier:
+
+\`\`\`python
+from vouch import Verifier
+
+is_valid, passport = Verifier.verify_credential(credential, public_key=issuer_public_jwk)
+print(is_valid, passport.subject_did)
+\`\`\`
+
+## Getting started
+
+New to the project? Pick up a [good first issue](https://github.com/vouch-protocol/vouch/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22). The badge is offered, never required.
+`,
+      },
+    ],
+  },
 ];


### PR DESCRIPTION
Documents the Vouch Verified Contributor credential in one place and points every assistant at it.

- A new knowledge page covering what the credential is, how it is issued and chained to the project root identity, and how to verify it. It is mirrored to the Claude skill, the OpenAI GPT, the Gemini gem, and the site assistant.
- A FAQ entry and a help guide on becoming a Verified Contributor.
- A decision-rule pointer in the Claude skill, the OpenAI GPT, and the Gemini gem so each can answer how the contributor badge works.
