### PR TITLE
Show the OS switcher only where it can do something

### DIFF
--- a/website/src/components/Nav.tsx
+++ b/website/src/components/Nav.tsx
@@ -107,6 +107,11 @@ function MoreMenu() {
 export default function Nav() {
     const pathname = usePathname();
     const [open, setOpen] = useState(false);
+    // The OS switcher only drives OSCodeBlock, which appears only on the FAQ and
+    // Help pages. Hide it elsewhere so it does not show where it has nothing to toggle.
+    const showOSSwitcher = ['/faq', '/help'].some(
+        (r) => pathname === r || (pathname?.startsWith(r + '/') ?? false),
+    );
 
     return (
         <nav className="sticky top-0 z-40 bg-parchment/95 backdrop-blur supports-[backdrop-filter]:bg-parchment/80 border-b border-rule">
@@ -123,7 +128,7 @@ export default function Nav() {
                         </Link>
                     ))}
                     <MoreMenu />
-                    <OSSwitcher />
+                    {showOSSwitcher && <OSSwitcher />}
                     <ThemeToggle />
                     <a
                         href="https://github.com/vouch-protocol/vouch"
@@ -171,10 +176,12 @@ export default function Nav() {
                         >
                             GitHub
                         </a>
-                        <div className="pt-3 flex flex-col gap-2">
-                            <span className="font-mono uppercase text-[0.6rem] tracking-[0.14em] text-ink-faint">Commands for</span>
-                            <OSSwitcher />
-                        </div>
+                        {showOSSwitcher && (
+                            <div className="pt-3 flex flex-col gap-2">
+                                <span className="font-mono uppercase text-[0.6rem] tracking-[0.14em] text-ink-faint">Commands for</span>
+                                <OSSwitcher />
+                            </div>
+                        )}
                         <div className="pt-2"><ThemeToggle /></div>
                     </div>
                 </div>


### PR DESCRIPTION
The nav OS switcher drives OSCodeBlock, which appears only on the FAQ and Help pages, so on every other page it had nothing to toggle and read as broken. This renders it only on FAQ and Help, in both the desktop and mobile nav.