### PR TITLE
Let npm OIDC trusted publishing authenticate

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -24,7 +24,8 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-          registry-url: "https://registry.npmjs.org"
+      # No registry-url: it writes an .npmrc token line that blocks OIDC.
+      # Trusted publishing authenticates through the id-token instead.
       - name: Update npm (trusted publishing needs npm >= 11.5.1)
         run: npm install -g npm@latest
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
npm publishing returned 404 because actions/setup-node with registry-url writes an .npmrc that pins token authentication, which prevents the OIDC trusted publisher from being used. Removing registry-url lets npm publish authenticate through the id-token. npm still publishes to registry.npmjs.org, its default.