### PR TITLE
Make the LangGraph and Goose packages self-contained on their deps

### DIFF
--- a/packages/vouch-goose/pyproject.toml
+++ b/packages/vouch-goose/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Ramprasad Gaddam" }]
 keywords = ["goose", "block", "mcp", "vouch", "ai-agents", "verifiable-credentials", "identity"]
-dependencies = ["vouch-protocol[goose]>=1.6.0", "vouch-mcp>=1.6.0"]
+dependencies = ["vouch-protocol>=1.6.0", "vouch-mcp>=1.6.0", "pyyaml>=6.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]

--- a/packages/vouch-langgraph/pyproject.toml
+++ b/packages/vouch-langgraph/pyproject.toml
@@ -11,7 +11,7 @@ requires-python = ">=3.9"
 license = { text = "Apache-2.0" }
 authors = [{ name = "Ramprasad Gaddam" }]
 keywords = ["langgraph", "langchain", "vouch", "ai-agents", "verifiable-credentials", "identity"]
-dependencies = ["vouch-protocol[langgraph]>=1.6.0"]
+dependencies = ["vouch-protocol>=1.6.0", "langgraph>=0.1.0"]
 
 [project.optional-dependencies]
 dev = ["pytest>=7.0"]


### PR DESCRIPTION
vouch-langgraph and vouch-goose depended on vouch-protocol extras (langgraph, goose) that the published vouch-protocol does not carry yet, so a fresh install would miss langgraph and pyyaml. This depends on those directly instead: vouch-langgraph pulls langgraph, and vouch-goose pulls vouch-mcp and pyyaml. This is what makes the published packages install and run cleanly.