### PR TITLE
Fix the TypeScript SDK CI check for the locally built core-wasm

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -69,8 +69,12 @@ jobs:
       - name: Install and test
         working-directory: packages/sdk-ts
         run: |
-          npm install
-          npm install --no-save ../../core/wasm/pkg
+          # core-wasm is an optional peer dependency, built locally in the step
+          # above rather than resolved from the registry. --legacy-peer-deps
+          # keeps npm from trying to fetch the optional peer, then the local
+          # build is installed for the tests that exercise it.
+          npm install --legacy-peer-deps
+          npm install --no-save --legacy-peer-deps ../../core/wasm/pkg
           npm test
 
   wasm:

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -98,7 +98,6 @@
  },
  "devDependencies": {
   "@noble/post-quantum": "^0.4.0",
-  "@vouch-protocol-official/core-wasm": "^2.0.0",
   "@types/node": "^20.10.0",
   "tsup": "^8.0.0",
   "typescript": "^5.3.0",


### PR DESCRIPTION
The TypeScript SDK check was failing at `npm install` for every PR because `@vouch-protocol-official/core-wasm` was pinned in `devDependencies` at `^2.0.0`, a version not yet on the registry (only `0.1.0` is published).

core-wasm is an optional peer dependency that CI builds locally in the step just before installing. This drops it from `devDependencies` and installs with `--legacy-peer-deps`, then adds the local build for the tests that use it. Verified with a dry-run install: the tree resolves with no ETARGET.

Once `core-wasm@2.0.0` is published, the optional peer resolves for consumers as well.
