### PR TITLE
Use an npm Automation token to publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,8 +4,7 @@
 #   @vouch-protocol-official/api-client  (sdks/clients/typescript)
 #
 # Trigger: push a tag like `npm-v0.1.0`, or run manually (workflow_dispatch).
-# Auth: npm Trusted Publishing (OIDC). Configure a trusted publisher for each
-# package on npmjs.com pointing at this repo and workflow. No token needed.
+# Required repo secret: NPM_TOKEN (an npm Automation token, which bypasses 2FA).
 name: Publish npm
 
 on:
@@ -16,18 +15,14 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
-      # No registry-url: it writes an .npmrc token line that blocks OIDC.
-      # Trusted publishing authenticates through the id-token instead.
-      - name: Update npm (trusted publishing needs npm >= 11.5.1)
-        run: npm install -g npm@latest
+          registry-url: "https://registry.npmjs.org"
       - uses: dtolnay/rust-toolchain@stable
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh


### PR DESCRIPTION
Restores token authentication for the npm publish workflow. It puts back registry-url and the NODE_AUTH_TOKEN environment and removes the OIDC-only steps. NPM_TOKEN should hold an npm Automation token, which bypasses two-factor authentication for CI publishing.