### PR TITLE
Release vouch-protocol 2.0.1 (includes the LangGraph, Goose, and A2A modules)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "2.0.0"
+version = "2.0.1"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -5,7 +5,7 @@ This package provides cryptographic identity binding for autonomous AI agents,
 enabling verifiable proof of intent and non-repudiation.
 """
 
-__version__ = "1.6.0"
+__version__ = "2.0.1"
 
 # Core signing/verification
 from .signer import Signer, sign


### PR DESCRIPTION
Bumps vouch-protocol to 2.0.1 so the published package includes the LangGraph, Goose, and A2A integration modules that landed after 2.0.0. The standalone vouch-langgraph, vouch-goose, and vouch-a2a packages re-export from those modules, so they need a vouch-protocol release that ships them. Also aligns the __version__ constant with the package version.