### PR TITLE
Install core-wasm for the sdk type build

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -98,6 +98,7 @@
  },
  "devDependencies": {
   "@noble/post-quantum": "^0.4.0",
+  "@vouch-protocol-official/core-wasm": "^2.0.0",
   "@types/node": "^20.10.0",
   "tsup": "^8.0.0",
   "typescript": "^5.3.0",


### PR DESCRIPTION
The sdk type build failed to resolve @vouch-protocol-official/core-wasm because it was only an optional peer dependency, which npm skips on install. This adds it as a dev dependency so it is present at build time, matching how @noble/post-quantum is handled.