### PR TITLE
Build and bundle the .NET native library across platforms

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,7 +1,12 @@
 # Publish the .NET SDK (VouchProtocol.Core) to NuGet.org.
 #
-# Trigger: push a tag like `dotnet-v0.1.0`, or run manually (workflow_dispatch).
-# Required repo secret: NUGET_API_KEY (nuget.org API key).
+# Trigger: push a tag like `dotnet-v2.0.0`, or run manually (workflow_dispatch).
+# Auth: NuGet Trusted Publishing (OIDC). Configure a trusted publisher on
+# nuget.org for this repository and this workflow file. No API key needed.
+#
+# The native core is built once per runtime identifier (Linux, macOS arm64 and
+# x64, Windows) and collected into runtimes/<rid>/native, which dotnet pack
+# bundles so the P/Invoke in Vouch.cs resolves the right binary on each OS.
 name: Publish NuGet
 
 on:
@@ -15,24 +20,67 @@ on:
         default: false
 
 jobs:
-  publish:
-    runs-on: ubuntu-latest
+  build-native:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, rids: "linux-x64" }
+          - { os: macos-latest, rids: "osx-arm64 osx-x64" }
+          - { os: windows-latest, rids: "win-x64" }
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: "8.0.x"
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - name: Build native libraries
         working-directory: sdks/dotnet/VouchCore
-        run: bash build-native.sh
+        shell: bash
+        run: for rid in ${{ matrix.rids }}; do bash build-native.sh "$rid"; done
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.os }}
+          path: sdks/dotnet/VouchCore/runtimes
+          if-no-files-found: error
+
+  publish:
+    needs: build-native
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "8.0.x"
+      - name: Collect native libraries into runtimes/
+        uses: actions/download-artifact@v4
+        with:
+          path: sdks/dotnet/VouchCore/runtimes
+          pattern: native-*
+          merge-multiple: true
       - name: Pack
         working-directory: sdks/dotnet/VouchCore
         run: dotnet pack -c Release -o ../../../dist-nuget
+      - name: Verify all runtimes are in the package
+        run: |
+          echo "Collected native libraries:"
+          find sdks/dotnet/VouchCore/runtimes -type f -name "*vouch_core_uniffi*" | sort
+          echo "Native libraries inside the .nupkg:"
+          unzip -l dist-nuget/*.nupkg | grep -E "runtimes/.*/native/" | sort
+          count=$(unzip -l dist-nuget/*.nupkg | grep -cE "runtimes/.*/native/.*vouch_core_uniffi")
+          echo "native library count in package: $count"
+          test "$count" -ge 4 || { echo "expected 4 native libraries, found $count"; exit 1; }
+      - name: Authenticate to NuGet (Trusted Publishing)
+        if: ${{ inputs.dry_run != true }}
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: Vouch_Protocol_Official
       - name: Push to NuGet
         if: ${{ inputs.dry_run != true }}
         run: |
           dotnet nuget push "dist-nuget/*.nupkg" \
-            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" \
             --source https://api.nuget.org/v3/index.json \
             --skip-duplicate

--- a/sdks/dotnet/VouchCore/build-native.sh
+++ b/sdks/dotnet/VouchCore/build-native.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Build the native core (core/uniffi) for one runtime identifier and place it
+# under runtimes/<rid>/native/ so `dotnet pack` bundles it. NuGet then resolves
+# the right binary per RID at consume time, and the P/Invoke in Vouch.cs
+# (DllImport "vouch_core_uniffi") finds it.
+#
+# Usage: build-native.sh [rid]
+#   With no argument it builds for the host. Pass a RID to cross-compile, e.g.
+#   `build-native.sh osx-x64` on an arm64 mac. Supported RIDs: linux-x64,
+#   osx-arm64, osx-x64, win-x64.
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+export PATH="$HOME/.cargo/bin:$PATH"
+
+CORE="../../../core/uniffi"
+NAME="vouch_core_uniffi"
+RID="${1:-}"
+
+if [ -z "$RID" ]; then
+  case "$(uname -s)-$(uname -m)" in
+    Linux-x86_64)                              RID="linux-x64";;
+    Darwin-arm64)                              RID="osx-arm64";;
+    Darwin-x86_64)                             RID="osx-x64";;
+    MINGW*-x86_64|MSYS*-x86_64|CYGWIN*-x86_64) RID="win-x64";;
+    *) echo "unsupported host: $(uname -s)-$(uname -m)"; exit 1;;
+  esac
+fi
+
+case "$RID" in
+  linux-x64) TARGET="x86_64-unknown-linux-gnu"; LIB="lib$NAME.so";;
+  osx-arm64) TARGET="aarch64-apple-darwin";     LIB="lib$NAME.dylib";;
+  osx-x64)   TARGET="x86_64-apple-darwin";       LIB="lib$NAME.dylib";;
+  win-x64)   TARGET="x86_64-pc-windows-msvc";    LIB="$NAME.dll";;
+  *) echo "unsupported rid: $RID"; exit 1;;
+esac
+
+rustup target add "$TARGET" >/dev/null 2>&1 || true
+
+echo "==> building $NAME for $RID ($TARGET)"
+( cd "$CORE" && cargo build --release --target "$TARGET" )
+
+mkdir -p "runtimes/$RID/native"
+cp "$CORE/target/$TARGET/release/$LIB" "runtimes/$RID/native/$LIB"
+echo "==> placed runtimes/$RID/native/$LIB"

--- a/sdks/dotnet/VouchCore/runtimes/.gitignore
+++ b/sdks/dotnet/VouchCore/runtimes/.gitignore
@@ -1,0 +1,3 @@
+# Native libraries are built per runtime identifier in CI, not committed.
+# Keep this file and NATIVE_LIBS.txt; ignore the built <rid>/ directories.
+*/


### PR DESCRIPTION
The .NET package needs the native core (vouch_core_uniffi) bundled per runtime identifier so the P/Invoke in Vouch.cs resolves it on each OS. This adds build-native.sh, which builds core/uniffi for the host and writes runtimes/<rid>/native/<lib>, and reworks publish-nuget.yml into a matrix that builds the library on Linux, macOS arm64 and x64, and Windows, collects the four runtimes into one package, and pushes through NuGet Trusted Publishing. The built libraries are produced in CI, not committed.