### PR TITLE
Install the Gemini client in the website-agent image

### DIFF
--- a/website-agent/backend/Dockerfile
+++ b/website-agent/backend/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 COPY pyproject.toml ./
-RUN pip install --no-cache-dir -e .
+# Include the gemini extra so the default hosted provider (google-genai) is in
+# the image; the assistant runs on Gemini via VOUCH_LLM_PROVIDER.
+RUN pip install --no-cache-dir -e ".[gemini]"
 
 COPY vouch_agent ./vouch_agent
 COPY knowledge ./knowledge


### PR DESCRIPTION
The hosted website assistant runs on Gemini, but the backend image installed core dependencies only, so `google-genai` was missing. Retrieval worked while chat responses failed to start.

This installs the `gemini` extra in the image so the client is present. Verified on the live app after deploy: `/chat` now streams a real answer and cites its sources.
