### PR TITLE
Add a transparency section to the interactive demos

### DIFF
--- a/website/src/app/demos/DemosClient.tsx
+++ b/website/src/app/demos/DemosClient.tsx
@@ -303,6 +303,51 @@ function Provenance() {
 }
 
 /* ------------------------------------------------------------------ */
+/* Section V - Action transparency (vouch.transparency)                */
+/* ------------------------------------------------------------------ */
+
+function Transparency() {
+  const [mode, setMode] = useState<'sound' | 'omit' | 'rewrite'>('sound');
+  const verdicts = {
+    sound: { ok: true, reason: 'inclusion proof holds and the new tree head extends the old', label: 'VERIFIED' },
+    omit: { ok: false, reason: 'inclusion_failed · this action is not in the log the tree head commits to', label: 'CAUGHT' },
+    rewrite: { ok: false, reason: 'consistency_failed · the log rewrote an entry it had already committed', label: 'CAUGHT' },
+  } as const;
+  const v = verdicts[mode];
+  return (
+    <div className="grid md:grid-cols-2 gap-8 items-start">
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          Consequential actions land in an append-only Merkle log that signs its size and root. A verifier demands an
+          <b className="text-ink"> inclusion proof</b> that an action is in the log, and a monitor demands a
+          <b className="text-ink"> consistency proof</b> that a newer tree head extends the older one, so nothing can be
+          omitted or rewritten.
+        </p>
+        <div className="eyebrow-faint mb-2">Try it as the monitor</div>
+        <div className="flex flex-col gap-2">
+          <button className={`demo-radio${mode === 'sound' ? ' on' : ''}`} onClick={() => setMode('sound')}>Check the log honestly</button>
+          <button className={`demo-radio${mode === 'omit' ? ' on' : ''}`} onClick={() => setMode('omit')}>Claim an action that was never logged</button>
+          <button className={`demo-radio${mode === 'rewrite' ? ' on' : ''}`} onClick={() => setMode('rewrite')}>The log rewrites an old entry</button>
+        </div>
+      </div>
+      <div>
+        <div className="demo-ledger" style={{ minHeight: '150px' }}>
+          <div className="demo-line"><span className="k">#0</span> transfer_funds · usd:5000 {mode === 'rewrite' ? '→ usd:50 ✗' : '✓'}</div>
+          <div className="demo-line"><span className="k">#1</span> publish · blog ✓</div>
+          <div className="demo-line"><span className="k">#2</span> delete · db:staging-3 ✓</div>
+          <div className="demo-line"><span className="k">STH</span> size 3 · root {mode === 'rewrite' ? 'uePe… recomputes ✗' : 'uePe… signed ✓'}</div>
+          {mode === 'omit' && <div className="demo-line"><span className="k">claim</span> exfiltrate · not in tree ✗</div>}
+        </div>
+        <div className="demo-verdict mt-4" style={{ borderColor: v.ok ? ALLOW : DENY }}>
+          <span className="demo-badge" style={{ color: v.ok ? ALLOW : DENY, borderColor: v.ok ? ALLOW : DENY }}>{v.label}</span>
+          <span className="font-mono text-[0.85rem] text-ink-soft">{v.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 
 export default function DemosClient() {
   return (
@@ -340,7 +385,7 @@ export default function DemosClient() {
         </div>
       </section>
 
-      <section id="provenance" className="scroll-mt-24">
+      <section id="provenance" className="border-b border-rule scroll-mt-24">
         <div className="container-wide py-16">
           <div className="section-heading">
             <span className="num">§ IV</span>
@@ -348,6 +393,17 @@ export default function DemosClient() {
           </div>
           <p className="eyebrow mb-6">Prove the output came from this model on this context · vouch.provenance</p>
           <Provenance />
+        </div>
+      </section>
+
+      <section id="transparency" className="scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ V</span>
+            <h2>The transparency log</h2>
+          </div>
+          <p className="eyebrow mb-6">An action can&apos;t be hidden or rewritten · vouch.transparency</p>
+          <Transparency />
         </div>
       </section>
     </>

--- a/website/src/app/demos/page.tsx
+++ b/website/src/app/demos/page.tsx
@@ -24,9 +24,10 @@ export default function DemosPage() {
           <p className="footnote mt-5">
             Every verdict here mirrors the shipped SDK modules
             {' '}<code className="font-mono text-[0.85em]">vouch.reasoning</code>,
-            {' '}<code className="font-mono text-[0.85em]">vouch.deliberation</code>, and
-            {' '}<code className="font-mono text-[0.85em]">vouch.caveats</code>, and
-            {' '}<code className="font-mono text-[0.85em]">vouch.provenance</code>. Disclosed as PAD-043, PAD-045, PAD-085, and PAD-086.
+            {' '}<code className="font-mono text-[0.85em]">vouch.deliberation</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.caveats</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.provenance</code>, and
+            {' '}<code className="font-mono text-[0.85em]">vouch.transparency</code>. Disclosed as PAD-043, PAD-045, PAD-085, and PAD-086.
           </p>
         </div>
       </section>

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -220,6 +220,7 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
       {
         q: 'How do I make agent actions publicly auditable so none can be hidden or rewritten?',
         a: `\`vouch.transparency\` submits consequential actions to an append-only RFC 6962 Merkle log that signs its size and root as a Signed Tree Head. A verifier can demand an inclusion proof that a specific action is in the log, and a monitor can demand a consistency proof that an older tree head is a strict prefix of a newer one. So the log cannot silently omit an action or rewrite history, and comparing tree heads across observers catches a split view. It is the same discipline Certificate Transparency brought to misissuance.`,
+        helpLinks: [{ label: 'See it: the transparency log', href: '/demos/#transparency' }],
       },
     ],
   },


### PR DESCRIPTION
Adds a fifth section (`/demos/#transparency`) to the interactive demos for the action transparency log, bringing all five shipped accountable-autonomy modules to demo parity.

As the monitor you can check the log honestly (**VERIFIED**), claim an action that was never logged (`inclusion_failed`), or watch the log rewrite an already-committed entry (`consistency_failed`), and the verdict flips. Styled in the site's parchment/burgundy/serif system like the other four.

Also updates the demos hero footnote to include `vouch.transparency` and deep-links the "How do I make agent actions publicly auditable?" FAQ answer to the new section.
