### PR TITLE
Restore the LangChain and CrewAI packages and add them to PyPI publishing

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -30,6 +30,8 @@ jobs:
           - { name: vouch-api-client, dir: "sdks/clients/python" }
           - { name: vouch-mcp, dir: "packages/vouch-mcp" }
           - { name: vouch-a2a, dir: "packages/vouch-a2a" }
+          - { name: vouch-langchain, dir: "packages/vouch-langchain" }
+          - { name: vouch-crewai, dir: "packages/vouch-crewai" }
           - { name: vouch-langgraph, dir: "packages/vouch-langgraph" }
           - { name: vouch-goose, dir: "packages/vouch-goose" }
     name: publish ${{ matrix.name }}

--- a/packages/vouch-crewai/README.md
+++ b/packages/vouch-crewai/README.md
@@ -1,0 +1,53 @@
+# vouch-crewai
+
+A [CrewAI](https://www.crewai.com/) tool that issues
+[Vouch](https://vouch-protocol.com) Credentials, so the agents in a crew can
+cryptographically authorize their tool calls, including across delegation.
+
+Each signed call carries a W3C Verifiable Credential with an `eddsa-jcs-2022`
+Data Integrity proof. When a supervisor agent delegates to a worker, the
+worker's credential extends the supervisor's chain and can only narrow the
+authority, never broaden it.
+
+## Install
+
+```bash
+pip install vouch-crewai
+```
+
+This pulls in `vouch-protocol[crewai]`.
+
+## Configure
+
+- `VOUCH_PRIVATE_KEY` the agent's private key (JWK JSON string).
+- `VOUCH_DID` the agent's DID, e.g. `did:web:agent.example.com`.
+
+## Use
+
+```python
+from vouch_crewai import sign_request
+
+# Give the tool to a CrewAI agent. It calls it before an authenticated request.
+credential_json = sign_request(
+    action="read",
+    target="https://api.example.com",
+    resource="customer:123",
+)
+```
+
+## Delegation between agents
+
+See `examples/integrations_delegation.py` in the main repo for a supervisor
+that issues a broad credential and a worker that narrows it under capability
+attenuation.
+
+## Verify on the receiving side
+
+```python
+from vouch import Verifier
+ok, passport = Verifier.verify_credential(received_json, public_key=agent_pubkey)
+```
+
+## License
+
+Apache-2.0.

--- a/packages/vouch-crewai/VERIFY.md
+++ b/packages/vouch-crewai/VERIFY.md
@@ -1,0 +1,38 @@
+# vouch-crewai: your verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-crew-test && source /tmp/vouch-crew-test/bin/activate
+pip install -e packages/vouch-crewai   # pulls vouch-protocol[crewai]
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-crewai/tests -q
+```
+
+Expect: 2 passed. They check the exports and that the signing path issues an
+`eddsa-jcs-2022` credential that verifies.
+
+## 3. Real crew with delegation (recommended)
+
+Run `examples/integrations_delegation.py` from the main repo, then give
+`sign_request` to a two-agent crew and confirm a supervisor credential and a
+narrowed worker credential both verify.
+
+## 4. Build
+
+```bash
+pip install build && python -m build packages/vouch-crewai
+unzip -l packages/vouch-crewai/dist/*.whl   # confirm only vouch_crewai is packaged
+```
+
+## 5. Only after the above
+
+- [ ] Publish to PyPI under your account.
+- [ ] Add the listing to the CrewAI tools docs or contribute to crewai-tools.

--- a/packages/vouch-crewai/pyproject.toml
+++ b/packages/vouch-crewai/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-crewai"
+version = "0.1.0"
+description = "CrewAI tool that issues Vouch Credentials to authorize multi-agent tool calls."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["crewai", "vouch", "ai-agents", "verifiable-credentials", "delegation"]
+dependencies = ["vouch-protocol[crewai]>=1.6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-crewai/src/vouch_crewai/__init__.py
+++ b/packages/vouch-crewai/src/vouch_crewai/__init__.py
@@ -1,0 +1,11 @@
+"""vouch-crewai: a CrewAI tool that issues Vouch Credentials.
+
+Thin distribution wrapping vouch.integrations.crewai. It exists so the tool can
+be installed and listed on its own while the implementation stays
+single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.crewai.tool import VouchCrewTools, sign_request
+
+__all__ = ["sign_request", "VouchCrewTools"]
+__version__ = "0.1.0"

--- a/packages/vouch-crewai/tests/test_smoke.py
+++ b/packages/vouch-crewai/tests/test_smoke.py
@@ -1,0 +1,35 @@
+"""Smoke tests for the vouch-crewai package.
+
+The signing path is verified through the shared helper so the test is robust
+whether or not CrewAI is installed (CrewAI wraps sign_request in a tool object).
+"""
+
+import json
+import os
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Verifier, generate_identity
+from vouch.integrations._common import load_signer, sign_tool_call_json
+
+
+def test_package_exports():
+    import vouch_crewai
+
+    assert vouch_crewai.sign_request is not None
+    assert vouch_crewai.VouchCrewTools is not None
+
+
+def test_signing_path_verifies():
+    kp = generate_identity()
+    os.environ["VOUCH_PRIVATE_KEY"] = kp.private_key_jwk
+    os.environ["VOUCH_DID"] = "did:web:agent.example.com"
+
+    out = sign_tool_call_json(load_signer(), "read", "https://api.example.com", "customer:123")
+    cred = json.loads(out)
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+    pub = Ed25519PublicKey.from_public_bytes(base64url_decode(json.loads(kp.public_key_jwk)["x"]))
+    ok, _ = Verifier.verify_credential(cred, public_key=pub)
+    assert ok is True

--- a/packages/vouch-langchain/README.md
+++ b/packages/vouch-langchain/README.md
@@ -1,0 +1,52 @@
+# vouch-langchain
+
+A [LangChain](https://www.langchain.com/) tool that issues
+[Vouch](https://vouch-protocol.com) Credentials, so a LangChain agent can
+cryptographically authorize the tool calls it makes.
+
+Each signed call carries a W3C Verifiable Credential with an `eddsa-jcs-2022`
+Data Integrity proof, and optionally a delegation chain back to an accountable
+human principal.
+
+## Install
+
+```bash
+pip install vouch-langchain
+```
+
+This pulls in `vouch-protocol[langchain]`.
+
+## Configure
+
+The tool reads two environment variables:
+
+- `VOUCH_PRIVATE_KEY` the agent's private key (JWK JSON string).
+- `VOUCH_DID` the agent's DID, e.g. `did:web:agent.example.com`.
+
+## Use
+
+```python
+from vouch_langchain import VouchSignerTool
+
+tool = VouchSignerTool()  # reads VOUCH_PRIVATE_KEY / VOUCH_DID
+credential_json = tool._run(
+    action="read",
+    target="https://api.example.com",
+    resource="customer:123",
+)
+# Attach credential_json as a 'Vouch-Credential' header on your request.
+```
+
+Add `tool` to any LangChain agent's tool list. The agent calls it before an
+authenticated request and forwards the credential to your service.
+
+## Verify on the receiving side
+
+```python
+from vouch import Verifier
+ok, passport = Verifier.verify_credential(received_json, public_key=agent_pubkey)
+```
+
+## License
+
+Apache-2.0.

--- a/packages/vouch-langchain/VERIFY.md
+++ b/packages/vouch-langchain/VERIFY.md
@@ -1,0 +1,40 @@
+# vouch-langchain: your verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-lc-test && source /tmp/vouch-lc-test/bin/activate
+pip install -e packages/vouch-langchain   # pulls vouch-protocol[langchain]
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-langchain/tests -q
+```
+
+Expect: 2 passed. They check the exports and that the tool issues an
+`eddsa-jcs-2022` credential that verifies.
+
+## 3. Real LangChain agent (recommended)
+
+Add `VouchSignerTool()` to an actual LangChain agent's tool list, run a prompt
+that triggers an authenticated call, and confirm the agent calls the tool and
+forwards the credential.
+
+## 4. Build
+
+```bash
+pip install build && python -m build packages/vouch-langchain
+unzip -l packages/vouch-langchain/dist/*.whl   # confirm only vouch_langchain is packaged
+```
+
+## 5. Only after the above
+
+- [ ] Publish to PyPI under your account.
+- [ ] Add the listing to LangChain's integration docs/registry. If their registry
+      expects the `langchain-vouch` name, publish the thin alias shim (see the
+      plan doc, Part 8) that depends on and re-exports `vouch-langchain`.

--- a/packages/vouch-langchain/pyproject.toml
+++ b/packages/vouch-langchain/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-langchain"
+version = "0.1.0"
+description = "LangChain tool that issues Vouch Credentials to authorize AI agent tool calls."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["langchain", "vouch", "ai-agents", "verifiable-credentials", "identity"]
+dependencies = ["vouch-protocol[langchain]>=1.6.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-langchain/src/vouch_langchain/__init__.py
+++ b/packages/vouch-langchain/src/vouch_langchain/__init__.py
@@ -1,0 +1,11 @@
+"""vouch-langchain: a LangChain tool that issues Vouch Credentials.
+
+Thin distribution wrapping vouch.integrations.langchain. It exists so the tool
+can be installed and listed on its own while the implementation stays
+single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.langchain.tool import VouchSignerInput, VouchSignerTool
+
+__all__ = ["VouchSignerTool", "VouchSignerInput"]
+__version__ = "0.1.0"

--- a/packages/vouch-langchain/tests/test_smoke.py
+++ b/packages/vouch-langchain/tests/test_smoke.py
@@ -1,0 +1,32 @@
+"""Smoke tests for the vouch-langchain package."""
+
+import json
+import os
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Verifier, generate_identity
+
+
+def test_package_exports():
+    import vouch_langchain
+
+    assert vouch_langchain.VouchSignerTool is not None
+    assert vouch_langchain.VouchSignerInput is not None
+
+
+def test_tool_issues_verifying_credential():
+    kp = generate_identity()
+    os.environ["VOUCH_PRIVATE_KEY"] = kp.private_key_jwk
+    os.environ["VOUCH_DID"] = "did:web:agent.example.com"
+
+    from vouch_langchain import VouchSignerTool
+
+    out = VouchSignerTool()._run("read", "https://api.example.com", "customer:123")
+    cred = json.loads(out)
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+    pub = Ed25519PublicKey.from_public_bytes(base64url_decode(json.loads(kp.public_key_jwk)["x"]))
+    ok, _ = Verifier.verify_credential(cred, public_key=pub)
+    assert ok is True


### PR DESCRIPTION
Brings the vouch-langchain and vouch-crewai standalone packages back to main (their source was on an unmerged branch) and adds them to the OIDC publish workflow so they stay in the automated release pipeline. Their integration code already ships in vouch-protocol, so the wrappers are thin re-exports. Both build and pass twine check.