### PR TITLE
Add a bystander-consent demo to the robotics demos page

### DIFF
--- a/website/src/app/demos/robotics/RoboticsDemos.tsx
+++ b/website/src/app/demos/robotics/RoboticsDemos.tsx
@@ -5,10 +5,11 @@ import React, { useState } from 'react';
 import styles from './RoboticsDemos.module.css';
 
 /**
- * Interactive demos for the three robotics capabilities shipped alongside this
- * page: infrastructure access (vouch.robotics.access), fused-sensor provenance
- * (vouch.robotics.fusion), and wear and degradation (vouch.robotics.wear). Each
- * mirrors the real credential shapes and the real verification logic, rendered
+ * Interactive demos for four robotics capabilities: infrastructure access
+ * (vouch.robotics.access), fused-sensor provenance (vouch.robotics.fusion), wear
+ * and degradation (vouch.robotics.wear), and bystander consent
+ * (vouch.robotics.consent). Each mirrors the real credential shapes and the real
+ * verification logic, rendered
  * as an on-brand illustration rather than a live signature so it runs with no
  * network call. Burgundy doubles as refuse, a parchment-harmonized green marks
  * allow, and both read on either theme.
@@ -237,6 +238,95 @@ function Wear() {
 }
 
 /* ------------------------------------------------------------------ */
+/* Consent: a bystander token and the robot's evidence, bound to one capture. */
+/* ------------------------------------------------------------------ */
+
+type ConsentScenario = 'explicit' | 'replay' | 'notice' | 'redacted';
+
+const CONSENT_SCENARIOS: Array<{ id: ConsentScenario; label: string }> = [
+  { id: 'explicit', label: 'A bystander consents to this capture' },
+  { id: 'replay', label: 'Reuse that consent for a different capture' },
+  { id: 'notice', label: 'Record under posted notice, no token' },
+  { id: 'redacted', label: 'Redact the capture instead' },
+];
+
+function Consent() {
+  const [scenario, setScenario] = useState<ConsentScenario>('explicit');
+
+  const basis = {
+    explicit: 'explicit-consent',
+    replay: 'explicit-consent',
+    notice: 'posted-notice',
+    redacted: 'redacted',
+  }[scenario];
+
+  const verdict = {
+    explicit: { ok: true, reason: 'verified · token bound to this capture' },
+    replay: { ok: false, reason: 'token is bound to a different capture' },
+    notice: { ok: true, reason: 'verified · posted-notice basis' },
+    redacted: { ok: true, reason: 'verified · redaction applied' },
+  }[scenario];
+
+  const showToken = scenario === 'explicit' || scenario === 'replay';
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          A robot that captures people records the basis it acted on, bound to the capture by its hash and holding only
+          hashes, never an image or anyone&apos;s identity. A bystander signs consent over one capture, so it cannot be
+          replayed to another recording.
+        </p>
+        <div className="eyebrow-faint mb-2">Choose the situation</div>
+        <div className={styles.controls}>
+          {CONSENT_SCENARIOS.map((s) => (
+            <button
+              key={s.id}
+              className={`${styles.radio}${scenario === s.id ? ' ' + styles.on : ''}`}
+              onClick={() => setScenario(s.id)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Robot evidence (signed)</div>
+          <div className={styles.mono}>
+            captureHash: {scenario === 'replay' ? 'uCAP-B…' : 'uCAP-A…'}
+            <br />
+            basis: {basis}
+            {scenario === 'redacted' ? (
+              <>
+                <br />
+                redactionHash: uRED…
+              </>
+            ) : null}
+          </div>
+        </div>
+        {showToken ? (
+          <div className={styles.card}>
+            <div className={styles.cardLabel}>Bystander token (signed)</div>
+            <div className={styles.mono}>
+              bystander: did:web:person-1
+              <br />
+              captureHash: uCAP-A… · robot: did:web:robot-a
+            </div>
+          </div>
+        ) : null}
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: verdict.ok ? ALLOW : DENY, borderColor: verdict.ok ? ALLOW : DENY }}>
+            {verdict.ok ? '✓ VERIFIED' : '✕ REFUSED'}
+          </span>
+          <span className={styles.reason}>{verdict.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 
 export default function RoboticsDemos() {
   return (
@@ -263,7 +353,7 @@ export default function RoboticsDemos() {
         </div>
       </section>
 
-      <section id="wear" className="scroll-mt-24">
+      <section id="wear" className="border-b border-rule scroll-mt-24">
         <div className="container-wide py-16">
           <div className="section-heading">
             <span className="num">§ III</span>
@@ -271,6 +361,17 @@ export default function RoboticsDemos() {
           </div>
           <p className="eyebrow mb-6">A worn robot narrows its own envelope, verifiably · vouch.robotics.wear</p>
           <Wear />
+        </div>
+      </section>
+
+      <section id="consent" className="scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ IV</span>
+            <h2>Bystander consent</h2>
+          </div>
+          <p className="eyebrow mb-6">Consent is bound to one capture and cannot be replayed · vouch.robotics.consent</p>
+          <Consent />
         </div>
       </section>
     </>

--- a/website/src/app/demos/robotics/page.tsx
+++ b/website/src/app/demos/robotics/page.tsx
@@ -5,7 +5,7 @@ import RoboticsDemos from './RoboticsDemos';
 export const metadata: Metadata = {
   title: 'Robotics interactive demos',
   description:
-    'See Vouch Protocol robotics controls run in the browser: a robot that opens a door with a grant the door authorizes offline, a fused world model bound to the exact sensor frames that made it, and a worn robot that narrows its own force and speed envelope as it degrades.',
+    'See Vouch Protocol robotics controls run in the browser: a robot that opens a door with a grant the door authorizes offline, a fused world model bound to the exact sensor frames that made it, a worn robot that narrows its own force and speed envelope as it degrades, and bystander consent bound to a single capture so it cannot be replayed.',
 };
 
 export default function RoboticsDemosPage() {
@@ -20,13 +20,14 @@ export default function RoboticsDemosPage() {
           <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-prose">
             A robot acts in the physical world, so the questions get sharper: what is it allowed to touch, is the world it
             sees real, and is it still fit to do the job. Vouch answers each with a credential the robot or the resource
-            can check on the spot. Three of them run below, on the real credential shapes.
+            can check on the spot. Four of them run below, on the real credential shapes.
           </p>
           <p className="footnote mt-5">
             Every verdict here mirrors the shipped SDK modules
             {' '}<code className="font-mono text-[0.85em]">vouch.robotics.access</code>,
-            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.fusion</code>, and
-            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.wear</code>. Disclosed as PAD-087 through PAD-092.
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.fusion</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.wear</code>, and
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.consent</code>. Disclosed as PAD-087 through PAD-094.
           </p>
         </div>
       </section>
@@ -40,8 +41,9 @@ export default function RoboticsDemosPage() {
               <strong className="text-ink">Build it yourself.</strong> Each demo maps to the same functions the SDK ships
               in Python, TypeScript, Go, and the Rust core:
               {' '}<code className="font-mono text-[0.85em]">authorize_access</code>,
-              {' '}<code className="font-mono text-[0.85em]">verify_fused_attestation</code>, and
-              {' '}<code className="font-mono text-[0.85em]">attenuate_for_wear</code>. See the{' '}
+              {' '}<code className="font-mono text-[0.85em]">verify_fused_attestation</code>,
+              {' '}<code className="font-mono text-[0.85em]">attenuate_for_wear</code>, and
+              {' '}<code className="font-mono text-[0.85em]">verify_consent_evidence</code>. See the{' '}
               <a href="/robotics/" className="prose-link">robotics overview</a> and the{' '}
               <a href="/help/" className="prose-link">guides</a> for the full walkthrough.
             </p>


### PR DESCRIPTION
This adds a fourth demo to the robotics demos page, for bystander consent, so every robotics capability with a shipped demo is covered.

The demo runs in the browser on the real credential shapes, with no network call. Pick a situation and watch the verdict: a bystander consents to a capture and the evidence verifies, the same consent reused for a different capture is refused because the token is bound to one capture, and a posted-notice or redacted basis verifies without a token. The evidence and token show that only hashes are held, never an image or a bystander's identity.

The section maps to the shipped SDK function verify_consent_evidence, and reuses the existing demos page and its component-scoped styles.
