### PR TITLE
Add MLflow and safetensors model-provenance integrations (vouch-protocol 2.0.2)

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -32,6 +32,8 @@ jobs:
           - { name: vouch-a2a, dir: "packages/vouch-a2a" }
           - { name: vouch-langgraph, dir: "packages/vouch-langgraph" }
           - { name: vouch-goose, dir: "packages/vouch-goose" }
+          - { name: vouch-mlflow, dir: "packages/vouch-mlflow" }
+          - { name: vouch-safetensors, dir: "packages/vouch-safetensors" }
     name: publish ${{ matrix.name }}
     steps:
       - uses: actions/checkout@v7

--- a/packages/vouch-mlflow/README.md
+++ b/packages/vouch-mlflow/README.md
@@ -1,0 +1,52 @@
+# vouch-mlflow
+
+Sign [MLflow](https://mlflow.org/) model artifacts with
+[Vouch](https://vouch-protocol.com) Credentials, so a registered model carries
+verifiable lineage: who registered it, on whose authority, and a content digest
+that breaks if the weights are tampered with.
+
+This complements OpenSSF Model Signing. OMS proves an artifact is intact and
+signed by a key; Vouch adds the agent and delegation dimension, which principal
+or pipeline registered the model, traceable back to an accountable human.
+
+## Install
+
+```bash
+pip install vouch-mlflow
+```
+
+It has no hard dependency on MLflow. The helpers work on any file or directory
+path, so they fit any artifact store.
+
+## Sign at registration time
+
+```python
+from vouch import Signer
+from vouch_mlflow import sign_model
+
+signer = Signer(private_key=PRIV_JWK, did="did:web:ml.acme.com")
+
+# After mlflow.log_model(...) wrote the model to a local path:
+credential = sign_model(signer, "runs:/abc/model_local_path", name="fraud-detector")
+
+# Attach to the run so it travels with the model:
+import mlflow, json
+mlflow.set_tag("vouch_credential", json.dumps(credential, separators=(",", ":")))
+```
+
+## Verify on load
+
+```python
+from vouch_mlflow import verify_model
+
+ok, passport = verify_model(model_path, credential, public_key=registrant_pubkey)
+if not ok:
+    raise RuntimeError("Model signature invalid or weights changed since signing")
+```
+
+`verify_model` checks both the signature and that the on-disk content still
+matches the digest the credential was bound to.
+
+## License
+
+Apache-2.0.

--- a/packages/vouch-mlflow/VERIFY.md
+++ b/packages/vouch-mlflow/VERIFY.md
@@ -1,0 +1,43 @@
+# vouch-mlflow: your verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-mlflow-test && source /tmp/vouch-mlflow-test/bin/activate
+pip install -e packages/vouch-mlflow   # pulls vouch-protocol
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-mlflow/tests -q
+```
+
+Expect: 4 passed. They check exports, sign-and-verify of a model file, that a
+tampered model fails closed, and that a directory model signs and verifies.
+
+## 3. Real MLflow run (recommended)
+
+```bash
+pip install mlflow
+```
+
+In a real MLflow run, log a model, call `sign_model` on its local path, set the
+returned credential as a run tag, then later `verify_model` on the downloaded
+artifact. Confirm a clean model verifies and a modified one fails.
+
+## 4. Build
+
+```bash
+pip install build && python -m build packages/vouch-mlflow
+unzip -l packages/vouch-mlflow/dist/*.whl   # confirm only vouch_mlflow is packaged
+```
+
+## 5. Only after the above
+
+- [ ] Publish to PyPI under your account.
+- [ ] No upstream PR is required (MLflow plugin model). Optionally write a short
+      MLflow docs/community post showing the pattern.

--- a/packages/vouch-mlflow/pyproject.toml
+++ b/packages/vouch-mlflow/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-mlflow"
+version = "0.1.0"
+description = "Sign MLflow model artifacts with Vouch Credentials for verifiable model lineage."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["mlflow", "vouch", "model-provenance", "model-signing", "verifiable-credentials", "mlops"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Security :: Cryptography",
+]
+dependencies = ["vouch-protocol>=2.0.2"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-mlflow/src/vouch_mlflow/__init__.py
+++ b/packages/vouch-mlflow/src/vouch_mlflow/__init__.py
@@ -1,0 +1,11 @@
+"""vouch-mlflow: sign MLflow model artifacts with Vouch Credentials.
+
+Thin distribution wrapping vouch.integrations.mlflow. It exists so the MLflow
+signing helpers can be installed and listed on their own while the
+implementation stays single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.mlflow import compute_model_digest, sign_model, verify_model
+
+__all__ = ["sign_model", "verify_model", "compute_model_digest"]
+__version__ = "0.1.0"

--- a/packages/vouch-mlflow/tests/test_smoke.py
+++ b/packages/vouch-mlflow/tests/test_smoke.py
@@ -1,0 +1,70 @@
+"""Smoke tests for the vouch-mlflow package."""
+
+import json
+import os
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Signer, generate_identity
+
+
+def _pub(kp):
+    return Ed25519PublicKey.from_public_bytes(base64url_decode(json.loads(kp.public_key_jwk)["x"]))
+
+
+def test_package_exports():
+    import vouch_mlflow
+
+    assert vouch_mlflow.sign_model is not None
+    assert vouch_mlflow.verify_model is not None
+    assert vouch_mlflow.compute_model_digest is not None
+
+
+def test_sign_and_verify_model(tmp_path):
+    from vouch_mlflow import sign_model, verify_model
+
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"fake model weights v1")
+
+    kp = generate_identity()
+    signer = Signer(private_key=kp.private_key_jwk, did="did:web:ml.acme.com")
+
+    cred = sign_model(signer, str(model), name="fraud-detector")
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+    ok, _ = verify_model(str(model), cred, public_key=_pub(kp))
+    assert ok is True
+
+
+def test_tampered_model_fails(tmp_path):
+    from vouch_mlflow import sign_model, verify_model
+
+    model = tmp_path / "model.bin"
+    model.write_bytes(b"fake model weights v1")
+
+    kp = generate_identity()
+    signer = Signer(private_key=kp.private_key_jwk, did="did:web:ml.acme.com")
+    cred = sign_model(signer, str(model))
+
+    # Tamper with the weights after signing.
+    model.write_bytes(b"poisoned weights")
+
+    ok, _ = verify_model(str(model), cred, public_key=_pub(kp))
+    assert ok is False
+
+
+def test_directory_model(tmp_path):
+    from vouch_mlflow import sign_model, verify_model
+
+    d = tmp_path / "model"
+    d.mkdir()
+    (d / "weights.bin").write_bytes(b"w")
+    (d / "config.json").write_bytes(b"{}")
+
+    kp = generate_identity()
+    signer = Signer(private_key=kp.private_key_jwk, did="did:web:ml.acme.com")
+    cred = sign_model(signer, str(d), name="dir-model")
+
+    ok, _ = verify_model(str(d), cred, public_key=_pub(kp))
+    assert ok is True

--- a/packages/vouch-safetensors/README.md
+++ b/packages/vouch-safetensors/README.md
@@ -1,0 +1,46 @@
+# vouch-safetensors
+
+Embed [Vouch](https://vouch-protocol.com) Credentials in a `.safetensors` file's
+existing `__metadata__` header, with zero changes to the safetensors format.
+
+This is deliberately complementary to OpenSSF Model Signing (OMS). OMS proves an
+artifact is intact and signed by a key. Vouch adds the agent and delegation
+dimension: which principal or pipeline produced the weights, traceable back to an
+accountable human. The credential is bound to a SHA-256 of the tensor data
+buffer, so any weight tampering breaks verification. Standard loaders (including
+Hugging Face) ignore the extra metadata key, so signed files load normally.
+
+## Install
+
+```bash
+pip install vouch-safetensors
+```
+
+## Sign a model
+
+```python
+from vouch import Signer
+from vouch_safetensors import sign_safetensors
+
+signer = Signer(private_key=PRIV_JWK, did="did:web:ml.acme.com")
+credential = sign_safetensors(signer, "model.safetensors", name="fraud-detector")
+# Writes the credential into model.safetensors __metadata__ (in place by default;
+# pass out_path=... to write a copy).
+```
+
+## Verify a model
+
+```python
+from vouch_safetensors import verify_safetensors
+
+ok, passport = verify_safetensors("model.safetensors", public_key=producer_pubkey)
+if not ok:
+    raise RuntimeError("Unsigned, invalid signature, or weights changed since signing")
+```
+
+`verify_safetensors` checks both the signature and that the tensor data still
+matches the digest the credential was bound to.
+
+## License
+
+Apache-2.0.

--- a/packages/vouch-safetensors/VERIFY.md
+++ b/packages/vouch-safetensors/VERIFY.md
@@ -1,0 +1,43 @@
+# vouch-safetensors: your verification checklist (do this before publishing)
+
+Nothing here has been published. Run these yourself, confirm each, then decide.
+
+## 1. Clean install
+
+```bash
+python -m venv /tmp/vouch-st-test && source /tmp/vouch-st-test/bin/activate
+pip install -e packages/vouch-safetensors   # pulls vouch-protocol
+```
+
+## 2. Smoke tests
+
+```bash
+pip install pytest
+pytest packages/vouch-safetensors/tests -q
+```
+
+Expect: 4 passed. They build a minimal safetensors file, sign and verify it,
+confirm tampered weights fail closed, and confirm an unsigned file fails closed.
+
+## 3. Real model + Hugging Face load (recommended)
+
+Sign a real `.safetensors` file, then load it with the `safetensors` library or
+`transformers` and confirm it still loads normally (the extra `__metadata__`
+key is ignored by standard loaders). Then `verify_safetensors` it.
+
+```bash
+pip install safetensors
+```
+
+## 4. Build
+
+```bash
+pip install build && python -m build packages/vouch-safetensors
+unzip -l packages/vouch-safetensors/dist/*.whl   # confirm only vouch_safetensors is packaged
+```
+
+## 5. Only after the above
+
+- [ ] Publish to PyPI under your account.
+- [ ] Engage the OpenSSF AI/ML Working Group to position the Vouch credential as
+      an identity payload alongside OMS, rather than a competing signature.

--- a/packages/vouch-safetensors/pyproject.toml
+++ b/packages/vouch-safetensors/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-safetensors"
+version = "0.1.0"
+description = "Embed Vouch Credentials in .safetensors model headers for verifiable agent/principal provenance."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["safetensors", "vouch", "model-provenance", "model-signing", "verifiable-credentials", "huggingface"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Security :: Cryptography",
+]
+dependencies = ["vouch-protocol>=2.0.2"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-safetensors/src/vouch_safetensors/__init__.py
+++ b/packages/vouch-safetensors/src/vouch_safetensors/__init__.py
@@ -1,0 +1,21 @@
+"""vouch-safetensors: embed Vouch Credentials in .safetensors headers.
+
+Thin distribution wrapping vouch.integrations.safetensors. It exists so the
+safetensors signing helpers can be installed and listed on their own while the
+implementation stays single-sourced in the vouch-protocol package.
+"""
+
+from vouch.integrations.safetensors import (
+    read_embedded_credential,
+    sign_safetensors,
+    tensor_data_digest,
+    verify_safetensors,
+)
+
+__all__ = [
+    "sign_safetensors",
+    "verify_safetensors",
+    "read_embedded_credential",
+    "tensor_data_digest",
+]
+__version__ = "0.1.0"

--- a/packages/vouch-safetensors/tests/test_smoke.py
+++ b/packages/vouch-safetensors/tests/test_smoke.py
@@ -1,0 +1,79 @@
+"""Smoke tests for the vouch-safetensors package.
+
+A minimal valid safetensors file is built in-test (8-byte little-endian header
+length, a JSON header with one tensor, then the tensor data buffer), so the test
+has no torch/numpy dependency.
+"""
+
+import json
+import struct
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from jwcrypto.common import base64url_decode
+
+from vouch import Signer, generate_identity
+
+
+def _pub(kp):
+    return Ed25519PublicKey.from_public_bytes(base64url_decode(json.loads(kp.public_key_jwk)["x"]))
+
+
+def _make_safetensors(path, data: bytes = b"\x00\x00\x00\x00"):
+    header = {"t": {"dtype": "F32", "shape": [1], "data_offsets": [0, len(data)]}}
+    hb = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(hb)))
+        f.write(hb)
+        f.write(data)
+
+
+def test_package_exports():
+    import vouch_safetensors
+
+    assert vouch_safetensors.sign_safetensors is not None
+    assert vouch_safetensors.verify_safetensors is not None
+
+
+def test_sign_and_verify(tmp_path):
+    from vouch_safetensors import sign_safetensors, verify_safetensors, read_embedded_credential
+
+    model = tmp_path / "model.safetensors"
+    _make_safetensors(str(model))
+
+    kp = generate_identity()
+    signer = Signer(private_key=kp.private_key_jwk, did="did:web:ml.acme.com")
+
+    cred = sign_safetensors(signer, str(model), name="m")
+    assert cred["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+    # credential is embedded and readable back
+    assert read_embedded_credential(str(model)) is not None
+
+    ok, _ = verify_safetensors(str(model), public_key=_pub(kp))
+    assert ok is True
+
+
+def test_tampered_weights_fail(tmp_path):
+    from vouch_safetensors import sign_safetensors, verify_safetensors
+
+    model = tmp_path / "model.safetensors"
+    _make_safetensors(str(model), data=b"\x01\x02\x03\x04")
+
+    kp = generate_identity()
+    signer = Signer(private_key=kp.private_key_jwk, did="did:web:ml.acme.com")
+    sign_safetensors(signer, str(model))
+
+    # Rewrite with different tensor bytes (keep it a valid file).
+    _make_safetensors(str(model), data=b"\x09\x09\x09\x09")
+
+    ok, _ = verify_safetensors(str(model), public_key=_pub(kp))
+    assert ok is False
+
+
+def test_unsigned_fails_closed(tmp_path):
+    from vouch_safetensors import verify_safetensors
+
+    model = tmp_path / "plain.safetensors"
+    _make_safetensors(str(model))
+    ok, passport = verify_safetensors(str(model), public_key=None)
+    assert ok is False
+    assert passport is None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "2.0.1"
+version = "2.0.2"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -5,7 +5,7 @@ This package provides cryptographic identity binding for autonomous AI agents,
 enabling verifiable proof of intent and non-repudiation.
 """
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 
 # Core signing/verification
 from .signer import Signer, sign

--- a/vouch/integrations/mlflow.py
+++ b/vouch/integrations/mlflow.py
@@ -1,0 +1,101 @@
+"""
+Vouch Protocol MLflow Integration.
+
+Sign a model artifact with a Vouch Credential at log or registration time, so a
+registered model carries verifiable lineage: who registered it, on whose
+authority, and a content digest that breaks if the weights are tampered with.
+
+This module has no hard dependency on MLflow. The core helpers operate on a file
+or directory path, so they work with any artifact store. If MLflow is installed,
+log the returned credential as a tag or artifact on the run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from typing import Any, Dict, Optional, Tuple
+
+from vouch import Signer, Verifier
+
+_RESOURCE_PREFIX = "model:sha256:"
+
+
+def compute_model_digest(path: str) -> str:
+    """Return a SHA-256 hex digest over a model file, or a directory of files.
+
+    For a directory, every file is hashed in sorted relative-path order, and the
+    relative path is mixed in, so the digest is stable and order-independent.
+    """
+    h = hashlib.sha256()
+    if os.path.isdir(path):
+        for root, _dirs, files in os.walk(path):
+            for name in sorted(files):
+                fp = os.path.join(root, name)
+                rel = os.path.relpath(fp, path).replace(os.sep, "/")
+                h.update(rel.encode("utf-8"))
+                h.update(b"\x00")
+                with open(fp, "rb") as f:
+                    for chunk in iter(lambda: f.read(65536), b""):
+                        h.update(chunk)
+    else:
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+    return h.hexdigest()
+
+
+def sign_model(
+    signer: Signer,
+    path: str,
+    *,
+    name: Optional[str] = None,
+    parent_credential: Optional[Dict[str, Any]] = None,
+    hybrid: bool = False,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Issue a Vouch Credential binding the model at ``path`` to the signer.
+
+    The credential's ``resource`` is the model's content digest, so any change to
+    the weights breaks verification.
+
+    Args:
+        signer: The registering principal's Signer.
+        path: Path to the model file or directory.
+        name: Human label for the model. Defaults to the basename of ``path``.
+        parent_credential: Optional parent credential to extend (delegation).
+        hybrid: Issue under the post-quantum hybrid profile when True.
+        valid_seconds: Optional validity window override.
+
+    Returns:
+        A signed Vouch Credential dict. Log it as an MLflow tag or artifact.
+    """
+    digest = compute_model_digest(path)
+    target = name or os.path.basename(os.path.normpath(path)) or "model"
+    intent = {"action": "register", "target": target, "resource": f"{_RESOURCE_PREFIX}{digest}"}
+    issue = signer.sign_hybrid if hybrid else signer.sign
+    return issue(
+        intent=intent,
+        parent_credential=parent_credential,
+        valid_seconds=valid_seconds,
+    )
+
+
+def verify_model(
+    path: str,
+    credential: Dict[str, Any],
+    public_key: Optional[Any] = None,
+) -> Tuple[bool, Optional[Any]]:
+    """Verify a model credential AND that the on-disk content still matches.
+
+    Returns ``(is_valid, passport)``. ``is_valid`` is False if the signature
+    fails OR the recomputed digest does not match the credential's bound digest.
+    """
+    ok, passport = Verifier.verify(credential, public_key=public_key)
+    if not ok:
+        return False, passport
+    intent = (credential.get("credentialSubject") or {}).get("intent") or {}
+    bound = intent.get("resource")
+    if bound != f"{_RESOURCE_PREFIX}{compute_model_digest(path)}":
+        return False, passport
+    return True, passport

--- a/vouch/integrations/safetensors.py
+++ b/vouch/integrations/safetensors.py
@@ -1,0 +1,126 @@
+"""
+Vouch Protocol safetensors Integration.
+
+Embed a Vouch Credential in a .safetensors file's existing ``__metadata__``
+header field, with zero changes to the safetensors format or its Rust core.
+
+This is deliberately complementary to OpenSSF Model Signing (OMS). OMS proves an
+artifact is intact and signed by a key. Vouch adds the agent and delegation
+dimension: which principal or pipeline produced the weights, traceable back to an
+accountable human. The credential is bound to a SHA-256 of the tensor data
+buffer, so any change to the weights breaks verification. Standard loaders
+(including Hugging Face) ignore the extra metadata key, so signed files load
+normally.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import struct
+from typing import Any, Dict, Optional, Tuple
+
+from vouch import Signer, Verifier
+
+_META_KEY = "vouch_credential"
+_RESOURCE_PREFIX = "model:safetensors:sha256:"
+
+
+def _read(path: str) -> Tuple[Dict[str, Any], bytes]:
+    """Return (header_dict, tensor_data_bytes) from a safetensors file."""
+    with open(path, "rb") as f:
+        header_len = struct.unpack("<Q", f.read(8))[0]
+        header = json.loads(f.read(header_len).decode("utf-8"))
+        data = f.read()
+    return header, data
+
+
+def _write(path: str, header: Dict[str, Any], data: bytes) -> None:
+    """Write a safetensors file from a header dict and the tensor data buffer."""
+    header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes)))
+        f.write(header_bytes)
+        f.write(data)
+
+
+def tensor_data_digest(path: str) -> str:
+    """Return the SHA-256 hex digest of the tensor data buffer (excludes header)."""
+    _header, data = _read(path)
+    return hashlib.sha256(data).hexdigest()
+
+
+def sign_safetensors(
+    signer: Signer,
+    path: str,
+    *,
+    out_path: Optional[str] = None,
+    name: Optional[str] = None,
+    parent_credential: Optional[Dict[str, Any]] = None,
+    hybrid: bool = False,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """Embed a Vouch Credential in a safetensors file's ``__metadata__``.
+
+    The credential binds to a digest of the tensor data buffer. The header gains
+    one string key; the tensor bytes are untouched.
+
+    Args:
+        signer: The producing principal's Signer.
+        path: Path to the input .safetensors file.
+        out_path: Where to write the signed file. Defaults to ``path`` (in place).
+        name: Human label for the model.
+        parent_credential: Optional parent credential to extend (delegation).
+        hybrid: Issue under the post-quantum hybrid profile when True.
+        valid_seconds: Optional validity window override.
+
+    Returns:
+        The signed Vouch Credential dict (also embedded in the file).
+    """
+    header, data = _read(path)
+    digest = hashlib.sha256(data).hexdigest()
+    intent = {
+        "action": "register",
+        "target": name or "safetensors-model",
+        "resource": f"{_RESOURCE_PREFIX}{digest}",
+    }
+    issue = signer.sign_hybrid if hybrid else signer.sign
+    credential = issue(
+        intent=intent,
+        parent_credential=parent_credential,
+        valid_seconds=valid_seconds,
+    )
+    metadata = dict(header.get("__metadata__") or {})
+    metadata[_META_KEY] = json.dumps(credential, separators=(",", ":"))
+    header["__metadata__"] = metadata
+    _write(out_path or path, header, data)
+    return credential
+
+
+def read_embedded_credential(path: str) -> Optional[Dict[str, Any]]:
+    """Return the embedded Vouch Credential, or None if the file is unsigned."""
+    header, _data = _read(path)
+    raw = (header.get("__metadata__") or {}).get(_META_KEY)
+    return json.loads(raw) if raw else None
+
+
+def verify_safetensors(
+    path: str,
+    public_key: Optional[Any] = None,
+) -> Tuple[bool, Optional[Any]]:
+    """Verify a signed safetensors file: signature AND tensor-data integrity.
+
+    Returns ``(is_valid, passport)``. ``is_valid`` is False if the file is
+    unsigned, the signature fails, or the tensor data no longer matches the
+    bound digest.
+    """
+    credential = read_embedded_credential(path)
+    if not credential:
+        return False, None
+    ok, passport = Verifier.verify(credential, public_key=public_key)
+    if not ok:
+        return False, passport
+    bound = (credential.get("credentialSubject") or {}).get("intent", {}).get("resource")
+    if bound != f"{_RESOURCE_PREFIX}{tensor_data_digest(path)}":
+        return False, passport
+    return True, passport


### PR DESCRIPTION
Ports the mlflow and safetensors integration modules into vouch-protocol, updated to the current sign and verify API, so it can sign an MLflow model artifact at registration and embed a credential in a .safetensors header. Restores the vouch-mlflow and vouch-safetensors wrapper packages, adds all of them to the OIDC publish workflow, and bumps vouch-protocol to 2.0.2 so the wrappers resolve the version that ships the modules. The wrapper smoke tests exercise the real sign and verify path.