### PR TITLE
docs: record the shipped reference implementation in PAD-043 and PAD-045

### DIFF
--- a/docs/disclosures/PAD-043-cryptographic-weight-binding.md
+++ b/docs/disclosures/PAD-043-cryptographic-weight-binding.md
@@ -223,6 +223,20 @@ gatekeeping. If model-intrinsic identity were a closed standard, the
 open-source AI community would build a parallel, fragmenting the
 ecosystem.
 
+## 7. Reference Implementation
+
+As of July 2026, the weight-binding credential layer of this mechanism
+ships in the open-source Vouch SDK as `vouch.provenance`. The
+`weights_hash` function computes the model's weight fingerprint, and
+`sign_inference_provenance` records that fingerprint inside a signed
+inference credential, so every output carries the hash of the exact
+model that produced it. On the verifier side, `check_replay` recomputes
+the weight hash from the model in hand and rejects the credential when
+it does not match the value the agent committed to, realizing the
+inference-time detection of §3.4. The behavior runs live under the
+provenance section at https://vouch-protocol.com/demos and maps to
+`examples/provenance_demo.py` in the repository.
+
 ---
 
 *Published as prior art to ensure that the binding between an AI

--- a/docs/disclosures/PAD-045-proof-of-non-hallucination-retrieval-anchoring.md
+++ b/docs/disclosures/PAD-045-proof-of-non-hallucination-retrieval-anchoring.md
@@ -278,6 +278,20 @@ hallucination accountability is foundational to AI agent trust and
 must be available as a public good rather than a vendor-locked
 feature.
 
+## 7. Reference Implementation
+
+As of July 2026, this mechanism ships in the open-source Vouch SDK as
+part of `vouch.provenance`. The `context_root` function computes the
+Merkle root over the retrieved chunks of §3.1, and
+`sign_inference_provenance` binds the output hash to that root inside a
+single signed credential, realizing the retrieval-commit and
+output-binding phases of §3.1 and §3.2. On the verifier side,
+`verify_context` re-derives the root from the supplied chunks and
+`check_replay` confirms the output and context the agent committed to,
+providing the Level 1 reconciliation of §3.3. The flow runs live under
+the provenance section at https://vouch-protocol.com/demos and maps to
+`examples/provenance_demo.py` in the repository.
+
 ---
 
 *Published as prior art to ensure that retrieval-anchored


### PR DESCRIPTION
PAD-043 (weight binding) and PAD-045 (retrieval anchoring) were published as disclosures before the code existed. Both now ship in the open-source SDK as `vouch.provenance`, so I added a Reference Implementation section to each that points at the shipped functions.

- PAD-043: `weights_hash` computes the model fingerprint and `check_replay` recomputes it on the verifier side, giving the inference-time detection described in section 3.4.
- PAD-045: `context_root` builds the retrieval Merkle root, `sign_inference_provenance` binds the output to it, and `verify_context` re-derives it, giving the commit, bind, and reconcile flow of sections 3.1 to 3.3.

Each note links the live demo and `examples/provenance_demo.py`. Docs only, no code or website changes.
