### PR TITLE
Add Root of Trust for Machine Identity

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,6 +212,36 @@ Codes are **stable and append-only**. Once published, a code's meaning does not 
 
 ---
 
+## Phase 6: Root of Trust for Machine Identity
+
+**Goal:** Let Vouch Protocol act as the trust anchor for AI agent and robot identity, so a verifier pins one Vouch root and can then verify any agent or robot without relying on an external certificate authority or a central per-agent lookup.
+
+### 6.1 Vouch Root of Trust
+- [x] Root of Trust credential format, self-issued by the root, that verifiers pin (`build_root_of_trust`)
+- [ ] Root credential distribution and a public reference root
+- [ ] Root key rotation and succession
+
+### 6.2 Recognized-issuer credentials
+- [x] Credential type by which the root recognizes issuers allowed to attest agent and robot identity (`build_recognized_issuer`)
+- [x] Chaining so a recognition traces back to the Vouch root (`recognizedIn`)
+- [x] Consume a recognition into the Vouch Shield `TrustRegistry` (`register_recognized_issuer`)
+- [x] Holder-presented, so verifiers need no central lookup
+
+### 6.3 Authority-issued identity credential
+- [x] Identity credential type where issuer differs from subject, binding an agent key to attributes (`build_agent_identity`)
+- [x] Revocation hook (`credentialStatus` passthrough plus `is_revoked` at verify time)
+- [ ] Interop vectors across Python / TypeScript / Go
+
+### 6.4 Verifier chain
+- [x] End-to-end verification: action → authority-issued identity → recognized issuer → Vouch root (`verify_identity_chain`)
+- [x] Offline verification with no per-agent lookup (did:key resolves in-process)
+- [ ] Documentation and interactive demo on the website
+
+### 6.5 Robot identity binding
+- [ ] Bind hardware-rooted robot keys to an authority-issued identity (coordinate with the robotics workstream)
+
+---
+
 ## PAD Coverage Matrix
 
 | PAD | Title | Implemented | Roadmap Phase |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -230,7 +230,8 @@ Codes are **stable and append-only**. Once published, a code's meaning does not 
 ### 6.3 Authority-issued identity credential
 - [x] Identity credential type where issuer differs from subject, binding an agent key to attributes (`build_agent_identity`)
 - [x] Revocation hook (`credentialStatus` passthrough plus `is_revoked` at verify time)
-- [ ] Interop vectors across Python / TypeScript / Go
+- [x] Canonical interop vector and Python runner (`test-vectors/root-of-trust/`)
+- [ ] TypeScript and Go interop runners (consume the same vector)
 
 ### 6.4 Verifier chain
 - [x] End-to-end verification: action → authority-issued identity → recognized issuer → Vouch root (`verify_identity_chain`)

--- a/docs/specs/w3c-cg-report.md
+++ b/docs/specs/w3c-cg-report.md
@@ -78,11 +78,12 @@ Transition pathways under consideration include the W3C Verifiable Credentials W
 15. [State Verifiability (Informative)](#15-state-verifiability-informative)
 16. [Implementer Interest and Charter Sponsors](#16-implementer-interest-and-charter-sponsors)
 17. [Conformance Levels](#17-conformance-levels)
-18. [Acknowledgements](#18-acknowledgements)
-19. [Appendix A: Relationship to Existing Standards](#appendix-a-relationship-to-existing-standards)
-20. [Appendix B: IANA Considerations](#appendix-b-iana-considerations)
-21. [Appendix C: Test Vectors](#appendix-c-test-vectors)
-22. [References](#references)
+18. [Root of Trust for Machine Identity](#18-root-of-trust-for-machine-identity)
+19. [Acknowledgements](#19-acknowledgements)
+20. [Appendix A: Relationship to Existing Standards](#appendix-a-relationship-to-existing-standards)
+21. [Appendix B: IANA Considerations](#appendix-b-iana-considerations)
+22. [Appendix C: Test Vectors](#appendix-c-test-vectors)
+23. [References](#references)
 
 ---
 
@@ -1199,7 +1200,122 @@ The deployment SHOULD re-validate against the cross-language test vector suite o
 
 ---
 
-## 18. Acknowledgements
+## 18. Root of Trust for Machine Identity
+
+The Vouch Credential format (Section 5) is self-issued: the agent is both the `issuer` and the `credentialSubject`, so a signature proves control of a key and, through the DID method (Section 6), binds that key to a domain or to the key itself. This section defines an OPTIONAL authority layer that lets a verifier anchor an agent's identity to a single trust root without an external certificate authority and without a central per-agent lookup. A verifier that has pinned one root DID can then verify any agent offline by walking a short credential chain.
+
+The model is federated. A root recognizes issuers, and each recognized issuer attests the identity of its own agents or robots. The root does not enumerate agents, and verification requires no network call beyond resolving the DIDs in the chain, which for `did:key` is performed in process.
+
+### 18.1 Trust-Layer Credential Types
+
+Three credential types compose the authority layer. Each is a Verifiable Credential secured with an `eddsa-jcs-2022` Data Integrity proof (Section 7). A trust-layer credential MUST carry exactly one of the three type values defined below in addition to `VerifiableCredential`. A credential that carries two or more of these types MUST be rejected, so that one signed object cannot be presented in a different position in the chain.
+
+#### 18.1.1 Root of Trust Credential
+
+A `VouchRootOfTrust` credential is self-issued by the root.
+
+- `issuer` MUST equal `credentialSubject.id`, and both MUST be the root DID.
+- `credentialSubject.rootOfTrust.name` is a human-readable name for the root.
+- `credentialSubject.rootOfTrust.scope` is an array naming what the root anchors, for example `"ai-agent"` or `"robot"`.
+
+The Root of Trust credential is descriptive. A verifier anchors trust by pinning the root DID out of band (Section 18.3); the credential lets the root describe itself and lets a verifier confirm the root is self-issued.
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+  "type": ["VerifiableCredential", "VouchRootOfTrust"],
+  "issuer": "did:web:root.example",
+  "validFrom": "2026-01-01T00:00:00Z",
+  "validUntil": "2126-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:root.example",
+    "vouchVersion": "1.0",
+    "rootOfTrust": { "name": "Example Machine Identity Root", "scope": ["ai-agent", "robot"] }
+  }
+}
+```
+
+#### 18.1.2 Recognized Issuer Credential
+
+A `RecognizedIssuerCredential` is issued by the root to authorize an issuer.
+
+- `issuer` MUST be the root DID.
+- `credentialSubject.id` MUST be the DID of the recognized issuer.
+- `credentialSubject.recognizedActions` MUST be an array of action identifiers the issuer is permitted to perform. This specification defines `issueAgentIdentity` and `issueRobotIdentity`.
+- `credentialSubject.recognizedIn` SHOULD reference the root DID, chaining the recognition to its anchor.
+
+A holder presents this credential alongside the identity it supports, so the verifier does not contact the root at verification time.
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+  "type": ["VerifiableCredential", "RecognizedIssuerCredential"],
+  "issuer": "did:web:root.example",
+  "validFrom": "2026-01-01T00:00:00Z",
+  "validUntil": "2027-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:issuer.example",
+    "recognizedActions": ["issueAgentIdentity"],
+    "recognizedIn": "did:web:root.example"
+  }
+}
+```
+
+#### 18.1.3 Agent Identity Credential
+
+An `AgentIdentityCredential` is issued by a recognized issuer to bind an agent's key to real attributes. Here the `issuer` and the `credentialSubject` differ.
+
+- `issuer` MUST be the DID of a recognized issuer.
+- `credentialSubject.id` MUST be the DID of the agent or robot the credential describes, and MUST NOT equal `issuer`.
+- `credentialSubject.identity` is an object of attributes bound to the subject, for example `owner`, `model`, `capabilityClass`, and `createdAt`. For a robot, it MAY reference a hardware-rooted key.
+
+```json
+{
+  "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+  "type": ["VerifiableCredential", "AgentIdentityCredential"],
+  "issuer": "did:web:issuer.example",
+  "validFrom": "2026-01-01T00:00:00Z",
+  "validUntil": "2027-01-01T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:web:agent.example",
+    "identity": { "owner": "Example Corp", "model": "example-model", "capabilityClass": "shopping" }
+  }
+}
+```
+
+### 18.2 Verification Algorithm
+
+A verifier is given an Agent Identity Credential, its Recognized Issuer Credential, and a pinned trusted root DID. It MAY also be given the agent's action credential (Section 5) and the Root of Trust credential. The verifier MUST perform the following checks and MUST reject the identity if any check fails:
+
+1. Verify the Recognized Issuer Credential's Data Integrity proof (Section 8), resolving the public key from its `issuer` DID. The proof's `proofPurpose` MUST be `assertionMethod` and the `verificationMethod` MUST belong to the `issuer`.
+2. The Recognized Issuer Credential's `issuer` MUST equal the pinned trusted root DID.
+3. The required action, `issueAgentIdentity` by default, MUST appear in `credentialSubject.recognizedActions`, which MUST be an array.
+4. Verify the Agent Identity Credential's proof, resolving the public key from its `issuer` DID, with the same proof-purpose and verification-method checks.
+5. The Agent Identity Credential's `issuer` MUST equal the `credentialSubject.id` of the Recognized Issuer Credential.
+6. If a Root of Trust credential is supplied, it MUST verify, MUST be self-issued, and its subject MUST equal the pinned trusted root DID.
+7. If an action credential is supplied, it MUST verify (Section 8) and its issuer MUST equal the Agent Identity Credential's `credentialSubject.id`.
+
+Each credential MUST be within its validity window (Section 5) at verification time. Because the Recognized Issuer Credential is re-checked on every verification, an Agent Identity Credential is honored only while the recognition that authorized its issuer remains valid.
+
+A verifier MUST return a structured reason on failure so that callers can distinguish, for example, an issuer that is not recognized by the pinned root from an identity that was not issued by the recognized issuer.
+
+### 18.3 Trust Anchor and Offline Operation
+
+The pinned root DID is the single trust decision a verifier makes in advance. It MAY be obtained by direct configuration, by resolving a well-known `did:web` root, or from a trust list. All subsequent checks follow cryptographically from that anchor.
+
+When every DID in the chain is a `did:key`, verification is fully offline, because each key is derived from its identifier (Section 6.1.2). A `did:web` DID in the chain requires HTTPS resolution and inherits the trust of that domain.
+
+### 18.4 Revocation
+
+A Recognized Issuer Credential or an Agent Identity Credential MAY carry a `credentialStatus` entry referencing a BitstringStatusList (Section 11). A verifier that enforces revocation MUST reject a credential whose status is revoked. A root revokes an issuer by revoking that issuer's Recognized Issuer Credential, which withdraws the authority behind every identity that issuer attested.
+
+### 18.5 Conformance
+
+Support for the Root of Trust for Machine Identity is OPTIONAL. An implementation that claims support MUST implement the verification algorithm in Section 18.2 and MUST pass the interoperability vector published at `test-vectors/root-of-trust/vector.json` (Appendix C).
+
+---
+
+## 19. Acknowledgements
 
 The editor thanks the following individuals and organizations for review, feedback, and adjacent contributions to the agent identity ecosystem:
 
@@ -1281,6 +1397,7 @@ Test vectors are published in the companion repository at `https://github.com/vo
 - **C.4 Delegation chain vectors**: Linear chains of depth 1, 3, and 5 with valid and invalid resource-narrowing examples.
 - **C.5 Heartbeat sequence vectors**: Sample heartbeat request/response pairs with canary reveal/commitment chains.
 - **C.6 Dual-proof post-quantum vectors**: Reference credentials carrying two independent Data Integrity proofs (one `eddsa-jcs-2022`, one `mldsa44-jcs-2026`) over the same JCS-canonicalized bytes, published at `test-vectors/hybrid-eddsa-mldsa44/vector.json` with deterministic generation parameters and cross-implementation interop tests in Python, TypeScript, and Go.
+- **C.7 Root of Trust vectors**: The three authority-layer credential types (`VouchRootOfTrust`, `RecognizedIssuerCredential`, `AgentIdentityCredential`) built from fixed seeds and timestamps, published at `test-vectors/root-of-trust/vector.json`, with a chain that verifies an agent identity against a pinned root.
 
 Implementations claiming conformance MUST pass all test vectors in this revision. Cross-implementation interoperability testing is REQUIRED before an implementation may be listed in the Implementer Interest section.
 

--- a/examples/root_of_trust_demo.py
+++ b/examples/root_of_trust_demo.py
@@ -1,0 +1,82 @@
+"""
+Root of Trust for Machine Identity: end-to-end demo.
+
+Shows Vouch Protocol acting as the trust anchor for AI agent identity. A
+verifier pins ONE root, then verifies an agent it has never seen before,
+entirely offline, and rejects a forgery.
+
+Run:  python examples/root_of_trust_demo.py
+"""
+
+from vouch.signer import Signer
+from vouch.root_of_trust import (
+    ACTION_ISSUE_AGENT_IDENTITY,
+    build_agent_identity,
+    build_recognized_issuer,
+    build_root_of_trust,
+    generate_did_key_identity,
+    verify_identity_chain,
+)
+
+
+def signer(label: str) -> Signer:
+    keys = generate_did_key_identity()
+    print(f"  {label:<24} {keys.did}")
+    return Signer.from_keypair(keys)
+
+
+def main() -> None:
+    print("Identities (each self-generated, no external CA):")
+    root = signer("Vouch root")
+    acme = signer("Acme (an issuer)")
+    agent = signer("Acme's agent #1007")
+    print()
+
+    # The root recognizes Acme as an issuer allowed to attest agent identity.
+    recognition = build_recognized_issuer(
+        root, issuer_did=acme.did, recognized_actions=[ACTION_ISSUE_AGENT_IDENTITY]
+    )
+
+    # Acme issues agent #1007 an identity binding its key to real attributes.
+    identity = build_agent_identity(
+        acme,
+        subject_did=agent.did,
+        attributes={"owner": "Acme", "model": "gpt-x", "capabilityClass": "shopping"},
+    )
+
+    # The agent signs an action with its own key.
+    action = agent.sign(
+        intent={
+            "action": "buy",
+            "target": "store",
+            "resource": "https://store.example/item/headphones",
+        }
+    )
+
+    # A verifier that pins ONLY the root DID verifies the whole chain offline.
+    result = verify_identity_chain(
+        identity,
+        recognition,
+        trusted_root=root.did,
+        action_credential=action,
+    )
+    print("Legitimate agent:")
+    print(f"  verified   : {result.ok}")
+    print(f"  agent      : {result.agent_did}")
+    print(f"  issuer     : {result.issuer_did}")
+    print(f"  attributes : {result.attributes}")
+    print(f"  action     : {result.action.action} -> {result.action.resource}")
+    print()
+
+    # A forger stands up their own root and recognizes themselves. It fails
+    # because the verifier only trusts the real root it pinned.
+    forger_root = signer("Forger's own root")
+    forged_recognition = build_recognized_issuer(forger_root, issuer_did=acme.did)
+    forged = verify_identity_chain(identity, forged_recognition, trusted_root=root.did)
+    print("Forged recognition (signed by a root the verifier did not pin):")
+    print(f"  verified   : {forged.ok}")
+    print(f"  reason     : {forged.reason}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test-vectors/root-of-trust/generate.py
+++ b/test-vectors/root-of-trust/generate.py
@@ -1,0 +1,114 @@
+"""
+Deterministic generator for the Root of Trust interop test vector.
+
+Produces the three authority-layer credential types (VouchRootOfTrust,
+RecognizedIssuerCredential, AgentIdentityCredential) from fixed Ed25519 seeds
+and fixed timestamps, so every language SDK can reproduce byte-identical
+proofValues and verify the same chain.
+
+Run:  python test-vectors/root-of-trust/generate.py   # rewrites vector.json
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+from datetime import datetime, timezone
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
+
+from vouch import multikey
+from vouch.signer import Signer
+from vouch.root_of_trust import (
+    ACTION_ISSUE_AGENT_IDENTITY,
+    build_agent_identity,
+    build_recognized_issuer,
+    build_root_of_trust,
+)
+
+# Fixed 32-byte Ed25519 seeds (test material only, never for production).
+ROOT_SEED = bytes([1]) * 32
+ISSUER_SEED = bytes([2]) * 32
+AGENT_SEED = bytes([3]) * 32
+
+# Fixed issuance time and a very long validity so the vector never expires.
+FIXED_TIME = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+CENTURY_SECONDS = 100 * 365 * 24 * 3600
+
+ROOT_ID = "urn:uuid:11111111-1111-1111-1111-111111111111"
+RECOGNITION_ID = "urn:uuid:22222222-2222-2222-2222-222222222222"
+IDENTITY_ID = "urn:uuid:33333333-3333-3333-3333-333333333333"
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _signer_from_seed(seed: bytes) -> Signer:
+    priv = Ed25519PrivateKey.from_private_bytes(seed)
+    pub = priv.public_key().public_bytes(Encoding.Raw, PublicFormat.Raw)
+    jwk = json.dumps({"kty": "OKP", "crv": "Ed25519", "d": _b64url(seed), "x": _b64url(pub)})
+    did = "did:key:" + multikey.encode_ed25519_public(pub)
+    return Signer(jwk, did)
+
+
+def build_vectors() -> dict:
+    """Build the full vector object deterministically."""
+    root = _signer_from_seed(ROOT_SEED)
+    issuer = _signer_from_seed(ISSUER_SEED)
+    agent = _signer_from_seed(AGENT_SEED)
+
+    root_cred = build_root_of_trust(
+        root,
+        name="Vouch Machine Identity Root",
+        valid_seconds=CENTURY_SECONDS,
+        valid_from=FIXED_TIME,
+        created=FIXED_TIME,
+        credential_id=ROOT_ID,
+    )
+    recognition = build_recognized_issuer(
+        root,
+        issuer_did=issuer.did,
+        recognized_actions=[ACTION_ISSUE_AGENT_IDENTITY],
+        valid_seconds=CENTURY_SECONDS,
+        valid_from=FIXED_TIME,
+        created=FIXED_TIME,
+        credential_id=RECOGNITION_ID,
+    )
+    identity = build_agent_identity(
+        issuer,
+        subject_did=agent.did,
+        attributes={"owner": "Acme", "model": "gpt-x", "capabilityClass": "shopping"},
+        valid_seconds=CENTURY_SECONDS,
+        valid_from=FIXED_TIME,
+        created=FIXED_TIME,
+        credential_id=IDENTITY_ID,
+    )
+
+    return {
+        "description": (
+            "Vouch Protocol Root of Trust interop vector. Built from fixed Ed25519 "
+            "seeds and a fixed timestamp. Every SDK must reproduce identical "
+            "proofValues and verify the chain (agent identity anchored to the root)."
+        ),
+        "trustedRoot": root.did,
+        "seeds": {"root": "0x01 x32", "issuer": "0x02 x32", "agent": "0x03 x32"},
+        "rootOfTrust": root_cred,
+        "recognizedIssuer": recognition,
+        "agentIdentity": identity,
+        "expected": {
+            "verifyIdentityChain": True,
+            "agentDid": agent.did,
+            "issuerDid": issuer.did,
+        },
+    }
+
+
+if __name__ == "__main__":
+    out_path = os.path.join(os.path.dirname(__file__), "vector.json")
+    with open(out_path, "w") as handle:
+        json.dump(build_vectors(), handle, indent=2)
+        handle.write("\n")
+    print(f"wrote {out_path}")

--- a/test-vectors/root-of-trust/vector.json
+++ b/test-vectors/root-of-trust/vector.json
@@ -1,0 +1,106 @@
+{
+  "description": "Vouch Protocol Root of Trust interop vector. Built from fixed Ed25519 seeds and a fixed timestamp. Every SDK must reproduce identical proofValues and verify the chain (agent identity anchored to the root).",
+  "trustedRoot": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX",
+  "seeds": {
+    "root": "0x01 x32",
+    "issuer": "0x02 x32",
+    "agent": "0x03 x32"
+  },
+  "rootOfTrust": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://vouch-protocol.com/contexts/v1"
+    ],
+    "id": "urn:uuid:11111111-1111-1111-1111-111111111111",
+    "type": [
+      "VerifiableCredential",
+      "VouchRootOfTrust"
+    ],
+    "issuer": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX",
+    "validFrom": "2026-01-01T00:00:00Z",
+    "validUntil": "2125-12-08T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX",
+      "vouchVersion": "1.0",
+      "rootOfTrust": {
+        "name": "Vouch Machine Identity Root",
+        "scope": [
+          "ai-agent",
+          "robot"
+        ]
+      }
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2022",
+      "created": "2026-01-01T00:00:00Z",
+      "verificationMethod": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4xeJ2LF1WN5y7sXPA7zqHvVgYCXmekbuXUpYB7Mp9JePkbQTgzXWj4zp1cuyJ55ghqnmRXpaESbwxnYW2LaNsQSe"
+    }
+  },
+  "recognizedIssuer": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://vouch-protocol.com/contexts/v1"
+    ],
+    "id": "urn:uuid:22222222-2222-2222-2222-222222222222",
+    "type": [
+      "VerifiableCredential",
+      "RecognizedIssuerCredential"
+    ],
+    "issuer": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX",
+    "validFrom": "2026-01-01T00:00:00Z",
+    "validUntil": "2125-12-08T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:key:z6Mko9hTggMwjSTEaJaPUfE6tqcy2xvU6BnNq3e3o8qVBiyH",
+      "recognizedActions": [
+        "issueAgentIdentity"
+      ],
+      "recognizedIn": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2022",
+      "created": "2026-01-01T00:00:00Z",
+      "verificationMethod": "did:key:z6Mkon3Necd6NkkyfoGoHxid2znGc59LU3K7mubaRcFbLfLX#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z2FSh4dJ8y7eDwFiVuWrSmreNw2uQ1osLejSg8Qnm2Jg4rpMoDy2Vp998ndstsntB6iWcfif9kzuohmtXvGcKmxAV"
+    }
+  },
+  "agentIdentity": {
+    "@context": [
+      "https://www.w3.org/ns/credentials/v2",
+      "https://vouch-protocol.com/contexts/v1"
+    ],
+    "id": "urn:uuid:33333333-3333-3333-3333-333333333333",
+    "type": [
+      "VerifiableCredential",
+      "AgentIdentityCredential"
+    ],
+    "issuer": "did:key:z6Mko9hTggMwjSTEaJaPUfE6tqcy2xvU6BnNq3e3o8qVBiyH",
+    "validFrom": "2026-01-01T00:00:00Z",
+    "validUntil": "2125-12-08T00:00:00Z",
+    "credentialSubject": {
+      "id": "did:key:z6MkvRXNYcE7MMduynWTgeKbDaT1iijDSC8pZqXZc8rHPrf2",
+      "identity": {
+        "owner": "Acme",
+        "model": "gpt-x",
+        "capabilityClass": "shopping"
+      }
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2022",
+      "created": "2026-01-01T00:00:00Z",
+      "verificationMethod": "did:key:z6Mko9hTggMwjSTEaJaPUfE6tqcy2xvU6BnNq3e3o8qVBiyH#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "z4L1zia38bYfefbR3Jmg2XjTLqDksGAgKjN4JyntsEju2WnfShMcvRuPW3wuTfKQmZ2h8kBsrq8ARB6qHrxJoLfuh"
+    }
+  },
+  "expected": {
+    "verifyIdentityChain": true,
+    "agentDid": "did:key:z6MkvRXNYcE7MMduynWTgeKbDaT1iijDSC8pZqXZc8rHPrf2",
+    "issuerDid": "did:key:z6Mko9hTggMwjSTEaJaPUfE6tqcy2xvU6BnNq3e3o8qVBiyH"
+  }
+}

--- a/tests/test_root_of_trust.py
+++ b/tests/test_root_of_trust.py
@@ -16,6 +16,7 @@ from vouch.vc import VC_CONTEXT_V2, VOUCH_CONTEXT_V1, VC_TYPE
 from vouch.root_of_trust import (
     ACTION_ISSUE_AGENT_IDENTITY,
     ACTION_ISSUE_ROBOT_IDENTITY,
+    AGENT_IDENTITY_TYPE,
     RECOGNIZED_ISSUER_TYPE,
     _sign,
     build_agent_identity,
@@ -275,6 +276,111 @@ def test_root_credential_self_consistency_checked(chain):
     # Editing the subject also breaks the self-issued proof; either reason is a
     # correct rejection of a non-self-issued root.
     assert result.reason in ("root_proof_invalid", "root_not_self_issued")
+
+
+# ---------------------------------------------------------------------------
+# Hardening: malformed inputs, type confusion, key confusion
+# ---------------------------------------------------------------------------
+
+
+def _signed_recognition(
+    root,
+    issuer,
+    *,
+    subject=None,
+    actions=None,
+    types=None,
+    valid_from="2020-01-01T00:00:00Z",
+    valid_until="2100-01-01T00:00:00Z",
+):
+    """Root-sign a recognition with arbitrary (possibly malformed) fields."""
+    if subject is None:
+        subject = {
+            "id": issuer.did,
+            "recognizedActions": [ACTION_ISSUE_AGENT_IDENTITY] if actions is None else actions,
+            "recognizedIn": root.did,
+        }
+    cred = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "id": "urn:uuid:hardening-test",
+        "type": [VC_TYPE, RECOGNIZED_ISSUER_TYPE] if types is None else types,
+        "issuer": root.did,
+        "validFrom": valid_from,
+        "validUntil": valid_until,
+        "credentialSubject": subject,
+    }
+    return _sign(root, cred)
+
+
+def test_credential_subject_as_list_does_not_crash(chain):
+    """A signed credential whose credentialSubject is an array rejects cleanly."""
+    forged = _signed_recognition(chain["root"], chain["issuer"], subject=[{"id": "x"}])
+    result = verify_identity_chain(chain["identity"], forged, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_bad_subject"
+
+
+def test_recognized_actions_as_string_does_not_substring_match(chain):
+    """recognizedActions must be a list; a string cannot substring-match past the check."""
+    forged = _signed_recognition(
+        chain["root"], chain["issuer"], actions="issueAgentIdentityAndMore"
+    )
+    result = verify_identity_chain(chain["identity"], forged, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "issuer_not_recognized_for_action"
+
+
+def test_ambiguous_multi_type_rejected(chain):
+    """A credential carrying two trust types cannot be replayed across slots."""
+    forged = _signed_recognition(
+        chain["root"],
+        chain["issuer"],
+        types=[VC_TYPE, RECOGNIZED_ISSUER_TYPE, AGENT_IDENTITY_TYPE],
+    )
+    result = verify_identity_chain(chain["identity"], forged, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_ambiguous_type"
+
+
+def test_not_yet_valid_recognition_rejected(chain):
+    """A recognition whose validFrom is in the future is rejected."""
+    forged = _signed_recognition(
+        chain["root"],
+        chain["issuer"],
+        valid_from="2099-01-01T00:00:00Z",
+        valid_until="2100-01-01T00:00:00Z",
+    )
+    result = verify_identity_chain(chain["identity"], forged, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_not_yet_valid"
+
+
+def test_cross_issuer_key_confusion_rejected(chain):
+    """An identity claiming issuer X but signed by key Y is rejected (vm mismatch)."""
+    issuer_x = chain["issuer"]
+    signer_y = _signer()
+    cred = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "id": "urn:uuid:key-confusion",
+        "type": [VC_TYPE, AGENT_IDENTITY_TYPE],
+        "issuer": issuer_x.did,  # claims to be issued by X
+        "validFrom": "2020-01-01T00:00:00Z",
+        "validUntil": "2100-01-01T00:00:00Z",
+        "credentialSubject": {"id": chain["agent"].did, "identity": {"owner": "x"}},
+    }
+    forged = _sign(signer_y, cred)  # but signed by Y, so vm points at Y
+    result = verify_identity_chain(forged, chain["recognition"], trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "identity_vm_mismatch"
+
+
+def test_hybrid_shaped_proof_array_rejected(chain):
+    """A proof supplied as an array (hybrid shape) is not accepted here."""
+    forged = copy.deepcopy(chain["identity"])
+    forged["proof"] = [forged["proof"]]
+    result = verify_identity_chain(forged, chain["recognition"], trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "identity_no_proof"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_root_of_trust.py
+++ b/tests/test_root_of_trust.py
@@ -1,0 +1,297 @@
+"""
+Tests for the Root of Trust for Machine Identity (vouch.root_of_trust).
+
+Covers the happy-path chain (root -> recognized issuer -> agent identity ->
+action) plus the forgery vectors the model is designed to stop: a fake root,
+self-recognition, tampering, an unrecognized issuer, an unauthorized action,
+revocation, and expiry. Everything runs offline with did:key identities.
+"""
+
+import copy
+
+import pytest
+
+from vouch.signer import Signer
+from vouch.vc import VC_CONTEXT_V2, VOUCH_CONTEXT_V1, VC_TYPE
+from vouch.root_of_trust import (
+    ACTION_ISSUE_AGENT_IDENTITY,
+    ACTION_ISSUE_ROBOT_IDENTITY,
+    RECOGNIZED_ISSUER_TYPE,
+    _sign,
+    build_agent_identity,
+    build_recognized_issuer,
+    build_root_of_trust,
+    generate_did_key_identity,
+    register_recognized_issuer,
+    verify_identity_chain,
+)
+
+
+def _signer():
+    """A fresh did:key signer."""
+    return Signer.from_keypair(generate_did_key_identity())
+
+
+@pytest.fixture
+def chain():
+    """A valid root -> recognized issuer -> agent identity -> action chain."""
+    root = _signer()
+    issuer = _signer()
+    agent = _signer()
+
+    root_cred = build_root_of_trust(root, name="Vouch Machine Identity Root")
+    recognition = build_recognized_issuer(
+        root,
+        issuer_did=issuer.did,
+        recognized_actions=[ACTION_ISSUE_AGENT_IDENTITY],
+    )
+    identity = build_agent_identity(
+        issuer,
+        subject_did=agent.did,
+        attributes={"owner": "Acme", "model": "gpt-x", "capabilityClass": "shopping"},
+    )
+    action = agent.sign(
+        intent={"action": "buy", "target": "store", "resource": "https://store.example/item/1"}
+    )
+    return {
+        "root": root,
+        "issuer": issuer,
+        "agent": agent,
+        "root_cred": root_cred,
+        "recognition": recognition,
+        "identity": identity,
+        "action": action,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_full_chain_verifies(chain):
+    result = verify_identity_chain(
+        chain["identity"],
+        chain["recognition"],
+        trusted_root=chain["root"].did,
+        action_credential=chain["action"],
+        root_credential=chain["root_cred"],
+    )
+    assert result.ok, result.reason
+    assert result.agent_did == chain["agent"].did
+    assert result.issuer_did == chain["issuer"].did
+    assert result.root_did == chain["root"].did
+    assert result.attributes["owner"] == "Acme"
+    assert result.action is not None
+    assert result.action.action == "buy"
+
+
+def test_identity_only_without_action(chain):
+    result = verify_identity_chain(
+        chain["identity"],
+        chain["recognition"],
+        trusted_root=chain["root"].did,
+    )
+    assert result.ok, result.reason
+    assert result.action is None
+
+
+def test_robot_issuer_scope(chain):
+    """An issuer recognized for robot identity verifies for that action."""
+    root = chain["root"]
+    issuer = chain["issuer"]
+    robot = _signer()
+    recognition = build_recognized_issuer(
+        root, issuer_did=issuer.did, recognized_actions=[ACTION_ISSUE_ROBOT_IDENTITY]
+    )
+    identity = build_agent_identity(
+        issuer, subject_did=robot.did, attributes={"owner": "Acme", "hardwareRoot": "se-050"}
+    )
+    result = verify_identity_chain(
+        identity,
+        recognition,
+        trusted_root=root.did,
+        required_action=ACTION_ISSUE_ROBOT_IDENTITY,
+    )
+    assert result.ok, result.reason
+
+
+# ---------------------------------------------------------------------------
+# Forgery vectors
+# ---------------------------------------------------------------------------
+
+
+def test_fake_root_rejected(chain):
+    """A recognition signed by a different root does not anchor to the pin."""
+    fake_root = _signer()
+    forged = build_recognized_issuer(fake_root, issuer_did=chain["issuer"].did)
+    result = verify_identity_chain(chain["identity"], forged, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_not_from_root"
+
+
+def test_self_recognition_rejected(chain):
+    """An issuer recognizing itself is not the pinned root."""
+    issuer = chain["issuer"]
+    self_reco = build_recognized_issuer(issuer, issuer_did=issuer.did)
+    result = verify_identity_chain(chain["identity"], self_reco, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_not_from_root"
+
+
+def test_wrong_pinned_root_rejected(chain):
+    """Pinning an unrelated root DID rejects a legitimate recognition."""
+    result = verify_identity_chain(
+        chain["identity"], chain["recognition"], trusted_root="did:key:zSomeoneElse"
+    )
+    assert not result.ok
+    assert result.reason == "recognized_issuer_not_from_root"
+
+
+def test_tampered_identity_attributes_rejected(chain):
+    """Editing identity attributes after signing breaks the proof."""
+    tampered = copy.deepcopy(chain["identity"])
+    tampered["credentialSubject"]["identity"]["capabilityClass"] = "admin"
+    result = verify_identity_chain(tampered, chain["recognition"], trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "identity_proof_invalid"
+
+
+def test_tampered_recognition_rejected(chain):
+    """Adding an action to a signed recognition breaks the proof."""
+    tampered = copy.deepcopy(chain["recognition"])
+    tampered["credentialSubject"]["recognizedActions"].append(ACTION_ISSUE_ROBOT_IDENTITY)
+    result = verify_identity_chain(chain["identity"], tampered, trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_proof_invalid"
+
+
+def test_identity_from_unrecognized_issuer_rejected(chain):
+    """An identity signed by an issuer the root never recognized is rejected."""
+    other_issuer = _signer()
+    identity = build_agent_identity(
+        other_issuer,
+        subject_did=chain["agent"].did,
+        attributes={"owner": "Impostor"},
+    )
+    result = verify_identity_chain(identity, chain["recognition"], trusted_root=chain["root"].did)
+    assert not result.ok
+    assert result.reason == "identity_not_from_recognized_issuer"
+
+
+def test_issuer_not_recognized_for_action(chain):
+    """An issuer recognized only for robots cannot mint an agent identity."""
+    recognition = build_recognized_issuer(
+        chain["root"],
+        issuer_did=chain["issuer"].did,
+        recognized_actions=[ACTION_ISSUE_ROBOT_IDENTITY],
+    )
+    result = verify_identity_chain(
+        chain["identity"],
+        recognition,
+        trusted_root=chain["root"].did,
+        required_action=ACTION_ISSUE_AGENT_IDENTITY,
+    )
+    assert not result.ok
+    assert result.reason == "issuer_not_recognized_for_action"
+
+
+def test_action_from_different_agent_rejected(chain):
+    """An action signed by an agent other than the identity subject is rejected."""
+    other_agent = _signer()
+    foreign_action = other_agent.sign(
+        intent={"action": "buy", "target": "store", "resource": "https://store.example/item/9"}
+    )
+    result = verify_identity_chain(
+        chain["identity"],
+        chain["recognition"],
+        trusted_root=chain["root"].did,
+        action_credential=foreign_action,
+    )
+    assert not result.ok
+    assert result.reason == "action_not_from_agent"
+
+
+def test_revoked_recognition_rejected(chain):
+    revoked_ids = {chain["recognition"]["id"]}
+    result = verify_identity_chain(
+        chain["identity"],
+        chain["recognition"],
+        trusted_root=chain["root"].did,
+        is_revoked=lambda cred: cred.get("id") in revoked_ids,
+    )
+    assert not result.ok
+    assert result.reason == "recognized_issuer_revoked"
+
+
+def test_revoked_identity_rejected(chain):
+    revoked_ids = {chain["identity"]["id"]}
+    result = verify_identity_chain(
+        chain["identity"],
+        chain["recognition"],
+        trusted_root=chain["root"].did,
+        is_revoked=lambda cred: cred.get("id") in revoked_ids,
+    )
+    assert not result.ok
+    assert result.reason == "identity_revoked"
+
+
+def test_expired_recognition_rejected(chain):
+    """A recognition whose validity window has passed is rejected."""
+    root = chain["root"]
+    issuer = chain["issuer"]
+    expired = _sign(
+        root,
+        {
+            "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+            "id": "urn:uuid:expired-recognition",
+            "type": [VC_TYPE, RECOGNIZED_ISSUER_TYPE],
+            "issuer": root.did,
+            "validFrom": "2020-01-01T00:00:00Z",
+            "validUntil": "2020-01-02T00:00:00Z",
+            "credentialSubject": {
+                "id": issuer.did,
+                "recognizedActions": [ACTION_ISSUE_AGENT_IDENTITY],
+                "recognizedIn": root.did,
+            },
+        },
+    )
+    result = verify_identity_chain(chain["identity"], expired, trusted_root=root.did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_expired"
+
+
+def test_root_credential_self_consistency_checked(chain):
+    """A root credential whose subject is not the pinned root is rejected."""
+    forged_root_cred = copy.deepcopy(chain["root_cred"])
+    forged_root_cred["credentialSubject"]["id"] = "did:key:zNotTheRoot"
+    result = verify_identity_chain(
+        chain["identity"],
+        chain["recognition"],
+        trusted_root=chain["root"].did,
+        root_credential=forged_root_cred,
+    )
+    assert not result.ok
+    # Editing the subject also breaks the self-issued proof; either reason is a
+    # correct rejection of a non-self-issued root.
+    assert result.reason in ("root_proof_invalid", "root_not_self_issued")
+
+
+# ---------------------------------------------------------------------------
+# TrustRegistry wiring
+# ---------------------------------------------------------------------------
+
+
+class _FakeRegistry:
+    def __init__(self):
+        self.trusted = []
+
+    def trust(self, did):
+        self.trusted.append(did)
+
+
+def test_register_recognized_issuer(chain):
+    reg = _FakeRegistry()
+    did = register_recognized_issuer(reg, chain["recognition"])
+    assert did == chain["issuer"].did
+    assert chain["issuer"].did in reg.trusted

--- a/tests/test_root_of_trust_vectors.py
+++ b/tests/test_root_of_trust_vectors.py
@@ -1,0 +1,70 @@
+"""
+Interop-vector tests for the Root of Trust.
+
+Locks the wire format: the committed vector.json must be byte-reproducible from
+the fixed seeds and timestamps, and its chain must verify. Language SDK ports
+consume the same vector.json to prove cross-implementation interop.
+"""
+
+import importlib.util
+import json
+import os
+
+from vouch.root_of_trust import verify_identity_chain
+
+_VECTOR_DIR = os.path.join(
+    os.path.dirname(os.path.dirname(__file__)), "test-vectors", "root-of-trust"
+)
+
+
+def _load_vector():
+    with open(os.path.join(_VECTOR_DIR, "vector.json")) as handle:
+        return json.load(handle)
+
+
+def _regenerate():
+    spec = importlib.util.spec_from_file_location(
+        "rot_generate", os.path.join(_VECTOR_DIR, "generate.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.build_vectors()
+
+
+def test_vector_is_reproducible():
+    """Regenerating from the fixed inputs matches the committed vector byte-for-byte."""
+    regenerated = _regenerate()
+    committed = _load_vector()
+    for key in ("rootOfTrust", "recognizedIssuer", "agentIdentity"):
+        assert regenerated[key] == committed[key], f"{key} drifted from the committed vector"
+    assert regenerated["trustedRoot"] == committed["trustedRoot"]
+
+
+def test_vector_chain_verifies():
+    """The committed vector's chain verifies and anchors to the pinned root."""
+    vector = _load_vector()
+    result = verify_identity_chain(
+        vector["agentIdentity"],
+        vector["recognizedIssuer"],
+        trusted_root=vector["trustedRoot"],
+        root_credential=vector["rootOfTrust"],
+    )
+    assert result.ok, result.reason
+    assert result.agent_did == vector["expected"]["agentDid"]
+    assert result.issuer_did == vector["expected"]["issuerDid"]
+    assert result.attributes["owner"] == "Acme"
+
+
+def test_vector_tamper_breaks_chain():
+    """Flipping a byte of the committed identity proof breaks verification."""
+    vector = _load_vector()
+    identity = json.loads(json.dumps(vector["agentIdentity"]))
+    pv = identity["proof"]["proofValue"]
+    identity["proof"]["proofValue"] = pv[:-1] + ("A" if pv[-1] != "A" else "B")
+    result = verify_identity_chain(
+        identity,
+        vector["recognizedIssuer"],
+        trusted_root=vector["trustedRoot"],
+    )
+    assert not result.ok
+    assert result.reason in ("identity_proof_invalid", "identity_proof_malformed")

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -64,6 +64,14 @@ from .recovery import (
 
 # Audio signing
 from .audio import AudioSigner, SignedAudioResult
+from .root_of_trust import (
+    IdentityChainResult,
+    build_agent_identity,
+    build_recognized_issuer,
+    build_root_of_trust,
+    generate_did_key_identity,
+    verify_identity_chain,
+)
 
 
 # Enterprise features (lazy imports to avoid requiring optional deps)
@@ -466,6 +474,13 @@ __all__ = [
     "VerificationError",
     "DelegationLink",
     "Auditor",
+    # Root of Trust for machine identity
+    "build_root_of_trust",
+    "build_recognized_issuer",
+    "build_agent_identity",
+    "verify_identity_chain",
+    "generate_did_key_identity",
+    "IdentityChainResult",
     # Key management
     "generate_identity",
     "KeyPair",

--- a/vouch/root_of_trust.py
+++ b/vouch/root_of_trust.py
@@ -130,6 +130,8 @@ def build_root_of_trust(
     name: str,
     scope: Optional[List[str]] = None,
     valid_seconds: int = _ROOT_VALID_SECONDS,
+    valid_from: Optional[datetime] = None,
+    created: Optional[datetime] = None,
     credential_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Self-issue the Vouch Root of Trust credential.
@@ -161,8 +163,9 @@ def build_root_of_trust(
         issuer=root_did,
         subject=subject,
         valid_seconds=valid_seconds,
+        valid_from=valid_from,
     )
-    return _sign(root_signer, credential)
+    return _sign(root_signer, credential, created=created)
 
 
 def build_recognized_issuer(
@@ -171,6 +174,8 @@ def build_recognized_issuer(
     issuer_did: str,
     recognized_actions: Optional[List[str]] = None,
     valid_seconds: int = _ISSUER_VALID_SECONDS,
+    valid_from: Optional[datetime] = None,
+    created: Optional[datetime] = None,
     credential_status: Optional[Dict[str, Any]] = None,
     credential_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -205,9 +210,10 @@ def build_recognized_issuer(
         issuer=root_did,
         subject=subject,
         valid_seconds=valid_seconds,
+        valid_from=valid_from,
         credential_status=credential_status,
     )
-    return _sign(root_signer, credential)
+    return _sign(root_signer, credential, created=created)
 
 
 def build_agent_identity(
@@ -216,6 +222,8 @@ def build_agent_identity(
     subject_did: str,
     attributes: Dict[str, Any],
     valid_seconds: int = _IDENTITY_VALID_SECONDS,
+    valid_from: Optional[datetime] = None,
+    created: Optional[datetime] = None,
     credential_status: Optional[Dict[str, Any]] = None,
     credential_id: Optional[str] = None,
 ) -> Dict[str, Any]:
@@ -249,9 +257,10 @@ def build_agent_identity(
         issuer=issuer_signer.did,
         subject=subject,
         valid_seconds=valid_seconds,
+        valid_from=valid_from,
         credential_status=credential_status,
     )
-    return _sign(issuer_signer, credential)
+    return _sign(issuer_signer, credential, created=created)
 
 
 # ---------------------------------------------------------------------------
@@ -417,10 +426,11 @@ def _envelope(
     issuer: str,
     subject: Dict[str, Any],
     valid_seconds: int,
+    valid_from: Optional[datetime] = None,
     credential_status: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     """Build the unsigned VC envelope shared by all three credential types."""
-    issued_at = datetime.now(timezone.utc)
+    issued_at = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
     expires_at = issued_at + timedelta(seconds=valid_seconds)
     credential: Dict[str, Any] = {
         "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
@@ -436,11 +446,14 @@ def _envelope(
     return credential
 
 
-def _sign(signer: Signer, credential: Dict[str, Any]) -> Dict[str, Any]:
+def _sign(
+    signer: Signer, credential: Dict[str, Any], *, created: Optional[datetime] = None
+) -> Dict[str, Any]:
     """Attach an eddsa-jcs-2022 Data Integrity proof using ``signer``'s key.
 
     Handles both in-process signers (raw Ed25519 key) and backend signers (a
-    sign-callback whose key lives outside the process).
+    sign-callback whose key lives outside the process). ``created`` overrides
+    the proof timestamp, which is used to produce reproducible test vectors.
     """
     if getattr(signer, "_raw_priv", None) is not None:
         key = signer._raw_priv
@@ -450,7 +463,7 @@ def _sign(signer: Signer, credential: Dict[str, Any]) -> Dict[str, Any]:
         raise ValueError("signer cannot sign: no private key or sign callback available")
     credential = dict(credential)
     credential["proof"] = data_integrity.build_proof(
-        credential, key, signer.verification_method_id()
+        credential, key, signer.verification_method_id(), created=created
     )
     return credential
 

--- a/vouch/root_of_trust.py
+++ b/vouch/root_of_trust.py
@@ -63,6 +63,11 @@ AGENT_IDENTITY_TYPE = "AgentIdentityCredential"
 ACTION_ISSUE_AGENT_IDENTITY = "issueAgentIdentity"
 ACTION_ISSUE_ROBOT_IDENTITY = "issueRobotIdentity"
 
+# The three trust-layer credential types. A single credential must carry exactly
+# one of these, otherwise one signed object could be replayed into a different
+# slot of the chain (type confusion).
+_TRUST_TYPES = frozenset({ROOT_OF_TRUST_TYPE, RECOGNIZED_ISSUER_TYPE, AGENT_IDENTITY_TYPE})
+
 # Default validity windows. Roots are long lived; issuer and identity
 # credentials rotate more often. All are overridable per call.
 _ROOT_VALID_SECONDS = 10 * 365 * 24 * 3600
@@ -316,11 +321,14 @@ def verify_identity_chain(
     if _issuer_of(recognized_issuer_credential) != trusted_root:
         return IdentityChainResult(ok=False, reason="recognized_issuer_not_from_root")
 
-    rec_subject = recognized_issuer_credential.get("credentialSubject") or {}
+    rec_subject = recognized_issuer_credential.get("credentialSubject")
+    if not isinstance(rec_subject, dict):
+        return IdentityChainResult(ok=False, reason="recognized_issuer_bad_subject")
     recognized_did = rec_subject.get("id")
     if not recognized_did:
         return IdentityChainResult(ok=False, reason="recognized_issuer_no_subject")
-    if required_action not in (rec_subject.get("recognizedActions") or []):
+    actions = rec_subject.get("recognizedActions")
+    if not isinstance(actions, list) or required_action not in actions:
         return IdentityChainResult(ok=False, reason="issuer_not_recognized_for_action")
     if is_revoked is not None and is_revoked(recognized_issuer_credential):
         return IdentityChainResult(ok=False, reason="recognized_issuer_revoked")
@@ -336,7 +344,9 @@ def verify_identity_chain(
     if is_revoked is not None and is_revoked(identity_credential):
         return IdentityChainResult(ok=False, reason="identity_revoked")
 
-    id_subject = identity_credential.get("credentialSubject") or {}
+    id_subject = identity_credential.get("credentialSubject")
+    if not isinstance(id_subject, dict):
+        return IdentityChainResult(ok=False, reason="identity_bad_subject")
     agent_did = id_subject.get("id")
     if not agent_did:
         return IdentityChainResult(ok=False, reason="identity_no_subject")
@@ -349,7 +359,9 @@ def verify_identity_chain(
         )
         if not ok:
             return IdentityChainResult(ok=False, reason=f"root_{reason}")
-        root_sub = root_credential.get("credentialSubject") or {}
+        root_sub = root_credential.get("credentialSubject")
+        if not isinstance(root_sub, dict):
+            return IdentityChainResult(ok=False, reason="root_bad_subject")
         if _issuer_of(root_credential) != trusted_root or root_sub.get("id") != trusted_root:
             return IdentityChainResult(ok=False, reason="root_not_self_issued")
 
@@ -464,6 +476,10 @@ def _verify_trust_credential(
     types = credential.get("type")
     if not isinstance(types, list) or expected_type not in types:
         return False, "wrong_type"
+    # Exactly one trust-layer type, so the credential cannot double as another
+    # link in the chain.
+    if len(_TRUST_TYPES.intersection(types)) != 1:
+        return False, "ambiguous_type"
 
     issuer = _issuer_of(credential)
     if not issuer:

--- a/vouch/root_of_trust.py
+++ b/vouch/root_of_trust.py
@@ -1,0 +1,531 @@
+"""
+Root of Trust for Machine Identity (Vouch Protocol).
+
+Lets Vouch Protocol act as the trust anchor for AI agent and robot identity.
+A verifier pins ONE Vouch root, then verifies any agent offline by walking:
+
+    action credential  ->  authority-issued identity credential
+        ->  recognized-issuer credential  ->  Vouch root
+
+Three credential types compose this chain, all secured with the same
+`eddsa-jcs-2022` Data Integrity proof used elsewhere in Vouch:
+
+  1. Root of Trust credential      self-issued by the root (issuer == subject)
+  2. Recognized-issuer credential  issued by the root, naming an issuer that
+                                   may attest agent or robot identity
+  3. Agent identity credential     issued by a recognized issuer, binding an
+                                   agent key to real attributes (issuer != subject)
+
+`vouch.vc.build_vouch_credential` is self-issued today (issuer == subject). This
+module adds the authority layer that turns a self-asserted DID into an identity
+anchored to a trust root, with no external certificate authority and no central
+per-agent lookup. Anyone can stand up their own root and recognize their own
+issuers, so the model stays self-sovereign.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Dict, List, Optional
+
+from jwcrypto.common import base64url_decode
+
+from . import data_integrity, multikey
+from .keys import KeyPair, generate_identity
+from .signer import Signer
+from .vc import PROTOCOL_VERSION, VC_CONTEXT_V2, VC_TYPE, VOUCH_CONTEXT_V1
+from .verifier import Verifier, CredentialPassport, _parse_iso8601
+
+__all__ = [
+    "ROOT_OF_TRUST_TYPE",
+    "RECOGNIZED_ISSUER_TYPE",
+    "AGENT_IDENTITY_TYPE",
+    "ACTION_ISSUE_AGENT_IDENTITY",
+    "ACTION_ISSUE_ROBOT_IDENTITY",
+    "IdentityChainResult",
+    "generate_did_key_identity",
+    "build_root_of_trust",
+    "build_recognized_issuer",
+    "build_agent_identity",
+    "verify_identity_chain",
+    "register_recognized_issuer",
+]
+
+# Credential type identifiers (the second entry in each `type` array).
+ROOT_OF_TRUST_TYPE = "VouchRootOfTrust"
+RECOGNIZED_ISSUER_TYPE = "RecognizedIssuerCredential"
+AGENT_IDENTITY_TYPE = "AgentIdentityCredential"
+
+# Actions an issuer can be recognized to perform.
+ACTION_ISSUE_AGENT_IDENTITY = "issueAgentIdentity"
+ACTION_ISSUE_ROBOT_IDENTITY = "issueRobotIdentity"
+
+# Default validity windows. Roots are long lived; issuer and identity
+# credentials rotate more often. All are overridable per call.
+_ROOT_VALID_SECONDS = 10 * 365 * 24 * 3600
+_ISSUER_VALID_SECONDS = 365 * 24 * 3600
+_IDENTITY_VALID_SECONDS = 365 * 24 * 3600
+
+
+@dataclass
+class IdentityChainResult:
+    """Outcome of :func:`verify_identity_chain`.
+
+    Attributes:
+      ok: True only if every link verified and anchored to the pinned root.
+      reason: Structured failure reason when ``ok`` is False, else None.
+      agent_did: The subject DID of the identity credential (the agent).
+      issuer_did: The recognized issuer that attested the agent identity.
+      root_did: The pinned Vouch root the chain anchored to.
+      attributes: The identity attributes bound to the agent.
+      action: The verified action passport when an action credential was
+        supplied and bound to the agent, else None.
+    """
+
+    ok: bool
+    reason: Optional[str] = None
+    agent_did: Optional[str] = None
+    issuer_did: Optional[str] = None
+    root_did: Optional[str] = None
+    attributes: Optional[Dict[str, Any]] = None
+    action: Optional[CredentialPassport] = None
+
+
+# ---------------------------------------------------------------------------
+# Identity helpers
+# ---------------------------------------------------------------------------
+
+
+def generate_did_key_identity() -> KeyPair:
+    """Generate a fresh ``did:key`` identity (self-certifying, no hosting).
+
+    Unlike :func:`vouch.keys.generate_identity`, which produces a ``did:web``
+    identity tied to a domain, this embeds the public key in the identifier so
+    the key resolves offline with no network. Wrap it with
+    ``Signer.from_keypair(keys)`` to sign.
+    """
+    keys = generate_identity()
+    pub = json.loads(keys.public_key_jwk)
+    raw = base64url_decode(pub["x"])
+    keys.did = "did:key:" + multikey.encode_ed25519_public(raw)
+    return keys
+
+
+# ---------------------------------------------------------------------------
+# Credential builders
+# ---------------------------------------------------------------------------
+
+
+def build_root_of_trust(
+    root_signer: Signer,
+    *,
+    name: str,
+    scope: Optional[List[str]] = None,
+    valid_seconds: int = _ROOT_VALID_SECONDS,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Self-issue the Vouch Root of Trust credential.
+
+    Issuer and subject are both the root's own DID. Verifiers pin the root DID
+    and MAY keep this credential to display what the root anchors. It is not
+    required for verification (the pinned DID is the anchor), but it makes the
+    root self-describing.
+
+    Args:
+      root_signer: Signer holding the root key.
+      name: Human-readable name of the root (e.g. "Vouch Machine Identity Root").
+      scope: What the root anchors. Defaults to ["ai-agent", "robot"].
+      valid_seconds: Validity window. Defaults to ten years.
+      credential_id: Optional credential id. Defaults to a fresh UUID URN.
+    """
+    root_did = root_signer.did
+    subject = {
+        "id": root_did,
+        "vouchVersion": PROTOCOL_VERSION,
+        "rootOfTrust": {
+            "name": name,
+            "scope": scope or ["ai-agent", "robot"],
+        },
+    }
+    credential = _envelope(
+        credential_id=credential_id,
+        types=[VC_TYPE, ROOT_OF_TRUST_TYPE],
+        issuer=root_did,
+        subject=subject,
+        valid_seconds=valid_seconds,
+    )
+    return _sign(root_signer, credential)
+
+
+def build_recognized_issuer(
+    root_signer: Signer,
+    *,
+    issuer_did: str,
+    recognized_actions: Optional[List[str]] = None,
+    valid_seconds: int = _ISSUER_VALID_SECONDS,
+    credential_status: Optional[Dict[str, Any]] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Issue a recognized-issuer credential from the root.
+
+    The root attests that ``issuer_did`` may issue the given identity actions.
+    ``recognizedIn`` chains back to the root DID so a verifier can trace the
+    recognition to the anchor it pinned. The holder staples this credential to
+    what it presents, so the verifier needs no central lookup.
+
+    Args:
+      root_signer: Signer holding the root key.
+      issuer_did: The DID being recognized as an issuer.
+      recognized_actions: Actions the issuer may perform. Defaults to
+        [ACTION_ISSUE_AGENT_IDENTITY].
+      valid_seconds: Validity window. Defaults to one year.
+      credential_status: Optional W3C `credentialStatus` entry for revocation
+        (e.g. via `vouch.status_list.build_status_list_entry`).
+      credential_id: Optional credential id.
+    """
+    if not issuer_did:
+        raise ValueError("issuer_did is required")
+    root_did = root_signer.did
+    subject = {
+        "id": issuer_did,
+        "recognizedActions": list(recognized_actions or [ACTION_ISSUE_AGENT_IDENTITY]),
+        "recognizedIn": root_did,
+    }
+    credential = _envelope(
+        credential_id=credential_id,
+        types=[VC_TYPE, RECOGNIZED_ISSUER_TYPE],
+        issuer=root_did,
+        subject=subject,
+        valid_seconds=valid_seconds,
+        credential_status=credential_status,
+    )
+    return _sign(root_signer, credential)
+
+
+def build_agent_identity(
+    issuer_signer: Signer,
+    *,
+    subject_did: str,
+    attributes: Dict[str, Any],
+    valid_seconds: int = _IDENTITY_VALID_SECONDS,
+    credential_status: Optional[Dict[str, Any]] = None,
+    credential_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Issue an authority-issued identity credential for an agent.
+
+    Here the issuer differs from the subject: a recognized issuer binds the
+    agent's DID to real attributes (owner, model, capability class, creation
+    time). This is the piece that turns a self-asserted agent DID into an
+    identity a third party stands behind.
+
+    Args:
+      issuer_signer: Signer of a recognized issuer.
+      subject_did: The agent's DID (the subject of this credential).
+      attributes: Identity attributes to bind (owner, model, capabilityClass,
+        createdAt, and so on).
+      valid_seconds: Validity window. Defaults to one year.
+      credential_status: Optional W3C `credentialStatus` entry for revocation.
+      credential_id: Optional credential id.
+    """
+    if not subject_did:
+        raise ValueError("subject_did is required")
+    if not isinstance(attributes, dict) or not attributes:
+        raise ValueError("attributes must be a non-empty dict")
+    subject = {
+        "id": subject_did,
+        "identity": dict(attributes),
+    }
+    credential = _envelope(
+        credential_id=credential_id,
+        types=[VC_TYPE, AGENT_IDENTITY_TYPE],
+        issuer=issuer_signer.did,
+        subject=subject,
+        valid_seconds=valid_seconds,
+        credential_status=credential_status,
+    )
+    return _sign(issuer_signer, credential)
+
+
+# ---------------------------------------------------------------------------
+# Verification
+# ---------------------------------------------------------------------------
+
+
+def verify_identity_chain(
+    identity_credential: Dict[str, Any],
+    recognized_issuer_credential: Dict[str, Any],
+    *,
+    trusted_root: str,
+    action_credential: Optional[Dict[str, Any]] = None,
+    root_credential: Optional[Dict[str, Any]] = None,
+    required_action: str = ACTION_ISSUE_AGENT_IDENTITY,
+    allow_did_resolution: bool = False,
+    trusted_roots: Optional[Dict[str, str]] = None,
+    clock_skew_seconds: int = 30,
+    is_revoked: Optional[Callable[[Dict[str, Any]], bool]] = None,
+) -> IdentityChainResult:
+    """Verify an agent identity against a pinned Vouch root.
+
+    Walks the chain: the recognized-issuer credential must be signed by the
+    pinned root and grant ``required_action``; the identity credential must be
+    signed by that recognized issuer; the optional action credential must be
+    signed by the agent the identity describes. Everything anchors at
+    ``trusted_root``, which is the ONE DID the verifier trusts up front.
+
+    With ``did:key`` identities this runs fully offline. Set
+    ``allow_did_resolution=True`` to resolve ``did:web`` issuers over the
+    network, or pass ``trusted_roots`` (DID -> public JWK JSON) to pin keys.
+
+    Args:
+      identity_credential: The authority-issued identity for the agent.
+      recognized_issuer_credential: The root's recognition of the issuer.
+      trusted_root: The Vouch root DID the verifier pins.
+      action_credential: Optional agent action credential to bind to the
+        identity (the agent's own signed action).
+      root_credential: Optional Root of Trust credential to check for
+        self-consistency against ``trusted_root``.
+      required_action: Action the issuer must be recognized for. Defaults to
+        ``issueAgentIdentity``.
+      allow_did_resolution: Allow network ``did:web`` resolution. Defaults False.
+      trusted_roots: Optional map of DID -> public JWK JSON for offline pinning.
+      clock_skew_seconds: Allowed clock drift for temporal checks.
+      is_revoked: Optional callable that returns True if a credential is
+        revoked. Called on the recognized-issuer and identity credentials.
+
+    Returns:
+      An :class:`IdentityChainResult`.
+    """
+    if not trusted_root:
+        return IdentityChainResult(ok=False, reason="no_trusted_root")
+
+    resolve_opts = dict(
+        trusted_roots=trusted_roots,
+        allow_did_resolution=allow_did_resolution,
+        clock_skew_seconds=clock_skew_seconds,
+    )
+
+    # 1. The recognition must be signed by the pinned root.
+    ok, reason = _verify_trust_credential(
+        recognized_issuer_credential, expected_type=RECOGNIZED_ISSUER_TYPE, **resolve_opts
+    )
+    if not ok:
+        return IdentityChainResult(ok=False, reason=f"recognized_issuer_{reason}")
+    if _issuer_of(recognized_issuer_credential) != trusted_root:
+        return IdentityChainResult(ok=False, reason="recognized_issuer_not_from_root")
+
+    rec_subject = recognized_issuer_credential.get("credentialSubject") or {}
+    recognized_did = rec_subject.get("id")
+    if not recognized_did:
+        return IdentityChainResult(ok=False, reason="recognized_issuer_no_subject")
+    if required_action not in (rec_subject.get("recognizedActions") or []):
+        return IdentityChainResult(ok=False, reason="issuer_not_recognized_for_action")
+    if is_revoked is not None and is_revoked(recognized_issuer_credential):
+        return IdentityChainResult(ok=False, reason="recognized_issuer_revoked")
+
+    # 2. The identity must be signed by the recognized issuer.
+    ok, reason = _verify_trust_credential(
+        identity_credential, expected_type=AGENT_IDENTITY_TYPE, **resolve_opts
+    )
+    if not ok:
+        return IdentityChainResult(ok=False, reason=f"identity_{reason}")
+    if _issuer_of(identity_credential) != recognized_did:
+        return IdentityChainResult(ok=False, reason="identity_not_from_recognized_issuer")
+    if is_revoked is not None and is_revoked(identity_credential):
+        return IdentityChainResult(ok=False, reason="identity_revoked")
+
+    id_subject = identity_credential.get("credentialSubject") or {}
+    agent_did = id_subject.get("id")
+    if not agent_did:
+        return IdentityChainResult(ok=False, reason="identity_no_subject")
+    attributes = id_subject.get("identity")
+
+    # 3. Optional: confirm the root credential is genuinely self-issued.
+    if root_credential is not None:
+        ok, reason = _verify_trust_credential(
+            root_credential, expected_type=ROOT_OF_TRUST_TYPE, **resolve_opts
+        )
+        if not ok:
+            return IdentityChainResult(ok=False, reason=f"root_{reason}")
+        root_sub = root_credential.get("credentialSubject") or {}
+        if _issuer_of(root_credential) != trusted_root or root_sub.get("id") != trusted_root:
+            return IdentityChainResult(ok=False, reason="root_not_self_issued")
+
+    # 4. Optional: bind the agent's own action to this identity.
+    action_passport: Optional[CredentialPassport] = None
+    if action_credential is not None:
+        verifier = Verifier(
+            trusted_roots=trusted_roots or None,
+            allow_did_resolution=allow_did_resolution,
+            clock_skew_seconds=clock_skew_seconds,
+        )
+        ok, passport = verifier.check_vouch_credential(action_credential)
+        if not ok or passport is None:
+            return IdentityChainResult(ok=False, reason="action_proof_invalid")
+        if passport.iss != agent_did:
+            return IdentityChainResult(ok=False, reason="action_not_from_agent")
+        action_passport = passport
+
+    return IdentityChainResult(
+        ok=True,
+        agent_did=agent_did,
+        issuer_did=recognized_did,
+        root_did=trusted_root,
+        attributes=attributes,
+        action=action_passport,
+    )
+
+
+def register_recognized_issuer(registry: Any, recognized_issuer_credential: Dict[str, Any]) -> str:
+    """Consume a recognized-issuer credential into a Vouch Shield TrustRegistry.
+
+    The caller should verify the credential first (via
+    :func:`verify_identity_chain` or :func:`_verify_trust_credential`). This
+    adds the recognized issuer DID to the registry's trusted set and returns it.
+    """
+    subject = recognized_issuer_credential.get("credentialSubject") or {}
+    issuer_did = subject.get("id")
+    if not issuer_did:
+        raise ValueError("recognized-issuer credential has no subject id")
+    registry.trust(issuer_did)
+    return issuer_did
+
+
+# ---------------------------------------------------------------------------
+# Module-private helpers
+# ---------------------------------------------------------------------------
+
+
+def _envelope(
+    *,
+    credential_id: Optional[str],
+    types: List[str],
+    issuer: str,
+    subject: Dict[str, Any],
+    valid_seconds: int,
+    credential_status: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Build the unsigned VC envelope shared by all three credential types."""
+    issued_at = datetime.now(timezone.utc)
+    expires_at = issued_at + timedelta(seconds=valid_seconds)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "id": credential_id or f"urn:uuid:{uuid.uuid4()}",
+        "type": types,
+        "issuer": issuer,
+        "validFrom": _iso(issued_at),
+        "validUntil": _iso(expires_at),
+        "credentialSubject": subject,
+    }
+    if credential_status is not None:
+        credential["credentialStatus"] = credential_status
+    return credential
+
+
+def _sign(signer: Signer, credential: Dict[str, Any]) -> Dict[str, Any]:
+    """Attach an eddsa-jcs-2022 Data Integrity proof using ``signer``'s key.
+
+    Handles both in-process signers (raw Ed25519 key) and backend signers (a
+    sign-callback whose key lives outside the process).
+    """
+    if getattr(signer, "_raw_priv", None) is not None:
+        key = signer._raw_priv
+    elif getattr(signer, "_sign_func", None) is not None:
+        key = signer._sign_func
+    else:
+        raise ValueError("signer cannot sign: no private key or sign callback available")
+    credential = dict(credential)
+    credential["proof"] = data_integrity.build_proof(
+        credential, key, signer.verification_method_id()
+    )
+    return credential
+
+
+def _verify_trust_credential(
+    credential: Dict[str, Any],
+    *,
+    expected_type: str,
+    trusted_roots: Optional[Dict[str, str]],
+    allow_did_resolution: bool,
+    clock_skew_seconds: int,
+) -> tuple[bool, Optional[str]]:
+    """Verify a trust-layer credential (root, recognized-issuer, or identity).
+
+    Unlike :meth:`Verifier.verify`, this does not require an ``intent.resource``
+    (those credentials carry claims, not an agent action). It checks the proof,
+    the proof purpose, that the verification method belongs to the issuer, the
+    credential type, and the validity window. Returns (ok, reason).
+    """
+    if not isinstance(credential, dict):
+        return False, "not_a_credential"
+
+    types = credential.get("type")
+    if not isinstance(types, list) or expected_type not in types:
+        return False, "wrong_type"
+
+    issuer = _issuer_of(credential)
+    if not issuer:
+        return False, "no_issuer"
+
+    proof = credential.get("proof")
+    if not isinstance(proof, dict):
+        return False, "no_proof"
+    if proof.get("proofPurpose") != "assertionMethod":
+        return False, "bad_proof_purpose"
+    vm = proof.get("verificationMethod")
+    if not isinstance(vm, str) or not vm or vm.split("#", 1)[0] != issuer:
+        return False, "vm_mismatch"
+
+    public_key = _resolve_key(issuer, vm, trusted_roots, allow_did_resolution)
+    if public_key is None:
+        return False, "unresolved_key"
+
+    try:
+        if not data_integrity.verify_proof(credential, public_key):
+            return False, "proof_invalid"
+    except ValueError:
+        return False, "proof_malformed"
+
+    now = datetime.now(timezone.utc)
+    valid_from = _parse_iso8601(credential.get("validFrom"))
+    valid_until = _parse_iso8601(credential.get("validUntil"))
+    if valid_from is None or valid_until is None:
+        return False, "no_validity_window"
+    if (now - valid_until).total_seconds() > clock_skew_seconds:
+        return False, "expired"
+    if (valid_from - now).total_seconds() > clock_skew_seconds:
+        return False, "not_yet_valid"
+
+    return True, None
+
+
+def _resolve_key(
+    did: str,
+    vm_id: Optional[str],
+    trusted_roots: Optional[Dict[str, str]],
+    allow_did_resolution: bool,
+):
+    """Resolve an issuer's Ed25519 public key, reusing the Verifier's resolver.
+
+    ``did:key`` resolves offline from the identifier; ``did:web`` needs
+    ``allow_did_resolution``; pinned keys come from ``trusted_roots``.
+    """
+    verifier = Verifier(
+        trusted_roots=trusted_roots or None,
+        allow_did_resolution=allow_did_resolution,
+    )
+    return verifier._resolve_credential_public_key(did, vm_id)
+
+
+def _issuer_of(credential: Dict[str, Any]) -> Optional[str]:
+    """Return the issuer DID, tolerating the list form used by multi-issuer VCs."""
+    issuer = credential.get("issuer")
+    if isinstance(issuer, list):
+        return issuer[0] if issuer else None
+    return issuer if isinstance(issuer, str) else None
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
This adds an optional authority layer so a verifier can anchor an agent identity to a single Vouch Protocol root, with no external certificate authority and no central per-agent lookup. A verifier pins one root DID and then verifies any agent by walking a short credential chain, offline when the DIDs are did:key.

Three credential types, all secured with the existing eddsa-jcs-2022 Data Integrity proof:

- VouchRootOfTrust: self-issued by the root (issuer equals subject). Verifiers pin the root DID; the credential lets the root describe itself.
- RecognizedIssuerCredential: issued by the root to authorize an issuer for specific actions (issueAgentIdentity, issueRobotIdentity), with recognizedIn chaining back to the root.
- AgentIdentityCredential: issued by a recognized issuer, binding an agent key to attributes such as owner, model, and capability class (issuer differs from subject).

verify_identity_chain walks action, identity, recognized issuer, and pinned root, and returns a structured result. A TrustRegistry hook lets a recognition feed the existing Vouch Shield trust store.

Security boundary:

- The chain anchors at one pinned root DID, the single trust decision the verifier makes in advance. Every other check follows cryptographically from that anchor.
- Each credential carries exactly one trust type, and each proof verification method must belong to its issuer, so a signed credential cannot be presented in a different position in the chain or reused across issuers.
- A recognition is honored only while it is signed by the pinned root and grants the required action, and an identity only while its recognized issuer remains recognized. Revocation is supported through credentialStatus and a verify-time hook.
- The model assumes issuer key secrecy and, for did:web, trust in the domain TLS.

The change includes the reference implementation, an adversarial test suite, a runnable example, a canonical interop vector under test-vectors/root-of-trust/, and a normative specification section (Section 18). TypeScript and Rust ports that consume the same vector follow in separate pull requests.
