### PR TITLE
Add four forward-looking robotics capabilities (reference, disclosures, demos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,24 @@ Implemented in Python, TypeScript, Go, and the Rust core (flowing to the Swift,
 Kotlin/JVM, .NET, C/C++, and WebAssembly wrappers), byte-identical and pinned by
 the robotics interop vector.
 
+#### Robotics: control, operating domain, swarm, and human handover
+
+The Python reference adds four forward-looking robotics capabilities, each with an
+interactive website demo and defensive disclosures:
+
+- `vouch.robotics.teleop`: accountable teleoperation handoff, a signed chain of
+  control-authority transfers between an autonomous policy and human teleoperators,
+  with a controller-at-time lookup and a control-continuity check.
+- `vouch.robotics.odd`: operating-domain conformance, an operator-certified operating
+  domain and a robot-signed attestation that it stayed inside it, with a deterministic
+  in-domain check.
+- `vouch.robotics.swarm`: multi-robot swarm accountability, verifiable swarm membership
+  and attribution of a collective action to its admitted members.
+- `vouch.robotics.handover`: safe robot-to-human handover, a signed handover with the
+  force and speed envelope at the release and a recipient acknowledgement bound to it.
+
+Disclosed as PAD-095 through PAD-102. Cross-language ports follow.
+
 ## [1.6.3] - 2026-06-15
 
 ### Added

--- a/docs/disclosures/PAD-095-control-authority-handoff-chain.md
+++ b/docs/disclosures/PAD-095-control-authority-handoff-chain.md
@@ -1,0 +1,118 @@
+# PAD-095: Accountable Control-Authority Handoff Chain Between Autonomy and Human Teleoperators
+
+**Identifier:** PAD-095  
+**Title:** Method for a Signed Chain of Control-Authority Handoffs Between an Autonomous Policy and Human Teleoperators, So Who or What Was in Control of a Robot at Any Moment Is Verifiable  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Teleoperation / Accountability  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-064 (Hardware-Rooted Robot Identity), PAD-083 (Physical Custody Handoff Chain), PAD-096 (Control Continuity)  
+
+---
+
+## 1. Abstract
+
+A method for making the transfer of control of a robot between an autonomous policy
+and human teleoperators accountable. A control handoff credential records that a
+receiving controller took control of a robot from a releasing controller, tagged
+with the control mode (autonomous, teleoperated, or shared), signed by the receiver,
+the party taking responsibility. Linking each handoff forms a chain a verifier walks
+to establish who held control, and a controller-at-time lookup returns who held it at
+any moment, so an incident traces to the controller in charge then.
+
+Key innovations:
+
+- **Mode-tagged control handoff.** Each handoff carries whether control passed to an
+  autonomous policy, a human teleoperator, or a shared mode, so the record
+  distinguishes machine control from human control for liability.
+- **Autonomy and human in one chain.** A controller is a Vouch identity that may be an
+  autonomous policy or a human operator, so control passing back and forth between them
+  is one verifiable structure.
+- **Controller-at-time attribution.** Given the chain and a time, the method returns the
+  controller in charge then, so an incident is attributed to whoever or whatever was
+  driving at that moment.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Control passes between autonomy and humans with no signed record
+
+An autonomous robot hands control to a remote operator for a hard case and takes it
+back afterward. When something goes wrong, the first question is who or what was in
+control, and the answer today is an unsigned log the infrastructure asserts.
+
+### 2.2 The machine-versus-human distinction is the liability question
+
+Whether a robot was under autonomous control or human teleoperation at the moment of
+an incident changes who is responsible, and nothing binds that distinction to the
+transfer in a verifiable form.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_control_handoff(...)` issues a `ControlHandoffCredential` whose subject carries
+the robot identifier, the releasing controller, the receiving controller, and the
+control mode, signed eddsa-jcs-2022 by the receiver. `verify_control_handoff(...)`
+checks the proof, that the issuer is the receiving controller, and that the mode is one
+an interoperable verifier accepts. `verify_control_chain(...)` walks an ordered list of
+handoffs, confirms each verifies under its receiver's key and every link's receiving
+controller matches the next link's releasing controller, and returns the current
+controller. `controller_at(...)` returns the controller in charge at a given time.
+Controllers are Vouch identities that may be autonomous policies or human operators, so
+the chain crosses the machine-human boundary. Because the credentials use the shared JCS
+plus eddsa-jcs-2022 primitives, the same chain verifies across the language SDKs. This is
+the open layer of signed handoffs and chain verification; latency-bound safe-takeover
+enforcement and biometric operator binding are out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Verifiable Credentials, custody chains, and handover logging each exist as prior art,
+including this project's own physical custody chain. This disclosure does **not** claim
+those mechanisms in the abstract. What is differentiated is the reduction to control
+authority over a robot:
+
+- **The subject is control of the robot itself**, not a task or object it carries, tagged
+  with the autonomous-or-human control mode.
+- **Autonomy and human operators in one chain**, so control passing between them is a
+  single verifiable structure.
+- **Controller-at-time attribution across the machine-human boundary**, so an incident
+  points at whoever or whatever was driving then.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_control_handoff`, `verify_control_handoff`,
+`verify_control_chain`, and `controller_at`, using the shared Data Integrity primitives
+so the same control chain verifies across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for a control-authority handoff chain in which each handoff credential records
+   a receiving controller taking control of a robot from a releasing controller, tagged
+   with a control mode, and is signed by the receiver.
+2. The method of claim 1 wherein the control mode distinguishes an autonomous policy, a
+   human teleoperator, and a shared mode.
+3. The method of claim 1 wherein a controller is an identity that may be an autonomous
+   policy or a human operator, so the chain crosses the machine-human boundary.
+4. The method of claim 1 wherein a controller-at-time lookup returns the controller in
+   charge at a given time, so an incident traces to whoever was driving then.
+5. The method of claim 1 wherein the credentials use canonicalization and signature
+   primitives shared across language SDKs, so the same chain verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-096-control-continuity-gap-overlap.md
+++ b/docs/disclosures/PAD-096-control-continuity-gap-overlap.md
@@ -1,0 +1,116 @@
+# PAD-096: Detecting an Unattributed-Control Gap or a Dual-Control Overlap in a Robot's Control Timeline
+
+**Identifier:** PAD-096  
+**Title:** Method for Verifying That a Robot's Control Timeline Is Continuous and Single-Held, Detecting a Moment With No Attributed Controller or Two Controllers at Once  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Teleoperation / Accountability  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-082 (Portable Agent Identity Fork Detection), PAD-095 (Control-Authority Handoff Chain)  
+
+---
+
+## 1. Abstract
+
+A method for confirming that control of a robot was continuous and held by exactly one
+controller at a time. Each control handoff names the controller it took over from. This
+method checks that every handoff after the first begins where the previous one left off,
+so there is no moment with no attributed controller (a gap where authority is
+unaccounted for) and no moment with two controllers claiming authority across the seam (an
+overlap). A seam whose releasing controller is not the previous receiving controller is
+reported, so a control timeline that silently dropped or double-counted authority is
+detected rather than assumed clean.
+
+Key innovations:
+
+- **Single-authority invariant over a control timeline.** The check enforces that control
+  is held by exactly one controller at every moment, the control analogue of a
+  single-body constraint on a portable identity.
+- **Gap and overlap named at the seam.** A discontinuity is returned as the specific seam
+  where the releasing controller does not match the previous receiving controller, so the
+  unaccounted moment is localized.
+- **Layered on the signed handoff chain.** Because each handoff is signed, the continuity
+  check runs over authenticated transfers, so a detected gap or overlap is attributable.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A verified chain can still hide a control gap
+
+A chain of signed handoffs can each verify individually while the sequence still contains
+a moment where no controller held authority, or where a new controller claimed it while
+the previous one had not released, and nothing flags that discontinuity.
+
+### 2.2 Gaps and overlaps are exactly the liability-sensitive moments
+
+The moment with no attributed controller, or with two, is where responsibility for an
+incident is most contested. There is no method that isolates those moments from the
+transfer record.
+
+---
+
+## 3. Solution (The Invention)
+
+`check_control_continuity(...)` walks an ordered list of control handoffs and confirms
+each handoff after the first begins where the previous one left off, that is, its
+releasing controller is the previous receiving controller. A link whose releasing
+controller does not match is reported both as a gap (the previous controller's authority
+is left unaccounted for across the seam) and as an overlap (a new controller claims
+authority the previous one had not released), and the offending seam is returned with the
+expected and found controllers. Combined with the signed handoff chain of PAD-095, this
+confirms both that transfers are authentic and that the control timeline is continuous and
+single-held. Because the handoffs use the shared JCS plus eddsa-jcs-2022 primitives, the
+same check runs across the language SDKs. This is the open layer of a software continuity
+check over signed transfers; enforcement mechanisms that prevent a gap in hardware are out
+of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Interval reconciliation, chain-of-custody continuity, and this project's own embodiment
+fork detection each exist as prior art. This disclosure does **not** claim those in the
+abstract. What is differentiated is the reduction to a robot's control timeline:
+
+- **A single-authority invariant over control of a robot**, distinct from a
+  single-body invariant over an identity.
+- **Naming a gap and an overlap at the specific seam** in the control record.
+- **Continuity layered on signed control handoffs**, so a detected discontinuity is
+  attributable.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `check_control_continuity`, which reconciles adjacent
+handoffs in a control chain and returns any seam that breaks the single-authority
+invariant, using the shared primitives so the same check runs across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for verifying a robot's control timeline in which each control handoff after
+   the first is required to begin where the previous one left off, so control is held by
+   exactly one controller at every moment.
+2. The method of claim 1 wherein a discontinuity is reported as a gap where the previous
+   controller's authority is unaccounted for and as an overlap where a new controller
+   claims authority not yet released.
+3. The method of claim 2 wherein the offending seam is returned with the expected and
+   found controllers.
+4. The method of claim 1 wherein the check runs over signed control handoffs, so a
+   detected discontinuity is attributable.
+5. The method of claim 1 wherein the primitives are shared across language SDKs, so the
+   same check runs cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-097-operating-domain-conformance.md
+++ b/docs/disclosures/PAD-097-operating-domain-conformance.md
@@ -1,0 +1,119 @@
+# PAD-097: Operator-Certified Operating Domain and Robot-Attested In-Domain Conformance
+
+**Identifier:** PAD-097  
+**Title:** Method for an Operator-Signed Operating-Domain Credential and a Robot-Signed Conformance Attestation That It Operated Inside the Certified Domain  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Autonomy Safety / Conformance  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-066 (Physical Capability Scope), PAD-072 (Living-Trust Heartbeat), PAD-079 (Regulatory Conformance), PAD-098 (In-Domain Predicate)  
+
+---
+
+## 1. Abstract
+
+A method for binding an autonomous robot to the operational design domain it is certified
+for and letting the robot attest that it stayed inside it. An operating-domain credential,
+signed by the operator, names the allowed zones, a maximum speed, condition bounds such as
+a maximum wind speed and a minimum visibility, and the time windows the robot is rated for.
+An operating-domain conformance attestation, signed by the robot, reports the operating
+parameters it observed over an interval and whether they stayed inside the domain. Acting
+outside the certified domain, where certification stops applying, becomes detectable and
+attributable.
+
+Key innovations:
+
+- **The operating domain as a signed credential.** The zones, speed regime, condition
+  bounds, and hours a robot is certified for are carried in an operator-signed credential,
+  so the domain a robot is bound to is verifiable rather than configuration.
+- **Robot-attested in-domain operation over intervals.** The robot self-signs the
+  parameters it observed and the in-domain verdict per interval, so a record of whether it
+  stayed in its envelope travels with it.
+- **The same credential base as the rest of the robot's trust.** The domain and the
+  conformance attestation are verifiable credentials on the shared primitives, so they
+  compose with the robot's identity, capability scope, and conformance work.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 The operating domain is configuration, not a signed fact
+
+An autonomous robot is certified for a specific operational design domain, but that domain
+usually lives in configuration or paperwork, not in a signed credential a verifier can
+check against the robot's identity.
+
+### 2.2 There is no portable record of staying in domain
+
+Whether a robot operated inside its certified domain over its shifts is exactly what an
+operator, insurer, or regulator wants to confirm after the fact, and there is no
+robot-signed, portable record of it.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_odd_credential(...)` issues an `OperatingDomainCredential` whose subject carries the
+robot identifier and the operating domain (allowed zones, maximum speed, condition bounds,
+and time windows), signed eddsa-jcs-2022 by the operator. `verify_odd_credential(...)`
+returns the certified domain. `build_odd_conformance(...)` issues an
+`ODDConformanceAttestation` in which the robot reports the operating parameters it observed
+over an interval and the in-domain verdict, signed by the robot. `verify_odd_conformance(...)`
+checks the robot's proof and, when the domain is supplied, that recomputing the in-domain
+check over the attested observations reproduces the attested verdict, so the robot cannot
+claim it stayed in domain when its own reported observations say otherwise. Because the
+credentials use the shared JCS plus eddsa-jcs-2022 primitives, the same domain and
+attestation verify across the language SDKs. This is the open layer of the signed domain
+credential, the conformance attestation, and the check; real-time out-of-domain prediction
+and automatic safe-stop enforcement are out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Verifiable Credentials, geofencing, and operational-limit configuration each exist as prior
+art, as does this project's own capability scope and regulatory conformance work. This
+disclosure does **not** claim those in the abstract. What is differentiated is the
+reduction to a certified operating domain for an autonomous robot:
+
+- **An operator-signed operating-domain credential** spanning zones, speed, environmental
+  conditions, and hours, bound to a robot identity.
+- **A robot-signed in-domain conformance attestation over intervals**, portable across
+  owners and regulators.
+- **Verification that reproduces the in-domain verdict** from the robot's own observations,
+  so an out-of-domain excursion cannot be signed away as in-domain.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_odd_credential`, `verify_odd_credential`,
+`build_odd_conformance`, and `verify_odd_conformance`, using the shared Data Integrity
+primitives so the same domain and attestation verify across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for binding an autonomous robot to its operating domain in which an
+   operator-signed credential names the allowed zones, a speed regime, condition bounds,
+   and time windows the robot is certified for.
+2. The method of claim 1 wherein the robot signs a conformance attestation reporting the
+   parameters it observed over an interval and whether they stayed inside the domain.
+3. The method of claim 2 wherein verification reproduces the in-domain verdict from the
+   attested observations, so an out-of-domain excursion cannot be claimed as in-domain.
+4. The method of claim 1 wherein the domain condition bounds carry named upper and lower
+   limits such as a maximum wind speed and a minimum visibility.
+5. The method of claim 1 wherein the credentials use canonicalization and signature
+   primitives shared across language SDKs, so the same records verify cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-098-in-domain-predicate.md
+++ b/docs/disclosures/PAD-098-in-domain-predicate.md
@@ -1,0 +1,112 @@
+# PAD-098: Deterministic Multi-Dimensional In-Domain Check for a Robot's Operating Parameters
+
+**Identifier:** PAD-098  
+**Title:** Method for a Deterministic, Reproducible Predicate That Decides Whether a Robot's Observed Operating Parameters Stayed Inside Its Certified Domain Across Zone, Speed, Condition, and Time Dimensions  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Autonomy Safety / Conformance  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-066 (Physical Capability Scope), PAD-097 (Operating-Domain Conformance)  
+
+---
+
+## 1. Abstract
+
+A method for deciding, deterministically and reproducibly, whether a robot's observed
+operating parameters stayed inside its certified operating domain. The check compares the
+observed maximum speed, the zones visited, the environmental conditions, and the time of
+operation against the corresponding dimensions of a signed operating-domain credential, and
+returns a pass with the specific reasons for any out-of-domain dimension. Because the check
+is a fixed computation, a verifier reproduces the in-domain verdict from the domain and the
+observations, so a robot cannot report parameters that are out of domain while claiming it
+stayed in.
+
+Key innovations:
+
+- **A single predicate over heterogeneous domain dimensions.** Zone membership, a numeric
+  speed cap, named condition bounds, and time windows are evaluated by one check that
+  returns a combined verdict and per-dimension reasons.
+- **Named condition bounds by direction.** A condition keyed with a maximum prefix is an
+  upper bound and one keyed with a minimum prefix is a lower bound, so a maximum wind speed
+  and a minimum visibility are both expressible and checkable.
+- **Deterministic and reproducible.** The check is a fixed computation reproduced across
+  language SDKs, so a verifier confirms the in-domain verdict rather than trusting it.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Out-of-domain has many dimensions
+
+A robot can leave its operating domain by speed, by zone, by an environmental condition, or
+by time of day, and a check that covers only one dimension misses the others.
+
+### 2.2 A self-reported verdict must be reproducible
+
+If a robot reports whether it stayed in domain, that verdict is only trustworthy if a
+verifier can reproduce it deterministically from the same domain and observations.
+
+---
+
+## 3. Solution (The Invention)
+
+`check_in_domain(...)` takes a certified operating domain and a set of observed operating
+parameters and returns a verdict with reasons. It compares the observed maximum speed
+against the domain maximum, the zones visited against the allowed set, each observed
+condition against its named bound (a key prefixed with a maximum term is an upper bound, a
+minimum term a lower bound), and the observed time against the domain time windows. An
+absent domain dimension is unconstrained by design. Because the check is a fixed
+computation over the credential fields, the same verdict is reproduced across language SDKs,
+which is what lets `verify_odd_conformance` of PAD-097 confirm a robot's self-reported
+in-domain verdict rather than trust it. This is the open layer of the deterministic check;
+predicting an imminent out-of-domain excursion and enforcing a safe stop are out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Predicate evaluation, geofencing, and envelope checks each exist as prior art, as does this
+project's own physical-action check. This disclosure does **not** claim those in the
+abstract. What is differentiated is the reduction to a robot's operating domain:
+
+- **One predicate spanning zone, speed, environmental condition, and time**, returning a
+  combined verdict with per-dimension reasons.
+- **Directional named condition bounds**, so both upper and lower environmental limits are
+  checkable.
+- **A deterministic, reproducible verdict**, so a self-reported in-domain claim is
+  confirmable from the domain and the observations.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `check_in_domain`, evaluated inside
+`build_odd_conformance` and reproduced inside `verify_odd_conformance`, using the shared
+primitives so the same verdict is produced across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for deciding whether a robot's observed operating parameters stayed inside a
+   certified operating domain by comparing observed speed, zones, conditions, and time
+   against the corresponding domain dimensions and returning a verdict with reasons.
+2. The method of claim 1 wherein a condition bound is interpreted as an upper or a lower
+   bound according to a named prefix, so both maximum and minimum environmental limits are
+   checkable.
+3. The method of claim 1 wherein an absent domain dimension is unconstrained.
+4. The method of claim 1 wherein the check is deterministic, so a verifier reproduces the
+   in-domain verdict from the domain and the observations.
+5. The method of claim 1 wherein the computation is shared across language SDKs, so the
+   same verdict is produced cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-099-verifiable-swarm-membership.md
+++ b/docs/disclosures/PAD-099-verifiable-swarm-membership.md
@@ -1,0 +1,106 @@
+# PAD-099: Verifiable Swarm Membership for a Multi-Robot Group
+
+**Identifier:** PAD-099  
+**Title:** Method for a Coordinator-Signed Membership Credential That Admits a Robot to a Named Swarm With an Optional Role  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Multi-Robot Systems / Accountability  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-064 (Hardware-Rooted Robot Identity), PAD-067 (Robot-to-Robot Handshake), PAD-100 (Collective-Action Attribution)  
+
+---
+
+## 1. Abstract
+
+A method for making membership in a multi-robot swarm verifiable. A swarm membership
+credential records that a coordinator admitted a robot to a named swarm, optionally with a
+role, signed by the coordinator. A verifier confirms that a robot is a member of a specific
+swarm under a specific coordinator, so a group of robots acting together has a checkable
+boundary of who belongs and who authorized them, rather than an anonymous collection.
+
+Key innovations:
+
+- **Coordinator-admitted membership scoped to a named swarm.** Membership is a signed
+  credential naming the swarm and the admitted robot, so belonging to a group is verifiable
+  and scoped rather than assumed.
+- **Role carried in the membership.** An optional role lets the membership distinguish what
+  part a robot plays in the swarm.
+- **The same identity base as a single robot.** The member is a Vouch robot identity, so
+  swarm membership composes with the robot's hardware-rooted identity and the rest of its
+  trust.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A swarm has no verifiable boundary
+
+Robots increasingly act as a group, but there is no signed way to say which robots are
+members of that group and who admitted them, so a collective action cannot be tied to an
+authorized membership.
+
+### 2.2 Anonymous membership defeats attribution
+
+If any robot can claim to be part of a swarm, a collective action cannot be attributed to
+the specific robots that were authorized to take part.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_swarm_membership(...)` issues a `SwarmMembershipCredential` whose subject carries the
+robot identifier and the swarm identifier, optionally with a role, signed eddsa-jcs-2022 by
+the coordinator. `verify_swarm_membership(...)` checks the coordinator's proof and, when a
+swarm identifier is supplied, that the membership is for that swarm, returning the subject.
+Because the member is a Vouch robot identity and the credential uses the shared JCS plus
+eddsa-jcs-2022 primitives, membership composes with the robot's identity and verifies
+across the language SDKs. This is the open layer of the signed membership credential and its
+verification; managed swarm orchestration and formation control are out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Verifiable Credentials, group membership tokens, and access-control lists each exist as
+prior art. This disclosure does **not** claim those in the abstract. What is differentiated
+is the reduction to a multi-robot swarm:
+
+- **A coordinator-signed membership scoped to a named swarm of robots**, bound to a robot
+  identity.
+- **A role carried in the membership**, distinguishing a member's part in the swarm.
+- **Membership that composes with a hardware-rooted robot identity**, so the boundary of a
+  swarm is as verifiable as a single robot.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_swarm_membership` and `verify_swarm_membership`,
+using the shared Data Integrity primitives so the same membership verifies across the
+language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for swarm membership in which a coordinator signs a credential admitting a robot
+   to a named swarm.
+2. The method of claim 1 wherein the membership carries an optional role for the member in
+   the swarm.
+3. The method of claim 1 wherein verification confirms the membership is for a specific
+   swarm under the coordinator's key.
+4. The method of claim 1 wherein the member is a hardware-rooted robot identity, so swarm
+   membership composes with the robot's identity.
+5. The method of claim 1 wherein the credentials use canonicalization and signature
+   primitives shared across language SDKs, so the same membership verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-100-collective-action-attribution.md
+++ b/docs/disclosures/PAD-100-collective-action-attribution.md
@@ -1,0 +1,111 @@
+# PAD-100: Attribution of a Multi-Robot Collective Action to Its Participating Members
+
+**Identifier:** PAD-100  
+**Title:** Method for a Coordinator-Signed Collective-Action Attestation Whose Participants Are Each Checkable as Admitted Members of the Same Swarm  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Multi-Robot Systems / Accountability  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-076 (Physical Quorum), PAD-099 (Verifiable Swarm Membership)  
+
+---
+
+## 1. Abstract
+
+A method for attributing a physical action taken by a swarm of robots to the specific
+members that performed it. A collective action attestation records the action, the swarm,
+and the participating members, signed by the coordinator. Each participant can be checked
+against a swarm membership signed by the same coordinator for the same swarm, so a
+collective physical action ties only to admitted members and the coordinator that
+authorized the group, rather than diffusing across an anonymous swarm.
+
+Key innovations:
+
+- **A collective physical action bound to its participants.** The attestation names the
+  members that took part in a specific action, so a group action is attributable to the
+  robots that performed it.
+- **Participants checkable as admitted members.** Each participant is confirmed to hold a
+  membership in the same swarm signed by the same coordinator, so an action cannot name a
+  non-member as a participant.
+- **The coordinator as the accountable authority.** The action and the memberships are both
+  signed by the coordinator, so the authority behind the collective action is the same
+  identity that admitted the members.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A collective action has no attributable set of actors
+
+When a swarm takes a physical action together, the responsibility diffuses across the
+group, and there is no signed record binding the action to the specific robots that
+performed it.
+
+### 2.2 Naming participants is meaningless without membership
+
+Listing participants in an action is only trustworthy if each named participant can be
+confirmed to have been an authorized member of the swarm at the time.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_collective_action(...)` issues a `CollectiveActionAttestation` whose subject carries
+the swarm identifier, the action, and the participants, signed eddsa-jcs-2022 by the
+coordinator. `verify_collective_action(...)` checks the coordinator's proof and, when the
+swarm memberships are supplied, that every participant holds a membership in the same swarm
+signed by the same coordinator, returning the participants that lack a valid membership.
+Because the memberships are coordinator-signed, they verify under the same coordinator key
+as the action, so a single authority binds the group and the action. Because the credentials
+use the shared JCS plus eddsa-jcs-2022 primitives, the same attestation verifies across the
+language SDKs. This is the open layer of the signed collective-action attestation and the
+membership check; managed swarm orchestration is out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Verifiable Credentials, multi-party attestation, and this project's own physical-quorum work
+each exist as prior art. This disclosure does **not** claim those in the abstract. What is
+differentiated is the reduction to a multi-robot collective action:
+
+- **A collective physical action bound to its participating members**, distinct from an
+  M-of-N approval of a single action.
+- **Participants confirmed as admitted members of the same swarm**, so an action cannot name
+  a non-member.
+- **A single coordinator authority** signing both the memberships and the action, so the
+  group and the action share one accountable source.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_collective_action` and `verify_collective_action`,
+which reconciles the participants against coordinator-signed memberships, using the shared
+Data Integrity primitives so the same attestation verifies across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for attributing a multi-robot collective action in which a coordinator signs an
+   attestation naming the swarm, the action, and the participating members.
+2. The method of claim 1 wherein each participant is confirmed to hold a swarm membership
+   signed by the same coordinator for the same swarm.
+3. The method of claim 2 wherein verification returns the participants that lack a valid
+   membership.
+4. The method of claim 1 wherein the memberships and the action are signed by one
+   coordinator, so the group and the action share one accountable authority.
+5. The method of claim 1 wherein the credentials use canonicalization and signature
+   primitives shared across language SDKs, so the same attestation verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-101-human-handover-envelope.md
+++ b/docs/disclosures/PAD-101-human-handover-envelope.md
@@ -1,0 +1,111 @@
+# PAD-101: Robot-to-Human Handover Credential With a Safety-Envelope Attestation at the Release
+
+**Identifier:** PAD-101  
+**Title:** Method for a Robot-Signed Handover Credential That Records the Force and Speed at the Moment It Released an Object to a Person and Whether They Stayed Inside the Near-Human Safety Envelope  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Physical Safety / Human-Robot Interaction  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-066 (Physical Capability Scope), PAD-083 (Physical Custody Handoff Chain), PAD-102 (Handover Acknowledgement)  
+
+---
+
+## 1. Abstract
+
+A method for making a robot's physical handover of an object to a person accountable at the
+point of release, which is the moment a human hand is inside the robot's working envelope.
+A human handover credential records that a robot released an object to a recipient, the
+force and speed of the robot at the moment of release, and whether those stayed inside the
+near-human safety envelope, signed by the robot. A handover injury then traces to whether
+the robot was inside its safety envelope at the release, rather than to an unsigned log.
+
+Key innovations:
+
+- **The release itself as the accountable event.** Where a custody chain covers a task
+  passing between actors, this covers the physical safety of the release, when the risk to a
+  person is highest.
+- **Force and speed attested at the handover moment.** The credential records the robot's
+  force and speed at release, so the physical conditions of the handover are verifiable.
+- **In-envelope verdict against the near-human safety scope.** Whether the release stayed
+  inside the near-human force and speed limits is computed and carried, and reproduced on
+  verification, so a claimed safe handover is confirmable.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 The release is the highest-risk moment and has no signed record
+
+A robot handing an object to a person puts a human hand inside its envelope at the instant
+of release. There is no signed record of the force and speed at that instant, so a handover
+injury cannot be tied to whether the robot was operating safely.
+
+### 2.2 A custody record does not cover physical release safety
+
+A custody handoff records that responsibility for a task passed between actors, but it says
+nothing about the physical safety of the release to a human.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_human_handover(...)` issues a `HumanHandoverCredential` whose subject carries the
+robot identifier, the recipient, the object identifier, and the force and speed at the
+handover, signed eddsa-jcs-2022 by the robot. When the near-human safety scope is supplied,
+whether the force and speed stayed inside it is computed and carried as an in-envelope
+verdict. `verify_human_handover(...)` checks the robot's proof and, when the scope is
+supplied, that recomputing the near-human envelope check over the attested force and speed
+reproduces the attested verdict, so a claimed safe handover cannot be signed when the
+attested conditions were unsafe. Because the credential uses the shared JCS plus
+eddsa-jcs-2022 primitives, the same handover verifies across the language SDKs. This is the
+open layer of the signed handover with its envelope attestation and check; hardware-sensed
+grip-release safety confirmation is out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Verifiable Credentials, collaborative-robot safety limits, and this project's own custody
+handoff and capability scope each exist as prior art. This disclosure does **not** claim
+those in the abstract. What is differentiated is the reduction to a robot-to-human release:
+
+- **The physical release to a person as the accountable event**, distinct from a
+  machine-to-machine custody transfer.
+- **Force and speed attested at the handover moment**, with an in-envelope verdict against
+  the near-human safety scope.
+- **Verification that reproduces the in-envelope verdict**, so a claimed safe handover is
+  confirmable from the attested conditions.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_human_handover` and `verify_human_handover`,
+using the shared Data Integrity primitives and the near-human safety-scope check so the same
+handover verifies across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for a robot-to-human handover in which the robot signs a credential recording
+   the object released, the recipient, and the force and speed at the moment of release.
+2. The method of claim 1 wherein an in-envelope verdict against a near-human safety scope is
+   computed from the attested force and speed and carried in the credential.
+3. The method of claim 2 wherein verification reproduces the in-envelope verdict, so a
+   claimed safe handover cannot be signed when the attested conditions were unsafe.
+4. The method of claim 1 wherein the subject of the handover is the physical release to a
+   person, distinct from a custody transfer between actors.
+5. The method of claim 1 wherein the credential uses canonicalization and signature
+   primitives shared across language SDKs, so the same handover verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/PAD-102-handover-acknowledgement.md
+++ b/docs/disclosures/PAD-102-handover-acknowledgement.md
@@ -1,0 +1,109 @@
+# PAD-102: Recipient Acknowledgement Bound to a Specific Robot-to-Human Handover
+
+**Identifier:** PAD-102  
+**Title:** Method for a Recipient-Signed Acknowledgement Bound to One Handover by Its Proof Value, So Receipt Is Mutual and Cannot Be Reused  
+**Publication Date:** July 6, 2026  
+**Prior Art Effective Date:** July 6, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Physical Safety / Human-Robot Interaction  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-094 (Capture-Bound Bystander Consent Token), PAD-101 (Human-Handover Credential)  
+
+---
+
+## 1. Abstract
+
+A method for making a robot-to-human handover mutual by letting the recipient sign an
+acknowledgement bound to that one handover. The recipient signs an acknowledgement that
+references the handover by its proof value, so the acknowledgement verifies only against the
+handover it was given for and cannot be reused for another. The robot's signed handover and
+the recipient's signed acknowledgement together are a two-sided, non-repudiable record that
+a specific object passed from the robot to the person.
+
+Key innovations:
+
+- **Receipt bound to one handover by its proof value.** The acknowledgement references the
+  specific handover credential, so it is meaningful only for that release and cannot be
+  replayed against a different one.
+- **A two-sided handover record.** The robot signs the release and the recipient signs the
+  receipt, so the transfer to a person is confirmed by both parties rather than asserted by
+  one.
+- **Non-repudiable by construction.** Each side signs under its own identity, so neither the
+  robot's release nor the recipient's receipt can be denied after the fact.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A one-sided handover record can be disputed
+
+A robot's signed handover states that it released an object, but without the recipient's
+confirmation the person can dispute receiving it, and the record is one-sided.
+
+### 2.2 A generic receipt can be reused
+
+A receipt that is not bound to the specific handover could be presented to acknowledge a
+different release, so a receipt must be tied to the one handover it belongs to.
+
+---
+
+## 3. Solution (The Invention)
+
+`build_handover_ack(...)` issues a `HandoverAcknowledgement` whose subject carries the
+recipient identifier, a reference to the handover by its proof value, and the object
+identifier, signed eddsa-jcs-2022 by the recipient. `verify_handover_ack(...)` checks the
+recipient's proof, that the issuer is the recipient, and that the acknowledgement is bound to
+the given handover by its proof value, so a receipt verifies only against the handover it was
+given for. Combined with the robot-signed handover of PAD-101, the pair is a two-sided,
+non-repudiable record of the transfer. Because the credentials use the shared JCS plus
+eddsa-jcs-2022 primitives, the same pair verifies across the language SDKs. This is the open
+layer of the recipient-bound acknowledgement; any hardware-sensed confirmation of the
+physical release is out of scope.
+
+---
+
+## 4. Prior Art Differentiation
+
+Verifiable Credentials, delivery receipts, and nonce binding each exist as prior art, as
+does this project's own capture-bound consent token. This disclosure does **not** claim those
+in the abstract. What is differentiated is the reduction to a robot-to-human handover:
+
+- **A recipient receipt bound to one handover by its proof value**, so it cannot be reused
+  for another release.
+- **A two-sided record** in which the robot signs the release and the recipient signs the
+  receipt.
+- **Non-repudiation on both sides**, each signing under its own identity.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `build_handover_ack` and `verify_handover_ack`, which
+bind and check an acknowledgement against a specific handover's proof value, using the shared
+Data Integrity primitives so the same pair verifies across the language SDKs.
+
+---
+
+## 6. Claims Summary
+
+1. A method for acknowledging a robot-to-human handover in which the recipient signs an
+   acknowledgement referencing the handover by its proof value.
+2. The method of claim 1 wherein verification accepts the acknowledgement only against the
+   handover whose proof value it references, so a receipt cannot be reused for another
+   release.
+3. The method of claim 1 wherein the robot-signed handover and the recipient-signed
+   acknowledgement together form a two-sided record of the transfer.
+4. The method of claim 3 wherein each side signs under its own identity, so neither the
+   release nor the receipt can be repudiated.
+5. The method of claim 1 wherein the credentials use canonicalization and signature
+   primitives shared across language SDKs, so the same pair verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented, to
+prevent patenting by any party and to keep them available to the open Vouch Protocol
+ecosystem and the robotics community.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -102,6 +102,26 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-092](./PAD-092-wear-driven-capability-attenuation.md) | Wear-Driven Automatic Attenuation of a Robot's Physical Capability Scope | 2026-07-05 | Published |
 | [PAD-093](./PAD-093-bystander-consent-evidence.md) | Privacy-Preserving Bystander-Consent Evidence for Robot Capture | 2026-07-06 | Published |
 | [PAD-094](./PAD-094-capture-bound-consent-token.md) | Capture-Bound Bystander Consent Token That Cannot Be Replayed | 2026-07-06 | Published |
+| [PAD-095](./PAD-095-control-authority-handoff-chain.md) | Accountable Control-Authority Handoff Chain Between Autonomy and Human Teleoperators | 2026-07-06 | Published |
+| [PAD-096](./PAD-096-control-continuity-gap-overlap.md) | Detecting an Unattributed-Control Gap or a Dual-Control Overlap in a Robot's Control Timeline | 2026-07-06 | Published |
+| [PAD-097](./PAD-097-operating-domain-conformance.md) | Operator-Certified Operating Domain and Robot-Attested In-Domain Conformance | 2026-07-06 | Published |
+| [PAD-098](./PAD-098-in-domain-predicate.md) | Deterministic Multi-Dimensional In-Domain Check for a Robot's Operating Parameters | 2026-07-06 | Published |
+| [PAD-099](./PAD-099-verifiable-swarm-membership.md) | Verifiable Swarm Membership for a Multi-Robot Group | 2026-07-06 | Published |
+| [PAD-100](./PAD-100-collective-action-attribution.md) | Attribution of a Multi-Robot Collective Action to Its Participating Members | 2026-07-06 | Published |
+| [PAD-101](./PAD-101-human-handover-envelope.md) | Robot-to-Human Handover Credential With a Safety-Envelope Attestation at the Release | 2026-07-06 | Published |
+| [PAD-102](./PAD-102-handover-acknowledgement.md) | Recipient Acknowledgement Bound to a Specific Robot-to-Human Handover | 2026-07-06 | Published |
+
+
+## July 6, 2026: Robotics Forward-Looking, Second Wave (PAD-095 to PAD-102)
+
+Four capabilities extend accountability to how robots are controlled, where they operate,
+how they act as a group, and how they hand objects to people. PAD-095 and PAD-096 make the
+transfer of control between autonomy and human teleoperators accountable, with a continuity
+check that catches a moment with no controller or two. PAD-097 and PAD-098 bind a robot to
+its certified operating domain and check, deterministically, whether it stayed inside it.
+PAD-099 and PAD-100 make swarm membership verifiable and attribute a collective action to its
+admitted members. PAD-101 and PAD-102 record a robot-to-human handover with the safety
+envelope at the release and a recipient receipt bound to that one handover.
 
 
 ## July 6, 2026: Bystander Consent for Robot Capture (PAD-093, PAD-094)

--- a/tests/test_robot_handover.py
+++ b/tests/test_robot_handover.py
@@ -1,0 +1,118 @@
+"""Tests for safe robot-to-human handover."""
+
+import unittest
+from datetime import datetime, timezone
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    build_handover_ack,
+    build_human_handover,
+    verify_handover_ack,
+    verify_human_handover,
+)
+
+T0 = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+SCOPE = {"maxForceN": 40.0, "maxSpeedNearHumansMps": 0.25}
+ROBOT = "did:web:robot-a.example.com"
+
+
+def _party(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestHumanHandover(unittest.TestCase):
+    def setUp(self):
+        self.robot_kp, self.robot = _party("robot-a.example.com")
+
+    def test_in_envelope_handover_verifies(self):
+        h = build_human_handover(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            recipient="did:web:person-1.example.com",
+            object_id="tote-7",
+            force_n=18.0,
+            speed_mps=0.15,
+            scope=SCOPE,
+            handover_at=T0,
+        )
+        ok, subject = verify_human_handover(h, self.robot_kp.public_key_jwk, scope=SCOPE)
+        self.assertTrue(ok)
+        self.assertTrue(subject["inEnvelope"])
+
+    def test_out_of_envelope_is_honest(self):
+        h = build_human_handover(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            recipient="did:web:person-1.example.com",
+            object_id="tote-7",
+            force_n=90.0,
+            speed_mps=0.9,
+            scope=SCOPE,
+            handover_at=T0,
+        )
+        ok, subject = verify_human_handover(h, self.robot_kp.public_key_jwk, scope=SCOPE)
+        self.assertTrue(ok)
+        self.assertFalse(subject["inEnvelope"])
+
+    def test_forged_in_envelope_verdict_rejected(self):
+        h = build_human_handover(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            recipient="did:web:person-1.example.com",
+            object_id="tote-7",
+            force_n=90.0,
+            speed_mps=0.9,
+            scope=SCOPE,
+            handover_at=T0,
+        )
+        h["credentialSubject"]["inEnvelope"] = True
+        ok, _ = verify_human_handover(h, self.robot_kp.public_key_jwk, scope=SCOPE)
+        self.assertFalse(ok)
+
+
+class TestHandoverAck(unittest.TestCase):
+    def setUp(self):
+        self.robot_kp, self.robot = _party("robot-a.example.com")
+        self.person_kp, self.person = _party("person-1.example.com")
+        self.handover = build_human_handover(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            recipient=self.person_kp.did,
+            object_id="tote-7",
+            force_n=18.0,
+            speed_mps=0.15,
+            scope=SCOPE,
+            handover_at=T0,
+        )
+
+    def test_ack_binds_to_handover(self):
+        ack = build_handover_ack(
+            self.person, recipient_did=self.person_kp.did, handover=self.handover
+        )
+        ok, subject = verify_handover_ack(
+            ack, self.person_kp.public_key_jwk, handover=self.handover
+        )
+        self.assertTrue(ok)
+        self.assertEqual(subject["objectId"], "tote-7")
+
+    def test_ack_does_not_verify_against_other_handover(self):
+        other = build_human_handover(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            recipient=self.person_kp.did,
+            object_id="tote-9",
+            force_n=10.0,
+            speed_mps=0.1,
+            scope=SCOPE,
+            handover_at=T0,
+        )
+        ack = build_handover_ack(
+            self.person, recipient_did=self.person_kp.did, handover=self.handover
+        )
+        ok, _ = verify_handover_ack(ack, self.person_kp.public_key_jwk, handover=other)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_odd.py
+++ b/tests/test_robot_odd.py
@@ -1,0 +1,128 @@
+"""Tests for operating-domain (ODD) conformance."""
+
+import unittest
+from datetime import datetime, timezone
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    build_odd_conformance,
+    build_odd_credential,
+    check_in_domain,
+    verify_odd_conformance,
+    verify_odd_credential,
+)
+
+T0 = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+DOMAIN = {
+    "allowedZones": ["yard-north", "yard-south"],
+    "maxSpeedMps": 3.0,
+    "conditions": {"maxWindMps": 12.0, "minVisibilityM": 50.0},
+    "timeWindows": [{"start": "06:00", "end": "20:00"}],
+}
+
+
+def _party(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestODDCredential(unittest.TestCase):
+    def test_credential_round_trips(self):
+        op_kp, operator = _party("facility-ops.example.com")
+        robot_kp, _ = _party("robot-a.example.com")
+        cred = build_odd_credential(
+            operator,
+            robot_did=robot_kp.did,
+            allowed_zones=DOMAIN["allowedZones"],
+            max_speed_mps=DOMAIN["maxSpeedMps"],
+            conditions=DOMAIN["conditions"],
+            time_windows=DOMAIN["timeWindows"],
+            valid_from=T0,
+        )
+        ok, domain = verify_odd_credential(cred, op_kp.public_key_jwk)
+        self.assertTrue(ok)
+        self.assertEqual(domain["maxSpeedMps"], 3.0)
+
+
+class TestInDomainCheck(unittest.TestCase):
+    def test_in_domain(self):
+        observed = {
+            "maxSpeedMps": 2.4,
+            "zones": ["yard-north"],
+            "conditions": {"maxWindMps": 8.0, "minVisibilityM": 120.0},
+            "timeHm": "10:30",
+        }
+        self.assertTrue(check_in_domain(DOMAIN, observed).ok)
+
+    def test_speed_out_of_domain(self):
+        res = check_in_domain(DOMAIN, {"maxSpeedMps": 4.5})
+        self.assertFalse(res.ok)
+        self.assertTrue(any("speed_out_of_domain" in r for r in res.reasons))
+
+    def test_zone_out_of_domain(self):
+        res = check_in_domain(DOMAIN, {"zones": ["yard-north", "street"]})
+        self.assertFalse(res.ok)
+        self.assertTrue(any("zone_out_of_domain" in r for r in res.reasons))
+
+    def test_condition_out_of_domain(self):
+        res = check_in_domain(DOMAIN, {"conditions": {"maxWindMps": 20.0, "minVisibilityM": 10.0}})
+        self.assertFalse(res.ok)
+        self.assertEqual(len(res.reasons), 2)
+
+    def test_time_out_of_domain(self):
+        res = check_in_domain(DOMAIN, {"timeHm": "23:00"})
+        self.assertFalse(res.ok)
+        self.assertTrue(any("time_out_of_domain" in r for r in res.reasons))
+
+
+class TestConformanceAttestation(unittest.TestCase):
+    def setUp(self):
+        self.robot_kp, self.robot = _party("robot-a.example.com")
+
+    def test_in_domain_attestation_verifies(self):
+        observed = {"maxSpeedMps": 2.0, "zones": ["yard-south"], "timeHm": "09:00"}
+        att = build_odd_conformance(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            domain=DOMAIN,
+            observed=observed,
+            interval_index=0,
+            attested_at=T0,
+        )
+        ok, subject = verify_odd_conformance(att, self.robot_kp.public_key_jwk, domain=DOMAIN)
+        self.assertTrue(ok)
+        self.assertTrue(subject["inDomain"])
+
+    def test_out_of_domain_attestation_is_honest(self):
+        observed = {"maxSpeedMps": 5.0, "zones": ["street"], "timeHm": "23:30"}
+        att = build_odd_conformance(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            domain=DOMAIN,
+            observed=observed,
+            interval_index=1,
+            attested_at=T0,
+        )
+        ok, subject = verify_odd_conformance(att, self.robot_kp.public_key_jwk, domain=DOMAIN)
+        self.assertTrue(ok)
+        self.assertFalse(subject["inDomain"])
+
+    def test_forged_in_domain_verdict_rejected(self):
+        observed = {"maxSpeedMps": 5.0, "zones": ["street"]}
+        att = build_odd_conformance(
+            self.robot,
+            robot_did=self.robot_kp.did,
+            domain=DOMAIN,
+            observed=observed,
+            interval_index=2,
+            attested_at=T0,
+        )
+        # Tamper the verdict to claim in-domain despite out-of-domain observations.
+        att["credentialSubject"]["inDomain"] = True
+        ok, _ = verify_odd_conformance(att, self.robot_kp.public_key_jwk, domain=DOMAIN)
+        self.assertFalse(ok)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_swarm.py
+++ b/tests/test_robot_swarm.py
@@ -1,0 +1,103 @@
+"""Tests for multi-robot swarm accountability."""
+
+import unittest
+from datetime import datetime, timezone
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    build_collective_action,
+    build_swarm_membership,
+    verify_collective_action,
+    verify_swarm_membership,
+)
+
+T0 = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+SWARM = "swarm-42"
+
+
+def _party(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestSwarmMembership(unittest.TestCase):
+    def setUp(self):
+        self.coord_kp, self.coordinator = _party("coordinator.example.com")
+        self.robot_kp, _ = _party("robot-a.example.com")
+
+    def test_membership_verifies(self):
+        m = build_swarm_membership(
+            self.coordinator,
+            swarm_id=SWARM,
+            robot_did=self.robot_kp.did,
+            role="picker",
+            valid_from=T0,
+        )
+        ok, subject = verify_swarm_membership(m, self.coord_kp.public_key_jwk, swarm_id=SWARM)
+        self.assertTrue(ok)
+        self.assertEqual(subject["role"], "picker")
+
+    def test_membership_for_other_swarm_rejected(self):
+        m = build_swarm_membership(
+            self.coordinator, swarm_id=SWARM, robot_did=self.robot_kp.did, valid_from=T0
+        )
+        ok, _ = verify_swarm_membership(m, self.coord_kp.public_key_jwk, swarm_id="swarm-99")
+        self.assertFalse(ok)
+
+
+class TestCollectiveAction(unittest.TestCase):
+    def setUp(self):
+        self.coord_kp, self.coordinator = _party("coordinator.example.com")
+        self.a_kp, _ = _party("robot-a.example.com")
+        self.b_kp, _ = _party("robot-b.example.com")
+        self.members = {
+            self.a_kp.did: self.a_kp.public_key_jwk,
+            self.b_kp.did: self.b_kp.public_key_jwk,
+        }
+        self.memberships = [
+            build_swarm_membership(
+                self.coordinator, swarm_id=SWARM, robot_did=self.a_kp.did, valid_from=T0
+            ),
+            build_swarm_membership(
+                self.coordinator, swarm_id=SWARM, robot_did=self.b_kp.did, valid_from=T0
+            ),
+        ]
+
+    def _action(self, participants):
+        return build_collective_action(
+            self.coordinator,
+            swarm_id=SWARM,
+            action="lift-beam",
+            participants=participants,
+            action_at=T0,
+        )
+
+    def test_action_verifies_with_members(self):
+        act = self._action([self.a_kp.did, self.b_kp.did])
+        ok, unverified = verify_collective_action(
+            act,
+            self.coord_kp.public_key_jwk,
+            memberships=self.memberships,
+        )
+        self.assertTrue(ok)
+        self.assertEqual(unverified, [])
+
+    def test_action_verifies_without_member_check(self):
+        act = self._action([self.a_kp.did])
+        ok, _ = verify_collective_action(act, self.coord_kp.public_key_jwk)
+        self.assertTrue(ok)
+
+    def test_non_member_participant_flagged(self):
+        stranger = "did:web:robot-z.example.com"
+        act = self._action([self.a_kp.did, stranger])
+        ok, unverified = verify_collective_action(
+            act,
+            self.coord_kp.public_key_jwk,
+            memberships=self.memberships,
+        )
+        self.assertFalse(ok)
+        self.assertEqual(unverified, [stranger])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_robot_teleop.py
+++ b/tests/test_robot_teleop.py
@@ -1,0 +1,180 @@
+"""Tests for accountable teleoperation handoff."""
+
+import unittest
+from datetime import datetime, timezone
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    build_control_handoff,
+    check_control_continuity,
+    controller_at,
+    verify_control_chain,
+    verify_control_handoff,
+)
+from vouch.robotics.identity import RoboticsError
+
+T0 = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+T1 = datetime(2026, 1, 1, 0, 10, 0, tzinfo=timezone.utc)
+MID = datetime(2026, 1, 1, 0, 5, 0, tzinfo=timezone.utc)
+AFTER = datetime(2026, 1, 1, 0, 20, 0, tzinfo=timezone.utc)
+
+ROBOT = "did:web:robot-a.example.com"
+AUTONOMY = "did:web:autopilot.example.com"
+OPERATOR = "did:web:operator-jane.example.com"
+
+
+def _party(domain):
+    kp = generate_identity(domain=domain)
+    return kp, Signer(private_key=kp.private_key_jwk, did=kp.did)
+
+
+class TestControlHandoff(unittest.TestCase):
+    def setUp(self):
+        self.op_kp, self.operator = _party("operator-jane.example.com")
+
+    def test_handoff_verifies(self):
+        h = build_control_handoff(
+            self.operator,
+            robot_did=ROBOT,
+            from_controller=AUTONOMY,
+            to_controller=self.op_kp.did,
+            mode="teleoperated",
+            handoff_at=T0,
+        )
+        ok, subject = verify_control_handoff(h, self.op_kp.public_key_jwk)
+        self.assertTrue(ok)
+        self.assertEqual(subject["mode"], "teleoperated")
+
+    def test_unknown_mode_rejected_at_build(self):
+        with self.assertRaises(RoboticsError):
+            build_control_handoff(
+                self.operator,
+                robot_did=ROBOT,
+                from_controller=AUTONOMY,
+                to_controller=self.op_kp.did,
+                mode="hovering",
+                handoff_at=T0,
+            )
+
+    def test_issuer_must_be_receiver(self):
+        h = build_control_handoff(
+            self.operator,
+            robot_did=ROBOT,
+            from_controller=AUTONOMY,
+            to_controller=self.op_kp.did,
+            mode="teleoperated",
+            handoff_at=T0,
+        )
+        h["issuer"] = AUTONOMY
+        ok, _ = verify_control_handoff(h, self.op_kp.public_key_jwk)
+        self.assertFalse(ok)
+
+
+class TestControlChain(unittest.TestCase):
+    def setUp(self):
+        self.auto_kp, self.autonomy = _party("autopilot.example.com")
+        self.op_kp, self.operator = _party("operator-jane.example.com")
+        self.auto_did = self.auto_kp.did
+        self.op_did = self.op_kp.did
+        # autonomy -> operator (takeover) at T0, operator -> autonomy (return) at T1
+        self.h1 = build_control_handoff(
+            self.operator,
+            robot_did=ROBOT,
+            from_controller=self.auto_did,
+            to_controller=self.op_did,
+            mode="teleoperated",
+            handoff_at=T0,
+        )
+        self.h2 = build_control_handoff(
+            self.autonomy,
+            robot_did=ROBOT,
+            from_controller=self.op_did,
+            to_controller=self.auto_did,
+            mode="autonomous",
+            handoff_at=T1,
+        )
+        self.keys = {
+            self.op_did: self.op_kp.public_key_jwk,
+            self.auto_did: self.auto_kp.public_key_jwk,
+        }
+
+    def test_chain_verifies_and_returns_current(self):
+        ok, current = verify_control_chain(
+            [self.h1, self.h2], self.keys, origin_controller=self.auto_did
+        )
+        self.assertTrue(ok)
+        self.assertEqual(current, self.auto_did)
+
+    def test_broken_link_rejected(self):
+        stranger = "did:web:someone-else.example.com"
+        bad = build_control_handoff(
+            self.autonomy,
+            robot_did=ROBOT,
+            from_controller=stranger,
+            to_controller=self.auto_did,
+            mode="autonomous",
+            handoff_at=T1,
+        )
+        ok, _ = verify_control_chain([self.h1, bad], self.keys)
+        self.assertFalse(ok)
+
+    def test_controller_at_time(self):
+        self.assertEqual(controller_at([self.h1, self.h2], "2026-01-01T00:05:00Z"), self.op_did)
+        self.assertEqual(controller_at([self.h1, self.h2], "2026-01-01T00:20:00Z"), self.auto_did)
+        self.assertIsNone(controller_at([self.h1, self.h2], "2025-12-31T23:59:00Z"))
+
+
+class TestControlContinuity(unittest.TestCase):
+    def test_continuous_chain_ok(self):
+        _, autonomy = _party("autopilot.example.com")
+        _, operator = _party("operator-jane.example.com")
+        h1 = build_control_handoff(
+            operator,
+            robot_did=ROBOT,
+            from_controller=AUTONOMY,
+            to_controller=OPERATOR,
+            mode="teleoperated",
+            handoff_at=T0,
+        )
+        h2 = build_control_handoff(
+            autonomy,
+            robot_did=ROBOT,
+            from_controller=OPERATOR,
+            to_controller=AUTONOMY,
+            mode="autonomous",
+            handoff_at=T1,
+        )
+        result = check_control_continuity([h1, h2])
+        self.assertTrue(result.ok)
+        self.assertEqual(result.gaps, [])
+        self.assertEqual(result.overlaps, [])
+
+    def test_discontinuity_flagged(self):
+        _, autonomy = _party("autopilot.example.com")
+        _, operator = _party("operator-jane.example.com")
+        h1 = build_control_handoff(
+            operator,
+            robot_did=ROBOT,
+            from_controller=AUTONOMY,
+            to_controller=OPERATOR,
+            mode="teleoperated",
+            handoff_at=T0,
+        )
+        # The second link does not begin where the first left off (claims control
+        # from autonomy while the operator still held it): a gap and an overlap.
+        h2 = build_control_handoff(
+            autonomy,
+            robot_did=ROBOT,
+            from_controller=AUTONOMY,
+            to_controller=AUTONOMY,
+            mode="autonomous",
+            handoff_at=T1,
+        )
+        result = check_control_continuity([h1, h2])
+        self.assertFalse(result.ok)
+        self.assertEqual(result.gaps[0]["expected"], OPERATOR)
+        self.assertEqual(result.overlaps[0]["found"], AUTONOMY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vouch/robotics/__init__.py
+++ b/vouch/robotics/__init__.py
@@ -25,6 +25,10 @@ robots and embodied agents:
   - fusion: signed provenance binding a fused world model to its input frames.
   - wear: signed wear and degradation attestation with capability auto-attenuation.
   - consent: bystander-consent evidence binding a consent basis to a robot capture.
+  - teleop: accountable teleoperation handoff, who or what was in control of a robot.
+  - odd: operating-domain conformance, a robot attests it stayed in its certified domain.
+  - swarm: multi-robot swarm membership and collective-action attribution.
+  - handover: safe robot-to-human handover with an envelope attestation and receipt.
 """
 
 from .capability import (
@@ -181,6 +185,42 @@ from .consent import (
     verify_consent_evidence,
     verify_consent_token,
 )
+from .teleop import (
+    CONTROL_HANDOFF_TYPE,
+    CONTROL_MODES,
+    ControlContinuity,
+    build_control_handoff,
+    check_control_continuity,
+    controller_at,
+    verify_control_chain,
+    verify_control_handoff,
+)
+from .odd import (
+    ODD_CONFORMANCE_TYPE,
+    OPERATING_DOMAIN_TYPE,
+    ODDResult,
+    build_odd_conformance,
+    build_odd_credential,
+    check_in_domain,
+    verify_odd_conformance,
+    verify_odd_credential,
+)
+from .swarm import (
+    COLLECTIVE_ACTION_TYPE,
+    SWARM_MEMBERSHIP_TYPE,
+    build_collective_action,
+    build_swarm_membership,
+    verify_collective_action,
+    verify_swarm_membership,
+)
+from .handover import (
+    HANDOVER_ACK_TYPE,
+    HUMAN_HANDOVER_TYPE,
+    build_handover_ack,
+    build_human_handover,
+    verify_handover_ack,
+    verify_human_handover,
+)
 
 __all__ = [
     # identity
@@ -307,6 +347,38 @@ __all__ = [
     "verify_consent_token",
     "build_consent_evidence",
     "verify_consent_evidence",
+    # teleoperation handoff (who or what controlled a robot, autonomy vs human)
+    "CONTROL_HANDOFF_TYPE",
+    "CONTROL_MODES",
+    "ControlContinuity",
+    "build_control_handoff",
+    "verify_control_handoff",
+    "verify_control_chain",
+    "controller_at",
+    "check_control_continuity",
+    # operating-domain conformance (robot attests it stayed in its certified ODD)
+    "OPERATING_DOMAIN_TYPE",
+    "ODD_CONFORMANCE_TYPE",
+    "ODDResult",
+    "build_odd_credential",
+    "verify_odd_credential",
+    "check_in_domain",
+    "build_odd_conformance",
+    "verify_odd_conformance",
+    # swarm accountability (membership + collective-action attribution)
+    "SWARM_MEMBERSHIP_TYPE",
+    "COLLECTIVE_ACTION_TYPE",
+    "build_swarm_membership",
+    "verify_swarm_membership",
+    "build_collective_action",
+    "verify_collective_action",
+    # human handover (robot-to-human release with envelope attestation + receipt)
+    "HUMAN_HANDOVER_TYPE",
+    "HANDOVER_ACK_TYPE",
+    "build_human_handover",
+    "verify_human_handover",
+    "build_handover_ack",
+    "verify_handover_ack",
     # safety record (incident/near-miss ledger + portable record)
     "SafetyEventLog",
     "verify_safety_log",

--- a/vouch/robotics/handover.py
+++ b/vouch/robotics/handover.py
@@ -1,0 +1,194 @@
+"""
+Safe robot-to-human handover.
+
+A robot handing a physical object to a person is one of the most safety-sensitive
+things it does, because a human hand is inside the robot's working envelope at the
+moment of release. Custody handoff covers a task passing between actors; this covers
+the physical safety of the release itself. A human handover credential records that
+a robot released an object to a recipient, with the force and speed of the robot at
+the moment of handover and whether those stayed inside the near-human safety
+envelope, signed by the robot. The recipient can sign an acknowledgement bound to
+that one handover, so receipt is mutual and non-repudiable.
+
+This is the open layer: the signed handover credential with its envelope
+attestation, the near-human safety check, and the recipient acknowledgement.
+Hardware-sensed grip-release safety confirmation is out of scope for the open layer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from ._signing import attach_proof
+from .identity import RoboticsError
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+HUMAN_HANDOVER_TYPE = "HumanHandoverCredential"
+HANDOVER_ACK_TYPE = "HandoverAcknowledgement"
+
+
+def _in_envelope(force_n: float, speed_mps: float, scope: Dict[str, Any]) -> bool:
+    """A handover is in envelope if force and near-human speed are within the scope."""
+    if "maxForceN" in scope and force_n > scope["maxForceN"]:
+        return False
+    cap = scope.get("maxSpeedNearHumansMps", scope.get("maxSpeedMps"))
+    if cap is not None and speed_mps > cap:
+        return False
+    return True
+
+
+def build_human_handover(
+    robot_signer: Any,
+    *,
+    robot_did: str,
+    recipient: str,
+    object_id: str,
+    force_n: float,
+    speed_mps: float,
+    scope: Optional[Dict[str, Any]] = None,
+    handover_at: Optional[datetime] = None,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed HumanHandoverCredential: the robot released `object_id` to
+    `recipient` with the given `force_n` and `speed_mps` at the moment of handover.
+    When `scope` is given, whether the handover stayed inside the near-human safety
+    envelope is computed and carried. Signed by the robot.
+    """
+    if not robot_did or not recipient or not object_id:
+        raise RoboticsError("robot_did, recipient, and object_id are required")
+    issued = (handover_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "recipient": recipient,
+        "objectId": object_id,
+        "envelope": {"forceN": force_n, "speedMps": speed_mps},
+    }
+    if scope is not None:
+        subject["inEnvelope"] = _in_envelope(force_n, speed_mps, scope)
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", HUMAN_HANDOVER_TYPE],
+        "issuer": robot_did,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, robot_signer)
+
+
+def verify_human_handover(
+    credential: Dict[str, Any],
+    robot_public_key: Any,
+    *,
+    scope: Optional[Dict[str, Any]] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a HumanHandoverCredential: the robot's proof and, when `scope` is given,
+    that recomputing the near-human envelope check over the attested force and speed
+    reproduces the attested `inEnvelope` verdict. Returns (ok, subject).
+    """
+    ok, subject = _verify_typed(credential, robot_public_key, HUMAN_HANDOVER_TYPE)
+    if not ok:
+        return False, None
+    if credential.get("issuer") != subject.get("id"):
+        return False, None
+    env = subject.get("envelope") or {}
+    if "forceN" not in env or "speedMps" not in env:
+        return False, None
+    if scope is not None and "inEnvelope" in subject:
+        recomputed = _in_envelope(env["forceN"], env["speedMps"], scope)
+        if recomputed != bool(subject.get("inEnvelope")):
+            return False, None
+    return True, subject
+
+
+def build_handover_ack(
+    recipient_signer: Any,
+    *,
+    recipient_did: str,
+    handover: Dict[str, Any],
+    acknowledged_at: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed HandoverAcknowledgement: the recipient confirms receiving the
+    object of a specific handover, bound to that handover by its proof value so the
+    acknowledgement cannot be reused for another. Signed by the recipient.
+    """
+    ref = (handover.get("proof") or {}).get("proofValue")
+    if not recipient_did or not ref:
+        raise RoboticsError("recipient_did and a signed handover are required")
+    subject_id = (handover.get("credentialSubject") or {}).get("objectId")
+    issued = (acknowledged_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", HANDOVER_ACK_TYPE],
+        "issuer": recipient_did,
+        "validFrom": _iso(issued),
+        "credentialSubject": {"id": recipient_did, "handoverRef": ref, "objectId": subject_id},
+    }
+    return attach_proof(credential, recipient_signer)
+
+
+def verify_handover_ack(
+    ack: Dict[str, Any],
+    recipient_public_key: Any,
+    *,
+    handover: Dict[str, Any],
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a HandoverAcknowledgement: the recipient's proof, that the issuer is the
+    recipient, and that it is bound to the given handover by its proof value. Returns
+    (ok, subject).
+    """
+    ok, subject = _verify_typed(ack, recipient_public_key, HANDOVER_ACK_TYPE)
+    if not ok:
+        return False, None
+    if ack.get("issuer") != subject.get("id"):
+        return False, None
+    ref = (handover.get("proof") or {}).get("proofValue")
+    if not ref or subject.get("handoverRef") != ref:
+        return False, None
+    return True, subject
+
+
+def _verify_typed(
+    credential: Dict[str, Any],
+    public_key: Any,
+    expected_type: str,
+) -> "tuple[bool, Dict[str, Any]]":
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if expected_type not in type_field:
+        return False, {}
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, {}
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, {}
+    except ValueError:
+        return False, {}
+    return True, credential.get("credentialSubject") or {}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "HUMAN_HANDOVER_TYPE",
+    "HANDOVER_ACK_TYPE",
+    "build_human_handover",
+    "verify_human_handover",
+    "build_handover_ack",
+    "verify_handover_ack",
+]

--- a/vouch/robotics/odd.py
+++ b/vouch/robotics/odd.py
@@ -1,0 +1,241 @@
+"""
+Operating-domain (ODD) conformance for robots.
+
+An autonomous robot is certified to operate inside an operational design domain:
+the zones it may work in, a speed regime, the environmental conditions it is rated
+for, and the hours it may run. Acting outside that domain is where certification
+stops applying and where incidents cluster. This module lets an operator certify a
+robot's operating domain as a signed credential, lets the robot self-sign that it
+stayed inside the domain over an interval, and provides a deterministic check that
+compares observed operating parameters against the certified domain, so operating
+out of domain is detectable and attributable.
+
+An operating-domain credential names the allowed zones, a maximum speed, condition
+bounds (for example a maximum wind speed and a minimum visibility), and the time
+windows the robot is rated for, signed by the operator. An ODD conformance
+attestation reports the parameters the robot observed over an interval and whether
+they stayed inside the domain, signed by the robot.
+
+This is the open layer: the signed domain credential, the conformance attestation,
+and the deterministic in-domain check. Real-time prediction of an imminent
+out-of-domain excursion and automatic safe-stop enforcement are out of scope for
+the open layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from ._signing import attach_proof
+from .identity import RoboticsError
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+OPERATING_DOMAIN_TYPE = "OperatingDomainCredential"
+ODD_CONFORMANCE_TYPE = "ODDConformanceAttestation"
+
+
+@dataclass
+class ODDResult:
+    ok: bool
+    reasons: List[str] = field(default_factory=list)
+
+
+def build_odd_credential(
+    operator_signer: Any,
+    *,
+    robot_did: str,
+    allowed_zones: Optional[List[str]] = None,
+    max_speed_mps: Optional[float] = None,
+    conditions: Optional[Dict[str, float]] = None,
+    time_windows: Optional[List[Dict[str, str]]] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed OperatingDomainCredential: the operator certifies `robot_did` to
+    operate within the given domain. `conditions` carries upper or lower bounds keyed
+    by name (for example maxWindMps or minVisibilityM). Signed by the operator.
+    """
+    if not robot_did:
+        raise RoboticsError("robot_did is required")
+    domain: Dict[str, Any] = {}
+    if allowed_zones is not None:
+        domain["allowedZones"] = list(allowed_zones)
+    if max_speed_mps is not None:
+        domain["maxSpeedMps"] = max_speed_mps
+    if conditions is not None:
+        domain["conditions"] = dict(conditions)
+    if time_windows is not None:
+        domain["timeWindows"] = list(time_windows)
+
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", OPERATING_DOMAIN_TYPE],
+        "issuer": operator_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": {"id": robot_did, "operatingDomain": domain},
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, operator_signer)
+
+
+def verify_odd_credential(
+    credential: Dict[str, Any],
+    operator_public_key: Any,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """Verify an OperatingDomainCredential and return (ok, operatingDomain)."""
+    ok, subject = _verify_typed(credential, operator_public_key, OPERATING_DOMAIN_TYPE)
+    if not ok:
+        return False, None
+    return True, subject.get("operatingDomain") or {}
+
+
+def check_in_domain(domain: Dict[str, Any], observed: Dict[str, Any]) -> ODDResult:
+    """
+    Check observed operating parameters against a certified domain. `observed` may
+    carry maxSpeedMps, zones (a list visited), conditions (observed values keyed by
+    the same names), and timeHm ("HH:MM"). A condition key prefixed max* is an upper
+    bound, min* a lower bound. An absent domain dimension is unconstrained.
+    """
+    reasons: List[str] = []
+
+    if "maxSpeedMps" in domain and observed.get("maxSpeedMps") is not None:
+        if observed["maxSpeedMps"] > domain["maxSpeedMps"]:
+            reasons.append(
+                f"speed_out_of_domain: {observed['maxSpeedMps']} > {domain['maxSpeedMps']}"
+            )
+
+    if "allowedZones" in domain and observed.get("zones") is not None:
+        allowed = set(domain["allowedZones"])
+        outside = [z for z in observed["zones"] if z not in allowed]
+        if outside:
+            reasons.append(f"zone_out_of_domain: {outside}")
+
+    if "conditions" in domain and observed.get("conditions") is not None:
+        for key, bound in domain["conditions"].items():
+            val = observed["conditions"].get(key)
+            if val is None:
+                continue
+            if key.startswith("max") and val > bound:
+                reasons.append(f"condition_out_of_domain: {key} {val} > {bound}")
+            elif key.startswith("min") and val < bound:
+                reasons.append(f"condition_out_of_domain: {key} {val} < {bound}")
+
+    if "timeWindows" in domain and observed.get("timeHm") is not None:
+        windows = domain["timeWindows"]
+        if windows and not any(_in_window(observed["timeHm"], w) for w in windows):
+            reasons.append(f"time_out_of_domain: {observed['timeHm']}")
+
+    return ODDResult(ok=not reasons, reasons=reasons)
+
+
+def build_odd_conformance(
+    robot_signer: Any,
+    *,
+    robot_did: str,
+    domain: Dict[str, Any],
+    observed: Dict[str, Any],
+    interval_index: int,
+    attested_at: Optional[datetime] = None,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed ODDConformanceAttestation: the robot reports the `observed`
+    operating parameters over interval `interval_index` and whether they stayed
+    inside `domain`. The in-domain verdict is computed here and carried in the
+    attestation. Signed by the robot.
+    """
+    if not robot_did:
+        raise RoboticsError("robot_did is required")
+    result = check_in_domain(domain, observed)
+    issued = (attested_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "intervalIndex": interval_index,
+        "observed": dict(observed),
+        "inDomain": result.ok,
+        "reasons": list(result.reasons),
+    }
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", ODD_CONFORMANCE_TYPE],
+        "issuer": robot_did,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, robot_signer)
+
+
+def verify_odd_conformance(
+    credential: Dict[str, Any],
+    robot_public_key: Any,
+    *,
+    domain: Optional[Dict[str, Any]] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify an ODDConformanceAttestation: the robot's proof and, when `domain` is
+    supplied, that recomputing the in-domain check over the attested observations
+    reproduces the attested `inDomain` verdict, so the robot cannot claim it stayed
+    in domain when its own reported observations say otherwise. Returns (ok, subject).
+    """
+    ok, subject = _verify_typed(credential, robot_public_key, ODD_CONFORMANCE_TYPE)
+    if not ok:
+        return False, None
+    if credential.get("issuer") != subject.get("id"):
+        return False, None
+    if domain is not None:
+        recomputed = check_in_domain(domain, subject.get("observed") or {})
+        if recomputed.ok != bool(subject.get("inDomain")):
+            return False, None
+    return True, subject
+
+
+def _in_window(hm: str, window: Dict[str, str]) -> bool:
+    return window.get("start", "00:00") <= hm <= window.get("end", "23:59")
+
+
+def _verify_typed(
+    credential: Dict[str, Any],
+    public_key: Any,
+    expected_type: str,
+) -> "tuple[bool, Dict[str, Any]]":
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if expected_type not in type_field:
+        return False, {}
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, {}
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, {}
+    except ValueError:
+        return False, {}
+    return True, credential.get("credentialSubject") or {}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "OPERATING_DOMAIN_TYPE",
+    "ODD_CONFORMANCE_TYPE",
+    "ODDResult",
+    "build_odd_credential",
+    "verify_odd_credential",
+    "check_in_domain",
+    "build_odd_conformance",
+    "verify_odd_conformance",
+]

--- a/vouch/robotics/swarm.py
+++ b/vouch/robotics/swarm.py
@@ -1,0 +1,201 @@
+"""
+Multi-robot swarm accountability.
+
+Robots increasingly act as a group: a fleet of pickers, a formation of drones, a
+team clearing a site. When the group takes a physical action together, two
+questions follow. Which robots were members of the group with authority to act, and
+which of them took part in a specific collective action. This module answers both
+with signed credentials, so a collective physical action is attributable to the
+members that performed it and the coordinator that authorized the group, rather than
+diffused across an anonymous swarm.
+
+A swarm membership credential records that a coordinator admitted a robot to a
+swarm, optionally with a role, signed by the coordinator. A collective action
+attestation records a physical action taken by the swarm and the members that
+participated, signed by the coordinator, and each participant can be checked against
+its membership so the action ties only to admitted members.
+
+This is the open layer: signed membership and collective-action credentials and
+their verification. Managed swarm orchestration and formation control are out of
+scope for the open layer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from ._signing import attach_proof
+from .identity import RoboticsError
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+SWARM_MEMBERSHIP_TYPE = "SwarmMembershipCredential"
+COLLECTIVE_ACTION_TYPE = "CollectiveActionAttestation"
+
+
+def build_swarm_membership(
+    coordinator_signer: Any,
+    *,
+    swarm_id: str,
+    robot_did: str,
+    role: Optional[str] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed SwarmMembershipCredential: the coordinator admits `robot_did` to
+    `swarm_id`, optionally with a `role`. Signed by the coordinator.
+    """
+    if not swarm_id or not robot_did:
+        raise RoboticsError("swarm_id and robot_did are required")
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {"id": robot_did, "swarmId": swarm_id}
+    if role is not None:
+        subject["role"] = role
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", SWARM_MEMBERSHIP_TYPE],
+        "issuer": coordinator_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, coordinator_signer)
+
+
+def verify_swarm_membership(
+    credential: Dict[str, Any],
+    coordinator_public_key: Any,
+    *,
+    swarm_id: Optional[str] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a SwarmMembershipCredential: the coordinator's proof and, when `swarm_id`
+    is given, that the membership is for that swarm. Returns (ok, subject).
+    """
+    ok, subject = _verify_typed(credential, coordinator_public_key, SWARM_MEMBERSHIP_TYPE)
+    if not ok:
+        return False, None
+    if not subject.get("swarmId") or not subject.get("id"):
+        return False, None
+    if swarm_id is not None and subject.get("swarmId") != swarm_id:
+        return False, None
+    return True, subject
+
+
+def build_collective_action(
+    coordinator_signer: Any,
+    *,
+    swarm_id: str,
+    action: str,
+    participants: List[str],
+    action_at: Optional[datetime] = None,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed CollectiveActionAttestation: the coordinator records that the
+    members in `participants` took `action` together as `swarm_id`. Signed by the
+    coordinator.
+    """
+    if not swarm_id or not action:
+        raise RoboticsError("swarm_id and action are required")
+    if not participants:
+        raise RoboticsError("participants must be a non-empty list")
+    issued = (action_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", COLLECTIVE_ACTION_TYPE],
+        "issuer": coordinator_signer.get_did(),
+        "validFrom": _iso(issued),
+        "credentialSubject": {
+            "swarmId": swarm_id,
+            "action": action,
+            "participants": list(participants),
+        },
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, coordinator_signer)
+
+
+def verify_collective_action(
+    credential: Dict[str, Any],
+    coordinator_public_key: Any,
+    *,
+    memberships: Optional[List[Dict[str, Any]]] = None,
+) -> "tuple[bool, List[str]]":
+    """
+    Verify a CollectiveActionAttestation: the coordinator's proof and, when
+    `memberships` is given, that every participant holds a membership in the same
+    swarm signed by the same coordinator. Memberships are coordinator-signed, so they
+    verify under the same `coordinator_public_key`. Returns (ok, unverified), where
+    `unverified` lists any participant without a valid membership.
+    """
+    ok, subject = _verify_typed(credential, coordinator_public_key, COLLECTIVE_ACTION_TYPE)
+    if not ok:
+        return False, []
+    swarm_id = subject.get("swarmId")
+    participants = subject.get("participants") or []
+    if not swarm_id or not participants:
+        return False, []
+
+    if memberships is None:
+        return True, []
+
+    by_member: Dict[str, Dict[str, Any]] = {}
+    for m in memberships:
+        msub = m.get("credentialSubject") or {}
+        holder = msub.get("id")
+        if isinstance(holder, str):
+            by_member[holder] = m
+
+    unverified: List[str] = []
+    for p in participants:
+        m = by_member.get(p)
+        if m is None:
+            unverified.append(p)
+            continue
+        mok, _ = verify_swarm_membership(m, coordinator_public_key, swarm_id=swarm_id)
+        if not mok:
+            unverified.append(p)
+    return (not unverified), unverified
+
+
+def _verify_typed(
+    credential: Dict[str, Any],
+    public_key: Any,
+    expected_type: str,
+) -> "tuple[bool, Dict[str, Any]]":
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if expected_type not in type_field:
+        return False, {}
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, {}
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, {}
+    except ValueError:
+        return False, {}
+    return True, credential.get("credentialSubject") or {}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "SWARM_MEMBERSHIP_TYPE",
+    "COLLECTIVE_ACTION_TYPE",
+    "build_swarm_membership",
+    "verify_swarm_membership",
+    "build_collective_action",
+    "verify_collective_action",
+]

--- a/vouch/robotics/teleop.py
+++ b/vouch/robotics/teleop.py
@@ -1,0 +1,233 @@
+"""
+Accountable teleoperation handoff: who or what was in control of a robot.
+
+Control of a robot passes back and forth between an autonomous policy and one or
+more human teleoperators: the autonomy drives, a remote operator takes over for a
+hard case, control returns to autonomy. When something goes wrong, the first
+question is who or what was in control at that moment. This module makes each
+transfer of control a signed record, so the answer is verifiable rather than
+asserted by a log.
+
+A control handoff credential records that a receiving controller took control of a
+robot from a releasing controller, tagged with the control mode (autonomous,
+teleoperated, or shared), signed by the receiver, the party taking responsibility.
+Linking each handoff forms a chain a verifier walks to establish who held control,
+and a controller-at-time lookup returns who held it at any moment, so an incident
+traces to the controller in charge then.
+
+This is the open layer: signed handoff credentials, chain verification, a
+controller-at-time helper, and software continuity checking. Latency-bound
+safe-takeover enforcement and biometric operator binding are out of scope for the
+open layer.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from ._signing import attach_proof
+from .identity import RoboticsError
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+CONTROL_HANDOFF_TYPE = "ControlHandoffCredential"
+
+# Control modes a verifier can rely on. Implementers MAY use additional values.
+CONTROL_MODES = frozenset({"autonomous", "teleoperated", "shared"})
+
+
+def build_control_handoff(
+    receiver_signer: Any,
+    *,
+    robot_did: str,
+    from_controller: str,
+    to_controller: str,
+    mode: str,
+    handoff_at: Optional[datetime] = None,
+    valid_seconds: Optional[int] = None,
+) -> Dict[str, Any]:
+    """
+    Build a signed control handoff: the receiving controller `to_controller` takes
+    control of `robot_did` from `from_controller` under `mode`, signed by the
+    receiver (the party taking responsibility). A controller is a Vouch identity
+    that may be an autonomous policy or a human operator.
+    """
+    if not robot_did or not from_controller or not to_controller:
+        raise RoboticsError("robot_did, from_controller, and to_controller are required")
+    if mode not in CONTROL_MODES:
+        raise RoboticsError(f"mode must be one of {sorted(CONTROL_MODES)}, got {mode!r}")
+    issued = (handoff_at or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "fromController": from_controller,
+        "toController": to_controller,
+        "mode": mode,
+    }
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", CONTROL_HANDOFF_TYPE],
+        "issuer": to_controller,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, receiver_signer)
+
+
+def verify_control_handoff(
+    credential: Dict[str, Any],
+    receiver_public_key: Any,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a control handoff: the receiver's proof, that the issuer is the receiving
+    controller, and that the mode is one an interoperable verifier accepts. Returns
+    (ok, subject).
+    """
+    ok, subject = _verify_typed(credential, receiver_public_key, CONTROL_HANDOFF_TYPE)
+    if not ok:
+        return False, None
+    if not subject.get("fromController") or not subject.get("toController"):
+        return False, None
+    if credential.get("issuer") != subject.get("toController"):
+        return False, None
+    if subject.get("mode") not in CONTROL_MODES:
+        return False, None
+    return True, subject
+
+
+def verify_control_chain(
+    handoffs: List[Dict[str, Any]],
+    public_keys: Dict[str, Any],
+    *,
+    origin_controller: Optional[str] = None,
+) -> "tuple[bool, Optional[str]]":
+    """
+    Verify an ordered list of control handoffs forms a valid chain: each handoff
+    verifies under its receiver's key, every link's toController matches the next
+    link's fromController, and (when given) the first fromController is
+    `origin_controller`. `public_keys` maps a controller DID to its key. Returns
+    (ok, current_controller).
+    """
+    expected_from = origin_controller
+    current: Optional[str] = origin_controller
+    for handoff in handoffs:
+        receiver = handoff.get("issuer")
+        if not isinstance(receiver, str) or receiver not in public_keys:
+            return False, None
+        ok, subject = verify_control_handoff(handoff, public_keys[receiver])
+        if not ok or subject is None:
+            return False, None
+        if expected_from is not None and subject.get("fromController") != expected_from:
+            return False, None
+        current = subject.get("toController")
+        expected_from = current
+    return True, current
+
+
+def controller_at(
+    handoffs: List[Dict[str, Any]],
+    at: str,
+) -> Optional[str]:
+    """
+    Return the controller in charge at ISO time `at`: the receiver (toController) of
+    the most recent handoff at or before `at`. Returns None if no handoff had
+    occurred yet. `handoffs` is assumed in chain order.
+    """
+    when = _parse_iso(at)
+    if when is None:
+        return None
+    holder: Optional[str] = None
+    for handoff in handoffs:
+        start = _parse_iso(handoff.get("validFrom"))
+        subject = handoff.get("credentialSubject") or {}
+        if start is not None and start <= when:
+            holder = subject.get("toController")
+    return holder
+
+
+class ControlContinuity:
+    """The outcome of a control-continuity check: ok plus any gaps or overlaps."""
+
+    def __init__(self, ok: bool, gaps: List[Dict[str, str]], overlaps: List[Dict[str, str]]):
+        self.ok = ok
+        self.gaps = gaps
+        self.overlaps = overlaps
+
+    def __repr__(self) -> str:
+        return f"ControlContinuity(ok={self.ok}, gaps={self.gaps}, overlaps={self.overlaps})"
+
+
+def check_control_continuity(handoffs: List[Dict[str, Any]]) -> ControlContinuity:
+    """
+    Confirm the control timeline is continuous and single-held: every handoff after
+    the first begins where the previous one left off (its fromController is the
+    previous toController), so there is no moment with no attributed controller and
+    no moment with two. A link whose fromController is not the previous toController
+    is reported as an overlap (two controllers claim authority across the seam); the
+    same discontinuity leaves the prior controller's authority unaccounted for and
+    is reported as a gap. Returns a ControlContinuity with the offending seams.
+    """
+    gaps: List[Dict[str, str]] = []
+    overlaps: List[Dict[str, str]] = []
+    prev_to: Optional[str] = None
+    for handoff in handoffs:
+        subject = handoff.get("credentialSubject") or {}
+        frm = subject.get("fromController")
+        to = subject.get("toController")
+        if prev_to is not None and frm != prev_to:
+            seam = {"expected": prev_to, "found": frm or ""}
+            gaps.append(seam)
+            overlaps.append(seam)
+        prev_to = to
+    return ControlContinuity(not gaps and not overlaps, gaps, overlaps)
+
+
+def _verify_typed(
+    credential: Dict[str, Any],
+    public_key: Any,
+    expected_type: str,
+) -> "tuple[bool, Dict[str, Any]]":
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if expected_type not in type_field:
+        return False, {}
+    resolved = _coerce_ed25519_public_key(public_key) if public_key is not None else None
+    if resolved is None:
+        return False, {}
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, {}
+    except ValueError:
+        return False, {}
+    return True, credential.get("credentialSubject") or {}
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+__all__ = [
+    "CONTROL_HANDOFF_TYPE",
+    "CONTROL_MODES",
+    "ControlContinuity",
+    "build_control_handoff",
+    "verify_control_handoff",
+    "verify_control_chain",
+    "controller_at",
+    "check_control_continuity",
+]

--- a/website/src/app/demos/robotics/RoboticsDemos.tsx
+++ b/website/src/app/demos/robotics/RoboticsDemos.tsx
@@ -5,14 +5,15 @@ import React, { useState } from 'react';
 import styles from './RoboticsDemos.module.css';
 
 /**
- * Interactive demos for four robotics capabilities: infrastructure access
+ * Interactive demos for eight robotics capabilities: infrastructure access
  * (vouch.robotics.access), fused-sensor provenance (vouch.robotics.fusion), wear
- * and degradation (vouch.robotics.wear), and bystander consent
- * (vouch.robotics.consent). Each mirrors the real credential shapes and the real
- * verification logic, rendered
- * as an on-brand illustration rather than a live signature so it runs with no
- * network call. Burgundy doubles as refuse, a parchment-harmonized green marks
- * allow, and both read on either theme.
+ * and degradation (vouch.robotics.wear), bystander consent (vouch.robotics.consent),
+ * teleoperation handoff (vouch.robotics.teleop), operating-domain conformance
+ * (vouch.robotics.odd), swarm accountability (vouch.robotics.swarm), and safe human
+ * handover (vouch.robotics.handover). Each mirrors the real credential shapes and the
+ * real verification logic, rendered as an on-brand illustration rather than a live
+ * signature so it runs with no network call. Burgundy doubles as refuse, a
+ * parchment-harmonized green marks allow, and both read on either theme.
  */
 
 const ALLOW = '#3f7d55';
@@ -327,6 +328,243 @@ function Consent() {
 }
 
 /* ------------------------------------------------------------------ */
+/* Teleop: who or what was in control, across handoffs.                */
+/* ------------------------------------------------------------------ */
+
+type TeleopScenario = 'takeover' | 'return' | 'gap';
+
+const TELEOP_SCENARIOS: Array<{ id: TeleopScenario; label: string }> = [
+  { id: 'takeover', label: 'Autonomy hands control to operator Jane' },
+  { id: 'return', label: 'Jane hands control back to autonomy' },
+  { id: 'gap', label: 'Autonomy reclaims control while Jane still holds it' },
+];
+
+function Teleop() {
+  const [scenario, setScenario] = useState<TeleopScenario>('takeover');
+
+  const view = {
+    takeover: { at: 'operator-jane', mode: 'teleoperated', ok: true, reason: 'continuous, single-held' },
+    return: { at: 'autopilot', mode: 'autonomous', ok: true, reason: 'continuous, single-held' },
+    gap: { at: 'autopilot', mode: 'autonomous', ok: false, reason: 'gap and overlap at the seam' },
+  }[scenario];
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          Control of a robot passes between an autonomous policy and human teleoperators. Each transfer is signed by the
+          party taking control, so the chain answers who or what was in control at any moment, and a continuity check
+          catches a seam where no one, or everyone, held it.
+        </p>
+        <div className="eyebrow-faint mb-2">Choose what happens</div>
+        <div className={styles.controls}>
+          {TELEOP_SCENARIOS.map((s) => (
+            <button
+              key={s.id}
+              className={`${styles.radio}${scenario === s.id ? ' ' + styles.on : ''}`}
+              onClick={() => setScenario(s.id)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Control handoff (signed by receiver)</div>
+          <div className={styles.mono}>
+            robot: did:web:robot-a
+            <br />
+            in control at t+05:00: {view.at} · mode: {view.mode}
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: view.ok ? ALLOW : DENY, borderColor: view.ok ? ALLOW : DENY }}>
+            {view.ok ? '✓ CONTINUOUS' : '✕ DISCONTINUITY'}
+          </span>
+          <span className={styles.reason}>{view.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* ODD: did the robot stay inside its certified operating domain.      */
+/* ------------------------------------------------------------------ */
+
+type OddScenario = 'inside' | 'speed' | 'zone' | 'weather';
+
+const ODD_SCENARIOS: Array<{ id: OddScenario; label: string }> = [
+  { id: 'inside', label: 'Ran at 2.4 m/s in yard-north, clear and midday' },
+  { id: 'speed', label: 'Ran at 4.5 m/s (over the speed regime)' },
+  { id: 'zone', label: 'Strayed into the street (outside the geofence)' },
+  { id: 'weather', label: 'Ran with visibility below the rated minimum' },
+];
+
+function Odd() {
+  const [scenario, setScenario] = useState<OddScenario>('inside');
+
+  const verdict = {
+    inside: { ok: true, reason: 'in domain' },
+    speed: { ok: false, reason: 'speed_out_of_domain: 4.5 > 3.0' },
+    zone: { ok: false, reason: 'zone_out_of_domain: [street]' },
+    weather: { ok: false, reason: 'condition_out_of_domain: minVisibilityM' },
+  }[scenario];
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          An operator certifies the robot's operating domain: the zones, a speed regime, weather bounds, and the hours it
+          is rated for. The robot signs what it observed each interval, and a deterministic check confirms it stayed in
+          domain, or names the dimension it left on.
+        </p>
+        <div className="eyebrow-faint mb-2">Choose what the robot observed</div>
+        <div className={styles.controls}>
+          {ODD_SCENARIOS.map((s) => (
+            <button
+              key={s.id}
+              className={`${styles.radio}${scenario === s.id ? ' ' + styles.on : ''}`}
+              onClick={() => setScenario(s.id)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Certified operating domain (operator-signed)</div>
+          <div className={styles.mono}>
+            zones: [yard-north, yard-south] · maxSpeed: 3.0 m/s
+            <br />
+            conditions: minVisibilityM 50 · hours: 06:00 to 20:00
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: verdict.ok ? ALLOW : DENY, borderColor: verdict.ok ? ALLOW : DENY }}>
+            {verdict.ok ? '✓ IN DOMAIN' : '✕ OUT OF DOMAIN'}
+          </span>
+          <span className={styles.reason}>{verdict.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Swarm: a collective action attributed to admitted members.          */
+/* ------------------------------------------------------------------ */
+
+type SwarmScenario = 'members' | 'nonmember';
+
+const SWARM_SCENARIOS: Array<{ id: SwarmScenario; label: string }> = [
+  { id: 'members', label: 'Robots A and B (both admitted) lift a beam' },
+  { id: 'nonmember', label: 'The action names robot Z, who was never admitted' },
+];
+
+function Swarm() {
+  const [scenario, setScenario] = useState<SwarmScenario>('members');
+
+  const verdict = {
+    members: { ok: true, reason: 'every participant is an admitted member' },
+    nonmember: { ok: false, reason: 'unverified participant: did:web:robot-z' },
+  }[scenario];
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          A coordinator admits robots to a swarm with signed memberships. When the swarm takes an action together, the
+          coordinator attributes it to the participants, and each one is checked against a membership, so a collective
+          action ties only to admitted members.
+        </p>
+        <div className="eyebrow-faint mb-2">Choose who took part</div>
+        <div className={styles.controls}>
+          {SWARM_SCENARIOS.map((s) => (
+            <button
+              key={s.id}
+              className={`${styles.radio}${scenario === s.id ? ' ' + styles.on : ''}`}
+              onClick={() => setScenario(s.id)}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Collective action (coordinator-signed)</div>
+          <div className={styles.mono}>
+            swarm: swarm-42 · action: lift-beam
+            <br />
+            participants: {scenario === 'nonmember' ? '[robot-a, robot-z]' : '[robot-a, robot-b]'}
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: verdict.ok ? ALLOW : DENY, borderColor: verdict.ok ? ALLOW : DENY }}>
+            {verdict.ok ? '✓ ATTRIBUTED' : '✕ FLAGGED'}
+          </span>
+          <span className={styles.reason}>{verdict.reason}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/* Handover: robot-to-human release inside the near-human envelope.     */
+/* ------------------------------------------------------------------ */
+
+function Handover() {
+  const [force, setForce] = useState(18);
+  const [speed, setSpeed] = useState(15);
+  const maxForce = 40;
+  const maxSpeed = 25; // hundredths of m/s, so 0.25 m/s
+  const inEnvelope = force <= maxForce && speed <= maxSpeed;
+
+  return (
+    <div className={styles.demo}>
+      <div>
+        <p className="text-ink-soft leading-relaxed mb-5">
+          Handing an object to a person puts a human hand inside the robot's envelope at the instant of release. The
+          robot signs the force and speed at that moment, checked against the near-human safety scope, and the recipient
+          can sign a receipt bound to the one handover.
+        </p>
+        <div className="eyebrow-faint mb-2">Set the release conditions</div>
+        <div className={styles.sliderRow}>
+          <input type="range" min={5} max={90} value={force} onChange={(e) => setForce(Number(e.target.value))} className={styles.slider} aria-label="force" />
+          <span className={styles.wearVal}>{force} N</span>
+        </div>
+        <div className={styles.sliderRow}>
+          <input type="range" min={5} max={90} value={speed} onChange={(e) => setSpeed(Number(e.target.value))} className={styles.slider} aria-label="speed" />
+          <span className={styles.wearVal}>{(speed / 100).toFixed(2)} m/s</span>
+        </div>
+      </div>
+      <div className={styles.stage}>
+        <div className={styles.card}>
+          <div className={styles.cardLabel}>Handover (robot-signed) + receipt (recipient-signed)</div>
+          <div className={styles.mono}>
+            robot: did:web:robot-a → recipient: did:web:person-1
+            <br />
+            object: tote-7 · force: {force} N · speed: {(speed / 100).toFixed(2)} m/s
+            <br />
+            near-human scope: maxForce 40 N · maxSpeed 0.25 m/s
+          </div>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.badge} style={{ color: inEnvelope ? ALLOW : DENY, borderColor: inEnvelope ? ALLOW : DENY }}>
+            {inEnvelope ? '✓ IN ENVELOPE' : '✕ OUT OF ENVELOPE'}
+          </span>
+          <span className={styles.reason}>{inEnvelope ? 'released safely, receipt binds to this handover' : 'force or speed exceeds the near-human limit'}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 
 export default function RoboticsDemos() {
   return (
@@ -364,7 +602,7 @@ export default function RoboticsDemos() {
         </div>
       </section>
 
-      <section id="consent" className="scroll-mt-24">
+      <section id="consent" className="border-b border-rule scroll-mt-24">
         <div className="container-wide py-16">
           <div className="section-heading">
             <span className="num">§ IV</span>
@@ -372,6 +610,50 @@ export default function RoboticsDemos() {
           </div>
           <p className="eyebrow mb-6">Consent is bound to one capture and cannot be replayed · vouch.robotics.consent</p>
           <Consent />
+        </div>
+      </section>
+
+      <section id="teleop" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ V</span>
+            <h2>Teleoperation handoff</h2>
+          </div>
+          <p className="eyebrow mb-6">Who or what was in control of a robot at any moment · vouch.robotics.teleop</p>
+          <Teleop />
+        </div>
+      </section>
+
+      <section id="odd" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ VI</span>
+            <h2>Operating-domain conformance</h2>
+          </div>
+          <p className="eyebrow mb-6">A robot proves it stayed inside its certified domain · vouch.robotics.odd</p>
+          <Odd />
+        </div>
+      </section>
+
+      <section id="swarm" className="border-b border-rule scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ VII</span>
+            <h2>Swarm accountability</h2>
+          </div>
+          <p className="eyebrow mb-6">A collective action ties to the members that performed it · vouch.robotics.swarm</p>
+          <Swarm />
+        </div>
+      </section>
+
+      <section id="handover" className="scroll-mt-24">
+        <div className="container-wide py-16">
+          <div className="section-heading">
+            <span className="num">§ VIII</span>
+            <h2>Safe human handover</h2>
+          </div>
+          <p className="eyebrow mb-6">A robot-to-human release, inside the near-human envelope · vouch.robotics.handover</p>
+          <Handover />
         </div>
       </section>
     </>

--- a/website/src/app/demos/robotics/page.tsx
+++ b/website/src/app/demos/robotics/page.tsx
@@ -5,7 +5,7 @@ import RoboticsDemos from './RoboticsDemos';
 export const metadata: Metadata = {
   title: 'Robotics interactive demos',
   description:
-    'See Vouch Protocol robotics controls run in the browser: a robot that opens a door with a grant the door authorizes offline, a fused world model bound to the exact sensor frames that made it, a worn robot that narrows its own force and speed envelope as it degrades, and bystander consent bound to a single capture so it cannot be replayed.',
+    'See Vouch Protocol robotics controls run in the browser: a robot that opens a door with a grant the door authorizes offline, a fused world model bound to the exact sensor frames that made it, a worn robot that narrows its own force and speed envelope as it degrades, bystander consent bound to a single capture, who or what was in control across a teleoperation handoff, operating-domain conformance, swarm accountability, and a safe robot-to-human handover.',
 };
 
 export default function RoboticsDemosPage() {
@@ -20,14 +20,18 @@ export default function RoboticsDemosPage() {
           <p className="text-ink-soft text-[1.05rem] leading-relaxed max-w-prose">
             A robot acts in the physical world, so the questions get sharper: what is it allowed to touch, is the world it
             sees real, and is it still fit to do the job. Vouch answers each with a credential the robot or the resource
-            can check on the spot. Four of them run below, on the real credential shapes.
+            can check on the spot. Eight of them run below, on the real credential shapes.
           </p>
           <p className="footnote mt-5">
             Every verdict here mirrors the shipped SDK modules
             {' '}<code className="font-mono text-[0.85em]">vouch.robotics.access</code>,
             {' '}<code className="font-mono text-[0.85em]">vouch.robotics.fusion</code>,
-            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.wear</code>, and
-            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.consent</code>. Disclosed as PAD-087 through PAD-094.
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.wear</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.consent</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.teleop</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.odd</code>,
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.swarm</code>, and
+            {' '}<code className="font-mono text-[0.85em]">vouch.robotics.handover</code>. Disclosed as PAD-087 through PAD-102.
           </p>
         </div>
       </section>
@@ -42,8 +46,12 @@ export default function RoboticsDemosPage() {
               in Python, TypeScript, Go, and the Rust core:
               {' '}<code className="font-mono text-[0.85em]">authorize_access</code>,
               {' '}<code className="font-mono text-[0.85em]">verify_fused_attestation</code>,
-              {' '}<code className="font-mono text-[0.85em]">attenuate_for_wear</code>, and
-              {' '}<code className="font-mono text-[0.85em]">verify_consent_evidence</code>. See the{' '}
+              {' '}<code className="font-mono text-[0.85em]">attenuate_for_wear</code>,
+              {' '}<code className="font-mono text-[0.85em]">verify_consent_evidence</code>,
+              {' '}<code className="font-mono text-[0.85em]">verify_control_chain</code>,
+              {' '}<code className="font-mono text-[0.85em]">verify_odd_conformance</code>,
+              {' '}<code className="font-mono text-[0.85em]">verify_collective_action</code>, and
+              {' '}<code className="font-mono text-[0.85em]">verify_human_handover</code>. See the{' '}
               <a href="/robotics/" className="prose-link">robotics overview</a> and the{' '}
               <a href="/help/" className="prose-link">guides</a> for the full walkthrough.
             </p>


### PR DESCRIPTION
This adds four forward-looking robotics capabilities as Python reference implementations, each with an interactive website demo and defensive disclosures.

- Teleoperation handoff (vouch.robotics.teleop): a signed chain of control-authority transfers between an autonomous policy and human teleoperators, with a controller-at-time lookup and a control-continuity check that catches a moment with no controller or two.
- Operating-domain conformance (vouch.robotics.odd): an operator-certified operating domain and a robot-signed attestation that it stayed inside it, with a deterministic in-domain check across zones, speed, conditions, and time.
- Multi-robot swarm accountability (vouch.robotics.swarm): verifiable swarm membership and attribution of a collective action to its admitted members.
- Safe robot-to-human handover (vouch.robotics.handover): a signed handover with the force and speed envelope at the release, checked against the near-human safety scope, and a recipient acknowledgement bound to that one handover.

Each capability has an interactive section on the robotics demos page, and the defensive disclosures PAD-095 through PAD-102 cover the mechanisms. Cross-language ports follow.
