### PR TITLE
Add vouch root CLI for the Root of Trust for Machine Identity

### DIFF
--- a/tests/test_cli_root.py
+++ b/tests/test_cli_root.py
@@ -1,0 +1,266 @@
+"""
+End-to-end tests for the `vouch root` command group (Root of Trust for Machine
+Identity).
+
+Drives the CLI handlers directly through argparse namespaces with a temp
+keystore and temp output files, so the full flow runs offline with did:key
+identities and no passphrase prompts:
+
+    root init  ->  root recognize  ->  root issue-identity  ->  root verify-chain
+
+Covers the happy path (a chain that verifies with the right agent, issuer, and
+attributes) and a rejection (verify-chain against a wrong pinned root DID).
+"""
+
+import json
+import types
+
+import pytest
+
+from vouch import cli
+from vouch.keys import KeyManager
+
+
+@pytest.fixture
+def temp_keystore(tmp_path, monkeypatch):
+    """Point KeyManager at a temp directory for the duration of a test."""
+    key_dir = str(tmp_path / "keys")
+    orig_init = KeyManager.__init__
+    monkeypatch.setattr(
+        KeyManager, "__init__", lambda self, key_dir=key_dir: orig_init(self, key_dir)
+    )
+    return tmp_path
+
+
+def _read(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+def _stored_dids(temp_keystore):
+    """Return the DIDs saved to the temp keystore, root first is not guaranteed."""
+    km = KeyManager()
+    return [ident["did"] for ident in km.list_identities()]
+
+
+def test_root_chain_happy_path(temp_keystore, capsys):
+    root_out = str(temp_keystore / "root-of-trust.json")
+    recognition_out = str(temp_keystore / "recognition.json")
+    identity_out = str(temp_keystore / "identity.json")
+
+    # 1. Create the root (did:key, non-interactive, no passphrase).
+    rc = cli.cmd_root_init(
+        types.SimpleNamespace(
+            name="Vouch Machine Identity Root",
+            scope=None,
+            domain=None,
+            out=root_out,
+            reference=True,
+            yes=True,
+        )
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Root DID:" in out
+    assert "reference root" in out.lower()
+
+    root_cred = _read(root_out)
+    root_did = root_cred["issuer"]
+    assert root_did.startswith("did:key:")
+    assert "VouchRootOfTrust" in root_cred["type"]
+
+    # 2. Create a recognized issuer identity to name. It just needs a DID and a
+    #    stored key, so reuse `root init` to mint a second did:key identity, then
+    #    recognize it from the root.
+    issuer_out = str(temp_keystore / "issuer-root.json")
+    assert (
+        cli.cmd_root_init(
+            types.SimpleNamespace(
+                name="Issuer",
+                scope=None,
+                domain=None,
+                out=issuer_out,
+                reference=False,
+                yes=True,
+            )
+        )
+        == 0
+    )
+    capsys.readouterr()
+    issuer_did = _read(issuer_out)["issuer"]
+    assert issuer_did != root_did
+
+    # 3. Root recognizes the issuer for issueAgentIdentity.
+    rc = cli.cmd_root_recognize(
+        types.SimpleNamespace(
+            issuer=issuer_did,
+            actions="issueAgentIdentity",
+            root_did=root_did,
+            out=recognition_out,
+        )
+    )
+    assert rc == 0
+    recognition = _read(recognition_out)
+    assert recognition["issuer"] == root_did
+    assert recognition["credentialSubject"]["id"] == issuer_did
+
+    # 4. The recognized issuer issues an agent identity with attributes.
+    agent_did = "did:key:z6MkagentSubjectPlaceholderDidForTest000000000000"
+    rc = cli.cmd_root_issue_identity(
+        types.SimpleNamespace(
+            subject=agent_did,
+            attr=["owner=Acme", "model=gpt-x", "capabilityClass=shopping"],
+            issuer_did=issuer_did,
+            out=identity_out,
+        )
+    )
+    assert rc == 0
+    identity = _read(identity_out)
+    assert identity["issuer"] == issuer_did
+    assert identity["credentialSubject"]["id"] == agent_did
+    assert identity["credentialSubject"]["identity"]["owner"] == "Acme"
+
+    # 5. Verify the chain against the correctly pinned root.
+    rc = cli.cmd_root_verify_chain(
+        types.SimpleNamespace(
+            identity=identity_out,
+            recognition=recognition_out,
+            root=root_did,
+            action=None,
+            root_cred=root_out,
+            action_required="issueAgentIdentity",
+        )
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Identity chain verified" in out
+    assert agent_did in out
+    assert issuer_did in out
+    assert "Acme" in out
+
+
+def test_verify_chain_wrong_root_rejected(temp_keystore, capsys):
+    root_out = str(temp_keystore / "root-of-trust.json")
+    recognition_out = str(temp_keystore / "recognition.json")
+    identity_out = str(temp_keystore / "identity.json")
+    issuer_out = str(temp_keystore / "issuer-root.json")
+
+    # Build a valid chain first.
+    assert (
+        cli.cmd_root_init(
+            types.SimpleNamespace(
+                name="Root", scope=None, domain=None, out=root_out, reference=False, yes=True
+            )
+        )
+        == 0
+    )
+    root_did = _read(root_out)["issuer"]
+    assert (
+        cli.cmd_root_init(
+            types.SimpleNamespace(
+                name="Issuer", scope=None, domain=None, out=issuer_out, reference=False, yes=True
+            )
+        )
+        == 0
+    )
+    issuer_did = _read(issuer_out)["issuer"]
+
+    assert (
+        cli.cmd_root_recognize(
+            types.SimpleNamespace(
+                issuer=issuer_did, actions=None, root_did=root_did, out=recognition_out
+            )
+        )
+        == 0
+    )
+    assert (
+        cli.cmd_root_issue_identity(
+            types.SimpleNamespace(
+                subject="did:key:z6MkagentSubjectPlaceholderDidForTest000000000000",
+                attr=["owner=Acme"],
+                issuer_did=issuer_did,
+                out=identity_out,
+            )
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    # Pin the WRONG root DID: verification must fail with a non-zero exit and a
+    # clear reason on stderr.
+    wrong_root = "did:key:z6MkNotTheRealRootDidPinnedByAnHonestVerifier00"
+    rc = cli.cmd_root_verify_chain(
+        types.SimpleNamespace(
+            identity=identity_out,
+            recognition=recognition_out,
+            root=wrong_root,
+            action=None,
+            root_cred=None,
+            action_required="issueAgentIdentity",
+        )
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "rejected" in err.lower()
+    assert "recognized_issuer_not_from_root" in err
+
+
+def test_verify_chain_full_via_main(temp_keystore):
+    """Drive the happy path through `cli.main` with argv lists, end to end."""
+    root_out = str(temp_keystore / "r.json")
+    issuer_out = str(temp_keystore / "i.json")
+    recognition_out = str(temp_keystore / "rec.json")
+    identity_out = str(temp_keystore / "id.json")
+
+    assert cli.main(["root", "init", "--yes", "--out", root_out]) == 0
+    assert cli.main(["root", "init", "--yes", "--out", issuer_out]) == 0
+    root_did = _read(root_out)["issuer"]
+    issuer_did = _read(issuer_out)["issuer"]
+
+    assert (
+        cli.main(
+            [
+                "root",
+                "recognize",
+                "--issuer",
+                issuer_did,
+                "--root-did",
+                root_did,
+                "--out",
+                recognition_out,
+            ]
+        )
+        == 0
+    )
+    assert (
+        cli.main(
+            [
+                "root",
+                "issue-identity",
+                "--subject",
+                "did:key:z6MkagentSubjectPlaceholderDidForTest000000000000",
+                "--attr",
+                "owner=Acme",
+                "--issuer-did",
+                issuer_did,
+                "--out",
+                identity_out,
+            ]
+        )
+        == 0
+    )
+    assert (
+        cli.main(
+            [
+                "root",
+                "verify-chain",
+                "--identity",
+                identity_out,
+                "--recognition",
+                recognition_out,
+                "--root",
+                root_did,
+            ]
+        )
+        == 0
+    )

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -307,6 +307,284 @@ def cmd_verify(args: argparse.Namespace) -> int:
         return 1
 
 
+# ---------------------------------------------------------------------------
+# Root of Trust for Machine Identity (`vouch root ...`)
+#
+# Stand up a self-hostable trust anchor for AI agent and robot identity. Anyone
+# runs `vouch root init` to create their own root, `vouch root recognize` to
+# name an issuer that may attest identities, `vouch root issue-identity` to bind
+# an agent DID to real attributes, and `vouch root verify-chain` to check an
+# agent against a pinned root fully offline.
+# ---------------------------------------------------------------------------
+
+
+def _load_stored_signer(target_did):
+    """Load a stored identity as a Signer, prompting for a passphrase if needed.
+
+    Mirrors the keystore selection in ``cmd_sign``: pick ``target_did`` if
+    given, else the single stored identity, else prompt from a numbered list.
+    Returns a :class:`Signer`, or None on error (message already printed).
+    """
+    km = KeyManager()
+    identities = km.list_identities()
+    if not identities:
+        print(
+            "Error: No identity found. Run 'vouch root init' to create a root first.",
+            file=sys.stderr,
+        )
+        return None
+
+    selected_did = target_did
+    if not selected_did:
+        if len(identities) == 1:
+            selected_did = identities[0]["did"]
+        else:
+            print("Multiple identities found:")
+            for i, ident in enumerate(identities):
+                print(f"{i + 1}. {ident['did']}")
+            try:
+                choice = int(input("Select identity (number): ")) - 1
+                selected_did = identities[choice]["did"]
+            except (ValueError, IndexError):
+                print("Invalid selection", file=sys.stderr)
+                return None
+
+    try:
+        try:
+            keys = km.load_identity(selected_did, None)
+        except ValueError as e:
+            if "Password required" in str(e) or "Decryption" in str(e):
+                passphrase = getpass.getpass(f"Enter passphrase for {selected_did}: ")
+                keys = km.load_identity(selected_did, passphrase)
+            else:
+                raise
+    except Exception as e:
+        print(f"Error loading identity: {e}", file=sys.stderr)
+        return None
+
+    return Signer.from_keypair(keys)
+
+
+def _write_json_file(obj, path) -> bool:
+    """Write ``obj`` as pretty JSON to ``path``. Returns True on success."""
+    try:
+        with open(path, "w") as f:
+            json.dump(obj, f, indent=2)
+        return True
+    except OSError as e:
+        print(f"Error writing {path}: {e}", file=sys.stderr)
+        return False
+
+
+def _read_json_file(path):
+    """Load and parse a JSON file. Returns the object, or None on error."""
+    try:
+        with open(path, "r") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"Error reading {path}: {e}", file=sys.stderr)
+        return None
+
+
+def cmd_root_init(args: argparse.Namespace) -> int:
+    """Create a Vouch root identity and write its self-issued Root of Trust credential."""
+    from vouch.root_of_trust import build_root_of_trust, generate_did_key_identity
+
+    try:
+        if args.domain:
+            keys = generate_identity(args.domain)
+        else:
+            keys = generate_did_key_identity()
+    except Exception as e:
+        print(f"Error generating root identity: {e}", file=sys.stderr)
+        return 1
+
+    print("Vouch root of trust created")
+    print(f"Root DID: {keys.did}")
+
+    km = KeyManager()
+
+    # Non-interactive when --yes is passed or stdin is not a TTY (CI, pipes), so
+    # the command never hangs waiting for a passphrase.
+    non_interactive = getattr(args, "yes", False) or not sys.stdin.isatty()
+    if non_interactive:
+        passphrase = None
+    else:
+        print("\nSecure storage")
+        passphrase = getpass.getpass(
+            f"Enter passphrase for {keys.did} (leave empty for no encryption): "
+        )
+        confirm = getpass.getpass("Confirm passphrase: ") if passphrase else ""
+        if passphrase != confirm:
+            print("Error: passphrases do not match", file=sys.stderr)
+            return 1
+
+    try:
+        km.save_identity(keys, passphrase if passphrase else None)
+        print(f"Root identity saved to: {km._get_filename(keys.did)}")
+        if not passphrase:
+            print("Warning: root key saved in plain text. Use a passphrase to encrypt it.")
+    except Exception as e:
+        print(f"Error saving root identity: {e}", file=sys.stderr)
+        return 1
+
+    signer = Signer.from_keypair(keys)
+    try:
+        credential = build_root_of_trust(
+            signer,
+            name=args.name,
+            scope=args.scope or None,
+        )
+    except Exception as e:
+        print(f"Error building Root of Trust credential: {e}", file=sys.stderr)
+        return 1
+
+    out_path = args.out or "root-of-trust.json"
+    if not _write_json_file(credential, out_path):
+        return 1
+    print(f"Root of Trust credential written to: {out_path}")
+
+    if args.reference:
+        print(
+            "\nReference root notice:\n"
+            "  This is a self-hosted reference root for testing and evaluation.\n"
+            "  It is not a vetted production authority. Verifiers must pin this\n"
+            f"  root DID out of band before trusting it:\n    {keys.did}"
+        )
+
+    return 0
+
+
+def cmd_root_recognize(args: argparse.Namespace) -> int:
+    """Sign a recognized-issuer credential from the root."""
+    from vouch.root_of_trust import build_recognized_issuer
+
+    if not args.issuer:
+        print("Error: --issuer DID is required", file=sys.stderr)
+        return 1
+
+    signer = _load_stored_signer(args.root_did)
+    if signer is None:
+        return 1
+
+    actions = None
+    if args.actions:
+        actions = [a.strip() for a in args.actions.split(",") if a.strip()]
+
+    try:
+        credential = build_recognized_issuer(
+            signer,
+            issuer_did=args.issuer,
+            recognized_actions=actions,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    out_path = args.out or "recognition.json"
+    if not _write_json_file(credential, out_path):
+        return 1
+
+    print("Recognized-issuer credential created")
+    print(f"Root DID:   {signer.did}")
+    print(f"Issuer DID: {args.issuer}")
+    print(f"Written to: {out_path}")
+    return 0
+
+
+def cmd_root_issue_identity(args: argparse.Namespace) -> int:
+    """Sign an agent identity credential from a recognized issuer."""
+    from vouch.root_of_trust import build_agent_identity
+
+    if not args.subject:
+        print("Error: --subject DID is required", file=sys.stderr)
+        return 1
+
+    attributes = {}
+    for item in args.attr or []:
+        if "=" not in item:
+            print(f"Error: --attr must be KEY=VALUE, got {item!r}", file=sys.stderr)
+            return 1
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            print(f"Error: --attr key is empty in {item!r}", file=sys.stderr)
+            return 1
+        attributes[key] = value
+    if not attributes:
+        print("Error: at least one --attr KEY=VALUE is required", file=sys.stderr)
+        return 1
+
+    signer = _load_stored_signer(args.issuer_did)
+    if signer is None:
+        return 1
+
+    try:
+        credential = build_agent_identity(
+            signer,
+            subject_did=args.subject,
+            attributes=attributes,
+        )
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    out_path = args.out or "identity.json"
+    if not _write_json_file(credential, out_path):
+        return 1
+
+    print("Agent identity credential created")
+    print(f"Issuer DID:  {signer.did}")
+    print(f"Subject DID: {args.subject}")
+    print(f"Attributes:  {json.dumps(attributes)}")
+    print(f"Written to:  {out_path}")
+    return 0
+
+
+def cmd_root_verify_chain(args: argparse.Namespace) -> int:
+    """Verify an agent identity against a pinned Vouch root DID."""
+    from vouch.root_of_trust import verify_identity_chain
+
+    identity = _read_json_file(args.identity)
+    if identity is None:
+        return 1
+    recognition = _read_json_file(args.recognition)
+    if recognition is None:
+        return 1
+
+    action_credential = None
+    if args.action:
+        action_credential = _read_json_file(args.action)
+        if action_credential is None:
+            return 1
+
+    root_credential = None
+    if args.root_cred:
+        root_credential = _read_json_file(args.root_cred)
+        if root_credential is None:
+            return 1
+
+    result = verify_identity_chain(
+        identity,
+        recognition,
+        trusted_root=args.root,
+        action_credential=action_credential,
+        root_credential=root_credential,
+        required_action=args.action_required,
+    )
+
+    if result.ok:
+        print("Identity chain verified")
+        print(f"Agent DID:  {result.agent_did}")
+        print(f"Issuer DID: {result.issuer_did}")
+        print(f"Root DID:   {result.root_did}")
+        print(f"Attributes: {json.dumps(result.attributes)}")
+        return 0
+
+    print(f"Identity chain rejected: {result.reason}", file=sys.stderr)
+    return 1
+
+
 def _export_vouch_key_to_ssh() -> tuple[str, str]:
     """Export Vouch identity to SSH key format.
 
@@ -1368,8 +1646,13 @@ def _guided_start() -> "list[str] | None":
         print("  Please enter 1, 2, 3, or 4.")
 
 
-def main() -> int:
-    """Main entry point for the CLI."""
+def main(argv: "list[str] | None" = None) -> int:
+    """Main entry point for the CLI.
+
+    ``argv`` defaults to ``sys.argv[1:]`` when None, and may be passed
+    explicitly (e.g. from tests) to drive the CLI without touching the process
+    arguments.
+    """
     parser = argparse.ArgumentParser(
         prog="vouch", description="Vouch Protocol CLI - Identity & Reputation for AI Agents"
     )
@@ -1464,6 +1747,112 @@ def main() -> int:
         "--c2pa", action="store_true", help="Verify C2PA manifest instead of Vouch signature"
     )
 
+    # root subcommand group (Root of Trust for Machine Identity)
+    p_root = subparsers.add_parser(
+        "root",
+        help="Root of Trust for machine identity (self-hostable trust anchor)",
+    )
+    root_subparsers = p_root.add_subparsers(dest="root_command", help="Root of trust commands")
+
+    # root init
+    p_root_init = root_subparsers.add_parser(
+        "init", help="Create a root identity and write its Root of Trust credential"
+    )
+    p_root_init.add_argument(
+        "--name",
+        default="Vouch Machine Identity Root",
+        help="Human-readable name for the root",
+    )
+    p_root_init.add_argument(
+        "--scope",
+        nargs="+",
+        help="What the root anchors (default: ai-agent robot)",
+    )
+    p_root_init.add_argument(
+        "--domain",
+        help="Create a did:web root for this domain instead of a did:key root",
+    )
+    p_root_init.add_argument(
+        "--out", help="Path to write the Root of Trust credential (default: root-of-trust.json)"
+    )
+    p_root_init.add_argument(
+        "--reference",
+        action="store_true",
+        help="Print a notice that this is a self-hosted reference root for testing",
+    )
+    p_root_init.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Non-interactive: save the root without prompting for a passphrase",
+    )
+
+    # root recognize
+    p_root_recognize = root_subparsers.add_parser(
+        "recognize", help="Recognize an issuer that may attest agent or robot identity"
+    )
+    p_root_recognize.add_argument("--issuer", required=True, help="DID of the issuer to recognize")
+    p_root_recognize.add_argument(
+        "--actions",
+        help="Comma-separated actions to grant (default: issueAgentIdentity)",
+    )
+    p_root_recognize.add_argument(
+        "--root-did",
+        dest="root_did",
+        help="DID of the root to sign with (default: the stored root)",
+    )
+    p_root_recognize.add_argument(
+        "--out", help="Path to write the recognition credential (default: recognition.json)"
+    )
+
+    # root issue-identity
+    p_root_issue = root_subparsers.add_parser(
+        "issue-identity", help="Issue an agent identity credential from a recognized issuer"
+    )
+    p_root_issue.add_argument("--subject", required=True, help="DID of the agent being identified")
+    p_root_issue.add_argument(
+        "--attr",
+        action="append",
+        metavar="KEY=VALUE",
+        help="Identity attribute to bind (repeatable), e.g. --attr owner=Acme",
+    )
+    p_root_issue.add_argument(
+        "--issuer-did",
+        dest="issuer_did",
+        help="DID of the recognized issuer to sign with (default: the stored issuer)",
+    )
+    p_root_issue.add_argument(
+        "--out", help="Path to write the identity credential (default: identity.json)"
+    )
+
+    # root verify-chain
+    p_root_verify = root_subparsers.add_parser(
+        "verify-chain", help="Verify an agent identity against a pinned root DID"
+    )
+    p_root_verify.add_argument(
+        "--identity", required=True, help="Path to the agent identity credential JSON"
+    )
+    p_root_verify.add_argument(
+        "--recognition", required=True, help="Path to the recognized-issuer credential JSON"
+    )
+    p_root_verify.add_argument(
+        "--root", required=True, help="The root DID the verifier pins as its trust anchor"
+    )
+    p_root_verify.add_argument(
+        "--action", help="Optional path to an agent action credential to bind to the identity"
+    )
+    p_root_verify.add_argument(
+        "--root-cred",
+        dest="root_cred",
+        help="Optional path to the Root of Trust credential to check for self-consistency",
+    )
+    p_root_verify.add_argument(
+        "--action-required",
+        dest="action_required",
+        default="issueAgentIdentity",
+        help="Action the issuer must be recognized for (default: issueAgentIdentity)",
+    )
+
     # scan command (PAD-058 detection stage; OSS leak scanner)
     p_scan = subparsers.add_parser(
         "scan",
@@ -1552,7 +1941,7 @@ def main() -> int:
         help="Show what would be written without creating files",
     )
 
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     setup_logging(args.verbose if hasattr(args, "verbose") else False)
 
@@ -1587,6 +1976,18 @@ def main() -> int:
             return cmd_media_verify(args)
         else:
             p_media.print_help()
+            return 0
+    elif args.command == "root":
+        if args.root_command == "init":
+            return cmd_root_init(args)
+        elif args.root_command == "recognize":
+            return cmd_root_recognize(args)
+        elif args.root_command == "issue-identity":
+            return cmd_root_issue_identity(args)
+        elif args.root_command == "verify-chain":
+            return cmd_root_verify_chain(args)
+        else:
+            p_root.print_help()
             return 0
     elif args.command == "scan":
         return cmd_scan(args)


### PR DESCRIPTION
This adds the `vouch root` command group for the Root of Trust for Machine Identity, stacked on the base feature.

- `vouch root init` stands up a root identity (did:key, or did:web with `--domain`) and writes its self-issued Root of Trust credential. The `--reference` flag labels it a self-hosted test root that verifiers pin out of band. This is the self-host mechanism: anyone can run their own root.
- `vouch root recognize --issuer <did>` has the root authorize an issuer for specific actions.
- `vouch root issue-identity --subject <did> --attr key=value` has a recognized issuer bind an agent to attributes.
- `vouch root verify-chain --identity ... --recognition ... --root <did>` walks the chain and reports the agent identity and attributes, or the structured rejection reason, with a matching exit code.

This makes the authority layer usable from the command line. The agent own `vouch init` flow is unchanged.
