### PR TITLE
ci: align the NuGet workflow action versions with the rest of the repo

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -30,13 +30,13 @@ jobs:
           - { os: windows-latest, rids: "win-x64" }
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
       - name: Build native libraries
         working-directory: sdks/dotnet/VouchCore
         shell: bash
         run: for rid in ${{ matrix.rids }}; do bash build-native.sh "$rid"; done
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: native-${{ matrix.os }}
           path: sdks/dotnet/VouchCore/runtimes
@@ -49,12 +49,12 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "8.0.x"
       - name: Collect native libraries into runtimes/
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: sdks/dotnet/VouchCore/runtimes
           pattern: native-*


### PR DESCRIPTION
Bumps actions/checkout, upload-artifact, and download-artifact in publish-nuget.yml to the versions every other workflow already uses (checkout v7, upload-artifact v7, download-artifact v8). publish-nuget.yml was the last file on v4, so merging this makes the three Dependabot PRs (#317, #318, #319) redundant and they will auto-close.