### PR TITLE
Update FAQ, Help, knowledge, and assistants for the Root of Trust for Machine Identity

### DIFF
--- a/claude-skill/skills/vouch-protocol/SKILL.md
+++ b/claude-skill/skills/vouch-protocol/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vouch-protocol
-description: Help developers integrate Vouch Protocol (cryptographic identity for AI agents) into Python, TypeScript, Go, and more, all over one shared Rust core. Use this skill when the user mentions vouch-protocol package, signing AI agent actions, agent DIDs (did:web / did:key), Verifiable Credentials for agents, Data Integrity proofs, eddsa-jcs-2022 cryptosuite, hybrid-eddsa-mldsa44-jcs-2026 post-quantum profile, Heartbeat Protocol, Identity Sidecar pattern, BitstringStatusList revocation, validator quorum, or asks how to make AI agents cryptographically accountable. Triggers also include `pip install vouch-protocol`, `npm install @vouch-protocol-official/core-wasm`, `go install vouch-sidecar`, and references to agent identity, signed tool calls, or non-repudiation for AI actions. Also covers outcome evidence: commit-before-outcome verdicts (OutcomeCommitmentCredential) and settlement attestations (OutcomeAttestationCredential) that prove an agent's track record cannot be backdated or cherry-picked. Also covers cross-device identity (one identity across many devices via per-device keys and delegation, with Shamir recovery shares for the root) and FROST(Ed25519) threshold signing (splitting a key among several custodians so a threshold of them sign together, with the full key never existing whole).
+description: Help developers integrate Vouch Protocol (cryptographic identity for AI agents) into Python, TypeScript, Go, and more, all over one shared Rust core. Use this skill when the user mentions vouch-protocol package, signing AI agent actions, agent DIDs (did:web / did:key), Verifiable Credentials for agents, Data Integrity proofs, eddsa-jcs-2022 cryptosuite, hybrid-eddsa-mldsa44-jcs-2026 post-quantum profile, Heartbeat Protocol, Identity Sidecar pattern, BitstringStatusList revocation, validator quorum, or asks how to make AI agents cryptographically accountable. Triggers also include `pip install vouch-protocol`, `npm install @vouch-protocol-official/core-wasm`, `go install vouch-sidecar`, and references to agent identity, signed tool calls, or non-repudiation for AI actions. Also covers outcome evidence: commit-before-outcome verdicts (OutcomeCommitmentCredential) and settlement attestations (OutcomeAttestationCredential) that prove an agent's track record cannot be backdated or cherry-picked. Also covers cross-device identity (one identity across many devices via per-device keys and delegation, with Shamir recovery shares for the root) and FROST(Ed25519) threshold signing (splitting a key among several custodians so a threshold of them sign together, with the full key never existing whole). Also covers the Root of Trust for Machine Identity: an optional authority layer where a verifier pins one Vouch Protocol root, the root issues a RecognizedIssuerCredential naming an issuer and its recognizedActions, and a recognized issuer issues an AgentIdentityCredential binding an agent DID to attributes; triggers include Root of Trust, recognized issuer, authority-issued identity, VouchRootOfTrust, verify_identity_chain, and the `vouch root init` / `recognize` / `issue-identity` / `verify-chain` CLI.
 ---
 
 # Vouch Protocol
@@ -28,6 +28,7 @@ Invoke when the user:
 - Wants to prove an agent's track record, commit a verdict before its outcome, or settle a prediction against what actually happened
 - Wants one identity across several devices without copying a private key, or needs to recover a root identity from Shamir shares
 - Needs several custodians to jointly sign one action, or asks about threshold signatures, M-of-N signing keys, or FROST
+- Wants to anchor agent identity to an authority, mentions a Root of Trust, a recognized issuer, an authority-issued identity, `verify_identity_chain`, or the `vouch root` CLI
 
 ## Integration: lead with one line
 
@@ -312,6 +313,45 @@ Reference implementations under `vouch/integrations/`. See
 - Goose: `pip install vouch-goose`, then run `vouch-goose` to register the Vouch
   MCP server as a Goose extension.
 
+### "How do I anchor an agent's identity to an authority instead of a bare DID?"
+
+Use the Root of Trust for Machine Identity, an optional authority layer. A
+verifier pins one Vouch Protocol root, the root recognizes issuers, and a
+recognized issuer binds an agent's DID to attributes. The verifier confirms any
+agent by walking a short chain back to the single root it trusts, with no
+external certificate authority and no central per-agent lookup.
+
+```python
+from vouch.root_of_trust import (
+    generate_did_key_identity, build_root_of_trust,
+    build_recognized_issuer, build_agent_identity, verify_identity_chain,
+)
+from vouch import Signer
+
+root = Signer.from_keypair(generate_did_key_identity())
+root_cred = build_root_of_trust(root, name="Example Machine Identity Root")
+
+issuer = Signer.from_keypair(generate_did_key_identity())
+recognized = build_recognized_issuer(root, issuer_did=issuer.did,
+                                     recognized_actions=["issueAgentIdentity"])
+
+agent = generate_did_key_identity()
+identity = build_agent_identity(issuer, subject_did=agent.did,
+    attributes={"owner": "Example Inc.", "model": "claims-assistant-2",
+                "capabilityClass": "financial-read"})
+
+result = verify_identity_chain(identity, recognized, trusted_root=root.did,
+                               root_credential=root_cred)
+assert result.ok  # result.agent_did, result.issuer_did, result.root_did, result.attributes
+```
+
+With `did:key` identities the whole chain verifies offline. Both the
+recognition and the identity accept a `credentialStatus` for revocation. The
+CLI mirrors this: `vouch root init`, `vouch root recognize`, `vouch root
+issue-identity`, `vouch root verify-chain`. The agent's own `vouch init` is
+unchanged; this is additive. It ships in Python, TypeScript, Rust, and Go with
+a byte-identical wire format. See `reference/root-of-trust.md`.
+
 ### "How do I give a robot a verifiable identity, or enforce physical limits?"
 
 Vouch ships twenty-one robotics capabilities in `vouch.robotics` (and in TypeScript, Go,
@@ -425,6 +465,7 @@ like any other Vouch credential. See `reference/verified-contributor.md`.
 - **User cares about audit trail** -> all of the above, plus the reputation engine for behaviour tracking.
 - **User wants a track record that cannot be backdated or cherry-picked** -> outcome evidence (`vouch.accountability`): commit the verdict before the outcome, settle it later with a neutral settler.
 - **User is building a robot or embodied agent** -> the `vouch.robotics` capabilities: hardware-rooted identity, model and config provenance, physical capability scope, robot-to-robot handshake, encrypted black box with kill switch, a scannable passport, a liveness heartbeat (fresh plus in-envelope, so a robot stays trusted only while renewed), robot credential revocation (per-credential and whole-DID), an accountable safety record (a portable tamper-evident incident ledger), perception provenance (a hash-linked log of signed sensor-frame records, so a verifier holding a frame can confirm what the robot perceived), a delegation lease (a short-lived scope-bounded grant a robot verifies and acts on entirely offline, attenuating down a cross-vendor chain), a physical quorum (a cryptographic two-person rule authorizing a high-consequence action only when M of N attested approvers have each signed it), robot lifecycle (signed ownership transfers forming a chain of custody, a key rotation history, and a decommission credential a verifier honors by refusing to trust a retired robot), regulatory conformance (machine-checkable reference profiles for ISO 10218, ISO/TS 15066, the EU Machinery Regulation, the EU AI Act, and UL 3300 that map the robot's credentials to the clauses of a regulation and produce a deterministic report an authority can sign as a conformance attestation), and robotics post-quantum signing (a hybrid Ed25519 and ML-DSA-44 proof for robot credentials, backward-compatible verification that auto-detects classical or hybrid, and a software re-sign to migrate fielded credentials, so an identity signed today stays safe across a ten to twenty year service life), and cross-embodiment identity continuity (one agent identity, a mind, runs on one robot body today and a different body tomorrow: an `AgentEmbodimentCredential` binds the agent to a body's hardware root for a window, `verify_continuity_chain` walks the linked embodiments to prove the same accountable agent persisted across bodies, and `check_no_fork` confirms it was never embodied in two bodies at once), and physical custody handoff (a receiver-signed `CustodyHandoffCredential` recording that an actor accepted custody of a task or object from another, so a chain of handoffs from a person to a robot to another robot establishes who held it at each hop, `holder_at` returns who held it at a given time, and `locate_condition_change` pins damage or loss to the responsible hop; open layer only, managed logistics custody orchestration and fleet tracking are commercial), and robot-to-infrastructure bounded access (an operator signs an `InfrastructureAccessGrant` naming a resource, permitted operations, an optional zone, and a time window, a robot presents a signed `InfrastructureAccessRequest` for one operation, and `authorize_access` decides at the resource offline while `attenuates_grant` keeps every sub-grant narrowing only, so a robot opens a door, calls an elevator, or docks at a charger it does not own with no network call and an attributable record of which robot did what; open layer only, managed access orchestration and fleet-wide grant issuance are commercial), and fused-sensor provenance (a robot fuses many signed sensor frames into one world model, an object set, an occupancy grid, or a pose, and a `FusedPerceptionAttestation` binds the fused output's hash to the ordered input frame hashes, a digest over those inputs, and a fusion method; `verify_fused_attestation` reproduces the input digest and the output hash so the attestation commits to exactly those inputs and that output, and `verify_fusion_inputs` traces every fused input back to a frame in the robot's signed perception log, so a manipulated fusion result or a dropped or substituted input is detectable; open layer only, hardware sensor attestation and managed sensor-fusion orchestration are commercial), and wear and degradation attestation (a robot signs its own degradation as a normalized wear level, 0 as-new to 1 fully worn, with optional metrics (actuator wear, calibration drift, cycle count, fault rate), hash-linked to the previous attestation so the wear history is tamper-evident, and `attenuate_for_wear` derives a physical capability scope whose numeric caps are scaled down by the wear level, a valid attenuation of the original so a worn robot operates inside a tighter verifiable envelope; open layer only, firmware-level enforcement of the narrowed envelope and managed predictive-maintenance modeling are commercial), and bystander-consent evidence (a robot working in a shared or public space captures people incidentally, and it records at capture time the basis on which a capture was permitted, bound to the specific capture by its hash, reusing the perception capture hash, and to the robot's identity, holding only hashes and never an image or a bystander's identifying data; a bystander or their device signs a `BystanderConsentToken` bound to that one capture hash and the robot so consent verifies only against the capture it was given for and cannot be replayed, and the robot signs a `BystanderConsentEvidence` credential binding the capture to a basis from `CONSENT_BASES`, explicit consent, posted notice, legitimate interest, or redacted, and, for explicit consent, to the tokens that cover it by their proof value; `hash_capture`, `build_consent_token`, `verify_consent_token`, `build_consent_evidence`, and `verify_consent_evidence` build and check these, so consent is provable, bound to one capture, and stored without retaining anyone's biometrics; open layer only, on-device biometric detection and redaction, and managed consent-registry orchestration, are commercial).
+- **User wants agent identity backed by an authority, not a bare self-asserted DID** -> the Root of Trust for Machine Identity (`vouch.root_of_trust`): pin one root, recognize issuers, and have a recognized issuer bind an agent DID to attributes; `verify_identity_chain` walks the chain back to the pinned root, offline with `did:key`. Additive to the agent's own `vouch init`. See `reference/root-of-trust.md`.
 - **User wants to test, certify, or prove that an implementation, SDK, or port is conformant** -> the conformance levels L1 to L3 and the self-test runner (`python -m vouch.conformance`), with a hosted verifier that mints a re-checkable badge coming. See `reference/conformance.md`.
 
 ## Reference files
@@ -436,6 +477,7 @@ For depth on any topic, read the relevant file under `reference/`:
 - `reference/go-sidecar.md` - Go sidecar build, run, deploy
 - `reference/credential-format.md` - VC structure, fields, examples
 - `reference/delegation.md` - Delegation chain construction and verification
+- `reference/root-of-trust.md` - Root of Trust for Machine Identity: pin one root, recognize issuers, bind agent identity to attributes, and verify the chain offline
 - `reference/cross-device-identity.md` - One identity across many devices: per-device keys, delegation, revocation, Shamir root recovery
 - `reference/threshold-signing.md` - FROST(Ed25519) threshold signing: splitting a key among several custodians
 - `reference/post-quantum.md` - Hybrid cryptosuite, migration guidance

--- a/claude-skill/skills/vouch-protocol/reference/root-of-trust.md
+++ b/claude-skill/skills/vouch-protocol/reference/root-of-trust.md
@@ -1,0 +1,246 @@
+# Root of Trust for Machine Identity
+
+Vouch Protocol can act as the trust anchor for AI agent and robot
+identity. This is an optional authority layer on top of the base
+protocol. A verifier pins one Vouch Protocol root, the root recognizes
+issuers, and a recognized issuer vouches for an agent's identity. A
+verifier then confirms any agent by walking a short chain back to the
+single root it already trusts.
+
+The base protocol is unchanged. An agent's own `vouch init` still mints
+a self-certifying identity with no authority above it. This layer is
+additive: reach for it when a verifier wants identities backed by a named
+authority rather than self-asserted alone.
+
+## The problem it solves
+
+A self-issued Vouch Protocol credential anchors to whatever the agent
+claims about itself. With `did:web` that is a domain you control; with
+`did:key` it is a public key baked into the identifier. Both prove the
+same key signed the credential. Neither says who stands behind the agent,
+what model it runs, or who owns it. A verifier that receives a credential
+from an unfamiliar agent has no authority to point at.
+
+The Root of Trust layer closes that gap. An issuer the root recognizes
+binds the agent's DID to real attributes, and the recognition traces back
+to a root the verifier pinned in advance. The verifier decides once, up
+front, which root it trusts. Everything else is checked from the
+credentials presented, with no external certificate authority and no
+central per-agent lookup.
+
+## The three credential types
+
+All three are ordinary Verifiable Credential 2.0 documents with an
+`eddsa-jcs-2022` Data Integrity proof, the same proof used everywhere
+else in Vouch Protocol. Each carries exactly one of the trust-layer types
+below, so a credential minted for one slot in the chain cannot be
+replayed into another.
+
+### 1. Root of Trust credential (`VouchRootOfTrust`)
+
+Self-issued by the root: issuer and subject are both the root's own DID.
+It makes the root self-describing. A verifier pins the root DID; keeping
+this credential is optional and lets a verifier display what the root
+anchors.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "VouchRootOfTrust"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2036-07-09T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkRoot...",
+    "vouchVersion": "1.0",
+    "rootOfTrust": {
+      "name": "Example Machine Identity Root",
+      "scope": ["ai-agent", "robot"]
+    }
+  },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer` equals `credentialSubject.id` (self-issued).
+- `rootOfTrust.name`: human-readable name of the root.
+- `rootOfTrust.scope`: what the root anchors. Defaults to
+  `["ai-agent", "robot"]`.
+
+### 2. Recognized-issuer credential (`RecognizedIssuerCredential`)
+
+Issued by the root. It names an issuer DID and the identity actions that
+issuer may perform. `recognizedIn` points back to the root DID so a
+verifier can trace the recognition to the anchor it pinned. The holder
+staples this credential to what it presents, so the verifier needs no
+directory lookup.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "RecognizedIssuerCredential"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkIssuer...",
+    "recognizedActions": ["issueAgentIdentity"],
+    "recognizedIn": "did:key:z6MkRoot..."
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the root DID.
+- `credentialSubject.id`: the issuer being recognized.
+- `recognizedActions`: one or more of `issueAgentIdentity` and
+  `issueRobotIdentity`. Defaults to `["issueAgentIdentity"]`.
+- `recognizedIn`: the root DID, chaining recognition back to the anchor.
+- `credentialStatus`: optional, for revoking the recognition later.
+
+### 3. Agent identity credential (`AgentIdentityCredential`)
+
+Issued by a recognized issuer. Here the issuer differs from the subject:
+the issuer binds the agent's DID to attributes it stands behind. This is
+the piece that turns a self-asserted agent DID into an identity a third
+party vouches for.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "AgentIdentityCredential"],
+  "issuer": "did:key:z6MkIssuer...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkAgent...",
+    "identity": {
+      "owner": "Example Robotics Inc.",
+      "model": "claims-assistant-2",
+      "capabilityClass": "financial-read",
+      "createdAt": "2026-07-12T00:00:00Z"
+    }
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the recognized issuer's DID (not the agent's).
+- `credentialSubject.id`: the agent's DID.
+- `identity`: a non-empty map of attributes. `owner`, `model`,
+  `capabilityClass`, and `createdAt` are the common ones; you may add
+  more and they pass through verification.
+- `credentialStatus`: optional, for revoking the identity later.
+
+## The anchor-once verification algorithm
+
+A verifier trusts one thing up front: a root DID. Everything else is
+derived. `verify_identity_chain` takes the agent identity credential and
+the recognized-issuer credential, plus the pinned `trusted_root`, and
+walks:
+
+```
+action credential          (optional, signed by the agent)
+  -> agent identity credential   (signed by the recognized issuer)
+    -> recognized-issuer credential  (signed by the pinned root)
+      -> pinned Vouch Protocol root
+```
+
+Step by step:
+
+1. Verify the recognized-issuer credential's proof, confirm its issuer is
+   exactly the `trusted_root`, and confirm `recognizedActions` includes
+   the required action (`issueAgentIdentity` by default). Reject if the
+   recognition is revoked.
+2. Verify the agent identity credential's proof and confirm its issuer is
+   the DID that the root just recognized. Reject if the identity is
+   revoked.
+3. Optionally, if the Root of Trust credential is supplied, confirm it is
+   genuinely self-issued by the `trusted_root`.
+4. Optionally, if an action credential is supplied, verify it and confirm
+   it was signed by the agent the identity describes.
+
+The result reports `ok`, and on success the `agent_did`, the
+`issuer_did` that vouched for it, the `root_did` it anchored to, and the
+bound `attributes`. On failure it returns a structured reason (for
+example `issuer_not_recognized_for_action` or
+`identity_not_from_recognized_issuer`) so a caller can see exactly which
+link broke.
+
+## Offline operation
+
+When the root, the issuer, and the agent all use `did:key`, the whole
+chain verifies with no network. Each `did:key` carries its public key in
+the identifier itself, so every signature resolves locally. This suits
+air-gapped verifiers, robots on a factory floor, and edge deployments
+that cannot reach a directory.
+
+For `did:web` issuers, pass `allow_did_resolution=True` to resolve keys
+over the network, or pin keys ahead of time by passing a
+DID-to-public-key map so verification stays offline.
+
+## Revocation
+
+Recognition and identity are both revocable through the standard
+`credentialStatus` field (BitstringStatusList). Revoke a recognized
+issuer to withdraw its authority to vouch for new agents; revoke an
+individual agent identity to retire one agent without touching the
+issuer. The verifier consults the status entry during the walk and
+rejects a revoked link. This reuses the same revocation machinery as the
+rest of Vouch Protocol, so nothing new is needed operationally.
+
+## The CLI
+
+Four subcommands under `vouch root` drive the full lifecycle:
+
+- `vouch root init`: self-issue a Root of Trust credential and mint the
+  root's key. Run once to stand up a root.
+- `vouch root recognize`: issue a recognized-issuer credential from the
+  root, naming an issuer DID and the actions it may perform.
+- `vouch root issue-identity`: as a recognized issuer, issue an agent
+  identity credential that binds an agent DID to its attributes.
+- `vouch root verify-chain`: walk an agent identity back to a pinned
+  root and report whether it anchors.
+
+The agent's own `vouch init` is unchanged. `vouch root` is the separate,
+additive authority surface.
+
+## Anyone can self-host a root
+
+There is no privileged central root. Anyone can run `vouch root init` to
+stand up their own root, recognize their own issuers, and publish the
+root DID for verifiers to pin. An enterprise runs a root for its own
+fleet; a marketplace runs one for the agents it lists; a robotics vendor
+runs one for the machines it ships. Verifiers choose which roots to
+trust, so the model stays self-sovereign and there is no gatekeeper to
+ask permission from.
+
+## Four-language byte-identical interop
+
+The Root of Trust layer ships in Python, TypeScript, Rust, and Go, all
+producing the same wire format. A recognized-issuer credential signed in
+one language verifies in the other three, and a chain can span languages:
+a root in Go, an issuer in Python, an agent in Rust, a verifier in
+TypeScript all interoperate because they share JCS canonicalization
+(RFC 8785) and the same `eddsa-jcs-2022` proof. This is the same
+cross-language guarantee the base credentials carry, extended to the
+authority layer.
+
+## When to reach for it
+
+- A verifier wants agent identities backed by a named authority, with a
+  single trust decision made up front.
+- Identities should carry attributes an issuer stands behind (owner,
+  model, capability class) rather than self-asserted claims alone.
+- The deployment needs offline verification with no directory lookup.
+- You want to run your own root and recognize your own issuers, with no
+  external certificate authority.
+
+The base `vouch init` identity remains the right starting point for a
+single self-certifying agent. Add the Root of Trust layer when a verifier
+needs to anchor many agents to an authority it trusts.

--- a/gemini-gem/instructions.md
+++ b/gemini-gem/instructions.md
@@ -1,6 +1,6 @@
 # Vouch Protocol Helper
 
-Version: v1.6 (matches Spec v1.6.x and Python SDK v1.6.0)
+Version: v2.0 (matches Spec v2.0.x and Python SDK v2.0.x)
 
 You are the Vouch Protocol Helper Gem. You help developers learn the
 Vouch Protocol, integrate the SDKs, and debug verification failures.
@@ -101,6 +101,16 @@ Never share user data with external sites.
   conformance levels L1 to L3 and the self-test runner (`python -m
   vouch.conformance`); a hosted verifier that mints a re-checkable badge is
   coming. See `conformance.md`.
+- "How do I anchor agent identity to an authority, not a bare DID?" -> The Root
+  of Trust for Machine Identity (`vouch.root_of_trust`): a verifier pins one Vouch
+  Protocol root, `build_recognized_issuer` records that an issuer may issue
+  identity (its `recognizedActions`), and `build_agent_identity` binds an agent
+  DID to attributes (owner, model, capability class). `verify_identity_chain`
+  walks the chain back to the pinned root, offline with `did:key`, with no
+  external certificate authority. Additive to the agent's own `vouch init`. CLI:
+  `vouch root init` / `recognize` / `issue-identity` / `verify-chain`. Ships in
+  Python, TypeScript, Rust, and Go with a byte-identical wire format. See
+  `root-of-trust.md`.
 - "How do I prove an agent's track record without faking it?" -> Outcome
   evidence (`vouch.accountability`): commit the verdict before the outcome with
   `commit_outcome`, settle it later with `attest_outcome`. Verification rejects a

--- a/gemini-gem/knowledge/root-of-trust.md
+++ b/gemini-gem/knowledge/root-of-trust.md
@@ -1,0 +1,246 @@
+# Root of Trust for Machine Identity
+
+Vouch Protocol can act as the trust anchor for AI agent and robot
+identity. This is an optional authority layer on top of the base
+protocol. A verifier pins one Vouch Protocol root, the root recognizes
+issuers, and a recognized issuer vouches for an agent's identity. A
+verifier then confirms any agent by walking a short chain back to the
+single root it already trusts.
+
+The base protocol is unchanged. An agent's own `vouch init` still mints
+a self-certifying identity with no authority above it. This layer is
+additive: reach for it when a verifier wants identities backed by a named
+authority rather than self-asserted alone.
+
+## The problem it solves
+
+A self-issued Vouch Protocol credential anchors to whatever the agent
+claims about itself. With `did:web` that is a domain you control; with
+`did:key` it is a public key baked into the identifier. Both prove the
+same key signed the credential. Neither says who stands behind the agent,
+what model it runs, or who owns it. A verifier that receives a credential
+from an unfamiliar agent has no authority to point at.
+
+The Root of Trust layer closes that gap. An issuer the root recognizes
+binds the agent's DID to real attributes, and the recognition traces back
+to a root the verifier pinned in advance. The verifier decides once, up
+front, which root it trusts. Everything else is checked from the
+credentials presented, with no external certificate authority and no
+central per-agent lookup.
+
+## The three credential types
+
+All three are ordinary Verifiable Credential 2.0 documents with an
+`eddsa-jcs-2022` Data Integrity proof, the same proof used everywhere
+else in Vouch Protocol. Each carries exactly one of the trust-layer types
+below, so a credential minted for one slot in the chain cannot be
+replayed into another.
+
+### 1. Root of Trust credential (`VouchRootOfTrust`)
+
+Self-issued by the root: issuer and subject are both the root's own DID.
+It makes the root self-describing. A verifier pins the root DID; keeping
+this credential is optional and lets a verifier display what the root
+anchors.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "VouchRootOfTrust"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2036-07-09T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkRoot...",
+    "vouchVersion": "1.0",
+    "rootOfTrust": {
+      "name": "Example Machine Identity Root",
+      "scope": ["ai-agent", "robot"]
+    }
+  },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer` equals `credentialSubject.id` (self-issued).
+- `rootOfTrust.name`: human-readable name of the root.
+- `rootOfTrust.scope`: what the root anchors. Defaults to
+  `["ai-agent", "robot"]`.
+
+### 2. Recognized-issuer credential (`RecognizedIssuerCredential`)
+
+Issued by the root. It names an issuer DID and the identity actions that
+issuer may perform. `recognizedIn` points back to the root DID so a
+verifier can trace the recognition to the anchor it pinned. The holder
+staples this credential to what it presents, so the verifier needs no
+directory lookup.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "RecognizedIssuerCredential"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkIssuer...",
+    "recognizedActions": ["issueAgentIdentity"],
+    "recognizedIn": "did:key:z6MkRoot..."
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the root DID.
+- `credentialSubject.id`: the issuer being recognized.
+- `recognizedActions`: one or more of `issueAgentIdentity` and
+  `issueRobotIdentity`. Defaults to `["issueAgentIdentity"]`.
+- `recognizedIn`: the root DID, chaining recognition back to the anchor.
+- `credentialStatus`: optional, for revoking the recognition later.
+
+### 3. Agent identity credential (`AgentIdentityCredential`)
+
+Issued by a recognized issuer. Here the issuer differs from the subject:
+the issuer binds the agent's DID to attributes it stands behind. This is
+the piece that turns a self-asserted agent DID into an identity a third
+party vouches for.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "AgentIdentityCredential"],
+  "issuer": "did:key:z6MkIssuer...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkAgent...",
+    "identity": {
+      "owner": "Example Robotics Inc.",
+      "model": "claims-assistant-2",
+      "capabilityClass": "financial-read",
+      "createdAt": "2026-07-12T00:00:00Z"
+    }
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the recognized issuer's DID (not the agent's).
+- `credentialSubject.id`: the agent's DID.
+- `identity`: a non-empty map of attributes. `owner`, `model`,
+  `capabilityClass`, and `createdAt` are the common ones; you may add
+  more and they pass through verification.
+- `credentialStatus`: optional, for revoking the identity later.
+
+## The anchor-once verification algorithm
+
+A verifier trusts one thing up front: a root DID. Everything else is
+derived. `verify_identity_chain` takes the agent identity credential and
+the recognized-issuer credential, plus the pinned `trusted_root`, and
+walks:
+
+```
+action credential          (optional, signed by the agent)
+  -> agent identity credential   (signed by the recognized issuer)
+    -> recognized-issuer credential  (signed by the pinned root)
+      -> pinned Vouch Protocol root
+```
+
+Step by step:
+
+1. Verify the recognized-issuer credential's proof, confirm its issuer is
+   exactly the `trusted_root`, and confirm `recognizedActions` includes
+   the required action (`issueAgentIdentity` by default). Reject if the
+   recognition is revoked.
+2. Verify the agent identity credential's proof and confirm its issuer is
+   the DID that the root just recognized. Reject if the identity is
+   revoked.
+3. Optionally, if the Root of Trust credential is supplied, confirm it is
+   genuinely self-issued by the `trusted_root`.
+4. Optionally, if an action credential is supplied, verify it and confirm
+   it was signed by the agent the identity describes.
+
+The result reports `ok`, and on success the `agent_did`, the
+`issuer_did` that vouched for it, the `root_did` it anchored to, and the
+bound `attributes`. On failure it returns a structured reason (for
+example `issuer_not_recognized_for_action` or
+`identity_not_from_recognized_issuer`) so a caller can see exactly which
+link broke.
+
+## Offline operation
+
+When the root, the issuer, and the agent all use `did:key`, the whole
+chain verifies with no network. Each `did:key` carries its public key in
+the identifier itself, so every signature resolves locally. This suits
+air-gapped verifiers, robots on a factory floor, and edge deployments
+that cannot reach a directory.
+
+For `did:web` issuers, pass `allow_did_resolution=True` to resolve keys
+over the network, or pin keys ahead of time by passing a
+DID-to-public-key map so verification stays offline.
+
+## Revocation
+
+Recognition and identity are both revocable through the standard
+`credentialStatus` field (BitstringStatusList). Revoke a recognized
+issuer to withdraw its authority to vouch for new agents; revoke an
+individual agent identity to retire one agent without touching the
+issuer. The verifier consults the status entry during the walk and
+rejects a revoked link. This reuses the same revocation machinery as the
+rest of Vouch Protocol, so nothing new is needed operationally.
+
+## The CLI
+
+Four subcommands under `vouch root` drive the full lifecycle:
+
+- `vouch root init`: self-issue a Root of Trust credential and mint the
+  root's key. Run once to stand up a root.
+- `vouch root recognize`: issue a recognized-issuer credential from the
+  root, naming an issuer DID and the actions it may perform.
+- `vouch root issue-identity`: as a recognized issuer, issue an agent
+  identity credential that binds an agent DID to its attributes.
+- `vouch root verify-chain`: walk an agent identity back to a pinned
+  root and report whether it anchors.
+
+The agent's own `vouch init` is unchanged. `vouch root` is the separate,
+additive authority surface.
+
+## Anyone can self-host a root
+
+There is no privileged central root. Anyone can run `vouch root init` to
+stand up their own root, recognize their own issuers, and publish the
+root DID for verifiers to pin. An enterprise runs a root for its own
+fleet; a marketplace runs one for the agents it lists; a robotics vendor
+runs one for the machines it ships. Verifiers choose which roots to
+trust, so the model stays self-sovereign and there is no gatekeeper to
+ask permission from.
+
+## Four-language byte-identical interop
+
+The Root of Trust layer ships in Python, TypeScript, Rust, and Go, all
+producing the same wire format. A recognized-issuer credential signed in
+one language verifies in the other three, and a chain can span languages:
+a root in Go, an issuer in Python, an agent in Rust, a verifier in
+TypeScript all interoperate because they share JCS canonicalization
+(RFC 8785) and the same `eddsa-jcs-2022` proof. This is the same
+cross-language guarantee the base credentials carry, extended to the
+authority layer.
+
+## When to reach for it
+
+- A verifier wants agent identities backed by a named authority, with a
+  single trust decision made up front.
+- Identities should carry attributes an issuer stands behind (owner,
+  model, capability class) rather than self-asserted claims alone.
+- The deployment needs offline verification with no directory lookup.
+- You want to run your own root and recognize your own issuers, with no
+  external certificate authority.
+
+The base `vouch init` identity remains the right starting point for a
+single self-certifying agent. Add the Root of Trust layer when a verifier
+needs to anchor many agents to an authority it trusts.

--- a/openai-gpt/instructions.md
+++ b/openai-gpt/instructions.md
@@ -100,6 +100,16 @@ been removed. See `integrations.md`.
   Vouch conformance levels L1 to L3 and the self-test runner (`python -m
   vouch.conformance`), with a hosted verifier that mints a re-checkable badge
   coming. See `conformance.md`.
+- "How do I anchor agent identity to an authority, not a bare DID?" -> The
+  Root of Trust for Machine Identity (`vouch.root_of_trust`): a verifier pins one
+  Vouch Protocol root, `build_recognized_issuer` records that an issuer may issue
+  identity (its `recognizedActions`), and `build_agent_identity` binds an agent
+  DID to attributes (owner, model, capability class). `verify_identity_chain`
+  walks the chain back to the pinned root, offline with `did:key`, with no
+  external certificate authority. Additive to the agent's own `vouch init`. CLI:
+  `vouch root init` / `recognize` / `issue-identity` / `verify-chain`. Ships in
+  Python, TypeScript, Rust, and Go with a byte-identical wire format. See
+  `root-of-trust.md`.
 - "Single validator or quorum?" -> Single is fine for development. For
   regulated production, M-of-N with role-tagged validators.
 - "How do I prove an agent was right, or track a record I cannot fake?" ->

--- a/openai-gpt/knowledge/root-of-trust.md
+++ b/openai-gpt/knowledge/root-of-trust.md
@@ -1,0 +1,246 @@
+# Root of Trust for Machine Identity
+
+Vouch Protocol can act as the trust anchor for AI agent and robot
+identity. This is an optional authority layer on top of the base
+protocol. A verifier pins one Vouch Protocol root, the root recognizes
+issuers, and a recognized issuer vouches for an agent's identity. A
+verifier then confirms any agent by walking a short chain back to the
+single root it already trusts.
+
+The base protocol is unchanged. An agent's own `vouch init` still mints
+a self-certifying identity with no authority above it. This layer is
+additive: reach for it when a verifier wants identities backed by a named
+authority rather than self-asserted alone.
+
+## The problem it solves
+
+A self-issued Vouch Protocol credential anchors to whatever the agent
+claims about itself. With `did:web` that is a domain you control; with
+`did:key` it is a public key baked into the identifier. Both prove the
+same key signed the credential. Neither says who stands behind the agent,
+what model it runs, or who owns it. A verifier that receives a credential
+from an unfamiliar agent has no authority to point at.
+
+The Root of Trust layer closes that gap. An issuer the root recognizes
+binds the agent's DID to real attributes, and the recognition traces back
+to a root the verifier pinned in advance. The verifier decides once, up
+front, which root it trusts. Everything else is checked from the
+credentials presented, with no external certificate authority and no
+central per-agent lookup.
+
+## The three credential types
+
+All three are ordinary Verifiable Credential 2.0 documents with an
+`eddsa-jcs-2022` Data Integrity proof, the same proof used everywhere
+else in Vouch Protocol. Each carries exactly one of the trust-layer types
+below, so a credential minted for one slot in the chain cannot be
+replayed into another.
+
+### 1. Root of Trust credential (`VouchRootOfTrust`)
+
+Self-issued by the root: issuer and subject are both the root's own DID.
+It makes the root self-describing. A verifier pins the root DID; keeping
+this credential is optional and lets a verifier display what the root
+anchors.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "VouchRootOfTrust"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2036-07-09T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkRoot...",
+    "vouchVersion": "1.0",
+    "rootOfTrust": {
+      "name": "Example Machine Identity Root",
+      "scope": ["ai-agent", "robot"]
+    }
+  },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer` equals `credentialSubject.id` (self-issued).
+- `rootOfTrust.name`: human-readable name of the root.
+- `rootOfTrust.scope`: what the root anchors. Defaults to
+  `["ai-agent", "robot"]`.
+
+### 2. Recognized-issuer credential (`RecognizedIssuerCredential`)
+
+Issued by the root. It names an issuer DID and the identity actions that
+issuer may perform. `recognizedIn` points back to the root DID so a
+verifier can trace the recognition to the anchor it pinned. The holder
+staples this credential to what it presents, so the verifier needs no
+directory lookup.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "RecognizedIssuerCredential"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkIssuer...",
+    "recognizedActions": ["issueAgentIdentity"],
+    "recognizedIn": "did:key:z6MkRoot..."
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the root DID.
+- `credentialSubject.id`: the issuer being recognized.
+- `recognizedActions`: one or more of `issueAgentIdentity` and
+  `issueRobotIdentity`. Defaults to `["issueAgentIdentity"]`.
+- `recognizedIn`: the root DID, chaining recognition back to the anchor.
+- `credentialStatus`: optional, for revoking the recognition later.
+
+### 3. Agent identity credential (`AgentIdentityCredential`)
+
+Issued by a recognized issuer. Here the issuer differs from the subject:
+the issuer binds the agent's DID to attributes it stands behind. This is
+the piece that turns a self-asserted agent DID into an identity a third
+party vouches for.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "AgentIdentityCredential"],
+  "issuer": "did:key:z6MkIssuer...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkAgent...",
+    "identity": {
+      "owner": "Example Robotics Inc.",
+      "model": "claims-assistant-2",
+      "capabilityClass": "financial-read",
+      "createdAt": "2026-07-12T00:00:00Z"
+    }
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the recognized issuer's DID (not the agent's).
+- `credentialSubject.id`: the agent's DID.
+- `identity`: a non-empty map of attributes. `owner`, `model`,
+  `capabilityClass`, and `createdAt` are the common ones; you may add
+  more and they pass through verification.
+- `credentialStatus`: optional, for revoking the identity later.
+
+## The anchor-once verification algorithm
+
+A verifier trusts one thing up front: a root DID. Everything else is
+derived. `verify_identity_chain` takes the agent identity credential and
+the recognized-issuer credential, plus the pinned `trusted_root`, and
+walks:
+
+```
+action credential          (optional, signed by the agent)
+  -> agent identity credential   (signed by the recognized issuer)
+    -> recognized-issuer credential  (signed by the pinned root)
+      -> pinned Vouch Protocol root
+```
+
+Step by step:
+
+1. Verify the recognized-issuer credential's proof, confirm its issuer is
+   exactly the `trusted_root`, and confirm `recognizedActions` includes
+   the required action (`issueAgentIdentity` by default). Reject if the
+   recognition is revoked.
+2. Verify the agent identity credential's proof and confirm its issuer is
+   the DID that the root just recognized. Reject if the identity is
+   revoked.
+3. Optionally, if the Root of Trust credential is supplied, confirm it is
+   genuinely self-issued by the `trusted_root`.
+4. Optionally, if an action credential is supplied, verify it and confirm
+   it was signed by the agent the identity describes.
+
+The result reports `ok`, and on success the `agent_did`, the
+`issuer_did` that vouched for it, the `root_did` it anchored to, and the
+bound `attributes`. On failure it returns a structured reason (for
+example `issuer_not_recognized_for_action` or
+`identity_not_from_recognized_issuer`) so a caller can see exactly which
+link broke.
+
+## Offline operation
+
+When the root, the issuer, and the agent all use `did:key`, the whole
+chain verifies with no network. Each `did:key` carries its public key in
+the identifier itself, so every signature resolves locally. This suits
+air-gapped verifiers, robots on a factory floor, and edge deployments
+that cannot reach a directory.
+
+For `did:web` issuers, pass `allow_did_resolution=True` to resolve keys
+over the network, or pin keys ahead of time by passing a
+DID-to-public-key map so verification stays offline.
+
+## Revocation
+
+Recognition and identity are both revocable through the standard
+`credentialStatus` field (BitstringStatusList). Revoke a recognized
+issuer to withdraw its authority to vouch for new agents; revoke an
+individual agent identity to retire one agent without touching the
+issuer. The verifier consults the status entry during the walk and
+rejects a revoked link. This reuses the same revocation machinery as the
+rest of Vouch Protocol, so nothing new is needed operationally.
+
+## The CLI
+
+Four subcommands under `vouch root` drive the full lifecycle:
+
+- `vouch root init`: self-issue a Root of Trust credential and mint the
+  root's key. Run once to stand up a root.
+- `vouch root recognize`: issue a recognized-issuer credential from the
+  root, naming an issuer DID and the actions it may perform.
+- `vouch root issue-identity`: as a recognized issuer, issue an agent
+  identity credential that binds an agent DID to its attributes.
+- `vouch root verify-chain`: walk an agent identity back to a pinned
+  root and report whether it anchors.
+
+The agent's own `vouch init` is unchanged. `vouch root` is the separate,
+additive authority surface.
+
+## Anyone can self-host a root
+
+There is no privileged central root. Anyone can run `vouch root init` to
+stand up their own root, recognize their own issuers, and publish the
+root DID for verifiers to pin. An enterprise runs a root for its own
+fleet; a marketplace runs one for the agents it lists; a robotics vendor
+runs one for the machines it ships. Verifiers choose which roots to
+trust, so the model stays self-sovereign and there is no gatekeeper to
+ask permission from.
+
+## Four-language byte-identical interop
+
+The Root of Trust layer ships in Python, TypeScript, Rust, and Go, all
+producing the same wire format. A recognized-issuer credential signed in
+one language verifies in the other three, and a chain can span languages:
+a root in Go, an issuer in Python, an agent in Rust, a verifier in
+TypeScript all interoperate because they share JCS canonicalization
+(RFC 8785) and the same `eddsa-jcs-2022` proof. This is the same
+cross-language guarantee the base credentials carry, extended to the
+authority layer.
+
+## When to reach for it
+
+- A verifier wants agent identities backed by a named authority, with a
+  single trust decision made up front.
+- Identities should carry attributes an issuer stands behind (owner,
+  model, capability class) rather than self-asserted claims alone.
+- The deployment needs offline verification with no directory lookup.
+- You want to run your own root and recognize your own issuers, with no
+  external certificate authority.
+
+The base `vouch init` identity remains the right starting point for a
+single self-certifying agent. Add the Root of Trust layer when a verifier
+needs to anchor many agents to an authority it trusts.

--- a/website-agent/backend/knowledge/root-of-trust.md
+++ b/website-agent/backend/knowledge/root-of-trust.md
@@ -1,0 +1,246 @@
+# Root of Trust for Machine Identity
+
+Vouch Protocol can act as the trust anchor for AI agent and robot
+identity. This is an optional authority layer on top of the base
+protocol. A verifier pins one Vouch Protocol root, the root recognizes
+issuers, and a recognized issuer vouches for an agent's identity. A
+verifier then confirms any agent by walking a short chain back to the
+single root it already trusts.
+
+The base protocol is unchanged. An agent's own `vouch init` still mints
+a self-certifying identity with no authority above it. This layer is
+additive: reach for it when a verifier wants identities backed by a named
+authority rather than self-asserted alone.
+
+## The problem it solves
+
+A self-issued Vouch Protocol credential anchors to whatever the agent
+claims about itself. With `did:web` that is a domain you control; with
+`did:key` it is a public key baked into the identifier. Both prove the
+same key signed the credential. Neither says who stands behind the agent,
+what model it runs, or who owns it. A verifier that receives a credential
+from an unfamiliar agent has no authority to point at.
+
+The Root of Trust layer closes that gap. An issuer the root recognizes
+binds the agent's DID to real attributes, and the recognition traces back
+to a root the verifier pinned in advance. The verifier decides once, up
+front, which root it trusts. Everything else is checked from the
+credentials presented, with no external certificate authority and no
+central per-agent lookup.
+
+## The three credential types
+
+All three are ordinary Verifiable Credential 2.0 documents with an
+`eddsa-jcs-2022` Data Integrity proof, the same proof used everywhere
+else in Vouch Protocol. Each carries exactly one of the trust-layer types
+below, so a credential minted for one slot in the chain cannot be
+replayed into another.
+
+### 1. Root of Trust credential (`VouchRootOfTrust`)
+
+Self-issued by the root: issuer and subject are both the root's own DID.
+It makes the root self-describing. A verifier pins the root DID; keeping
+this credential is optional and lets a verifier display what the root
+anchors.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "VouchRootOfTrust"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2036-07-09T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkRoot...",
+    "vouchVersion": "1.0",
+    "rootOfTrust": {
+      "name": "Example Machine Identity Root",
+      "scope": ["ai-agent", "robot"]
+    }
+  },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer` equals `credentialSubject.id` (self-issued).
+- `rootOfTrust.name`: human-readable name of the root.
+- `rootOfTrust.scope`: what the root anchors. Defaults to
+  `["ai-agent", "robot"]`.
+
+### 2. Recognized-issuer credential (`RecognizedIssuerCredential`)
+
+Issued by the root. It names an issuer DID and the identity actions that
+issuer may perform. `recognizedIn` points back to the root DID so a
+verifier can trace the recognition to the anchor it pinned. The holder
+staples this credential to what it presents, so the verifier needs no
+directory lookup.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "RecognizedIssuerCredential"],
+  "issuer": "did:key:z6MkRoot...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkIssuer...",
+    "recognizedActions": ["issueAgentIdentity"],
+    "recognizedIn": "did:key:z6MkRoot..."
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the root DID.
+- `credentialSubject.id`: the issuer being recognized.
+- `recognizedActions`: one or more of `issueAgentIdentity` and
+  `issueRobotIdentity`. Defaults to `["issueAgentIdentity"]`.
+- `recognizedIn`: the root DID, chaining recognition back to the anchor.
+- `credentialStatus`: optional, for revoking the recognition later.
+
+### 3. Agent identity credential (`AgentIdentityCredential`)
+
+Issued by a recognized issuer. Here the issuer differs from the subject:
+the issuer binds the agent's DID to attributes it stands behind. This is
+the piece that turns a self-asserted agent DID into an identity a third
+party vouches for.
+
+Required shape:
+
+```json
+{
+  "type": ["VerifiableCredential", "AgentIdentityCredential"],
+  "issuer": "did:key:z6MkIssuer...",
+  "validFrom": "2026-07-12T00:00:00Z",
+  "validUntil": "2027-07-12T00:00:00Z",
+  "credentialSubject": {
+    "id": "did:key:z6MkAgent...",
+    "identity": {
+      "owner": "Example Robotics Inc.",
+      "model": "claims-assistant-2",
+      "capabilityClass": "financial-read",
+      "createdAt": "2026-07-12T00:00:00Z"
+    }
+  },
+  "credentialStatus": { "...": "optional revocation entry" },
+  "proof": { "cryptosuite": "eddsa-jcs-2022", "...": "..." }
+}
+```
+
+- `issuer`: the recognized issuer's DID (not the agent's).
+- `credentialSubject.id`: the agent's DID.
+- `identity`: a non-empty map of attributes. `owner`, `model`,
+  `capabilityClass`, and `createdAt` are the common ones; you may add
+  more and they pass through verification.
+- `credentialStatus`: optional, for revoking the identity later.
+
+## The anchor-once verification algorithm
+
+A verifier trusts one thing up front: a root DID. Everything else is
+derived. `verify_identity_chain` takes the agent identity credential and
+the recognized-issuer credential, plus the pinned `trusted_root`, and
+walks:
+
+```
+action credential          (optional, signed by the agent)
+  -> agent identity credential   (signed by the recognized issuer)
+    -> recognized-issuer credential  (signed by the pinned root)
+      -> pinned Vouch Protocol root
+```
+
+Step by step:
+
+1. Verify the recognized-issuer credential's proof, confirm its issuer is
+   exactly the `trusted_root`, and confirm `recognizedActions` includes
+   the required action (`issueAgentIdentity` by default). Reject if the
+   recognition is revoked.
+2. Verify the agent identity credential's proof and confirm its issuer is
+   the DID that the root just recognized. Reject if the identity is
+   revoked.
+3. Optionally, if the Root of Trust credential is supplied, confirm it is
+   genuinely self-issued by the `trusted_root`.
+4. Optionally, if an action credential is supplied, verify it and confirm
+   it was signed by the agent the identity describes.
+
+The result reports `ok`, and on success the `agent_did`, the
+`issuer_did` that vouched for it, the `root_did` it anchored to, and the
+bound `attributes`. On failure it returns a structured reason (for
+example `issuer_not_recognized_for_action` or
+`identity_not_from_recognized_issuer`) so a caller can see exactly which
+link broke.
+
+## Offline operation
+
+When the root, the issuer, and the agent all use `did:key`, the whole
+chain verifies with no network. Each `did:key` carries its public key in
+the identifier itself, so every signature resolves locally. This suits
+air-gapped verifiers, robots on a factory floor, and edge deployments
+that cannot reach a directory.
+
+For `did:web` issuers, pass `allow_did_resolution=True` to resolve keys
+over the network, or pin keys ahead of time by passing a
+DID-to-public-key map so verification stays offline.
+
+## Revocation
+
+Recognition and identity are both revocable through the standard
+`credentialStatus` field (BitstringStatusList). Revoke a recognized
+issuer to withdraw its authority to vouch for new agents; revoke an
+individual agent identity to retire one agent without touching the
+issuer. The verifier consults the status entry during the walk and
+rejects a revoked link. This reuses the same revocation machinery as the
+rest of Vouch Protocol, so nothing new is needed operationally.
+
+## The CLI
+
+Four subcommands under `vouch root` drive the full lifecycle:
+
+- `vouch root init`: self-issue a Root of Trust credential and mint the
+  root's key. Run once to stand up a root.
+- `vouch root recognize`: issue a recognized-issuer credential from the
+  root, naming an issuer DID and the actions it may perform.
+- `vouch root issue-identity`: as a recognized issuer, issue an agent
+  identity credential that binds an agent DID to its attributes.
+- `vouch root verify-chain`: walk an agent identity back to a pinned
+  root and report whether it anchors.
+
+The agent's own `vouch init` is unchanged. `vouch root` is the separate,
+additive authority surface.
+
+## Anyone can self-host a root
+
+There is no privileged central root. Anyone can run `vouch root init` to
+stand up their own root, recognize their own issuers, and publish the
+root DID for verifiers to pin. An enterprise runs a root for its own
+fleet; a marketplace runs one for the agents it lists; a robotics vendor
+runs one for the machines it ships. Verifiers choose which roots to
+trust, so the model stays self-sovereign and there is no gatekeeper to
+ask permission from.
+
+## Four-language byte-identical interop
+
+The Root of Trust layer ships in Python, TypeScript, Rust, and Go, all
+producing the same wire format. A recognized-issuer credential signed in
+one language verifies in the other three, and a chain can span languages:
+a root in Go, an issuer in Python, an agent in Rust, a verifier in
+TypeScript all interoperate because they share JCS canonicalization
+(RFC 8785) and the same `eddsa-jcs-2022` proof. This is the same
+cross-language guarantee the base credentials carry, extended to the
+authority layer.
+
+## When to reach for it
+
+- A verifier wants agent identities backed by a named authority, with a
+  single trust decision made up front.
+- Identities should carry attributes an issuer stands behind (owner,
+  model, capability class) rather than self-asserted claims alone.
+- The deployment needs offline verification with no directory lookup.
+- You want to run your own root and recognize your own issuers, with no
+  external certificate authority.
+
+The base `vouch init` identity remains the right starting point for a
+single self-certifying agent. Add the Root of Trust layer when a verifier
+needs to anchor many agents to an authority it trusts.

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -250,6 +250,54 @@ A consumer does not trust a server's number: it fetches the receipts and recompu
   },
 
   // =====================================================================
+  // ROOT OF TRUST FOR MACHINE IDENTITY
+  // =====================================================================
+  {
+    id: 'root-of-trust',
+    audience: 'Root of trust',
+    title: 'Anchoring agent identity to an authority you pin',
+    items: [
+      {
+        q: 'What is the Root of Trust for Machine Identity?',
+        a: `It is an optional authority layer. A verifier pins one Vouch Protocol root, the root recognizes issuers, and a recognized issuer vouches for an agent's identity. A verifier then confirms any agent by walking a short chain back to the single root it already trusts.
+
+Your agent's own \`vouch init\` identity is unchanged. This layer is additive: reach for it when a verifier wants identities backed by a named authority rather than self-asserted alone.`,
+        meta: 'Spec section 18',
+      },
+      {
+        q: 'Why would I need it if my agent already has a DID?',
+        a: `A self-issued credential anchors to whatever the agent claims about itself: a domain with \`did:web\`, or a public key with \`did:key\`. That proves the same key signed the credential, but it does not say who stands behind the agent, what model it runs, or who owns it.
+
+The Root of Trust layer closes that gap. A recognized issuer binds the agent's DID to real attributes (owner, model, capability class), and the recognition traces back to a root the verifier pinned in advance. There is no external certificate authority and no central per-agent lookup.`,
+      },
+      {
+        q: 'What are the three credential types?',
+        a: `1. **Root of Trust credential** (\`VouchRootOfTrust\`), self-issued by the root so it describes itself.
+2. **Recognized-issuer credential** (\`RecognizedIssuerCredential\`), issued by the root, naming an issuer, its \`recognizedActions\` (like \`issueAgentIdentity\` or \`issueRobotIdentity\`), and a \`recognizedIn\` pointer back to the root.
+3. **Agent identity credential** (\`AgentIdentityCredential\`), issued by a recognized issuer (issuer differs from subject), binding an agent DID to attributes.
+
+All three are ordinary Verifiable Credentials with the same \`eddsa-jcs-2022\` proof used everywhere else in Vouch Protocol.`,
+      },
+      {
+        q: 'How does verification work, and can it run offline?',
+        a: `\`verify_identity_chain\` walks the chain: the recognized-issuer credential must be signed by the pinned root and grant the required action, the identity credential must be signed by that recognized issuer, and an optional action credential must be signed by the agent the identity describes. Everything anchors at the one root DID the verifier trusts up front.
+
+When the root, issuer, and agent all use \`did:key\`, the whole chain verifies with no network, since each \`did:key\` carries its public key in the identifier. For \`did:web\` issuers you can resolve keys over the network or pin them ahead of time.`,
+      },
+      {
+        q: 'How do I revoke a recognition or an identity?',
+        a: `Both the recognized-issuer credential and the agent identity credential carry an optional \`credentialStatus\` (BitstringStatusList). Revoke a recognized issuer to withdraw its authority to vouch for new agents; revoke a single identity to retire one agent without touching the issuer. The verifier checks the status during the walk and rejects a revoked link.`,
+      },
+      {
+        q: 'Who runs the root? Is there a central one?',
+        a: `There is no privileged central root. Anyone can run \`vouch root init\` to stand up their own root, recognize their own issuers, and publish the root DID for verifiers to pin. An enterprise runs one for its fleet, a marketplace for the agents it lists, a robotics vendor for the machines it ships. Verifiers choose which roots to trust.
+
+The four CLI commands are \`vouch root init\`, \`vouch root recognize\`, \`vouch root issue-identity\`, and \`vouch root verify-chain\`. The layer ships in Python, TypeScript, Rust, and Go with a byte-identical wire format, so a chain can span languages and still verify.`,
+      },
+    ],
+  },
+
+  // =====================================================================
   // EMBODIED AGENTS (ROBOTICS)
   // =====================================================================
   {

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -889,6 +889,90 @@ assert valid
 A true multi-device ceremony, where custodians never share a coordinator process, calls \`threshold.commit\`, \`threshold.sign_share\`, and \`threshold.aggregate\` directly on each device, passing commitments and shares over the network instead of holding every share in one \`ThresholdSigner\`.
 `,
       },
+      {
+        id: 'root-of-trust',
+        title: 'Anchoring Identity to a Root of Trust',
+        summary: 'Make Vouch Protocol the authority for agent identity: pin one root, recognize issuers, and verify any agent by walking a short chain back to the root.',
+        body: `
+## Why a root of trust
+
+A self-issued Vouch Protocol credential anchors to whatever the agent claims about itself: a domain with \`did:web\`, or a public key with \`did:key\`. That proves the same key signed, but it does not say who stands behind the agent, what model it runs, or who owns it.
+
+The Root of Trust layer adds that authority. A verifier pins one root up front. The root recognizes issuers. A recognized issuer binds an agent's DID to real attributes. A verifier then confirms any agent by walking a short chain back to the single root it already trusts, with no external certificate authority and no central per-agent lookup.
+
+Your agent's own \`vouch init\` identity is unchanged. This is an additive layer; reach for it when a verifier wants identities backed by a named authority.
+
+## The three credentials
+
+All three are ordinary Verifiable Credentials with the same \`eddsa-jcs-2022\` proof used everywhere else in Vouch Protocol.
+
+1. **Root of Trust** (\`VouchRootOfTrust\`): self-issued by the root, so it describes itself. The verifier pins the root DID.
+2. **Recognized-issuer** (\`RecognizedIssuerCredential\`): issued by the root. Names an issuer, its \`recognizedActions\` (\`issueAgentIdentity\`, \`issueRobotIdentity\`), and a \`recognizedIn\` pointer back to the root.
+3. **Agent identity** (\`AgentIdentityCredential\`): issued by a recognized issuer, where the issuer differs from the subject. Binds the agent's DID to attributes (owner, model, capability class).
+
+## Build a chain in Python
+
+\`\`\`python
+from vouch.root_of_trust import (
+  generate_did_key_identity, build_root_of_trust,
+  build_recognized_issuer, build_agent_identity, verify_identity_chain,
+)
+from vouch import Signer
+
+# Stand up a root (self-issued).
+root_keys = generate_did_key_identity()
+root = Signer.from_keypair(root_keys)
+root_cred = build_root_of_trust(root, name="Example Machine Identity Root")
+
+# The root recognizes an issuer.
+issuer_keys = generate_did_key_identity()
+issuer = Signer.from_keypair(issuer_keys)
+recognized = build_recognized_issuer(
+  root, issuer_did=issuer.did, recognized_actions=["issueAgentIdentity"],
+)
+
+# The recognized issuer vouches for an agent's identity.
+agent_keys = generate_did_key_identity()
+identity = build_agent_identity(
+  issuer, subject_did=agent_keys.did,
+  attributes={"owner": "Example Inc.", "model": "claims-assistant-2",
+              "capabilityClass": "financial-read"},
+)
+\`\`\`
+
+## Verify against the pinned root
+
+\`\`\`python
+result = verify_identity_chain(
+  identity, recognized,
+  trusted_root=root.did,        # the ONE DID this verifier trusts
+  root_credential=root_cred,    # optional self-consistency check
+)
+assert result.ok
+print(result.agent_did, result.issuer_did, result.root_did)
+print(result.attributes)
+\`\`\`
+
+The walk confirms the recognition is signed by the pinned root and grants the required action, then that the identity is signed by that recognized issuer. Pass an \`action_credential\` too and it also confirms the agent signed its own action. On failure the result carries a structured reason showing which link broke.
+
+## Offline and revocation
+
+When the root, issuer, and agent all use \`did:key\`, the whole chain verifies with no network, since each \`did:key\` carries its public key in the identifier. For \`did:web\` issuers, resolve keys over the network or pin them ahead of time.
+
+Both the recognized-issuer and identity credentials accept an optional \`credentialStatus\` (BitstringStatusList). Revoke a recognized issuer to withdraw its authority to vouch for new agents; revoke a single identity to retire one agent. The verifier checks the status during the walk.
+
+## From the command line
+
+Four subcommands drive the lifecycle:
+
+- \`vouch root init\` self-issues a root and mints its key.
+- \`vouch root recognize\` issues a recognized-issuer credential.
+- \`vouch root issue-identity\` issues an agent identity as a recognized issuer.
+- \`vouch root verify-chain\` walks an agent identity back to a pinned root.
+
+Anyone can run \`vouch root init\` and publish the root DID for verifiers to pin. The layer ships in Python, TypeScript, Rust, and Go with a byte-identical wire format, so a chain can span languages and still verify.
+`,
+      },
     ],
   },
 


### PR DESCRIPTION
This updates the documentation and assistant surfaces for the Root of Trust for Machine Identity.

- FAQ: a new Root of Trust section explaining the authority layer and how a verifier pins one root to verify any agent.
- Help: a new guide with the Python build and verify flow and the `vouch root` CLI.
- Knowledge base: a `root-of-trust` reference document added across the four assistant knowledge sets, kept byte-identical.
- Claude skill, OpenAI GPT, and Gemini gem: updated so each recognizes and explains the capability.

The reference document covers the three credential types and their required fields, the anchor-once verification algorithm, the four `vouch root` commands, offline did:key operation, credentialStatus revocation, self-hostable roots, and the byte-identical interop across Python, TypeScript, Rust, and Go.
