### PR TITLE
Align the MCP server with the 2026-07-28 specification revision

### DIFF
--- a/packages/vouch-mcp/VERIFY.md
+++ b/packages/vouch-mcp/VERIFY.md
@@ -19,7 +19,7 @@ pip install pytest
 pytest packages/vouch-mcp/tests -q
 ```
 
-Expect: 3 passed. They check the package exports, that the FastMCP server has
+Expect: 3 passed. They check the package exports, that the MCP server has
 `sign` / `create_session` / `get_identity` registered, and that the
 issued credential is `eddsa-jcs-2022` and verifies.
 

--- a/packages/vouch-mcp/tests/test_smoke.py
+++ b/packages/vouch-mcp/tests/test_smoke.py
@@ -1,8 +1,9 @@
 """Smoke tests for the vouch-mcp package.
 
-These prove the package imports, the server object is the official FastMCP
-type with the expected tools registered, and the server's signing path
-produces a credential that verifies.
+These prove the package imports, the server object is the official SDK's
+high-level server type with the expected tools registered, and the server's
+signing path produces a credential that verifies. They pass against both
+mcp 1.x (FastMCP) and mcp 2.x (MCPServer, the 2026-07-28 protocol revision).
 """
 
 import asyncio
@@ -19,7 +20,9 @@ def test_package_exports():
     import vouch_mcp
 
     assert callable(vouch_mcp.main)
-    assert type(vouch_mcp.mcp).__name__ == "FastMCP"
+    # mcp 1.x names the high-level server class FastMCP; mcp 2.x (the
+    # 2026-07-28 protocol revision) renamed it MCPServer.
+    assert type(vouch_mcp.mcp).__name__ in ("FastMCP", "MCPServer")
 
 
 def test_registered_tool_names():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,9 @@ crewai = ["crewai>=0.1.0"]
 langgraph = ["langgraph>=0.1.0"]
 goose = ["pyyaml>=6.0"]
 autogen = ["pyautogen>=0.2.0"]
-mcp = ["mcp>=0.1.0"]
+# mcp 1.2 is the first release with the FastMCP high-level API; the server
+# also supports mcp 2.x (the 2026-07-28 stateless protocol revision).
+mcp = ["mcp>=1.2.0"]
 vertex = ["google-cloud-aiplatform>=1.0.0"]
 streamlit = ["streamlit>=1.0.0"]
 

--- a/vouch/integrations/mcp/__init__.py
+++ b/vouch/integrations/mcp/__init__.py
@@ -1,4 +1,4 @@
-"""Vouch MCP Server integration (built on the official MCP SDK / FastMCP)."""
+"""Vouch MCP Server integration (built on the official MCP Python SDK)."""
 
 from .server import main, mcp
 

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -1,9 +1,16 @@
 """
 Vouch Protocol MCP Server.
 
-A Model Context Protocol server, built on the official MCP Python SDK
-(FastMCP), that lets MCP-compatible clients (Claude Desktop, Cursor, agent
+A Model Context Protocol server, built on the official MCP Python SDK,
+that lets MCP-compatible clients (Claude Desktop, Cursor, agent
 frameworks in any language) both *issue* and *verify* Vouch Credentials.
+
+Works with both major lines of the official SDK: mcp 1.x (protocol
+revisions up to 2025-11-25, FastMCP class) and mcp 2.x (the stateless
+2026-07-28 revision, MCPServer class). All tools here are stateless
+request/response functions, and session vouchers are explicit signed
+handles the client passes back in, which is exactly the state model the
+2026-07-28 revision prescribes.
 
 Relationship to ``vouch.autosign``:
 
@@ -35,25 +42,41 @@ import json
 import os
 from typing import Optional
 
+# The official MCP Python SDK renamed its high-level server class for the
+# 2026-07-28 protocol revision: mcp>=2.0 ships ``mcp.server.MCPServer``
+# (stateless core, no initialize handshake, server/discover), while mcp 1.x
+# ships ``mcp.server.fastmcp.FastMCP``. The tool decorator API is identical,
+# so we support both and let the installed SDK determine the protocol
+# revisions spoken on the wire.
 try:
-    from mcp.server.fastmcp import FastMCP
-except ImportError as exc:  # pragma: no cover
-    raise SystemExit(
-        "The Vouch MCP server requires the MCP SDK. Install it with:\n"
-        "    pip install 'vouch-protocol[mcp]'\n"
-        "or\n"
-        "    pip install mcp\n"
-        f"(import error: {exc})"
-    )
+    from mcp.server import MCPServer as _ServerClass  # mcp >= 2.0
+
+    _MCP_SDK_V2 = True
+except ImportError:
+    try:
+        from mcp.server.fastmcp import FastMCP as _ServerClass  # mcp 1.x
+
+        _MCP_SDK_V2 = False
+    except ImportError as exc:  # pragma: no cover
+        raise SystemExit(
+            "The Vouch MCP server requires the MCP SDK. Install it with:\n"
+            "    pip install 'vouch-protocol[mcp]'\n"
+            "or\n"
+            "    pip install mcp\n"
+            f"(import error: {exc})"
+        )
 
 from vouch.autosign import resolve_signer, sign_intent
 
 
-mcp = FastMCP(
-    "vouch",
-    host=os.getenv("VOUCH_MCP_HOST", "127.0.0.1"),
-    port=int(os.getenv("VOUCH_MCP_PORT", "8080")),
-)
+_HOST = os.getenv("VOUCH_MCP_HOST", "127.0.0.1")
+_PORT = int(os.getenv("VOUCH_MCP_PORT", "8080"))
+
+if _MCP_SDK_V2:
+    # mcp>=2.0 takes host/port per transport at run() time, not here.
+    mcp = _ServerClass("vouch")
+else:
+    mcp = _ServerClass("vouch", host=_HOST, port=_PORT)
 
 
 @mcp.tool()
@@ -252,13 +275,21 @@ def main() -> None:
 
     - 'stdio' (default): for local clients like Claude Desktop and Cursor.
     - 'http' / 'streamable-http': for remote / hosted deployments.
-    - 'sse': legacy Server-Sent Events transport.
+    - 'sse': the HTTP+SSE transport, deprecated by the MCP specification;
+      kept for existing clients during the deprecation window. Use
+      Streamable HTTP for anything new.
     """
     transport = os.getenv("VOUCH_MCP_TRANSPORT", "stdio").lower().replace("_", "-")
     if transport in ("http", "streamable-http"):
-        mcp.run(transport="streamable-http")
+        if _MCP_SDK_V2:
+            mcp.run(transport="streamable-http", host=_HOST, port=_PORT)
+        else:
+            mcp.run(transport="streamable-http")
     elif transport == "sse":
-        mcp.run(transport="sse")
+        if _MCP_SDK_V2:
+            mcp.run(transport="sse", host=_HOST, port=_PORT)
+        else:
+            mcp.run(transport="sse")
     else:
         mcp.run()
 


### PR DESCRIPTION
Aligns the MCP server with the 2026-07-28 specification revision.

The Python SDK's 2.x line renames the server class and moves host and port from the constructor to run(), so the server now supports both SDK lines through a small compatibility shim: mcp.server.MCPServer on 2.x with a fallback to mcp.server.fastmcp.FastMCP on 1.x. The tool surface is unchanged; all five tools are pure stateless request/response, which already matches the revision's stateless core and explicit-handle state model. The SSE transport option keeps working on both lines and its docstring now points to Streamable HTTP as the current choice. The mcp extra's version floor is raised to the first release that ships the server API in use.

Smoke tests and an end-to-end stdio session (tools list, get_identity, sign, verify) pass against both mcp 1.28.1 and the 2.0.0 release candidate. ruff format and lint are clean.
