### PR TITLE
docs: prior art disclosures for continuous-trust authorization and live trust standing (PAD-104, PAD-063)

### DIFF
--- a/docs/disclosures/PAD-063-live-trust-standing-propagation-a2a.md
+++ b/docs/disclosures/PAD-063-live-trust-standing-propagation-a2a.md
@@ -1,0 +1,145 @@
+# PAD-063: Live Trust-Standing Propagation Across Agent-to-Agent Calls
+
+**Identifier:** PAD-063  
+**Title:** Method for Carrying and Evaluating a Caller Agent's Live Time-Decayed Trust Standing, Identity, and Delegation Chain Across a Cross-Domain Agent-to-Agent Protocol Call  
+**Publication Date:** July 12, 2026  
+**Prior Art Effective Date:** July 12, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** AI Safety / Multi-Agent Systems / Agent-to-Agent Interoperability / Continuous Trust / Cross-Domain Authorization  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-002 (Chain of Custody), PAD-016 (Dynamic Credential Renewal), PAD-104 (Per-Tool-Call Continuous-Trust Authorization)  
+
+---
+
+## 1. Abstract
+
+A method by which a calling agent, when invoking another agent over an
+agent-to-agent (A2A) protocol, carries in the call's transport metadata not only
+a verifiable identity credential and its delegation chain but a **live trust
+standing**: a SessionVoucher whose time-decaying trust value the callee evaluates
+**at the moment the call is received**. The callee thereby decides whether to
+cooperate based on the caller's current trust, not merely on whether the caller
+once held a valid credential.
+
+Key innovations:
+
+- **Trust value travels with the call, evaluated on receipt.** The caller's
+  decaying trust is transmitted (as the voucher parameters) and recomputed by the
+  callee at receive time, so a caller whose trust has decayed is refused even with
+  a structurally valid identity.
+- **Namespaced extension carrier.** The identity, chain, and voucher travel in the
+  A2A message metadata under a single extension URI, so they coexist with other
+  A2A extensions without collision.
+- **Capability-card advertisement of a trust requirement.** The callee's agent
+  card advertises that it requires a Vouch identity, so the requirement is
+  discoverable before the first call.
+- **Chain-attenuated cross-domain trust.** The delegation chain accompanies the
+  call so the callee can see the full "on behalf of" lineage back to the human or
+  root agent, across trust domains.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A2A calls authenticate the channel, not the live standing of the caller
+
+Agent interoperability protocols establish that a message came from some agent,
+but the receiving agent has no standard way to learn the caller's current trust
+standing (how recently the caller was attested, how much its trust has decayed)
+or the chain of authority on whose behalf the caller acts.
+
+### 2.2 Static credentials do not capture mid-session degradation
+
+A caller may hold a valid identity credential yet have stopped heartbeating or
+have drifted from its declared intent. Without a live, decaying trust signal
+carried into the call, the callee cannot distinguish a freshly attested caller
+from a stale one.
+
+### 2.3 Cross-domain cooperation lacks a portable trust artifact
+
+When two agents belong to different operators, the callee cannot evaluate the
+caller's home-domain trust unless that trust is presented in a verifiable,
+self-contained form at call time.
+
+---
+
+## 3. Solution (The Invention)
+
+The calling agent attaches, to the A2A message metadata under the extension URI
+`https://vouch-protocol.com/ext/a2a/v1`, a block carrying:
+
+- a signed Vouch identity credential (with its delegation chain), and
+- an optional SessionVoucher carrying `initialTrust`, `decayLambda`, and
+  `validFrom`.
+
+On receipt, the callee:
+
+1. extracts the block from the message (or from the `message/send` params),
+2. verifies the credential proof and delegation-chain attenuation,
+3. recomputes the caller's trust `trust(now) = initialTrust * exp(-decayLambda *
+   (now - validFrom))` at receive time and compares it to the callee's threshold
+   for the requested operation, and
+4. binds the credential to the exact skill or endpoint being invoked
+   (confused-deputy guard).
+
+The callee advertises the requirement by adding a Vouch extension entry to its
+agent card's `capabilities.extensions`, optionally marked required, so a caller
+discovers the need for a Vouch identity before calling. A handler decorator
+refuses any incoming call whose carried trust standing fails verification.
+
+---
+
+## 4. Prior Art Differentiation
+
+- **mTLS / signed requests / API gateways.** Authenticate the channel or the
+  sender but do not carry a decaying trust scalar evaluated on receipt, nor the
+  delegation lineage.
+- **A2A base protocols.** Provide message and task structures and agent cards but
+  do not define carrying or evaluating a live, time-decayed trust standing or a
+  delegation chain in the message metadata.
+- **PAD-016 / PAD-104.** Establish continuous trust at the credential layer and at
+  the single-tool-call layer respectively. The present method extends the live
+  trust evaluation to the cross-agent A2A boundary, with a namespaced carrier and
+  agent-card advertisement, which neither addresses.
+
+---
+
+## 5. Technical Implementation
+
+A reference integration provides: `build_vouch_extension` (the agent-card entry),
+`attach_identity` (embed the credential and voucher in a message's metadata under
+the extension URI without mutating the input), `extract_identity` (read the block
+from a message, a params object, or raw metadata), `verify_incoming` (extract and
+run the conjunctive per-call verification, including the receive-time trust
+recomputation), and a `requires_vouch_a2a` handler decorator. The verification
+reuses the same engine as the per-tool-call gate (PAD-104), so the trust
+recomputation and resource binding are identical across MCP and A2A.
+
+---
+
+## 6. Claims Summary
+
+1. A method for carrying, in the metadata of an agent-to-agent protocol call, a
+   caller agent's verifiable identity, delegation chain, and a SessionVoucher
+   describing a time-decaying trust value, and evaluating that trust at the moment
+   the call is received to decide whether to cooperate.
+2. The method of claim 1 wherein the carried artifacts reside under a single
+   extension URI in the message metadata so as to coexist with other extensions.
+3. The method of claim 1 wherein the receiving agent advertises a requirement for
+   such an identity in its capability card prior to the first call.
+4. The method of claim 1 wherein the delegation chain conveys the cross-domain
+   "on behalf of" lineage and the receiving agent binds the credential to the
+   exact skill or endpoint invoked.
+5. The method of claim 1 wherein the receive-time trust evaluation refuses a
+   caller whose trust has decayed below a per-operation threshold despite a
+   structurally valid identity.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods are released under Apache 2.0 and may be freely
+implemented. Publication is intended to prevent patenting by any party and to keep
+the methods available to the open Vouch Protocol ecosystem.

--- a/docs/disclosures/PAD-104-per-tool-call-continuous-trust-authorization.md
+++ b/docs/disclosures/PAD-104-per-tool-call-continuous-trust-authorization.md
@@ -1,0 +1,182 @@
+# PAD-104: Per-Tool-Call Continuous-Trust Authorization with Resource-Bound Delegation
+
+**Identifier:** PAD-104  
+**Title:** Method for Authorizing an Individual Agent Tool Call on the Conjunction of Credential Validity, Delegation-Chain Attenuation, Time-Decaying Trust, and Exact-Resource Binding  
+**Publication Date:** July 12, 2026  
+**Prior Art Effective Date:** July 12, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** AI Safety / Agent Authorization / Tool-Call Governance / Confused-Deputy Prevention / Continuous Trust  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-001 (Cryptographic Agent Identity), PAD-016 (Dynamic Credential Renewal), PAD-021 (Inverse Capability Protocol), PAD-039 (Deterministic Multi-Party Trust State)  
+
+---
+
+## 1. Abstract
+
+A method for authorizing a single agent tool call (for example a Model Context
+Protocol tool invocation) by evaluating, at the moment of the call, the logical
+conjunction of four independent conditions, and refusing the call unless all hold:
+
+1. **Credential validity.** The caller presents a Verifiable Credential whose
+   Data Integrity proof, temporal window, and required resource binding verify.
+2. **Delegation-chain attenuation.** Every link in the credential's delegation
+   chain is a proper subset of its parent, so a sub-agent cannot exceed what it
+   was delegated.
+3. **Current time-decayed trust.** An accompanying SessionVoucher's trust value
+   is recomputed at call time under an exponential decay function and compared
+   against a per-operation threshold (high, medium, or low stakes).
+4. **Exact-resource binding.** The credential's declared `intent.resource` is
+   identical to the concrete resource the tool call is about to touch.
+
+Key innovations:
+
+- **Trust as a continuous, per-call quantity.** Unlike a static bearer token
+  checked once at session start, trust is recomputed for every individual tool
+  call as a decaying value, so a call made late in a session can be refused even
+  though the same session's first call was allowed.
+- **Conjunctive gate at the tool boundary.** The four conditions are evaluated
+  together, at the tool-execution boundary, as a single accept/reject decision,
+  rather than as separate checks at separate layers.
+- **Resource binding as confused-deputy proof.** Binding the credential to the
+  exact resource the call touches turns a generic capability into a
+  single-resource capability, so a prompt injection cannot redirect an
+  authorized agent to a different resource.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 Session-level authorization is too coarse for autonomous agents
+
+Agent frameworks authorize a session once (an API key, an OAuth token) and then
+trust every subsequent tool call for the session's life. An agent that turns
+malicious or is hijacked mid-session keeps its authorization. There is no
+standard mechanism that re-decides authorization per individual tool call as a
+function of how much time and how many actions have elapsed.
+
+### 2.2 The confused-deputy problem at the tool boundary
+
+A tool call carries a verb and a target, but the agent that issues it may have
+been redirected by untrusted input (a prompt injection) to call the same tool
+against a different, attacker-chosen resource. A capability that says "this agent
+may POST" does not constrain where it POSTs.
+
+### 2.3 Delegation chains are verified for structure but not fused with trust
+
+Existing delegation models verify that a chain attenuates, and separate systems
+track reputation or liveness, but no method fuses chain attenuation, a live
+decaying-trust value, and an exact-resource binding into one per-call decision.
+
+---
+
+## 3. Solution (The Invention)
+
+The verifier exposes a single operation, `verify_tool_call(credential, ...)`,
+invoked at the tool boundary before the tool executes. It accepts the caller's
+credential, an optional SessionVoucher, the concrete resource the call will
+touch, and an operation stakes level, and returns one boolean decision plus a
+structured reason set.
+
+The decision is the conjunction:
+
+```
+ok = credential_valid
+     AND delegation_chain_attenuates
+     AND (required_resource is None OR intent.resource == required_resource)
+     AND (threshold is None OR trust(now) >= threshold)
+```
+
+where:
+
+- `credential_valid` is the eddsa-jcs-2022 proof verification plus temporal and
+  required-resource-binding checks.
+- `delegation_chain_attenuates` applies the capability-attenuation rule to every
+  link (each link a proper subset of its parent across at least one dimension and
+  broader on none).
+- `trust(now) = initialTrust * exp(-decayLambda * (now - validFrom))`, recomputed
+  at the instant of the call, with the threshold drawn from the operation's
+  stakes band (for example >= 0.9 for high stakes, >= 0.75 for medium, >= 0.5 for
+  low).
+
+Because the trust term is evaluated at call time, the same credential and voucher
+yield accept earlier in a session and reject later, with no re-issuance. Because
+the resource term requires byte-equality between the granted resource and the
+invoked resource, a redirected call to a different resource fails even though the
+signature and trust are valid.
+
+A decorator form (`requires_vouch`) wraps a tool handler so an unverified call
+never reaches the handler, and the same engine is reused across transports (the
+MCP integration and the Agent2Agent integration both call it).
+
+---
+
+## 4. Prior Art Differentiation
+
+- **OAuth / API keys / JWT bearer tokens.** Authorize a session or a request
+  window statically; they do not recompute a decaying trust value per call, do
+  not fuse delegation attenuation, and do not bind to an exact resource.
+- **PAD-016 (Dynamic Credential Renewal).** Establishes continuous trust and
+  trust entropy at the credential-renewal layer (the SessionVoucher). The present
+  method consumes that decaying trust at the per-tool-call decision point and
+  fuses it with delegation attenuation and exact-resource binding, which PAD-016
+  does not address.
+- **PAD-021 (Inverse Capability).** Governs how much autonomy a capable agent
+  gets; it does not define the per-call conjunctive gate or the confused-deputy
+  resource binding.
+- **Capability systems (object capabilities, macaroons).** Attenuate authority
+  but do not incorporate a time-decaying trust scalar evaluated at use time.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation exposes `verify_tool_call` and a `requires_vouch`
+decorator. Inputs: the credential (object or JSON), an optional issuer public key
+or DID-resolution flag, an optional SessionVoucher, a `required_resource`, an
+optional `required_action`, and a stakes selector or explicit `min_trust`.
+
+Processing:
+
+1. Verify the credential proof (offline against a supplied key, or by resolving
+   the issuer DID).
+2. Run the delegation-chain attenuation check over `credentialSubject.delegationChain`.
+3. If `required_resource` is set, compare it to `credentialSubject.intent.resource`.
+4. If a SessionVoucher is present and a threshold is set, compute
+   `trust(now)` and compare; also confirm the voucher's subject matches the
+   credential subject.
+5. Return `ok` as the conjunction plus per-condition reasons.
+
+The same call is exposed inside an MCP server as an open tool and inside an
+Agent2Agent integration, so the per-call gate runs at whichever boundary the
+deployment uses.
+
+---
+
+## 6. Claims Summary
+
+1. A method for authorizing an individual agent tool call by evaluating, at the
+   moment of the call, the conjunction of credential validity, delegation-chain
+   attenuation, a time-decayed trust value, and an exact-resource binding, and
+   refusing the call unless all conditions hold.
+2. The method of claim 1 wherein the trust value is recomputed per call under an
+   exponential decay so the same credential yields accept earlier and reject
+   later within one session without re-issuance.
+3. The method of claim 1 wherein the resource binding requires equality between
+   the credential's declared resource and the concrete resource the call will
+   touch, preventing a redirected (confused-deputy) call.
+4. The method of claim 1 wherein the per-operation trust threshold is selected
+   from a stakes band so higher-impact operations demand higher current trust.
+5. The method of claim 1 implemented as a handler decorator so an unverified call
+   never reaches the tool, and reused across Model Context Protocol and
+   Agent2Agent transports.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of
+the date above. The methods described are released under Apache 2.0 and may be
+freely implemented. Publication is intended to prevent the patenting of these
+methods by any party and to keep them available to the open Vouch Protocol
+ecosystem.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -72,6 +72,7 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-060](./PAD-060-single-use-audited-override-of-egress-block.md) | Method for One-Time Time-Bounded Override of a Deterministic Egress-Time Policy Block, with Cryptographically Auditable Override Event and Structural Prevention of Repeated Re-Use | 2026-05-14 | Published |
 | [PAD-061](./PAD-061-per-region-human-ai-code-attribution.md) | Per-Region Authorship Attribution for Mixed Human and AI Source Code via Edit-Channel Capture and Independently-Keyed Signatures | 2026-06-10 | Published |
 | [PAD-062](./PAD-062-self-contained-agent-passport.md) | Self-Contained, Offline-Verifiable Agent Passport Stapled Into Transport Metadata | 2026-07-12 | Published |
+| [PAD-063](./PAD-063-live-trust-standing-propagation-a2a.md) | Live Trust-Standing Propagation Across Agent-to-Agent Calls | 2026-07-12 | Published |
 | [PAD-064](./PAD-064-hardware-rooted-robot-identity.md) | Hardware-Rooted Verifiable Robot Identity and Lifecycle Credential | 2026-06-14 | Published |
 | [PAD-065](./PAD-065-model-config-provenance-attestation.md) | Re-Signable Model-and-Config Provenance Attestation for Embodied Agents | 2026-06-14 | Published |
 | [PAD-066](./PAD-066-physical-capability-scope-attenuation.md) | Physical Capability Scope as Cryptographically Enforceable Attenuation | 2026-06-14 | Published |
@@ -112,6 +113,7 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-101](./PAD-101-human-handover-envelope.md) | Robot-to-Human Handover Credential With a Safety-Envelope Attestation at the Release | 2026-07-06 | Published |
 | [PAD-102](./PAD-102-handover-acknowledgement.md) | Recipient Acknowledgement Bound to a Specific Robot-to-Human Handover | 2026-07-06 | Published |
 | [PAD-103](./PAD-103-root-anchored-hardware-rooted-robot-identity.md) | Root-Anchored, Hardware-Rooted Robot Identity Binding | 2026-07-12 | Published |
+| [PAD-104](./PAD-104-per-tool-call-continuous-trust-authorization.md) | Per-Tool-Call Continuous-Trust Authorization with Resource-Bound Delegation | 2026-07-12 | Published |
 
 
 ## July 12, 2026: Root-Anchored Hardware-Rooted Robot Identity (PAD-103)


### PR DESCRIPTION
Adds two defensive prior art disclosures for continuous trust in agent interactions.

PAD-104 covers authorizing an individual agent tool call (for example an MCP tool invocation) on the conjunction of four independently verifiable conditions at call time: credential validity, delegation-chain attenuation where every link is a proper subset of its parent, time-decaying trust standing above the tool's threshold, and exact-resource binding that prevents confused-deputy substitution.

PAD-063 covers carrying a caller agent's live, time-decaying trust standing, identity, and delegation chain in the transport metadata of a cross-domain agent-to-agent call, so the callee decides to cooperate based on the caller's standing at the moment the call arrives rather than on a credential that was valid at issuance.

Both compose with the published Heartbeat renewal protocol (PAD-016) and the deterministic multi-party trust state (PAD-039), and the index rows are added.
