### PR TITLE
Add vouch-openai integration package

### DIFF
--- a/packages/vouch-openai/README.md
+++ b/packages/vouch-openai/README.md
@@ -1,0 +1,60 @@
+# vouch-openai
+
+Sign the tool (function) calls an OpenAI agent makes with Vouch Protocol Credentials, so every action an OpenAI-driven agent takes carries a verifiable identity and a non-repudiable record.
+
+It works with the OpenAI Python SDK function calling (Chat Completions and the Responses API) and with the OpenAI Agents SDK, because all of them dispatch to Python tool callables and expose a tool call as a name plus JSON arguments.
+
+## Install
+
+```bash
+pip install vouch-openai
+```
+
+## Configure an identity
+
+```bash
+export VOUCH_DID='did:web:your-agent.example.com'
+export VOUCH_PRIVATE_KEY='{"kty":"OKP","crv":"Ed25519",...}'
+```
+
+Generate one with `vouch init --domain your-agent.example.com --env`, or pass a `Signer` explicitly.
+
+## Sign the model's requested tool call
+
+```python
+from openai import OpenAI
+from vouch.integrations.openai import sign_tool_call
+
+client = OpenAI()
+response = client.chat.completions.create(model="gpt-4o", messages=messages, tools=tools)
+
+for call in response.choices[0].message.tool_calls:
+    credential = sign_tool_call(call)   # binds the action and its arguments
+    result = dispatch(call)             # run your tool
+```
+
+## Sign the tool callables
+
+```python
+from vouch.integrations.openai import signed_tool, protect
+
+@signed_tool
+def get_weather(city: str) -> str:
+    ...
+
+tools = protect([get_weather, send_email])   # every invocation is signed
+```
+
+## Verify
+
+```python
+from vouch.integrations.openai import verify_tool_call
+
+ok, passport = verify_tool_call(credential)
+```
+
+A tool runs whether or not an identity is resolved; when none is configured, signing is skipped and the call proceeds unsigned.
+
+## License
+
+Apache-2.0. Part of [Vouch Protocol](https://vouch-protocol.com).

--- a/packages/vouch-openai/VERIFY.md
+++ b/packages/vouch-openai/VERIFY.md
@@ -1,0 +1,41 @@
+# Verifying vouch-openai
+
+A quick end-to-end check that signing and verification work.
+
+```bash
+pip install vouch-openai
+```
+
+```python
+import json
+from vouch.keys import generate_identity
+from vouch import Signer
+from vouch.integrations.openai import sign_tool_call, verify_tool_call
+
+keys = generate_identity(domain="agent.example.com")
+signer = Signer(private_key=keys.private_key_jwk, did=keys.did)
+
+# An OpenAI-shaped tool call (name plus JSON arguments).
+tool_call = {"function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})}}
+
+credential = sign_tool_call(tool_call, signer=signer, publish=False)
+print("action:", credential["credentialSubject"]["intent"]["action"])   # get_weather
+
+ok, passport = verify_tool_call(credential, public_key=keys.public_key_jwk)
+print("verified:", ok)                                                   # True
+print("action:", passport.action)                                        # get_weather
+```
+
+Expected output:
+
+```
+action: get_weather
+verified: True
+action: get_weather
+```
+
+The smoke tests in `tests/test_smoke.py` cover the dict and object tool-call shapes, the `signed_tool` decorator, and `protect`. Run them with:
+
+```bash
+PYTHONPATH=src python -m pytest tests/ -q
+```

--- a/packages/vouch-openai/pyproject.toml
+++ b/packages/vouch-openai/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vouch-openai"
+version = "0.1.0"
+description = "Sign OpenAI agent tool calls with Vouch Credentials."
+readme = "README.md"
+requires-python = ">=3.9"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Ramprasad Gaddam" }]
+keywords = ["openai", "vouch", "ai-agents", "verifiable-credentials", "identity"]
+dependencies = ["vouch-protocol>=1.6.0", "openai>=1.0.0"]
+
+[project.optional-dependencies]
+dev = ["pytest>=7.0"]
+
+[project.urls]
+Homepage = "https://vouch-protocol.com"
+Source = "https://github.com/vouch-protocol/vouch"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/packages/vouch-openai/src/vouch_openai/__init__.py
+++ b/packages/vouch-openai/src/vouch_openai/__init__.py
@@ -1,0 +1,15 @@
+"""Sign OpenAI agent tool calls with Vouch Credentials.
+
+Thin re-export of :mod:`vouch.integrations.openai` so the integration installs
+as a standalone package that pulls in both ``vouch-protocol`` and ``openai``.
+"""
+
+from vouch.integrations.openai import (
+    protect,
+    sign_tool_call,
+    signed_tool,
+    verify_tool_call,
+)
+
+__all__ = ["protect", "signed_tool", "sign_tool_call", "verify_tool_call"]
+__version__ = "0.1.0"

--- a/packages/vouch-openai/tests/test_smoke.py
+++ b/packages/vouch-openai/tests/test_smoke.py
@@ -1,0 +1,78 @@
+"""Smoke tests for vouch-openai.
+
+Hermetic: each test generates a throwaway identity and passes the Signer
+explicitly, so no environment variables or network are needed.
+"""
+
+import json
+
+import pytest
+
+from vouch import Signer
+from vouch.keys import generate_identity
+from vouch_openai import protect, sign_tool_call, signed_tool, verify_tool_call
+
+
+def _identity():
+    keys = generate_identity(domain="agent.example.com")
+    return keys, Signer(private_key=keys.private_key_jwk, did=keys.did)
+
+
+def test_sign_and_verify_dict_tool_call():
+    keys, signer = _identity()
+    call = {"function": {"name": "get_weather", "arguments": json.dumps({"city": "Paris"})}}
+    credential = sign_tool_call(call, signer=signer, publish=False)
+
+    assert credential is not None
+    assert credential["credentialSubject"]["intent"]["action"] == "get_weather"
+
+    ok, passport = verify_tool_call(credential, public_key=keys.public_key_jwk)
+    assert ok
+    assert passport.action == "get_weather"
+
+
+def test_sign_object_tool_call():
+    class _Fn:
+        def __init__(self, name, arguments):
+            self.name = name
+            self.arguments = arguments
+
+    class _Call:
+        def __init__(self, fn):
+            self.function = fn
+
+    keys, signer = _identity()
+    call = _Call(_Fn("send_email", json.dumps({"to": "a@example.com"})))
+    credential = sign_tool_call(call, signer=signer, publish=False)
+
+    assert credential["credentialSubject"]["intent"]["action"] == "send_email"
+    ok, _ = verify_tool_call(credential, public_key=keys.public_key_jwk)
+    assert ok
+
+
+def test_signed_tool_decorator_runs_and_marks():
+    _, signer = _identity()
+
+    @signed_tool(signer=signer)
+    def add(a, b):
+        return a + b
+
+    assert getattr(add, "__vouch_signed__", False) is True
+    assert add(2, 3) == 5
+
+
+def test_protect_wraps_callables():
+    _, signer = _identity()
+
+    def fetch():
+        return "ok"
+
+    wrapped = protect([fetch], signer=signer)
+    assert getattr(wrapped[0], "__vouch_signed__", False) is True
+    assert wrapped[0]() == "ok"
+
+
+def test_missing_function_name_raises():
+    _, signer = _identity()
+    with pytest.raises(ValueError):
+        sign_tool_call({"function": {"arguments": "{}"}}, signer=signer, publish=False)

--- a/vouch/integrations/openai.py
+++ b/vouch/integrations/openai.py
@@ -1,0 +1,198 @@
+"""
+Vouch Protocol OpenAI Integration.
+
+Sign the tool (function) calls an OpenAI agent makes with Vouch Credentials, so
+every action an OpenAI-driven agent takes carries a verifiable identity. This
+works with the OpenAI Python SDK function calling (Chat Completions and the
+Responses API) and with the OpenAI Agents SDK, because all of them dispatch to
+Python tool callables and expose a tool call as a name plus JSON arguments.
+
+Two entry points:
+
+- :func:`sign_tool_call` signs the model's requested tool call (a name plus its
+  JSON arguments) before you dispatch it, giving you a credential to attach to
+  the result or to log.
+- :func:`signed_tool` and :func:`protect` wrap the Python tool callables you
+  dispatch to, so each execution issues its own Vouch Credential.
+
+Neither imports the OpenAI SDK, so the core package carries no extra dependency;
+the standalone ``vouch-openai`` package declares ``openai`` for you.
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+from typing import Any, Callable, List, Optional, Sequence, Tuple
+
+from vouch import Signer
+from vouch.autosign import sign_intent
+from vouch.verifier import verify as _verify_credential
+
+__all__ = ["protect", "signed_tool", "sign_tool_call", "verify_tool_call"]
+
+_TARGET = "openai:tool"
+
+
+def signed_tool(
+    fn: Optional[Callable[..., Any]] = None,
+    *,
+    signer: Optional[Signer] = None,
+    action: Optional[str] = None,
+    resource: Optional[str] = None,
+) -> Callable[..., Any]:
+    """Wrap an OpenAI tool (a Python callable) so each execution is signed.
+
+    Use as a decorator on a function tool. The credential records the tool
+    running, under the function name unless ``action`` is given, and binds the
+    call arguments. The tool runs whether or not an identity is resolved; when
+    none is, signing is skipped and the call proceeds unsigned.
+
+    Example::
+
+        from vouch.integrations.openai import signed_tool
+
+        @signed_tool
+        def get_weather(city: str) -> str: ...
+
+        @signed_tool(action="charge_card")
+        def bill(amount: int) -> str: ...
+    """
+
+    def decorate(func: Callable[..., Any]) -> Callable[..., Any]:
+        tool_action = action or getattr(func, "__name__", "tool")
+        res = resource or f"{_TARGET}:{tool_action}"
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            sign_intent(
+                tool_action,
+                target=_TARGET,
+                resource=res,
+                signer=signer,
+                extra={"arguments": _json_safe(kwargs)},
+            )
+            return func(*args, **kwargs)
+
+        wrapper.__vouch_signed__ = True
+        return wrapper
+
+    if fn is not None:
+        return decorate(fn)
+    return decorate
+
+
+def protect(
+    tools: Sequence[Any],
+    *,
+    signer: Optional[Signer] = None,
+    **signed_kwargs: Any,
+) -> List[Any]:
+    """Sign-wrap a list of OpenAI function-tool callables.
+
+    Each plain callable is wrapped so every invocation is signed. Anything that
+    is already signed, or is not callable, is returned unchanged.
+
+    Example::
+
+        from vouch.integrations.openai import protect
+
+        tools = protect([get_weather, send_email])
+    """
+    out: List[Any] = []
+    for t in tools:
+        if callable(t) and not getattr(t, "__vouch_signed__", False):
+            out.append(signed_tool(t, signer=signer, **signed_kwargs))
+        else:
+            out.append(t)
+    return out
+
+
+def sign_tool_call(
+    tool_call: Any,
+    *,
+    signer: Optional[Signer] = None,
+    resource: Optional[str] = None,
+    publish: bool = True,
+) -> Optional[dict]:
+    """Sign the model's requested tool call and return a Vouch Credential.
+
+    Accepts the OpenAI SDK tool-call object (``tool_call.function.name`` and
+    ``tool_call.function.arguments``) or the equivalent dict shape. The
+    credential binds the action to the tool name and to the arguments the model
+    asked to run with.
+
+    Example::
+
+        for call in message.tool_calls:
+            credential = sign_tool_call(call)
+            result = dispatch(call)
+    """
+    name, arguments = _extract(tool_call)
+    res = resource or f"{_TARGET}:{name}"
+    return sign_intent(
+        name,
+        target=_TARGET,
+        resource=res,
+        signer=signer,
+        extra={"arguments": arguments},
+        publish=publish,
+    )
+
+
+def verify_tool_call(credential: Any, *, public_key: Any = None):
+    """Verify a signed tool-call credential. Returns ``(is_valid, passport)``.
+
+    With no ``public_key`` the issuer key is resolved from the credential's DID.
+    """
+    return _verify_credential(credential, public_key=public_key)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract(tool_call: Any) -> Tuple[str, Any]:
+    """Pull (name, arguments) from an OpenAI tool call object or dict."""
+    fn = getattr(tool_call, "function", None)
+    if fn is None and isinstance(tool_call, dict):
+        fn = tool_call.get("function", tool_call)
+    if fn is None:
+        raise ValueError("tool_call has no function payload")
+
+    if isinstance(fn, dict):
+        name = fn.get("name")
+        raw_args = fn.get("arguments")
+    else:
+        name = getattr(fn, "name", None)
+        raw_args = getattr(fn, "arguments", None)
+
+    if not name:
+        raise ValueError("tool_call is missing a function name")
+    return name, _parse_args(raw_args)
+
+
+def _parse_args(raw: Any) -> Any:
+    """OpenAI passes tool arguments as a JSON string; normalize to a value."""
+    if raw is None:
+        return {}
+    if isinstance(raw, (dict, list)):
+        return _json_safe(raw)
+    if isinstance(raw, str):
+        try:
+            return json.loads(raw)
+        except (ValueError, TypeError):
+            return {"_raw": raw}
+    return {"_raw": str(raw)}
+
+
+def _json_safe(value: Any) -> Any:
+    """Return value unchanged if JSON-serializable, else a stringified form."""
+    try:
+        json.dumps(value)
+        return value
+    except (TypeError, ValueError):
+        if isinstance(value, dict):
+            return {k: str(v) for k, v in value.items()}
+        return str(value)


### PR DESCRIPTION
This adds a vouch-openai integration so the tool (function) calls an OpenAI agent makes carry a Vouch Protocol Credential.

- sign_tool_call(tool_call) signs the model requested function call, binding the action to the tool name and its arguments. It accepts the OpenAI SDK tool-call object or the equivalent dict.
- signed_tool and protect wrap the Python tool callables you dispatch to, so each execution issues its own credential.
- verify_tool_call verifies a signed credential.

It works with the OpenAI Python SDK function calling (Chat Completions and the Responses API) and the OpenAI Agents SDK. The core module imports no OpenAI SDK, so vouch-protocol carries no new dependency; the standalone vouch-openai package declares openai. Ships with a README, a verification guide, and smoke tests covering the dict and object tool-call shapes, the decorator, and protect.

Security boundary: the credential is a standard eddsa-jcs-2022 Vouch Credential over the tool name and its arguments, so it proves which agent identity requested a given tool call with given arguments. When no identity is configured the call still runs, so adding Vouch never blocks an agent.
