### PR TITLE
Add root-anchored verify and agent enroll to the Root of Trust

### DIFF
--- a/examples/agent_enroll_and_verify.py
+++ b/examples/agent_enroll_and_verify.py
@@ -1,0 +1,88 @@
+"""
+Enroll an agent and verify its portable identity bundle.
+
+Shows the one-command handoff Vouch Protocol gives the Root of Trust for Machine
+Identity. An operator recognized by a root enrolls an agent into a single
+portable bundle. A verifier that pins only the root DID checks the bundle
+offline, and rejects a bundle that chains to a root it never pinned.
+
+The recognized issuer is always the operator's own key, a parameter, never a
+fixed authority. Anyone can stand up their own root and recognize their own
+issuers, so the model stays self-sovereign.
+
+Run:  python examples/agent_enroll_and_verify.py
+"""
+
+from vouch.signer import Signer
+from vouch.root_of_trust import (
+    ACTION_ISSUE_AGENT_IDENTITY,
+    build_agent_identity,
+    build_identity_bundle,
+    build_recognized_issuer,
+    build_root_of_trust,
+    generate_did_key_identity,
+    verify_bundle,
+)
+
+
+def signer(label: str) -> Signer:
+    keys = generate_did_key_identity()
+    print(f"  {label:<24} {keys.did}")
+    return Signer.from_keypair(keys)
+
+
+def main() -> None:
+    print("Identities (each self-generated, no external CA):")
+    root = signer("Root")
+    operator = signer("Operator (an issuer)")
+    agent = signer("Operator's agent")
+    print()
+
+    # The root self-describes and recognizes the operator as an issuer that may
+    # attest agent identity.
+    root_cred = build_root_of_trust(root, name="Vouch Machine Identity Root")
+    recognition = build_recognized_issuer(
+        root, issuer_did=operator.did, recognized_actions=[ACTION_ISSUE_AGENT_IDENTITY]
+    )
+
+    # Enroll: the operator attests the agent's identity, then packages the
+    # identity, the recognition, and the root into one portable bundle.
+    identity = build_agent_identity(
+        operator,
+        subject_did=agent.did,
+        attributes={"owner": "Acme", "model": "gpt-x", "capabilityClass": "shopping"},
+    )
+    action = agent.sign(
+        intent={
+            "action": "buy",
+            "target": "store",
+            "resource": "https://store.example/item/headphones",
+        }
+    )
+    bundle = build_identity_bundle(
+        identity=identity, recognition=recognition, action=action, root=root_cred
+    )
+
+    # A verifier that pins ONLY the root DID checks the whole bundle offline.
+    result = verify_bundle(bundle, trusted_root=root.did)
+    print("Enrolled agent (bundle pinned to the real root):")
+    print(f"  verified   : {result.ok}")
+    print(f"  agent      : {result.agent_did}")
+    print(f"  issuer     : {result.issuer_did}")
+    print(f"  attributes : {result.attributes}")
+    print(f"  action     : {result.action.action} -> {result.action.resource}")
+    print()
+
+    # A forger stands up their own root and hands out a bundle. It fails because
+    # the verifier only trusts the root it pinned out of band.
+    forger_root = signer("Forger's own root")
+    forged_recognition = build_recognized_issuer(forger_root, issuer_did=operator.did)
+    forged_bundle = build_identity_bundle(identity=identity, recognition=forged_recognition)
+    forged = verify_bundle(forged_bundle, trusted_root=root.did)
+    print("Forged bundle (chains to a root the verifier did not pin):")
+    print(f"  verified   : {forged.ok}")
+    print(f"  reason     : {forged.reason}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agent_enroll.py
+++ b/tests/test_agent_enroll.py
@@ -1,0 +1,302 @@
+"""
+Tests for the portable identity bundle and the one-command enroll and
+root-anchored verify flow.
+
+Covers the library layer (build_identity_bundle + verify_bundle, happy path and
+a wrong pinned root) and the CLI (`vouch agent enroll` produces a bundle that
+`vouch agent verify` accepts against the correct root and rejects against a
+wrong one). Everything runs offline with did:key identities and a temp keystore,
+no network and no passphrase prompts.
+"""
+
+import json
+import types
+
+import pytest
+
+from vouch import cli
+from vouch.keys import KeyManager
+from vouch.signer import Signer
+from vouch.root_of_trust import (
+    ACTION_ISSUE_AGENT_IDENTITY,
+    IDENTITY_BUNDLE_TYPE,
+    build_agent_identity,
+    build_identity_bundle,
+    build_recognized_issuer,
+    build_root_of_trust,
+    generate_did_key_identity,
+    verify_bundle,
+)
+
+
+def _signer():
+    """A fresh did:key signer."""
+    return Signer.from_keypair(generate_did_key_identity())
+
+
+def _read(path):
+    with open(path, "r") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def temp_keystore(tmp_path, monkeypatch):
+    """Point KeyManager at a temp directory for the duration of a test."""
+    key_dir = str(tmp_path / "keys")
+    orig_init = KeyManager.__init__
+    monkeypatch.setattr(
+        KeyManager, "__init__", lambda self, key_dir=key_dir: orig_init(self, key_dir)
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Library: build_identity_bundle + verify_bundle
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_happy_path():
+    """Root recognizes issuer, issuer attests agent, bundle verifies to root."""
+    root = _signer()
+    issuer = _signer()
+    agent = _signer()
+
+    root_cred = build_root_of_trust(root, name="Vouch Machine Identity Root")
+    recognition = build_recognized_issuer(
+        root, issuer_did=issuer.did, recognized_actions=[ACTION_ISSUE_AGENT_IDENTITY]
+    )
+    identity = build_agent_identity(
+        issuer,
+        subject_did=agent.did,
+        attributes={"owner": "Acme", "model": "gpt-x", "capabilityClass": "shopping"},
+    )
+    action = agent.sign(
+        intent={"action": "buy", "target": "store", "resource": "https://store.example/item/1"}
+    )
+
+    bundle = build_identity_bundle(
+        identity=identity, recognition=recognition, action=action, root=root_cred
+    )
+    assert bundle["type"] == IDENTITY_BUNDLE_TYPE
+    assert bundle["vouchVersion"] == "1.0"
+    assert bundle["identity"] == identity
+    assert bundle["recognizedIssuer"] == recognition
+    assert bundle["action"] == action
+    assert bundle["root"] == root_cred
+
+    result = verify_bundle(bundle, trusted_root=root.did)
+    assert result.ok
+    assert result.agent_did == agent.did
+    assert result.issuer_did == issuer.did
+    assert result.root_did == root.did
+    assert result.attributes == {
+        "owner": "Acme",
+        "model": "gpt-x",
+        "capabilityClass": "shopping",
+    }
+    assert result.action is not None
+
+
+def test_bundle_omits_optional_keys_when_none():
+    root = _signer()
+    issuer = _signer()
+    agent = _signer()
+    recognition = build_recognized_issuer(root, issuer_did=issuer.did)
+    identity = build_agent_identity(issuer, subject_did=agent.did, attributes={"owner": "Acme"})
+
+    bundle = build_identity_bundle(identity=identity, recognition=recognition)
+    assert "action" not in bundle
+    assert "root" not in bundle
+    assert verify_bundle(bundle, trusted_root=root.did).ok
+
+
+def test_bundle_wrong_root_rejected():
+    """A bundle pinned to a root the verifier does not trust is rejected."""
+    root = _signer()
+    issuer = _signer()
+    agent = _signer()
+    recognition = build_recognized_issuer(root, issuer_did=issuer.did)
+    identity = build_agent_identity(issuer, subject_did=agent.did, attributes={"owner": "Acme"})
+    bundle = build_identity_bundle(identity=identity, recognition=recognition)
+
+    wrong_root = _signer()
+    result = verify_bundle(bundle, trusted_root=wrong_root.did)
+    assert not result.ok
+    assert result.reason == "recognized_issuer_not_from_root"
+
+
+def test_verify_bundle_malformed():
+    assert verify_bundle({}, trusted_root="did:key:zabc").reason == "bad_bundle"
+    assert verify_bundle("nope", trusted_root="did:key:zabc").reason == "bad_bundle"
+    assert (
+        verify_bundle(
+            {"type": IDENTITY_BUNDLE_TYPE, "identity": 1, "recognizedIssuer": {}},
+            trusted_root="did:key:zabc",
+        ).reason
+        == "bad_bundle"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI: agent enroll -> agent verify
+# ---------------------------------------------------------------------------
+
+
+def _init_root(temp_keystore, out_name, capsys):
+    """Mint a did:key identity via `root init` and return its DID."""
+    out = str(temp_keystore / out_name)
+    assert (
+        cli.cmd_root_init(
+            types.SimpleNamespace(
+                name="Root", scope=None, domain=None, out=out, reference=False, yes=True
+            )
+        )
+        == 0
+    )
+    capsys.readouterr()
+    return _read(out)["issuer"]
+
+
+def test_cli_enroll_and_verify(temp_keystore, capsys):
+    # Root and issuer identities (both stored in the temp keystore).
+    root_did = _init_root(temp_keystore, "root.json", capsys)
+    issuer_did = _init_root(temp_keystore, "issuer.json", capsys)
+
+    # Root recognizes the issuer.
+    recognition_out = str(temp_keystore / "recognition.json")
+    assert (
+        cli.cmd_root_recognize(
+            types.SimpleNamespace(
+                issuer=issuer_did, actions=None, root_did=root_did, out=recognition_out
+            )
+        )
+        == 0
+    )
+    capsys.readouterr()
+
+    # Enroll an agent: generate a fresh agent DID, attest it, write the bundle.
+    bundle_out = str(temp_keystore / "identity-bundle.json")
+    rc = cli.cmd_agent_enroll(
+        types.SimpleNamespace(
+            agent_did=None,
+            issuer_did=issuer_did,
+            attr=["owner=Acme", "model=gpt-x"],
+            recognition=recognition_out,
+            action=None,
+            out=bundle_out,
+            yes=True,
+        )
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Agent enrolled" in out
+    assert "Generated agent identity:" in out
+
+    bundle = _read(bundle_out)
+    assert bundle["type"] == IDENTITY_BUNDLE_TYPE
+    agent_did = bundle["identity"]["credentialSubject"]["id"]
+    assert bundle["identity"]["issuer"] == issuer_did
+
+    # Verify the bundle against the correct root.
+    rc = cli.cmd_agent_verify(
+        types.SimpleNamespace(
+            bundle=bundle_out, root=root_did, action_required="issueAgentIdentity"
+        )
+    )
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Identity bundle verified" in out
+    assert agent_did in out
+    assert issuer_did in out
+    assert "Acme" in out
+
+    # Verify against a WRONG root: non-zero exit and a clear reason on stderr.
+    rc = cli.cmd_agent_verify(
+        types.SimpleNamespace(
+            bundle=bundle_out,
+            root="did:key:z6MkNotTheRealRootDidPinnedByAnHonestVerifier00",
+            action_required="issueAgentIdentity",
+        )
+    )
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "rejected" in err.lower()
+    assert "recognized_issuer_not_from_root" in err
+
+
+def test_cli_enroll_verify_via_main(temp_keystore):
+    """Drive the flow through cli.main with argv lists, including a supplied DID."""
+    root_out = str(temp_keystore / "r.json")
+    issuer_out = str(temp_keystore / "i.json")
+    recognition_out = str(temp_keystore / "rec.json")
+    bundle_out = str(temp_keystore / "bundle.json")
+
+    assert cli.main(["root", "init", "--yes", "--out", root_out]) == 0
+    assert cli.main(["root", "init", "--yes", "--out", issuer_out]) == 0
+    root_did = _read(root_out)["issuer"]
+    issuer_did = _read(issuer_out)["issuer"]
+
+    assert (
+        cli.main(
+            [
+                "root",
+                "recognize",
+                "--issuer",
+                issuer_did,
+                "--root-did",
+                root_did,
+                "--out",
+                recognition_out,
+            ]
+        )
+        == 0
+    )
+
+    agent_did = "did:key:z6MkagentSubjectPlaceholderDidForTest000000000000"
+    assert (
+        cli.main(
+            [
+                "agent",
+                "enroll",
+                "--agent-did",
+                agent_did,
+                "--issuer-did",
+                issuer_did,
+                "--attr",
+                "owner=Acme",
+                "--recognition",
+                recognition_out,
+                "--out",
+                bundle_out,
+            ]
+        )
+        == 0
+    )
+    assert _read(bundle_out)["identity"]["credentialSubject"]["id"] == agent_did
+
+    # Correct root via --root.
+    assert cli.main(["agent", "verify", "--bundle", bundle_out, "--root", root_did]) == 0
+
+    # Root supplied through the VOUCH_TRUSTED_ROOT env var (no --root).
+    import os
+
+    os.environ["VOUCH_TRUSTED_ROOT"] = root_did
+    try:
+        assert cli.main(["agent", "verify", "--bundle", bundle_out]) == 0
+    finally:
+        del os.environ["VOUCH_TRUSTED_ROOT"]
+
+    # Wrong root: non-zero.
+    assert (
+        cli.main(
+            [
+                "agent",
+                "verify",
+                "--bundle",
+                bundle_out,
+                "--root",
+                "did:key:z6MkWrongRoot000000000000000000000000000000000000",
+            ]
+        )
+        == 1
+    )

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -67,9 +67,11 @@ from .audio import AudioSigner, SignedAudioResult
 from .root_of_trust import (
     IdentityChainResult,
     build_agent_identity,
+    build_identity_bundle,
     build_recognized_issuer,
     build_root_of_trust,
     generate_did_key_identity,
+    verify_bundle,
     verify_identity_chain,
 )
 
@@ -479,6 +481,8 @@ __all__ = [
     "build_recognized_issuer",
     "build_agent_identity",
     "verify_identity_chain",
+    "build_identity_bundle",
+    "verify_bundle",
     "generate_did_key_identity",
     "IdentityChainResult",
     # Key management

--- a/vouch/cli.py
+++ b/vouch/cli.py
@@ -585,6 +585,157 @@ def cmd_root_verify_chain(args: argparse.Namespace) -> int:
     return 1
 
 
+# ---------------------------------------------------------------------------
+# One-command enroll and root-anchored verify (`vouch agent ...`)
+#
+# `vouch agent enroll` is the local self-host path: the operator holds the
+# recognized issuer key, attests an agent DID, and writes a portable identity
+# bundle. `vouch agent verify` pins a root DID and checks a bundle offline. A
+# hosted issuer service (where a provider signs attestations for you) is a
+# separate path and is not what these commands do.
+# ---------------------------------------------------------------------------
+
+
+def cmd_agent_enroll(args: argparse.Namespace) -> int:
+    """Enroll an agent and write a portable identity bundle.
+
+    Loads or mints the agent identity, has the recognized issuer attest it, then
+    packages the identity plus the issuer recognition into one bundle a verifier
+    can check against a pinned root. The issuer is always a parameter (the
+    operator's own recognized issuer key), never a hardcoded authority.
+    """
+    from vouch.root_of_trust import (
+        build_agent_identity,
+        build_identity_bundle,
+        generate_did_key_identity,
+    )
+
+    # 1. Determine the agent DID. If none was supplied, mint a fresh did:key
+    #    agent identity, save it to the keystore, and print its DID.
+    agent_did = args.agent_did
+    if not agent_did:
+        try:
+            agent_keys = generate_did_key_identity()
+        except Exception as e:
+            print(f"Error generating agent identity: {e}", file=sys.stderr)
+            return 1
+
+        km = KeyManager()
+        non_interactive = getattr(args, "yes", False) or not sys.stdin.isatty()
+        if non_interactive:
+            passphrase = None
+        else:
+            passphrase = getpass.getpass(
+                f"Enter passphrase for {agent_keys.did} (leave empty for no encryption): "
+            )
+            confirm = getpass.getpass("Confirm passphrase: ") if passphrase else ""
+            if passphrase != confirm:
+                print("Error: passphrases do not match", file=sys.stderr)
+                return 1
+
+        try:
+            km.save_identity(agent_keys, passphrase if passphrase else None)
+        except Exception as e:
+            print(f"Error saving agent identity: {e}", file=sys.stderr)
+            return 1
+
+        agent_did = agent_keys.did
+        print(f"Generated agent identity: {agent_did}")
+        if not passphrase:
+            print("Warning: agent key saved in plain text. Use a passphrase to encrypt it.")
+
+    # 2. Parse the identity attributes to bind (owner, model, and so on).
+    attributes = {}
+    for item in args.attr or []:
+        if "=" not in item:
+            print(f"Error: --attr must be KEY=VALUE, got {item!r}", file=sys.stderr)
+            return 1
+        key, value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            print(f"Error: --attr key is empty in {item!r}", file=sys.stderr)
+            return 1
+        attributes[key] = value
+    if not attributes:
+        print("Error: at least one --attr KEY=VALUE is required", file=sys.stderr)
+        return 1
+
+    # 3. Load the recognized issuer signer. This is a parameter (the operator's
+    #    own issuer key from the keystore), never a fixed authority.
+    signer = _load_stored_signer(args.issuer_did)
+    if signer is None:
+        return 1
+
+    # 4. Load the recognition that proves this issuer is recognized by a root,
+    #    so the bundle is verifiable against that root.
+    recognition = _read_json_file(args.recognition)
+    if recognition is None:
+        return 1
+
+    action_credential = None
+    if args.action:
+        action_credential = _read_json_file(args.action)
+        if action_credential is None:
+            return 1
+
+    # 5. Attest the agent identity and package the bundle.
+    try:
+        identity = build_agent_identity(signer, subject_did=agent_did, attributes=attributes)
+    except ValueError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    bundle = build_identity_bundle(
+        identity=identity,
+        recognition=recognition,
+        action=action_credential,
+    )
+
+    out_path = args.out or "identity-bundle.json"
+    if not _write_json_file(bundle, out_path):
+        return 1
+
+    print("Agent enrolled")
+    print(f"Agent DID:  {agent_did}")
+    print(f"Issuer DID: {signer.did}")
+    print(f"Bundle:     {out_path}")
+    return 0
+
+
+def cmd_agent_verify(args: argparse.Namespace) -> int:
+    """Verify a portable identity bundle against a pinned root DID."""
+    from vouch.root_of_trust import verify_bundle
+
+    root = args.root or os.environ.get("VOUCH_TRUSTED_ROOT")
+    if not root:
+        print(
+            "Error: a root DID is required. Pass --root or set VOUCH_TRUSTED_ROOT.",
+            file=sys.stderr,
+        )
+        return 1
+
+    bundle = _read_json_file(args.bundle)
+    if bundle is None:
+        return 1
+
+    result = verify_bundle(
+        bundle,
+        trusted_root=root,
+        required_action=args.action_required,
+    )
+
+    if result.ok:
+        print("Identity bundle verified")
+        print(f"Agent DID:  {result.agent_did}")
+        print(f"Issuer DID: {result.issuer_did}")
+        print(f"Root DID:   {result.root_did}")
+        print(f"Attributes: {json.dumps(result.attributes)}")
+        return 0
+
+    print(f"Identity bundle rejected: {result.reason}", file=sys.stderr)
+    return 1
+
+
 def _export_vouch_key_to_ssh() -> tuple[str, str]:
     """Export Vouch identity to SSH key format.
 
@@ -1853,6 +2004,77 @@ def main(argv: "list[str] | None" = None) -> int:
         help="Action the issuer must be recognized for (default: issueAgentIdentity)",
     )
 
+    # agent command group (one-command enroll and root-anchored verify)
+    p_agent = subparsers.add_parser(
+        "agent",
+        help="Enroll an agent and verify its portable identity bundle",
+    )
+    agent_subparsers = p_agent.add_subparsers(dest="agent_command", help="Agent commands")
+
+    # agent enroll
+    p_agent_enroll = agent_subparsers.add_parser(
+        "enroll",
+        help="Attest an agent and write a portable identity bundle",
+        description=(
+            "Local self-host path: the operator holds the recognized issuer key, "
+            "attests an agent identity, and writes a portable bundle a verifier "
+            "can check against a pinned root. A hosted issuer service, where a "
+            "provider signs attestations for you, is a separate path."
+        ),
+    )
+    p_agent_enroll.add_argument(
+        "--agent-did",
+        dest="agent_did",
+        help="DID of the agent to attest (default: generate a fresh did:key agent identity)",
+    )
+    p_agent_enroll.add_argument(
+        "--issuer-did",
+        dest="issuer_did",
+        help="DID of the recognized issuer to sign with (default: the stored issuer)",
+    )
+    p_agent_enroll.add_argument(
+        "--attr",
+        action="append",
+        metavar="KEY=VALUE",
+        help="Identity attribute to bind (repeatable), e.g. --attr owner=Acme",
+    )
+    p_agent_enroll.add_argument(
+        "--recognition",
+        required=True,
+        help="Path to the recognized-issuer credential proving the issuer is recognized by a root",
+    )
+    p_agent_enroll.add_argument(
+        "--action",
+        help="Optional path to an agent action credential to include in the bundle",
+    )
+    p_agent_enroll.add_argument(
+        "--out",
+        help="Path to write the identity bundle (default: identity-bundle.json)",
+    )
+    p_agent_enroll.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="Non-interactive: save a generated agent key without prompting for a passphrase",
+    )
+
+    # agent verify
+    p_agent_verify = agent_subparsers.add_parser(
+        "verify",
+        help="Verify a portable identity bundle against a pinned root DID",
+    )
+    p_agent_verify.add_argument("--bundle", required=True, help="Path to the identity bundle JSON")
+    p_agent_verify.add_argument(
+        "--root",
+        help="The root DID the verifier pins (default: the VOUCH_TRUSTED_ROOT env var)",
+    )
+    p_agent_verify.add_argument(
+        "--action-required",
+        dest="action_required",
+        default="issueAgentIdentity",
+        help="Action the issuer must be recognized for (default: issueAgentIdentity)",
+    )
+
     # scan command (PAD-058 detection stage; OSS leak scanner)
     p_scan = subparsers.add_parser(
         "scan",
@@ -1988,6 +2210,14 @@ def main(argv: "list[str] | None" = None) -> int:
             return cmd_root_verify_chain(args)
         else:
             p_root.print_help()
+            return 0
+    elif args.command == "agent":
+        if args.agent_command == "enroll":
+            return cmd_agent_enroll(args)
+        elif args.agent_command == "verify":
+            return cmd_agent_verify(args)
+        else:
+            p_agent.print_help()
             return 0
     elif args.command == "scan":
         return cmd_scan(args)

--- a/vouch/root_of_trust.py
+++ b/vouch/root_of_trust.py
@@ -52,12 +52,21 @@ __all__ = [
     "build_agent_identity",
     "verify_identity_chain",
     "register_recognized_issuer",
+    "IDENTITY_BUNDLE_TYPE",
+    "build_identity_bundle",
+    "verify_bundle",
 ]
 
 # Credential type identifiers (the second entry in each `type` array).
 ROOT_OF_TRUST_TYPE = "VouchRootOfTrust"
 RECOGNIZED_ISSUER_TYPE = "RecognizedIssuerCredential"
 AGENT_IDENTITY_TYPE = "AgentIdentityCredential"
+
+# Type tag for the portable identity bundle produced by
+# :func:`build_identity_bundle`. A bundle packages the credentials a verifier
+# needs to check an agent against a pinned root, so an operator can hand off a
+# single file and the receiver verifies it offline.
+IDENTITY_BUNDLE_TYPE = "VouchIdentityBundle"
 
 # Actions an issuer can be recognized to perform.
 ACTION_ISSUE_AGENT_IDENTITY = "issueAgentIdentity"
@@ -396,6 +405,108 @@ def verify_identity_chain(
         root_did=trusted_root,
         attributes=attributes,
         action=action_passport,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Portable identity bundle
+# ---------------------------------------------------------------------------
+
+
+def build_identity_bundle(
+    *,
+    identity: Dict[str, Any],
+    recognition: Dict[str, Any],
+    action: Optional[Dict[str, Any]] = None,
+    root: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Package a verifiable identity into one portable bundle.
+
+    A bundle staples the pieces a verifier needs together so an operator can
+    hand off a single file. The receiver pins a root DID and calls
+    :func:`verify_bundle`, with no central lookup and no network for
+    ``did:key`` identities.
+
+    Args:
+      identity: The authority-issued agent identity credential.
+      recognition: The recognized-issuer credential that proves the identity's
+        issuer is recognized by a root. Required so the bundle is verifiable.
+      action: Optional agent action credential to carry alongside the identity.
+      root: Optional Root of Trust credential, so the bundle is self-describing
+        about the anchor it chains to.
+
+    Returns:
+      A JSON-serializable bundle dict. Optional keys are omitted when None.
+    """
+    bundle: Dict[str, Any] = {
+        "type": IDENTITY_BUNDLE_TYPE,
+        "vouchVersion": "1.0",
+        "identity": identity,
+        "recognizedIssuer": recognition,
+    }
+    if action is not None:
+        bundle["action"] = action
+    if root is not None:
+        bundle["root"] = root
+    return bundle
+
+
+def verify_bundle(
+    bundle: Dict[str, Any],
+    *,
+    trusted_root: str,
+    required_action: str = ACTION_ISSUE_AGENT_IDENTITY,
+    allow_did_resolution: bool = False,
+    trusted_roots: Optional[Dict[str, str]] = None,
+    clock_skew_seconds: int = 30,
+    is_revoked: Optional[Callable[[Dict[str, Any]], bool]] = None,
+) -> IdentityChainResult:
+    """Verify a portable identity bundle against a pinned root.
+
+    Reads the credentials out of the bundle and delegates to
+    :func:`verify_identity_chain`, so verifying a bundle verifies the agent
+    identity against the pinned root as well as any bundled action. A malformed
+    bundle returns a clean rejection with reason ``bad_bundle``.
+
+    Args:
+      bundle: A bundle produced by :func:`build_identity_bundle`.
+      trusted_root: The root DID the verifier pins as its trust anchor.
+      required_action: Action the issuer must be recognized for. Defaults to
+        ``issueAgentIdentity``.
+      allow_did_resolution: Allow network ``did:web`` resolution. Defaults False.
+      trusted_roots: Optional map of DID -> public JWK JSON for offline pinning.
+      clock_skew_seconds: Allowed clock drift for temporal checks.
+      is_revoked: Optional callable that returns True if a credential is revoked.
+
+    Returns:
+      An :class:`IdentityChainResult`.
+    """
+    if not isinstance(bundle, dict) or bundle.get("type") != IDENTITY_BUNDLE_TYPE:
+        return IdentityChainResult(ok=False, reason="bad_bundle")
+
+    identity = bundle.get("identity")
+    recognition = bundle.get("recognizedIssuer")
+    if not isinstance(identity, dict) or not isinstance(recognition, dict):
+        return IdentityChainResult(ok=False, reason="bad_bundle")
+
+    action = bundle.get("action")
+    if action is not None and not isinstance(action, dict):
+        return IdentityChainResult(ok=False, reason="bad_bundle")
+    root = bundle.get("root")
+    if root is not None and not isinstance(root, dict):
+        return IdentityChainResult(ok=False, reason="bad_bundle")
+
+    return verify_identity_chain(
+        identity,
+        recognition,
+        trusted_root=trusted_root,
+        action_credential=action,
+        root_credential=root,
+        required_action=required_action,
+        allow_did_resolution=allow_did_resolution,
+        trusted_roots=trusted_roots,
+        clock_skew_seconds=clock_skew_seconds,
+        is_revoked=is_revoked,
     )
 
 


### PR DESCRIPTION
This adds the enroll-and-verify path for the Root of Trust for Machine Identity, so verifying an agent action also verifies the agent identity against a pinned root.

- build_identity_bundle / verify_bundle: package an action, an identity credential, and its recognition together, and verify the whole bundle anchored to one pinned root in a single call.
- vouch agent enroll: one command has a recognized issuer you specify attest an agent DID and write a portable bundle. The issuer is always a parameter, so it works with your own issuer or any recognized issuer and stays self-sovereign.
- vouch agent verify --bundle --root (with a VOUCH_TRUSTED_ROOT fallback): root-anchored verification as the default path. The existing action-only vouch verify is unchanged.

Security boundary: verify_bundle walks action to identity to recognized issuer to pinned root, so a verified action is bound to an agent identity that a recognized issuer attested under the root the verifier trusts. The recognized issuer is never fixed by the protocol; the verifier trust reduces to the single root DID it pins.

Includes tests for the bundle happy path, wrong-root rejection, a malformed-bundle guard, and the CLI enroll-then-verify flow, plus a runnable example.
