### PR TITLE
Add the Halos safety-evidence recorder for NVIDIA Halos-certified robots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,25 @@ Implemented in Python (`vouch.robotics.root_identity`), TypeScript, Go, and the 
 core, with the root-anchored robot identity added to the Root of Trust interop vector
 (`test-vectors/root-of-trust/vector.json`).
 
+#### Halos safety-evidence recorder (NVIDIA Halos integration)
+
+An evidence layer for a robot running an NVIDIA Halos-certified stack. Halos certifies
+that the stack is safe and secure by design; this records what a specific robot actually
+did and binds it to the robot's identity:
+
+- **`SafetyEventRecorder`**: captures the Halos safety-event stream (the Outside-In
+  Safety Blueprint components SIPP, SAIM, SEI, SDM, plus emergency stops and operator
+  actions) into the tamper-evident, encrypted black-box.
+- **`build_safety_evidence` / `verify_safety_evidence`**: the robot signs a
+  `HalosSafetyEvidenceCredential` that seals the black-box head and entry count and binds
+  them to its identity and to the Halos stack elements it ran on (IGX system-on-module,
+  Halos Core, Blueprint applications). A verifier confirms, without the black-box key,
+  that the record is unaltered, untruncated, attributable to that robot, and tied to the
+  certified configuration, while the payloads stay confidential.
+
+Implemented in the Python reference (`vouch.robotics.halos`) and the Rust core, exposed
+through the curated robotics C ABI.
+
 #### State Verifiability runtime (Specification §11, §15)
 
 First-class implementation of the State Verifiability layer the spec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,7 +149,7 @@ Implemented in Python (`vouch.robotics.root_identity`), TypeScript, Go, and the 
 core, with the root-anchored robot identity added to the Root of Trust interop vector
 (`test-vectors/root-of-trust/vector.json`).
 
-#### Halos safety-evidence recorder (NVIDIA Halos integration)
+#### Halos safety-evidence recorder (NVIDIA Halos integration, PAD-105)
 
 An evidence layer for a robot running an NVIDIA Halos-certified stack. Halos certifies
 that the stack is safe and secure by design; this records what a specific robot actually

--- a/core/uniffi/src/c_api.rs
+++ b/core/uniffi/src/c_api.rs
@@ -713,3 +713,39 @@ pub extern "C" fn vouch_robotics_verify_handoff_chain(
         vouch_core::robotics_json::verify_handoff_chain(&params).map_err(|e| e.to_string())
     })
 }
+
+/// Seal a robot's Halos safety-event record into a signed
+/// HalosSafetyEvidenceCredential. params_json carries {halosStack, window,
+/// blackboxHead, entryCount, robotIdentity?, validSeconds?, validFrom, created}.
+/// The robot DID is derived from the signer seed. Returns the signed credential JSON.
+#[no_mangle]
+pub extern "C" fn vouch_robotics_build_safety_evidence(
+    signer_seed_b64: *const c_char,
+    params_json: *const c_char,
+    err_out: *mut *mut c_char,
+) -> *mut c_char {
+    guard(err_out, move || {
+        let seed = unb64(&cstr_in(signer_seed_b64)?)?;
+        let params = cstr_in(params_json)?;
+        vouch_core::robotics_json::build_safety_evidence(&seed, &params).map_err(|e| e.to_string())
+    })
+}
+
+/// Verify a Halos safety-evidence credential. Pass the robot public key (base64)
+/// and, optionally, the black-box entries as a JSON array (or NULL) to check the
+/// chain against the sealed head and entry count. Returns JSON {ok, subject}.
+#[no_mangle]
+pub extern "C" fn vouch_robotics_verify_safety_evidence(
+    credential_json: *const c_char,
+    robot_public_b64: *const c_char,
+    entries_json: *const c_char,
+    err_out: *mut *mut c_char,
+) -> *mut c_char {
+    guard(err_out, move || {
+        let cred = cstr_in(credential_json)?;
+        let pk = unb64(&cstr_in(robot_public_b64)?)?;
+        let entries = cstr_in_opt(entries_json)?.unwrap_or_default();
+        vouch_core::robotics_json::verify_safety_evidence(&cred, &pk, &entries)
+            .map_err(|e| e.to_string())
+    })
+}

--- a/core/vouch-core/src/robotics.rs
+++ b/core/vouch-core/src/robotics.rs
@@ -1237,6 +1237,166 @@ pub fn verify_killswitch_credential(
 }
 
 // ---------------------------------------------------------------------------
+// Halos safety-evidence recorder (NVIDIA Halos integration)
+// ---------------------------------------------------------------------------
+//
+// Byte-exact port of the Python reference `vouch/robotics/halos.py`.
+//
+// Halos certifies that a robot's stack is functionally safe and secure by design.
+// It does not, on its own, produce a verifiable record of what a specific robot
+// did or bind that record to the robot's identity. This is the evidence layer
+// under a Halos-certified stack: the robot seals its black-box chain head and
+// entry count into a signed `HalosSafetyEvidenceCredential` that binds them to its
+// identity, to the Halos stack elements it ran on, and to a time window. A
+// verifier that holds the credential and the entries confirms, without the
+// black-box key, that the record is unaltered, was not truncated or extended since
+// it was sealed, and is attributable to that robot. This composes the existing
+// black-box and credential primitives and adds no new cryptography.
+
+pub const HALOS_SAFETY_EVIDENCE_TYPE: &str = "HalosSafetyEvidenceCredential";
+
+/// Format Unix epoch seconds as "YYYY-MM-DDTHH:MM:SSZ" for a whole-second UTC
+/// instant. Howard Hinnant's civil-from-days algorithm, matching the rest of the
+/// core so a `valid_seconds` lifetime renders identically across languages.
+fn halos_epoch_to_iso(epoch: i64) -> String {
+    let days = epoch.div_euclid(86400);
+    let secs = epoch.rem_euclid(86400);
+    let z = days + 719468;
+    let era = (if z >= 0 { z } else { z - 146096 }) / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if m <= 2 { y + 1 } else { y };
+    let hh = secs / 3600;
+    let mm = (secs % 3600) / 60;
+    let ss = secs % 60;
+    format!("{year:04}-{m:02}-{d:02}T{hh:02}:{mm:02}:{ss:02}Z")
+}
+
+/// Parameters for [`build_safety_evidence`]. The robot DID is derived from
+/// `signer_seed` (a did:key), mirroring the Python signer. `blackbox_head` and
+/// `entry_count` seal the robot's black-box chain; `halos_stack` names the
+/// certified configuration; `window` covers the recorded events. Timestamps are
+/// caller-supplied ISO-8601 strings.
+#[derive(Debug, Clone)]
+pub struct BuildSafetyEvidence {
+    pub halos_stack: Value,
+    pub window_from: String,
+    pub window_to: String,
+    pub blackbox_head: String,
+    pub entry_count: u64,
+    pub robot_identity: Option<String>,
+    pub valid_seconds: Option<i64>,
+    pub valid_from: String,
+    pub created: String,
+}
+
+/// Seal a robot's Halos safety-event record into a signed
+/// `HalosSafetyEvidenceCredential`. The robot signs a credential binding the
+/// black-box chain head and entry count to its identity, to the Halos stack
+/// elements it ran on, and to the time window.
+pub fn build_safety_evidence(signer_seed: &[u8], params: &BuildSafetyEvidence) -> Result<Value> {
+    match params.halos_stack.as_object() {
+        Some(o) if !o.is_empty() => {}
+        _ => return Err(CoreError::Json("halos_stack is required".into())),
+    }
+    if params.window_from.is_empty() || params.window_to.is_empty() {
+        return Err(CoreError::Json(
+            "window with 'from' and 'to' is required".into(),
+        ));
+    }
+
+    let kp = keys::Ed25519KeyPair::from_seed_slice(signer_seed)?;
+    let robot_did = keys::ed25519_to_did_key(&kp.public_key())?;
+
+    let mut subject = Map::new();
+    subject.insert("id".into(), json!(robot_did));
+    subject.insert("blackboxHead".into(), json!(params.blackbox_head));
+    subject.insert("entryCount".into(), json!(params.entry_count));
+    subject.insert("halosStack".into(), params.halos_stack.clone());
+    subject.insert(
+        "window".into(),
+        json!({ "from": params.window_from, "to": params.window_to }),
+    );
+    if let Some(robot_identity) = &params.robot_identity {
+        subject.insert("robotIdentity".into(), json!(robot_identity));
+    }
+
+    let mut cred = Map::new();
+    cred.insert("@context".into(), json!([VC_CONTEXT_V2, VOUCH_CONTEXT_V1]));
+    cred.insert(
+        "type".into(),
+        json!(["VerifiableCredential", HALOS_SAFETY_EVIDENCE_TYPE]),
+    );
+    cred.insert("issuer".into(), json!(robot_did));
+    cred.insert("validFrom".into(), json!(params.valid_from));
+    if let Some(valid_seconds) = params.valid_seconds {
+        let from = crate::time::iso_to_epoch_seconds(&params.valid_from)?;
+        cred.insert(
+            "validUntil".into(),
+            json!(halos_epoch_to_iso(from + valid_seconds)),
+        );
+    }
+    cred.insert("credentialSubject".into(), Value::Object(subject));
+
+    let opts = BuildProofOptions::new(format!("{robot_did}#key-1"), &params.created);
+    data_integrity::sign(&Value::Object(cred), signer_seed, &opts)
+}
+
+/// Verify a `HalosSafetyEvidenceCredential`: the robot's proof and that the issuer
+/// is the robot (`credentialSubject.id`). When `entries` is supplied, also checks
+/// that the black-box chain is intact, that its length matches the sealed entry
+/// count, and that its head matches the sealed head, so a truncated, extended,
+/// reordered, or tampered record is rejected. Returns `(ok, credentialSubject)`.
+pub fn verify_safety_evidence(
+    credential: &Value,
+    robot_public_key: &[u8],
+    entries: Option<&[Value]>,
+) -> Result<(bool, Option<Value>)> {
+    if !has_type(credential.get("type"), HALOS_SAFETY_EVIDENCE_TYPE) {
+        return Ok((false, None));
+    }
+    if !data_integrity::verify_proof(credential, robot_public_key)? {
+        return Ok((false, None));
+    }
+
+    let subject = match credential.get("credentialSubject") {
+        Some(s) if s.is_object() => s.clone(),
+        _ => return Ok((false, None)),
+    };
+    let subject_id = subject.get("id").and_then(|v| v.as_str());
+    if subject_id.is_none() || subject_id != credential.get("issuer").and_then(|v| v.as_str()) {
+        return Ok((false, None));
+    }
+
+    if let Some(entries) = entries {
+        if !verify_blackbox_chain(entries, None).ok {
+            return Ok((false, None));
+        }
+        if subject.get("entryCount").and_then(|v| v.as_u64()) != Some(entries.len() as u64) {
+            return Ok((false, None));
+        }
+        let head = match entries.last() {
+            Some(last) => last
+                .get("entryHash")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string(),
+            None => genesis_prev_hash(),
+        };
+        if Some(head.as_str()) != subject.get("blackboxHead").and_then(|v| v.as_str()) {
+            return Ok((false, None));
+        }
+    }
+
+    Ok((true, Some(subject)))
+}
+
+// ---------------------------------------------------------------------------
 // Scannable robot passport (Phase 5.6)
 // ---------------------------------------------------------------------------
 
@@ -4814,6 +4974,111 @@ mod tests {
         let cred = mint_robot_identity(&robot_seed, &params).unwrap();
         let subject = verify_robot_identity(&cred, &robot_kp.public_key()).unwrap();
         assert!(subject.is_some(), "round-trip identity must verify");
+    }
+
+    // Cross-language interop: this HalosSafetyEvidenceCredential, its black-box
+    // entries, and the robot public key were produced by the Python reference
+    // (vouch/robotics/halos.py) from a fixed Ed25519 seed (0x05 x32), a fixed
+    // black-box key, and a fixed `created` timestamp. The Rust verify must accept
+    // it, and must reject a tampered entry or a wrong entry count.
+    const PY_HALOS_CREDENTIAL: &str = r#"{"@context":["https://www.w3.org/ns/credentials/v2","https://vouch-protocol.com/contexts/v1"],"type":["VerifiableCredential","HalosSafetyEvidenceCredential"],"issuer":"did:key:z6MkmtWtY63GQVBrpMyRJWEzsnxfsGkemu6CtMDwGTv4RYj2","validFrom":"2026-01-01T00:00:00Z","credentialSubject":{"id":"did:key:z6MkmtWtY63GQVBrpMyRJWEzsnxfsGkemu6CtMDwGTv4RYj2","blackboxHead":"utfv4sSWc6TH-n0HrNqB35Hacy3lYVksU0QYz6gbHol8","entryCount":3,"halosStack":{"igxSom":"IGX-Orin-64","halosCore":"1.4.0","blueprint":["SAIM","SEI","SDM"]},"window":{"from":"2026-01-01T00:00:00Z","to":"2026-01-01T00:00:10Z"},"robotIdentity":"urn:uuid:robot-identity-1"},"proof":{"type":"DataIntegrityProof","cryptosuite":"eddsa-jcs-2022","created":"2026-01-01T00:00:00Z","verificationMethod":"did:key:z6MkmtWtY63GQVBrpMyRJWEzsnxfsGkemu6CtMDwGTv4RYj2#key-1","proofPurpose":"assertionMethod","proofValue":"z5FjYsg9oQ543K8jtAsaYyYS3YG53ixoUYnhYop8oJWuLCoZp45uYos4416i13JR2bkt4tPtKB9hTk5xG9s8mQoQd"}}"#;
+
+    const PY_HALOS_ENTRIES: &str = r#"[{"version":"1.0","seq":0,"timestamp":"2026-01-01T00:00:01Z","event":"hazard_detected","ciphertext":"uzhrB2FNU_UNfM5ey2Dx1ogaX4_IuPx-0ylXC7022a7TqQ5ktnB9GmFqmrv9VzRx7ecoSyCAC6b6pcp1r7K2nQLSsDnmX2oar","prevHash":"uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA","entryHash":"uZm_cIGAA1kuQio4QWWwbE27xBVZE9QSuvAGweybxZZk"},{"version":"1.0","seq":1,"timestamp":"2026-01-01T00:00:02Z","event":"slow_stop","ciphertext":"ulQY1i5OnYlWdSJOS0Rp4esqwLIyh_4TM4WO-apHKoJde3AgFaGHgPIZ2GIb8q5sYKjtB9Az6kUnajkhzYA7VPQ6ChvF_3yQGfHuIM1lnaF5JEg","prevHash":"uZm_cIGAA1kuQio4QWWwbE27xBVZE9QSuvAGweybxZZk","entryHash":"uPulCLvRvEs_zV1R3koher2EMjyBZy5Rfe-Sv0Y64Tfk"},{"version":"1.0","seq":2,"timestamp":"2026-01-01T00:00:03Z","event":"cleared","ciphertext":"us7pdRfPVAGSeKCQU7RgEb1ee_2358wbs_P4epd4gPJoUUx9bw3hJSiVPGKwc2Xc3PjZySEaWKgK_F0h5mU2sxb0pEZ-E_FwwQQk3","prevHash":"uPulCLvRvEs_zV1R3koher2EMjyBZy5Rfe-Sv0Y64Tfk","entryHash":"utfv4sSWc6TH-n0HrNqB35Hacy3lYVksU0QYz6gbHol8"}]"#;
+
+    // Robot public key (raw 32-byte Ed25519) as base64url-no-pad.
+    const PY_HALOS_ROBOT_PUB: &str = "bnoc3Smwt4_ROvTFWY_v9O8qlxZuPKby5Pv8zYBQW_E";
+
+    #[test]
+    fn build_verify_safety_evidence_roundtrip() {
+        let robot_seed = [5u8; 32];
+        let robot_kp = Ed25519KeyPair::from_seed(&robot_seed);
+
+        // A black-box chain the robot recorded.
+        let mut log = BlackBoxLog::new(&[9u8; 32], None).unwrap();
+        log.append(
+            "hazard_detected",
+            &json!({"zone": "cell-3"}),
+            "2026-01-01T00:00:01Z",
+        )
+        .unwrap();
+        log.append(
+            "slow_stop",
+            &json!({"reason": "human"}),
+            "2026-01-01T00:00:02Z",
+        )
+        .unwrap();
+        let entries: Vec<Value> = log.entries().to_vec();
+
+        let params = BuildSafetyEvidence {
+            halos_stack: json!({"igxSom": "IGX-Orin-64", "halosCore": "1.4.0"}),
+            window_from: "2026-01-01T00:00:00Z".into(),
+            window_to: "2026-01-01T00:00:10Z".into(),
+            blackbox_head: log.head().to_string(),
+            entry_count: entries.len() as u64,
+            robot_identity: Some("urn:uuid:robot-identity-1".into()),
+            valid_seconds: Some(3600),
+            valid_from: "2026-01-01T00:00:00Z".into(),
+            created: "2026-01-01T00:00:00Z".into(),
+        };
+        let cred = build_safety_evidence(&robot_seed, &params).unwrap();
+
+        // The issuer is the did:key derived from the seed and the validUntil is
+        // rendered from the valid_seconds lifetime.
+        assert_eq!(
+            cred["issuer"],
+            json!("did:key:z6MkmtWtY63GQVBrpMyRJWEzsnxfsGkemu6CtMDwGTv4RYj2")
+        );
+        assert_eq!(cred["validUntil"], json!("2026-01-01T01:00:00Z"));
+
+        let (ok, subject) =
+            verify_safety_evidence(&cred, &robot_kp.public_key(), Some(&entries)).unwrap();
+        assert!(ok, "a Rust-built evidence credential must verify in Rust");
+        assert_eq!(subject.unwrap()["entryCount"], json!(2));
+
+        // A credential whose issuer is not the subject id is rejected.
+        let mut forged = cred.clone();
+        forged["issuer"] = json!("did:key:z6Mkother");
+        let (ok_forged, _) = verify_safety_evidence(&forged, &robot_kp.public_key(), None).unwrap();
+        assert!(!ok_forged, "issuer must equal credentialSubject.id");
+    }
+
+    #[test]
+    fn verifies_python_halos_evidence() {
+        let credential: Value = serde_json::from_str(PY_HALOS_CREDENTIAL).unwrap();
+        let entries: Vec<Value> = serde_json::from_str(PY_HALOS_ENTRIES).unwrap();
+        let robot_pub = URL_SAFE_NO_PAD.decode(PY_HALOS_ROBOT_PUB).unwrap();
+
+        // The Python-produced credential and its entries verify in Rust.
+        let (ok, subject) =
+            verify_safety_evidence(&credential, &robot_pub, Some(&entries)).unwrap();
+        assert!(ok, "the Python Halos evidence must verify in Rust");
+        let subject = subject.expect("subject present on success");
+        assert_eq!(subject["entryCount"], json!(3));
+        assert_eq!(
+            subject["blackboxHead"],
+            json!("utfv4sSWc6TH-n0HrNqB35Hacy3lYVksU0QYz6gbHol8")
+        );
+
+        // The proof and issuer binding hold even without the entries.
+        let (ok_no_entries, _) = verify_safety_evidence(&credential, &robot_pub, None).unwrap();
+        assert!(
+            ok_no_entries,
+            "proof and issuer binding verify without entries"
+        );
+
+        // Tampering one entry breaks the chain, so verification fails.
+        let mut tampered = entries.clone();
+        tampered[1]["ciphertext"] = json!("utampered_ciphertext_value_that_does_not_match_hash");
+        let (ok_tampered, subj_tampered) =
+            verify_safety_evidence(&credential, &robot_pub, Some(&tampered)).unwrap();
+        assert!(!ok_tampered, "a tampered entry must be rejected");
+        assert!(subj_tampered.is_none());
+
+        // A wrong entry count (here a truncated log) is rejected against the seal.
+        let truncated = entries[..2].to_vec();
+        let (ok_truncated, _) =
+            verify_safety_evidence(&credential, &robot_pub, Some(&truncated)).unwrap();
+        assert!(!ok_truncated, "a wrong entry count must be rejected");
     }
 
     #[test]

--- a/core/vouch-core/src/robotics_json.rs
+++ b/core/vouch-core/src/robotics_json.rs
@@ -353,6 +353,51 @@ pub fn verify_killswitch_credential(
     )?))
 }
 
+// ---- halos safety evidence ------------------------------------------------
+
+/// Seal a robot's Halos safety-event record into a signed
+/// `HalosSafetyEvidenceCredential`. `params_json` carries `{halosStack, window:
+/// {from, to}, blackboxHead, entryCount, robotIdentity?, validSeconds?, validFrom,
+/// created}`. The robot DID is derived from `signer_seed`.
+pub fn build_safety_evidence(signer_seed: &[u8], params_json: &str) -> Result<String> {
+    let p = parse(params_json)?;
+    let window = p.get("window").cloned().unwrap_or(Value::Null);
+    let params = r::BuildSafetyEvidence {
+        halos_stack: p.get("halosStack").cloned().unwrap_or(Value::Null),
+        window_from: gs(&window, "from"),
+        window_to: gs(&window, "to"),
+        blackbox_head: gs(&p, "blackboxHead"),
+        entry_count: p.get("entryCount").and_then(|v| v.as_u64()).unwrap_or(0),
+        robot_identity: gos(&p, "robotIdentity"),
+        valid_seconds: p.get("validSeconds").and_then(|v| v.as_i64()),
+        valid_from: gs(&p, "validFrom"),
+        created: gs(&p, "created"),
+    };
+    Ok(r::build_safety_evidence(signer_seed, &params)?.to_string())
+}
+
+/// Verify a Halos safety-evidence credential. `entries_json` is the black-box
+/// entries as a JSON array, or `""`/`"null"` for none. Returns `{ok, subject}`
+/// where `subject` is the credentialSubject or the JSON literal `null`.
+pub fn verify_safety_evidence(
+    credential_json: &str,
+    robot_pub: &[u8],
+    entries_json: &str,
+) -> Result<String> {
+    let credential = parse(credential_json)?;
+    let entries = opt_obj(Some(entries_json))?;
+    let entries_slice = match &entries {
+        Some(v) => Some(
+            v.as_array()
+                .ok_or_else(|| CoreError::Json("entries must be a JSON array".into()))?
+                .as_slice(),
+        ),
+        None => None,
+    };
+    let (ok, subject) = r::verify_safety_evidence(&credential, robot_pub, entries_slice)?;
+    Ok(json!({"ok": ok, "subject": subject.unwrap_or(Value::Null)}).to_string())
+}
+
 // ---- passport -------------------------------------------------------------
 
 pub fn build_passport(signer_seed: &[u8], params_json: &str) -> Result<String> {

--- a/docs/disclosures/PAD-105-safety-island-evidence-record.md
+++ b/docs/disclosures/PAD-105-safety-island-evidence-record.md
@@ -1,0 +1,145 @@
+# PAD-105: Signed Tamper-Evident Safety-Evidence Record Bound to a Robot's Identity and Certified Stack
+
+**Identifier:** PAD-105  
+**Title:** Method for Sealing a Robot's Functional-Safety Event Stream Into a Confidential, Tamper-Evident Record Bound to the Robot's Identity and the Certified Safety Stack It Ran On  
+**Publication Date:** July 12, 2026  
+**Prior Art Effective Date:** July 12, 2026  
+**Status:** Public Disclosure (Defensive Publication)  
+**Category:** Robotics / Safety / Evidence  
+**Author:** Ramprasad Anandam Gaddam  
+**License:** Apache 2.0  
+**Related:** PAD-064 (Hardware-Rooted Robot Identity), PAD-072 (Encrypted Black-Box and Kill-Switch), PAD-103 (Root-Anchored Hardware-Rooted Robot Identity)  
+
+---
+
+## 1. Abstract
+
+A method by which a robot turns the event stream produced by its functional-safety
+subsystem into a signed record that is confidential, tamper-evident, attributable to
+the specific robot, and tied to the certified safety stack the robot ran on. A
+design-time safety certification establishes that a robot's stack meets a standard. It
+does not, on its own, produce a verifiable account of what a specific robot actually did.
+This method supplies that account as the evidence layer beneath such a certification.
+
+The robot records each safety-relevant event, from a safety monitor, a safety event
+integrator, a safety decision maker running on an isolated safety island, a sensor input
+pipeline, an emergency stop, or an operator action, into an encrypted, hash-linked,
+append-only log. The robot then signs a credential that seals the log's chain head and
+its entry count and binds them to the robot's identity and to the named elements of the
+certified safety stack, such as the compute module, the safety operating system version,
+and the safety-application set. A verifier that holds the sealed credential and the log
+entries, without the log's confidentiality key, confirms four things: the record is
+unaltered, it has not been truncated or extended since it was sealed, it is attributable
+to that specific robot, and it was produced on the named certified configuration.
+
+Key innovations:
+
+- **A safety-island event stream sealed into a tamper-evident record.** The events a
+  robot's functional-safety subsystem produces are captured into a hash-linked encrypted
+  log, so the sequence is confidential yet any alteration is detectable.
+- **A seal over both the record's length and its content.** The signed credential
+  binds both the chain head and the entry count, so a later truncation or extension of
+  the log is detected, along with any change to an existing entry.
+- **Evidence bound to identity and to the certified configuration.** The seal ties the
+  record to the robot's identity and to the specific certified safety-stack elements it
+  ran on, so the account is attributable and tied to the configuration a certifier
+  assessed.
+- **Verifiable without the confidentiality key.** The chain and the seal verify from the
+  encrypted entries alone, so a certifier, insurer, or investigator confirms integrity,
+  length, attribution, and configuration without being able to read the payloads.
+
+---
+
+## 2. Problem Statement
+
+### 2.1 A safety certification does not record what a specific robot did
+
+A functional-safety certification assesses that a robot's stack is safe by design. It
+produces no signed, verifiable record of the events a specific unit produced in service,
+so after an incident there is no attributable account tied to the certified stack.
+
+### 2.2 A plain log can be altered, truncated, or detached from the robot
+
+A log kept by the robot can be edited, shortened to hide events, or presented apart from
+the robot's identity and the configuration it ran on. A record that stored the events in
+the clear to prove them would also expose whatever the robot captured.
+
+### 2.3 Proving the record should not require reading it
+
+A party that needs to confirm a record is intact and complete, such as a certifier or an
+insurer, is often not the party permitted to read its contents. Integrity and
+completeness should be checkable without decrypting the payloads.
+
+---
+
+## 3. Solution (The Invention)
+
+A `SafetyEventRecorder` writes each safety-relevant event, tagged by its source in the
+functional-safety subsystem, into an append-only log in which every entry's payload is
+encrypted and every entry is hash-linked to the previous one, so the log is confidential
+and any change breaks the chain. `build_safety_evidence(...)` has the robot sign a
+credential whose subject carries the log's chain head, the entry count, the robot
+identity, the named certified safety-stack elements, and the covered time window.
+`verify_safety_evidence(...)` checks the robot's proof and that the issuer is the robot,
+and, when the entries are supplied, that the hash chain is intact, that the number of
+entries equals the sealed count, and that the head of the presented entries equals the
+sealed head. A tampered, truncated, extended, or reordered log is therefore rejected, and
+the payloads never need to be read to perform the check. Because the credentials use the
+shared JCS plus eddsa-jcs-2022 primitives, the same evidence verifies across the language
+SDKs. This is the open evidence layer; multi-party quorum issuance of the record and
+continuous behavioral binding of the robot are out of scope for this disclosure.
+
+---
+
+## 4. Prior Art Differentiation
+
+Encrypted flight recorders, hash-linked logs, Verifiable Credentials, and functional-safety
+certification each exist as prior art. This disclosure does **not** claim those mechanisms
+in the abstract. What is differentiated is their reduction to a safety-evidence record for
+a certified robot:
+
+- **Sealing a functional-safety event stream with both a head and a count**, so a later
+  truncation or extension of the record is detected, along with any change to an entry.
+- **Binding the sealed record to the robot's identity and to the named certified
+  safety-stack elements**, so the account is attributable and tied to the assessed
+  configuration.
+- **Confirming integrity, completeness, attribution, and configuration without the
+  confidentiality key**, so a party that may not read the payloads can still verify the
+  record.
+
+---
+
+## 5. Technical Implementation
+
+A reference implementation provides `SafetyEventRecorder`, `build_safety_evidence`, and
+`verify_safety_evidence`, composing an encrypted hash-linked log with the robot-identity
+and Data Integrity primitives, so the same evidence verifies across the language SDKs and
+through a C application binding interface.
+
+---
+
+## 6. Claims Summary
+
+1. A method in which a robot records the event stream of its functional-safety subsystem
+   into an encrypted, hash-linked, append-only log and signs a credential that seals the
+   log's chain head and entry count and binds them to the robot's identity and to the
+   certified safety-stack elements it ran on.
+2. The method of claim 1 wherein verification of the sealed credential against the log
+   entries rejects a record that has been altered, truncated, extended, or reordered,
+   using the sealed head and count.
+3. The method of claim 1 wherein the log entries are encrypted so that integrity,
+   completeness, attribution, and configuration are verified without reading the payloads.
+4. The method of claim 1 wherein the sealed record names the compute module, the safety
+   operating system version, and the safety-application set of the certified stack, and
+   the robot identity is a hardware-rooted identity.
+5. The method of claim 1 wherein the credentials use canonicalization and signature
+   primitives shared across language SDKs, so the same evidence verifies cross-language.
+
+---
+
+## Prior Art Declaration
+
+This document is published as a defensive disclosure to establish prior art as of the
+date above. The methods are released under Apache 2.0 and may be freely implemented,
+to prevent patenting by any party and to keep them available to the open Vouch
+Protocol ecosystem and the robotics community.

--- a/docs/disclosures/README.md
+++ b/docs/disclosures/README.md
@@ -114,6 +114,17 @@ These disclosures establish prior art for novel concepts, preventing others from
 | [PAD-102](./PAD-102-handover-acknowledgement.md) | Recipient Acknowledgement Bound to a Specific Robot-to-Human Handover | 2026-07-06 | Published |
 | [PAD-103](./PAD-103-root-anchored-hardware-rooted-robot-identity.md) | Root-Anchored, Hardware-Rooted Robot Identity Binding | 2026-07-12 | Published |
 | [PAD-104](./PAD-104-per-tool-call-continuous-trust-authorization.md) | Per-Tool-Call Continuous-Trust Authorization with Resource-Bound Delegation | 2026-07-12 | Published |
+| [PAD-105](./PAD-105-safety-island-evidence-record.md) | Signed Tamper-Evident Safety-Evidence Record Bound to a Robot's Identity and Certified Stack | 2026-07-12 | Published |
+
+
+## July 12, 2026: Safety-Island Evidence Record (PAD-105)
+
+PAD-105 seals the event stream from a robot's functional-safety subsystem into an
+encrypted, hash-linked log, then has the robot sign a credential fixing the log's chain
+head and entry count and binding them to its identity and to the certified safety-stack
+elements it ran on. A verifier confirms the record is unaltered, untruncated, attributable
+to that robot, and tied to the certified configuration, all without the log's
+confidentiality key. It is the evidence layer beneath a design-time safety certification.
 
 
 ## July 12, 2026: Root-Anchored Hardware-Rooted Robot Identity (PAD-103)

--- a/go-sidecar/robotics/halos.go
+++ b/go-sidecar/robotics/halos.go
@@ -1,0 +1,223 @@
+// Halos safety-evidence recorder (NVIDIA Halos integration), Go.
+//
+// Mirrors vouch/robotics/halos.py. NVIDIA Halos certifies that a robot's stack
+// is functionally safe and secure by design. It does not, on its own, produce a
+// verifiable record of what a specific robot did, or bind that record to the
+// robot's identity. This file is the evidence layer that sits under a
+// Halos-certified stack.
+//
+// A SafetyEventRecorder captures the safety-relevant event stream produced by
+// the Halos Outside-In Safety Blueprint components (the Safety AI Monitor, the
+// Safety Event Integrator, the Safety Decision Maker, and the sensor input
+// pipeline), plus emergency stops and operator actions, into the tamper-evident,
+// encrypted black-box. The robot then signs a HalosSafetyEvidenceCredential that
+// seals the black-box chain head and entry count and binds them to the robot's
+// identity and to the exact Halos stack elements it ran on.
+//
+// A verifier that holds the sealed credential and the entries confirms, without
+// the black-box key, that the record is unaltered, has not been truncated or
+// extended since it was sealed, is attributable to that specific robot, and
+// names the certified Halos configuration it was produced on. This composes the
+// existing black-box and robot-identity primitives and adds no new cryptography.
+package robotics
+
+import (
+	"crypto/ed25519"
+	"time"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+// HalosSafetyEvidenceType is the credential type for a sealed Halos record.
+const HalosSafetyEvidenceType = "HalosSafetyEvidenceCredential"
+
+// HalosEventSources is the set of safety-relevant event producers in a
+// Halos-certified stack: the four Outside-In Safety Blueprint components, plus
+// an emergency stop and an operator action. A recorder rejects any event from a
+// source outside this set, so the record maps to a known part of the stack.
+var HalosEventSources = map[string]bool{
+	"SIPP":     true, // Sensor Input Processing Pipeline
+	"SAIM":     true, // Safety AI Monitor
+	"SEI":      true, // Safety Event Integrator
+	"SDM":      true, // Safety Decision Maker (IGX Functional Safety Island)
+	"estop":    true, // emergency stop
+	"operator": true, // human operator action
+}
+
+// HalosError is returned for invalid Halos safety-evidence input.
+type HalosError struct{ Msg string }
+
+func (e *HalosError) Error() string { return e.Msg }
+
+// SafetyEventRecorder records the Halos safety-event stream into the
+// tamper-evident black-box. It wraps a BlackBoxLog: each recorded event is
+// encrypted and hash-linked, so the stream is confidential yet tamper-evident.
+// The key is 32 bytes (AES-256).
+type SafetyEventRecorder struct {
+	log *BlackBoxLog
+}
+
+// NewSafetyEventRecorder builds a recorder over a fresh black-box. The key is 32
+// bytes (AES-256).
+func NewSafetyEventRecorder(key []byte) (*SafetyEventRecorder, error) {
+	log, err := NewBlackBoxLog(key, "")
+	if err != nil {
+		return nil, err
+	}
+	return &SafetyEventRecorder{log: log}, nil
+}
+
+// Record records one safety event from a named Halos stack source. An empty
+// timestamp uses now. A nil detail records an empty object.
+func (r *SafetyEventRecorder) Record(source, event string, detail map[string]any, timestamp string) (map[string]any, error) {
+	if !HalosEventSources[source] {
+		return nil, &HalosError{"unknown Halos event source: " + source}
+	}
+	if detail == nil {
+		detail = map[string]any{}
+	}
+	payload := map[string]any{"source": source, "detail": detail}
+	return r.log.Append(event, payload, timestamp)
+}
+
+// Head returns the current black-box chain head hash.
+func (r *SafetyEventRecorder) Head() string { return r.log.Head() }
+
+// Count returns the number of recorded entries.
+func (r *SafetyEventRecorder) Count() int { return len(r.log.entries) }
+
+// Entries returns a shallow copy of the recorded entries.
+func (r *SafetyEventRecorder) Entries() []map[string]any { return r.log.Entries() }
+
+// OpenEntry decrypts one entry with this recorder's black-box key.
+func (r *SafetyEventRecorder) OpenEntry(entry map[string]any) (map[string]any, error) {
+	return r.log.OpenEntry(entry)
+}
+
+// BuildSafetyEvidenceOptions configures BuildSafetyEvidence. Pass either
+// Recorder, or both BlackboxHead and an EntryCount via HasEntryCount.
+type BuildSafetyEvidenceOptions struct {
+	HalosStack map[string]any    // required certified Halos configuration
+	Window     map[string]string // required {"from": iso, "to": iso}
+
+	Recorder      *SafetyEventRecorder // source of head and count
+	BlackboxHead  string               // explicit head when Recorder is nil
+	EntryCount    int                  // explicit count when Recorder is nil
+	HasEntryCount bool                 // set when EntryCount is supplied explicitly
+
+	RobotIdentity string    // optional reference to the robot's identity credential
+	ValidSeconds  int       // 0 omits validUntil
+	ValidFrom     time.Time // zero uses now
+}
+
+// BuildSafetyEvidence seals a robot's Halos safety-event record into a signed
+// HalosSafetyEvidenceCredential. The robot signs a credential that binds the
+// black-box chain head and entry count to its identity, to the Halos stack
+// elements it ran on, and to the time window.
+func BuildSafetyEvidence(robotSigner *signer.Signer, opts BuildSafetyEvidenceOptions) (map[string]any, error) {
+	if len(opts.HalosStack) == 0 {
+		return nil, &HalosError{"halos_stack is required"}
+	}
+	if _, ok := opts.Window["from"]; !ok {
+		return nil, &HalosError{"window with 'from' and 'to' is required"}
+	}
+	if _, ok := opts.Window["to"]; !ok {
+		return nil, &HalosError{"window with 'from' and 'to' is required"}
+	}
+
+	var head string
+	var count int
+	if opts.Recorder != nil {
+		head = opts.Recorder.Head()
+		count = opts.Recorder.Count()
+	} else {
+		if opts.BlackboxHead == "" || !opts.HasEntryCount {
+			return nil, &HalosError{"pass a recorder, or both blackbox_head and entry_count"}
+		}
+		head = opts.BlackboxHead
+		count = opts.EntryCount
+	}
+	if count < 0 {
+		return nil, &HalosError{"entry_count cannot be negative"}
+	}
+
+	robotDID := robotSigner.DID()
+	issued := opts.ValidFrom
+	if issued.IsZero() {
+		issued = time.Now().UTC()
+	}
+
+	subject := map[string]any{
+		"id":           robotDID,
+		"blackboxHead": head,
+		"entryCount":   count,
+		"halosStack":   opts.HalosStack,
+		"window":       map[string]any{"from": opts.Window["from"], "to": opts.Window["to"]},
+	}
+	if opts.RobotIdentity != "" {
+		subject["robotIdentity"] = opts.RobotIdentity
+	}
+
+	cred := map[string]any{
+		"@context":          []any{vcContextV2, vouchContextV1},
+		"type":              []any{"VerifiableCredential", HalosSafetyEvidenceType},
+		"issuer":            robotDID,
+		"validFrom":         iso(issued),
+		"credentialSubject": subject,
+	}
+	if opts.ValidSeconds > 0 {
+		cred["validUntil"] = iso(issued.Add(time.Duration(opts.ValidSeconds) * time.Second))
+	}
+	return robotSigner.AttachProof(cred)
+}
+
+// VerifySafetyEvidenceOptions configures VerifySafetyEvidence. When Entries is
+// non-nil, the black-box chain is checked against the sealed head and count.
+type VerifySafetyEvidenceOptions struct {
+	Entries []map[string]any
+}
+
+// VerifySafetyEvidence verifies a HalosSafetyEvidenceCredential. It checks the
+// robot's proof and that the issuer is the robot. When Entries are supplied, it
+// also checks that the black-box chain is intact, that its length matches the
+// sealed entry count, and that its head matches the sealed head, so a truncated,
+// extended, reordered, or tampered record is rejected. Returns (ok, subject).
+func VerifySafetyEvidence(cred map[string]any, robotPub ed25519.PublicKey, opts VerifySafetyEvidenceOptions) (bool, map[string]any) {
+	if !hasType(cred["type"], HalosSafetyEvidenceType) {
+		return false, nil
+	}
+	if robotPub == nil {
+		return false, nil
+	}
+	if ok, err := signer.VerifyDataIntegrityProof(cred, robotPub); err != nil || !ok {
+		return false, nil
+	}
+
+	subject, _ := cred["credentialSubject"].(map[string]any)
+	if subject == nil {
+		return false, nil
+	}
+	issuer, _ := cred["issuer"].(string)
+	if id, _ := subject["id"].(string); id != issuer {
+		return false, nil
+	}
+
+	if opts.Entries != nil {
+		if r := VerifyBlackboxChain(opts.Entries, ""); !r.OK {
+			return false, nil
+		}
+		sealedCount, ok := toInt(subject["entryCount"])
+		if !ok || len(opts.Entries) != sealedCount {
+			return false, nil
+		}
+		head := GenesisPrevHash
+		if len(opts.Entries) > 0 {
+			head, _ = opts.Entries[len(opts.Entries)-1]["entryHash"].(string)
+		}
+		if sealedHead, _ := subject["blackboxHead"].(string); head != sealedHead {
+			return false, nil
+		}
+	}
+
+	return true, subject
+}

--- a/go-sidecar/robotics/halos_test.go
+++ b/go-sidecar/robotics/halos_test.go
@@ -1,0 +1,291 @@
+package robotics
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+var halosStack = map[string]any{
+	"igxSom":    "IGX-Thor-SoM",
+	"halosCore": "Halos Core Linux 1.0",
+	"blueprint": []any{"SAIM", "SEI", "SDM"},
+}
+
+var halosWindow = map[string]string{
+	"from": "2026-07-12T00:00:00Z",
+	"to":   "2026-07-12T01:00:00Z",
+}
+
+type halosScenario struct {
+	robot *signer.Signer
+	rec   *SafetyEventRecorder
+	ev    map[string]any
+}
+
+func newHalosScenario(t *testing.T) halosScenario {
+	t.Helper()
+	robot := newRobot(t, "did:web:robot.example.com")
+	rec, err := NewSafetyEventRecorder(filled(9))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rec.Record("SAIM", "camera_blockage_cleared", map[string]any{"cam": 2}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rec.Record("SEI", "multi_camera_fused", map[string]any{"objects": 3}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rec.Record("SDM", "slow_stop", map[string]any{"reason": "out_of_distribution"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rec.Record("estop", "emergency_stop", map[string]any{"by": "operator-7"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	ev, err := BuildSafetyEvidence(robot, BuildSafetyEvidenceOptions{
+		HalosStack:    halosStack,
+		Window:        halosWindow,
+		Recorder:      rec,
+		RobotIdentity: "urn:uuid:robot-id",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return halosScenario{robot: robot, rec: rec, ev: ev}
+}
+
+func TestHalosHappyPathSealsAndVerifies(t *testing.T) {
+	s := newHalosScenario(t)
+	ok, subject := VerifySafetyEvidence(s.ev, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: s.rec.Entries()})
+	if !ok {
+		t.Fatal("expected the sealed evidence to verify")
+	}
+	if subject["id"] != s.robot.DID() {
+		t.Fatalf("unexpected subject id: %v", subject["id"])
+	}
+	if n, _ := toInt(subject["entryCount"]); n != 4 {
+		t.Fatalf("unexpected entry count: %v", subject["entryCount"])
+	}
+	if subject["blackboxHead"] != s.rec.Head() {
+		t.Fatalf("sealed head did not match the recorder head: %v", subject["blackboxHead"])
+	}
+	if subject["robotIdentity"] != "urn:uuid:robot-id" {
+		t.Fatalf("robot identity did not survive into the subject: %v", subject["robotIdentity"])
+	}
+	if !hasType(s.ev["type"], HalosSafetyEvidenceType) {
+		t.Fatal("missing HalosSafetyEvidenceCredential type")
+	}
+}
+
+func TestHalosSignatureOnlyPathWithoutEntries(t *testing.T) {
+	s := newHalosScenario(t)
+	ok, subject := VerifySafetyEvidence(s.ev, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{})
+	if !ok {
+		t.Fatal("expected signature-only verification to pass")
+	}
+	if n, _ := toInt(subject["entryCount"]); n != 4 {
+		t.Fatalf("unexpected entry count: %v", subject["entryCount"])
+	}
+}
+
+func TestHalosUnknownEventSourceRejected(t *testing.T) {
+	rec, err := NewSafetyEventRecorder(filled(9))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rec.Record("bogus", "whatever", map[string]any{}, ""); err == nil {
+		t.Fatal("expected an unknown Halos event source to be rejected")
+	}
+}
+
+func TestHalosTamperedEntryRejected(t *testing.T) {
+	s := newHalosScenario(t)
+	entries := s.rec.Entries()
+	entries[1]["event"] = "forged_event"
+	if ok, _ := VerifySafetyEvidence(s.ev, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: entries}); ok {
+		t.Fatal("expected a tampered entry to be rejected")
+	}
+}
+
+func TestHalosTruncatedRecordRejected(t *testing.T) {
+	s := newHalosScenario(t)
+	entries := s.rec.Entries()
+	entries = entries[:len(entries)-1]
+	if ok, _ := VerifySafetyEvidence(s.ev, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: entries}); ok {
+		t.Fatal("expected a truncated record to be rejected")
+	}
+}
+
+func TestHalosAppendedAfterSealRejected(t *testing.T) {
+	s := newHalosScenario(t)
+	// Seal, then keep recording: the presented log no longer matches the seal.
+	if _, err := s.rec.Record("operator", "resume", map[string]any{"by": "operator-7"}, ""); err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := VerifySafetyEvidence(s.ev, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: s.rec.Entries()}); ok {
+		t.Fatal("expected a record extended after sealing to be rejected")
+	}
+}
+
+func TestHalosReorderedEntriesRejected(t *testing.T) {
+	s := newHalosScenario(t)
+	entries := s.rec.Entries()
+	entries[0], entries[2] = entries[2], entries[0]
+	if ok, _ := VerifySafetyEvidence(s.ev, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: entries}); ok {
+		t.Fatal("expected reordered entries to be rejected")
+	}
+}
+
+func TestHalosWrongRobotKeyRejected(t *testing.T) {
+	s := newHalosScenario(t)
+	other := newRobot(t, "did:web:other.example.com")
+	if ok, _ := VerifySafetyEvidence(s.ev, other.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: s.rec.Entries()}); ok {
+		t.Fatal("expected verification under the wrong robot key to fail")
+	}
+}
+
+func TestHalosForgedEvidenceNotAttributableToRobot(t *testing.T) {
+	// An attacker seals the robot's real head under its own key. Verifying with
+	// the robot's key fails, so the evidence cannot be attributed to the robot.
+	s := newHalosScenario(t)
+	attacker := newRobot(t, "did:web:attacker.example.com")
+	forged, err := BuildSafetyEvidence(attacker, BuildSafetyEvidenceOptions{
+		HalosStack:    halosStack,
+		Window:        halosWindow,
+		BlackboxHead:  s.rec.Head(),
+		EntryCount:    s.rec.Count(),
+		HasEntryCount: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := VerifySafetyEvidence(forged, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: s.rec.Entries()}); ok {
+		t.Fatal("expected forged evidence to not be attributable to the robot")
+	}
+}
+
+func TestHalosHeadMismatchRejected(t *testing.T) {
+	s := newHalosScenario(t)
+	bad, err := BuildSafetyEvidence(s.robot, BuildSafetyEvidenceOptions{
+		HalosStack:    halosStack,
+		Window:        halosWindow,
+		BlackboxHead:  "uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		EntryCount:    s.rec.Count(),
+		HasEntryCount: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok, _ := VerifySafetyEvidence(bad, s.robot.PublicKeyEd25519(), VerifySafetyEvidenceOptions{Entries: s.rec.Entries()}); ok {
+		t.Fatal("expected a sealed head that does not match the entries to be rejected")
+	}
+}
+
+func TestHalosMissingStackOrWindowRejected(t *testing.T) {
+	robot := newRobot(t, "did:web:robot.example.com")
+	if _, err := BuildSafetyEvidence(robot, BuildSafetyEvidenceOptions{
+		HalosStack: map[string]any{}, Window: halosWindow, BlackboxHead: "u", HasEntryCount: true,
+	}); err == nil {
+		t.Fatal("expected a missing halos stack to be rejected")
+	}
+	if _, err := BuildSafetyEvidence(robot, BuildSafetyEvidenceOptions{
+		HalosStack: halosStack, Window: map[string]string{}, BlackboxHead: "u", HasEntryCount: true,
+	}); err == nil {
+		t.Fatal("expected a missing window to be rejected")
+	}
+}
+
+func TestHalosPayloadsConfidentialButChainPublic(t *testing.T) {
+	// The chain verifies from the encrypted entries without the key, while the
+	// payloads open only with the black-box key.
+	s := newHalosScenario(t)
+	entries := s.rec.Entries()
+	blob, err := json.Marshal(entries)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(blob), "operator-7") {
+		t.Fatal("payload leaked in the encrypted entries")
+	}
+	opened, err := s.rec.OpenEntry(entries[3])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opened["source"] != "estop" {
+		t.Fatalf("unexpected opened source: %v", opened["source"])
+	}
+	detail, _ := opened["detail"].(map[string]any)
+	if detail["by"] != "operator-7" {
+		t.Fatalf("unexpected opened detail: %v", detail)
+	}
+}
+
+// pythonHalosVector was produced by the Python reference (vouch/robotics/halos.py)
+// from a fixed Ed25519 seed (bytes 0x00..0x1f) and a fixed created timestamp, so
+// Go verifies a credential and black-box chain it did not itself produce.
+const pythonHalosVector = `{
+  "credential": {
+    "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+    "type": ["VerifiableCredential", "HalosSafetyEvidenceCredential"],
+    "issuer": "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd",
+    "validFrom": "2026-07-12T00:50:00Z",
+    "credentialSubject": {
+      "id": "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd",
+      "blackboxHead": "u82fjhvgrn0z7P-mnnZbLLee30hikdpF8COrLgbYWYv4",
+      "entryCount": 4,
+      "halosStack": {
+        "igxSom": "IGX-Thor-SoM",
+        "halosCore": "Halos Core Linux 1.0",
+        "blueprint": ["SAIM", "SEI", "SDM"]
+      },
+      "window": {"from": "2026-07-12T00:00:00Z", "to": "2026-07-12T01:00:00Z"},
+      "robotIdentity": "urn:uuid:robot-id"
+    },
+    "proof": {
+      "type": "DataIntegrityProof",
+      "cryptosuite": "eddsa-jcs-2022",
+      "created": "2026-07-12T00:50:00Z",
+      "verificationMethod": "did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd#key-1",
+      "proofPurpose": "assertionMethod",
+      "proofValue": "zwZDBkeCbWz26pJni7iiueDaMT3zpNMz8EF7KqeaVxpttQbqv6FR8weZT7sDAp6AbD4pQDN2HNVF8dyZbe2S1gvZ"
+    }
+  },
+  "entries": [
+    {"version": "1.0", "seq": 0, "timestamp": "2026-07-12T00:10:00Z", "event": "camera_blockage_cleared", "ciphertext": "uN6UCEOV0Zc7ncB-i388PHo9o2wmfS8WOlxtO59mL-fspPWlYvPUWzh3wZpzlacOX8dXFn4llu6PUgbhP_Y2EYA", "prevHash": "uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "entryHash": "uo0RaFa1FdMUfZqu-xRpTHylocM-JpONylczvx4rE3ts"},
+    {"version": "1.0", "seq": 1, "timestamp": "2026-07-12T00:20:00Z", "event": "multi_camera_fused", "ciphertext": "uy0rELnEUcMADjg07QGGOa5-saZ5QQlu2-l-IBL67icySRxMXm4RHvTHA7BSbnY1Po8rohlOXuWouP58YWSwRg8hM-g", "prevHash": "uo0RaFa1FdMUfZqu-xRpTHylocM-JpONylczvx4rE3ts", "entryHash": "uj8OqxWIId9iqNxz0uADLvcg8MGA3xM6cg-236DwnFFE"},
+    {"version": "1.0", "seq": 2, "timestamp": "2026-07-12T00:30:00Z", "event": "slow_stop", "ciphertext": "uTFOWlyw1DQ-JqN__u6GKViUB6GWpVhFB20UepI8T7gfHMMOuulywBrgaL_ldF4KOX-QE9nvB39HR1VF7MqVtBkSaQ3ov7BzD_YyUs6Im4eypzheGG-w", "prevHash": "uj8OqxWIId9iqNxz0uADLvcg8MGA3xM6cg-236DwnFFE", "entryHash": "uOmuDhcXxLB5CgtLwWfQ88idpH2wJPDrpGvS-smoboOs"},
+    {"version": "1.0", "seq": 3, "timestamp": "2026-07-12T00:40:00Z", "event": "emergency_stop", "ciphertext": "u1iORDTzr9ZsRVceldvJL4qSoojs3IeLNkcSnwSfIhRUyB4BiyJeOWhE4_3HSBfhOVOWvkX25nyFPhbEXTSYdb7suwshOj3e0w66u", "prevHash": "uOmuDhcXxLB5CgtLwWfQ88idpH2wJPDrpGvS-smoboOs", "entryHash": "u82fjhvgrn0z7P-mnnZbLLee30hikdpF8COrLgbYWYv4"}
+  ],
+  "robot_public_key_jwk": {"kty": "OKP", "crv": "Ed25519", "x": "A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg"}
+}`
+
+// TestHalosVerifyPythonVector is the cross-language proof: Go verifies a
+// HalosSafetyEvidenceCredential and its black-box chain produced by the Python
+// reference, and rejects the same record once one entry is tampered.
+func TestHalosVerifyPythonVector(t *testing.T) {
+	var v struct {
+		Credential        map[string]any   `json:"credential"`
+		Entries           []map[string]any `json:"entries"`
+		RobotPublicKeyJWK map[string]any   `json:"robot_public_key_jwk"`
+	}
+	if err := json.Unmarshal([]byte(pythonHalosVector), &v); err != nil {
+		t.Fatal(err)
+	}
+	pub := ed25519FromJWK(t, v.RobotPublicKeyJWK)
+
+	ok, subject := VerifySafetyEvidence(v.Credential, pub, VerifySafetyEvidenceOptions{Entries: v.Entries})
+	if !ok {
+		t.Fatal("expected the Python-produced Halos evidence to verify in Go")
+	}
+	if subject["robotIdentity"] != "urn:uuid:robot-id" {
+		t.Fatalf("unexpected subject: %v", subject)
+	}
+
+	// Tamper with one entry: the chain no longer matches the sealed head.
+	v.Entries[1]["event"] = "forged_event"
+	if ok, _ := VerifySafetyEvidence(v.Credential, pub, VerifySafetyEvidenceOptions{Entries: v.Entries}); ok {
+		t.Fatal("expected a tampered Python entry to be rejected in Go")
+	}
+}

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -300,6 +300,19 @@ export type {
   VerifyDecommissionOptions,
 } from './robotics/lifecycle';
 
+// Halos safety-evidence recorder (NVIDIA Halos integration): a robot-signed
+// credential sealing a tamper-evident black-box of Halos safety events to the
+// robot's identity and certified stack, byte-identical with the Python module.
+export {
+  HALOS_SAFETY_EVIDENCE_TYPE,
+  HALOS_EVENT_SOURCES,
+  HalosError,
+  SafetyEventRecorder,
+  buildSafetyEvidence,
+  verifySafetyEvidence,
+} from './robotics/halos';
+export type { BuildSafetyEvidenceOptions } from './robotics/halos';
+
 // Regulatory conformance profiles, deterministic checker, and signed
 // point-in-time attestation, byte-identical with the Python module.
 export {

--- a/packages/sdk-ts/src/robotics/halos.ts
+++ b/packages/sdk-ts/src/robotics/halos.ts
@@ -1,0 +1,215 @@
+/**
+ * Halos safety-evidence recorder (NVIDIA Halos integration), TypeScript.
+ *
+ * Mirrors `vouch/robotics/halos.py` with byte-identical output. NVIDIA Halos
+ * certifies that a robot's stack is functionally safe and secure by design. It
+ * does not, on its own, produce a verifiable record of what a specific robot
+ * did, or bind that record to the robot's identity. This module is the evidence
+ * layer that sits under a Halos-certified stack.
+ *
+ * A `SafetyEventRecorder` captures the safety-relevant event stream produced by
+ * the Halos Outside-In Safety Blueprint components (the Safety AI Monitor, the
+ * Safety Event Integrator, the Safety Decision Maker, and the sensor input
+ * pipeline), plus emergency stops and operator actions, into the tamper-evident,
+ * encrypted black-box. The robot then signs a `HalosSafetyEvidenceCredential`
+ * that seals the black-box chain head and entry count and binds them to the
+ * robot's identity and to the exact Halos stack elements it ran on.
+ *
+ * A verifier that holds the sealed credential and the entries confirms the
+ * record is unaltered, that it has not been truncated or extended since it was
+ * sealed, that it is attributable to that specific robot, and that it names the
+ * certified Halos configuration it was produced on, all without the black-box
+ * key. Only a holder of the black-box key can read the payloads, so the record
+ * stays confidential while remaining verifiable.
+ *
+ * This composes the existing black-box and robot-identity primitives and adds no
+ * new cryptography.
+ */
+
+import * as crypto from 'crypto';
+
+import { verifyProof } from '../data-integrity';
+import type { Signer } from '../signer';
+import { VC_CONTEXT_V2, VOUCH_CONTEXT_V1 } from '../vc';
+
+import { GENESIS_PREV_HASH, BlackBoxLog, verifyBlackboxChain } from './blackbox';
+
+export const HALOS_SAFETY_EVIDENCE_TYPE = 'HalosSafetyEvidenceCredential';
+
+/**
+ * The safety-relevant event producers in a Halos-certified stack: the four
+ * Outside-In Safety Blueprint components, plus an emergency stop and an operator
+ * action. A recorder rejects any event from a source outside this set, so the
+ * record maps to a known part of the certified stack.
+ */
+export const HALOS_EVENT_SOURCES: ReadonlySet<string> = new Set([
+  'SIPP', // Sensor Input Processing Pipeline
+  'SAIM', // Safety AI Monitor
+  'SEI', // Safety Event Integrator
+  'SDM', // Safety Decision Maker (runs on the IGX Functional Safety Island)
+  'estop', // emergency stop
+  'operator', // human operator action
+]);
+
+export class HalosError extends Error {}
+
+function iso(d: Date): string {
+  return d.toISOString().replace(/\.\d{3}Z$/, 'Z');
+}
+
+/**
+ * Records the Halos safety-event stream into the tamper-evident black-box.
+ *
+ * Wraps a `BlackBoxLog`: each recorded event is encrypted and hash-linked, so
+ * the stream is confidential yet tamper-evident. `key` is 32 bytes (AES-256).
+ */
+export class SafetyEventRecorder {
+  private log: BlackBoxLog;
+
+  constructor(key: Uint8Array) {
+    this.log = new BlackBoxLog(key);
+  }
+
+  /** Record one safety event from a named Halos stack source. */
+  record(
+    source: string,
+    event: string,
+    detail?: Record<string, unknown>,
+    opts: { timestamp?: string } = {}
+  ): Record<string, unknown> {
+    if (!HALOS_EVENT_SOURCES.has(source)) {
+      throw new HalosError(`unknown Halos event source: ${JSON.stringify(source)}`);
+    }
+    const payload: Record<string, unknown> = { source, detail: detail ?? {} };
+    return this.log.append(event, payload, opts);
+  }
+
+  head(): string {
+    return this.log.head();
+  }
+
+  count(): number {
+    return this.log.entries().length;
+  }
+
+  entries(): Array<Record<string, unknown>> {
+    return this.log.entries();
+  }
+
+  /** Decrypt one entry with this recorder's black-box key. */
+  openEntry(entry: Record<string, unknown>): Record<string, unknown> {
+    return this.log.openEntry(entry);
+  }
+}
+
+export interface BuildSafetyEvidenceOptions {
+  halosStack: Record<string, unknown>;
+  window: { from: string; to: string };
+  recorder?: SafetyEventRecorder;
+  blackboxHead?: string;
+  entryCount?: number;
+  robotIdentity?: string;
+  validSeconds?: number;
+  validFrom?: Date;
+  created?: Date;
+}
+
+/**
+ * Seal a robot's Halos safety-event record into a signed
+ * HalosSafetyEvidenceCredential.
+ *
+ * The robot signs a credential that binds the black-box chain head and entry
+ * count to its identity, to the Halos stack elements it ran on, and to the time
+ * window. Pass either a `recorder` or an explicit `blackboxHead` + `entryCount`.
+ */
+export async function buildSafetyEvidence(
+  robotSigner: Signer,
+  opts: BuildSafetyEvidenceOptions
+): Promise<Record<string, unknown>> {
+  const { halosStack, window } = opts;
+  if (!halosStack || Object.keys(halosStack).length === 0) {
+    throw new HalosError('halosStack is required');
+  }
+  if (!window || window.from === undefined || window.to === undefined) {
+    throw new HalosError("window with 'from' and 'to' is required");
+  }
+
+  let head: string;
+  let count: number;
+  if (opts.recorder !== undefined) {
+    head = opts.recorder.head();
+    count = opts.recorder.count();
+  } else {
+    if (opts.blackboxHead === undefined || opts.entryCount === undefined) {
+      throw new HalosError('pass a recorder, or both blackboxHead and entryCount');
+    }
+    head = opts.blackboxHead;
+    count = opts.entryCount;
+  }
+  if (count < 0) {
+    throw new HalosError('entryCount cannot be negative');
+  }
+
+  const robotDid = robotSigner.getDid();
+  const issued = opts.validFrom ?? new Date();
+  const subject: Record<string, unknown> = {
+    id: robotDid,
+    blackboxHead: head,
+    entryCount: count,
+    halosStack,
+    window: { from: window.from, to: window.to },
+  };
+  if (opts.robotIdentity !== undefined) subject.robotIdentity = opts.robotIdentity;
+
+  const credential: Record<string, unknown> = {
+    '@context': [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+    type: ['VerifiableCredential', HALOS_SAFETY_EVIDENCE_TYPE],
+    issuer: robotDid,
+    validFrom: iso(issued),
+    credentialSubject: subject,
+  };
+  if (opts.validSeconds !== undefined) {
+    credential.validUntil = iso(new Date(issued.getTime() + opts.validSeconds * 1000));
+  }
+  return robotSigner.attachProof(credential, { created: opts.created });
+}
+
+/**
+ * Verify a HalosSafetyEvidenceCredential.
+ *
+ * Checks the robot's proof and that the issuer is the robot. When `entries` are
+ * supplied, also checks that the black-box chain is intact, that its length
+ * matches the sealed entry count, and that its head matches the sealed head, so
+ * a truncated, extended, reordered, or tampered record is rejected. Returns
+ * `{ ok, subject }`.
+ */
+export function verifySafetyEvidence(
+  credential: Record<string, any>,
+  robotPublicKey: crypto.KeyObject,
+  opts: { entries?: Array<Record<string, any>> } = {}
+): { ok: boolean; subject?: Record<string, unknown> } {
+  const typeField = credential.type;
+  const types = Array.isArray(typeField) ? typeField : [typeField];
+  if (!types.includes(HALOS_SAFETY_EVIDENCE_TYPE)) return { ok: false };
+
+  if (robotPublicKey === null || robotPublicKey === undefined) return { ok: false };
+  try {
+    if (!verifyProof(credential, robotPublicKey)) return { ok: false };
+  } catch {
+    return { ok: false };
+  }
+
+  const subject = (credential.credentialSubject ?? {}) as Record<string, unknown>;
+  if (subject.id !== credential.issuer) return { ok: false };
+
+  const entries = opts.entries;
+  if (entries !== undefined) {
+    if (!verifyBlackboxChain(entries).ok) return { ok: false };
+    if (entries.length !== subject.entryCount) return { ok: false };
+    const head =
+      entries.length > 0 ? (entries[entries.length - 1].entryHash as string) : GENESIS_PREV_HASH;
+    if (head !== subject.blackboxHead) return { ok: false };
+  }
+
+  return { ok: true, subject };
+}

--- a/packages/sdk-ts/tests/robotics-halos.test.ts
+++ b/packages/sdk-ts/tests/robotics-halos.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Adversarial tests for the Halos safety-evidence recorder (TypeScript).
+ *
+ * Mirrors the Python tests/test_halos_evidence.py suite: a robot records the
+ * Halos safety-event stream into the tamper-evident black-box, seals the chain
+ * head and entry count into a signed HalosSafetyEvidenceCredential, and a
+ * verifier confirms the record is unaltered, untruncated, unextended, and
+ * attributable to that robot, all without the black-box key.
+ *
+ * The cross-language case loads a credential, black-box entries, and robot
+ * public key produced by the Python reference from a fixed Ed25519 seed and a
+ * fixed proof timestamp, and confirms the TypeScript verifier accepts it and
+ * rejects a tampered entry.
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  Signer,
+  generateIdentity,
+  HALOS_SAFETY_EVIDENCE_TYPE,
+  HalosError,
+  SafetyEventRecorder,
+  buildSafetyEvidence,
+  verifySafetyEvidence,
+} from '../src';
+
+const KEY = new Uint8Array(32).fill(9);
+const HALOS_STACK = {
+  igxSom: 'IGX-Thor-SoM',
+  halosCore: 'Halos Core Linux 1.0',
+  blueprint: ['SAIM', 'SEI', 'SDM'],
+};
+const WINDOW = { from: '2026-07-12T00:00:00Z', to: '2026-07-12T01:00:00Z' };
+
+function publicKeyFromJwk(jwk: unknown): crypto.KeyObject {
+  return crypto.createPublicKey({ key: jwk as crypto.JsonWebKey, format: 'jwk' });
+}
+
+async function robotParty() {
+  const keys = await generateIdentity('robot.example.com');
+  const did = 'did:web:robot.example.com';
+  const signer = new Signer({ privateKey: keys.privateKeyJwk, did });
+  const pub = publicKeyFromJwk(JSON.parse(keys.publicKeyJwk));
+  return { signer, pub, did };
+}
+
+async function scenario() {
+  const robot = await robotParty();
+  const rec = new SafetyEventRecorder(KEY);
+  rec.record('SAIM', 'camera_blockage_cleared', { cam: 2 });
+  rec.record('SEI', 'multi_camera_fused', { objects: 3 });
+  rec.record('SDM', 'slow_stop', { reason: 'out_of_distribution' });
+  rec.record('estop', 'emergency_stop', { by: 'operator-7' });
+  const evidence = await buildSafetyEvidence(robot.signer, {
+    halosStack: HALOS_STACK,
+    window: WINDOW,
+    recorder: rec,
+    robotIdentity: 'urn:uuid:robot-id',
+  });
+  return { robot, rec, evidence };
+}
+
+describe('Halos safety evidence', () => {
+  it('seals and verifies (happy path)', async () => {
+    const s = await scenario();
+    const { ok, subject } = verifySafetyEvidence(s.evidence, s.robot.pub, {
+      entries: s.rec.entries(),
+    });
+    expect(ok).toBe(true);
+    expect(subject?.id).toBe(s.robot.did);
+    expect(subject?.entryCount).toBe(4);
+    expect(subject?.blackboxHead).toBe(s.rec.head());
+    expect((subject?.halosStack as { blueprint: string[] }).blueprint).toEqual([
+      'SAIM',
+      'SEI',
+      'SDM',
+    ]);
+    expect(subject?.robotIdentity).toBe('urn:uuid:robot-id');
+    expect(s.evidence.type as string[]).toContain(HALOS_SAFETY_EVIDENCE_TYPE);
+  });
+
+  it('verifies on the signature-only path without entries', async () => {
+    const s = await scenario();
+    const { ok, subject } = verifySafetyEvidence(s.evidence, s.robot.pub);
+    expect(ok).toBe(true);
+    expect(subject?.entryCount).toBe(4);
+  });
+
+  it('rejects an unknown event source', () => {
+    const rec = new SafetyEventRecorder(KEY);
+    expect(() => rec.record('bogus', 'whatever', {})).toThrow(HalosError);
+  });
+
+  it('rejects a tampered entry', async () => {
+    const s = await scenario();
+    const entries = s.rec.entries();
+    entries[1].event = 'forged_event';
+    expect(verifySafetyEvidence(s.evidence, s.robot.pub, { entries }).ok).toBe(false);
+  });
+
+  it('rejects a truncated record', async () => {
+    const s = await scenario();
+    const entries = s.rec.entries().slice(0, -1);
+    expect(verifySafetyEvidence(s.evidence, s.robot.pub, { entries }).ok).toBe(false);
+  });
+
+  it('rejects a record appended after the seal', async () => {
+    const s = await scenario();
+    // Seal, then keep recording: the presented log no longer matches the seal.
+    s.rec.record('operator', 'resume', { by: 'operator-7' });
+    expect(
+      verifySafetyEvidence(s.evidence, s.robot.pub, { entries: s.rec.entries() }).ok
+    ).toBe(false);
+  });
+
+  it('rejects reordered entries', async () => {
+    const s = await scenario();
+    const entries = s.rec.entries();
+    const tmp = entries[0];
+    entries[0] = entries[2];
+    entries[2] = tmp;
+    expect(verifySafetyEvidence(s.evidence, s.robot.pub, { entries }).ok).toBe(false);
+  });
+
+  it('rejects the wrong robot key', async () => {
+    const s = await scenario();
+    const other = await robotParty();
+    expect(
+      verifySafetyEvidence(s.evidence, other.pub, { entries: s.rec.entries() }).ok
+    ).toBe(false);
+  });
+
+  it('rejects forged evidence not attributable to the robot', async () => {
+    // An attacker seals the robot's real head under its own key. Verifying with
+    // the robot's key fails, so the evidence cannot be attributed to the robot.
+    const s = await scenario();
+    const attacker = await robotParty();
+    const forged = await buildSafetyEvidence(attacker.signer, {
+      halosStack: HALOS_STACK,
+      window: WINDOW,
+      blackboxHead: s.rec.head(),
+      entryCount: s.rec.count(),
+    });
+    expect(
+      verifySafetyEvidence(forged, s.robot.pub, { entries: s.rec.entries() }).ok
+    ).toBe(false);
+  });
+
+  it('rejects a sealed head that does not match the entries', async () => {
+    const s = await scenario();
+    const bad = await buildSafetyEvidence(s.robot.signer, {
+      halosStack: HALOS_STACK,
+      window: WINDOW,
+      blackboxHead: 'uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      entryCount: s.rec.count(),
+    });
+    expect(
+      verifySafetyEvidence(bad, s.robot.pub, { entries: s.rec.entries() }).ok
+    ).toBe(false);
+  });
+
+  it('rejects a missing stack or window at build time', async () => {
+    const robot = await robotParty();
+    await expect(
+      buildSafetyEvidence(robot.signer, {
+        halosStack: {},
+        window: WINDOW,
+        blackboxHead: 'u',
+        entryCount: 0,
+      })
+    ).rejects.toThrow(HalosError);
+    await expect(
+      buildSafetyEvidence(robot.signer, {
+        halosStack: HALOS_STACK,
+        window: {} as { from: string; to: string },
+        blackboxHead: 'u',
+        entryCount: 0,
+      })
+    ).rejects.toThrow(HalosError);
+  });
+
+  it('keeps payloads confidential while the chain stays public', async () => {
+    // The chain verifies from the encrypted entries without the key, while the
+    // payloads open only with the black-box key.
+    const s = await scenario();
+    const entries = s.rec.entries();
+    expect(JSON.stringify(entries)).not.toContain('operator-7'); // payload is encrypted
+    const opened = s.rec.openEntry(entries[3]);
+    expect(opened.source).toBe('estop');
+    expect((opened.detail as { by: string }).by).toBe('operator-7');
+  });
+});
+
+// A credential, black-box entries, and robot public key produced by the Python
+// reference (vouch/robotics/halos.py) from a fixed Ed25519 seed (bytes 0..31)
+// and a fixed proof timestamp. The TypeScript verifier reproduces the Python
+// verifier's decision byte for byte.
+const PY_VECTOR = {
+  robot_public_key_jwk: {
+    crv: 'Ed25519',
+    kty: 'OKP',
+    x: 'A6EHv_POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg',
+  },
+  credential: {
+    '@context': [
+      'https://www.w3.org/ns/credentials/v2',
+      'https://vouch-protocol.com/contexts/v1',
+    ],
+    credentialSubject: {
+      blackboxHead: 'urYXkiOGIdmxj57LWsU_9Zv_D694V18SCdkEfEq_NO2A',
+      entryCount: 4,
+      halosStack: {
+        blueprint: ['SAIM', 'SEI', 'SDM'],
+        halosCore: 'Halos Core Linux 1.0',
+        igxSom: 'IGX-Thor-SoM',
+      },
+      id: 'did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd',
+      robotIdentity: 'urn:uuid:robot-id',
+      window: { from: '2026-07-12T00:00:00Z', to: '2026-07-12T01:00:00Z' },
+    },
+    issuer: 'did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd',
+    proof: {
+      created: '2026-07-12T00:00:00Z',
+      cryptosuite: 'eddsa-jcs-2022',
+      proofPurpose: 'assertionMethod',
+      proofValue:
+        'zfDfsG4FnFFmtrC1SvmT1AJznggTXKhqrHuHv57nHDNEb34HEN73nJNLxntHV27JMtMwuin5QfEgdVwM7XYCzE4C',
+      type: 'DataIntegrityProof',
+      verificationMethod:
+        'did:key:z6MkehRgf7yJbgaGfYsdoAsKdBPE3dj2CYhowQdcjqSJgvVd#key-1',
+    },
+    type: ['VerifiableCredential', 'HalosSafetyEvidenceCredential'],
+    validFrom: '2026-07-12T05:40:47Z',
+  },
+  entries: [
+    {
+      ciphertext:
+        'ugIc9Kox7w0ywai3RIUSeKxwRKSONEZg2nfyf4z2ozayOXVa8GDfgWvxjwEFxU2iu4TiH5PgaZsms5jqTZezgEQ',
+      entryHash: 'u4ggbbwZRrSzKbWY-BI5npkqc-_tU75fueRjCR5S28Q8',
+      event: 'camera_blockage_cleared',
+      prevHash: 'uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+      seq: 0,
+      timestamp: '2026-07-12T00:10:00Z',
+      version: '1.0',
+    },
+    {
+      ciphertext:
+        'ui8ENxqwT-h6hGT96Fi13l0YEcf6vKaJnHwaedWwfu2jhjefp1V0SjHSXLQqxCMDYu80B2nlWFFxHAV-torzX2R-LXQ',
+      entryHash: 'uwIOJ3t8Kl5JETt4pj0onfFE0PupYFbhAO5KOyiVGl_M',
+      event: 'multi_camera_fused',
+      prevHash: 'u4ggbbwZRrSzKbWY-BI5npkqc-_tU75fueRjCR5S28Q8',
+      seq: 1,
+      timestamp: '2026-07-12T00:20:00Z',
+      version: '1.0',
+    },
+    {
+      ciphertext:
+        'uS6bJimEWxw0MGltkiicoZ0_-yEeBa_8256fIOg7WtndgMTWx4jV8o2O1MIrVRrhyeUxKtHMy3DgN6I5pr-3f4Kg77ep5Tssec0uBRYuTPXagfOry0Ik',
+      entryHash: 'uTLIUUCFFAWYSmX9785rlAtQ23tTc80JX-UHcA-v-IzY',
+      event: 'slow_stop',
+      prevHash: 'uwIOJ3t8Kl5JETt4pj0onfFE0PupYFbhAO5KOyiVGl_M',
+      seq: 2,
+      timestamp: '2026-07-12T00:30:00Z',
+      version: '1.0',
+    },
+    {
+      ciphertext:
+        'uPdmT-fJj869X4ahq4eLRUcYP-CwovN0j0gDmQRtO8VwTI-ZNiV3_rt424NpyLFj46XrLUzJabp23HGf0e1tTph260TqIO5YR4IJm',
+      entryHash: 'urYXkiOGIdmxj57LWsU_9Zv_D694V18SCdkEfEq_NO2A',
+      event: 'emergency_stop',
+      prevHash: 'uTLIUUCFFAWYSmX9785rlAtQ23tTc80JX-UHcA-v-IzY',
+      seq: 3,
+      timestamp: '2026-07-12T00:40:00Z',
+      version: '1.0',
+    },
+  ],
+};
+
+describe('Halos safety evidence (cross-language interop)', () => {
+  it('verifies a Python-produced credential with its entries', () => {
+    const robotKey = publicKeyFromJwk(PY_VECTOR.robot_public_key_jwk);
+    const { ok, subject } = verifySafetyEvidence(PY_VECTOR.credential, robotKey, {
+      entries: PY_VECTOR.entries.map((e) => ({ ...e })),
+    });
+    expect(ok).toBe(true);
+    expect(subject?.entryCount).toBe(4);
+    expect(subject?.blackboxHead).toBe(
+      PY_VECTOR.entries[PY_VECTOR.entries.length - 1].entryHash
+    );
+  });
+
+  it('rejects a Python-produced credential when an entry is tampered', () => {
+    const robotKey = publicKeyFromJwk(PY_VECTOR.robot_public_key_jwk);
+    const entries = PY_VECTOR.entries.map((e) => ({ ...e }));
+    entries[2].event = 'tampered_event';
+    expect(verifySafetyEvidence(PY_VECTOR.credential, robotKey, { entries }).ok).toBe(
+      false
+    );
+  });
+});

--- a/sdks/cpp/include/vouch_core.h
+++ b/sdks/cpp/include/vouch_core.h
@@ -316,6 +316,26 @@ char *vouch_robotics_verify_continuity_chain(const char *params_json,
  */
 char *vouch_robotics_verify_handoff_chain(const char *params_json, char **err_out);
 
+/**
+ * Seal a robot's Halos safety-event record into a signed
+ * HalosSafetyEvidenceCredential. params_json carries {halosStack, window,
+ * blackboxHead, entryCount, robotIdentity?, validSeconds?, validFrom, created}.
+ * The robot DID is derived from the signer seed. Returns the signed credential JSON.
+ */
+char *vouch_robotics_build_safety_evidence(const char *signer_seed_b64,
+                                           const char *params_json,
+                                           char **err_out);
+
+/**
+ * Verify a Halos safety-evidence credential. Pass the robot public key (base64)
+ * and, optionally, the black-box entries as a JSON array (or NULL) to check the
+ * chain against the sealed head and entry count. Returns JSON {ok, subject}.
+ */
+char *vouch_robotics_verify_safety_evidence(const char *credential_json,
+                                            const char *robot_public_b64,
+                                            const char *entries_json,
+                                            char **err_out);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif  // __cplusplus

--- a/tests/test_halos_evidence.py
+++ b/tests/test_halos_evidence.py
@@ -1,0 +1,161 @@
+"""Adversarial tests for the Halos safety-evidence recorder."""
+
+import unittest
+
+from vouch import Signer
+from vouch.root_of_trust import generate_did_key_identity
+from vouch.robotics import (
+    HALOS_SAFETY_EVIDENCE_TYPE,
+    HalosError,
+    SafetyEventRecorder,
+    build_safety_evidence,
+    verify_safety_evidence,
+)
+
+KEY = bytes([9] * 32)
+HALOS_STACK = {
+    "igxSom": "IGX-Thor-SoM",
+    "halosCore": "Halos Core Linux 1.0",
+    "blueprint": ["SAIM", "SEI", "SDM"],
+}
+WINDOW = {"from": "2026-07-12T00:00:00Z", "to": "2026-07-12T01:00:00Z"}
+
+
+def _robot():
+    return Signer.from_keypair(generate_did_key_identity())
+
+
+def _scenario():
+    robot_kp = generate_did_key_identity()
+    robot = Signer.from_keypair(robot_kp)
+    rec = SafetyEventRecorder(KEY)
+    rec.record("SAIM", "camera_blockage_cleared", {"cam": 2})
+    rec.record("SEI", "multi_camera_fused", {"objects": 3})
+    rec.record("SDM", "slow_stop", {"reason": "out_of_distribution"})
+    rec.record("estop", "emergency_stop", {"by": "operator-7"})
+    evidence = build_safety_evidence(
+        robot,
+        halos_stack=HALOS_STACK,
+        window=WINDOW,
+        recorder=rec,
+        robot_identity="urn:uuid:robot-id",
+    )
+    return {
+        "robot": robot,
+        "robot_pub": robot_kp.public_key_jwk,
+        "rec": rec,
+        "evidence": evidence,
+    }
+
+
+class TestHalosSafetyEvidence(unittest.TestCase):
+    def test_happy_path_seals_and_verifies(self):
+        s = _scenario()
+        ok, subject = verify_safety_evidence(
+            s["evidence"], s["robot_pub"], entries=s["rec"].entries()
+        )
+        self.assertTrue(ok, subject)
+        self.assertEqual(subject["id"], s["robot"].get_did())
+        self.assertEqual(subject["entryCount"], 4)
+        self.assertEqual(subject["blackboxHead"], s["rec"].head())
+        self.assertEqual(subject["halosStack"]["blueprint"], ["SAIM", "SEI", "SDM"])
+        self.assertEqual(subject["robotIdentity"], "urn:uuid:robot-id")
+        self.assertIn(HALOS_SAFETY_EVIDENCE_TYPE, s["evidence"]["type"])
+
+    def test_signature_only_path_without_entries(self):
+        s = _scenario()
+        ok, subject = verify_safety_evidence(s["evidence"], s["robot_pub"])
+        self.assertTrue(ok, subject)
+        self.assertEqual(subject["entryCount"], 4)
+
+    def test_unknown_event_source_rejected(self):
+        rec = SafetyEventRecorder(KEY)
+        with self.assertRaises(HalosError):
+            rec.record("bogus", "whatever", {})
+
+    def test_tampered_entry_rejected(self):
+        s = _scenario()
+        entries = s["rec"].entries()
+        entries[1]["event"] = "forged_event"
+        ok, _ = verify_safety_evidence(s["evidence"], s["robot_pub"], entries=entries)
+        self.assertFalse(ok)
+
+    def test_truncated_record_rejected(self):
+        s = _scenario()
+        entries = s["rec"].entries()[:-1]
+        ok, _ = verify_safety_evidence(s["evidence"], s["robot_pub"], entries=entries)
+        self.assertFalse(ok)
+
+    def test_appended_after_seal_rejected(self):
+        s = _scenario()
+        # Seal, then keep recording: the presented log no longer matches the seal.
+        s["rec"].record("operator", "resume", {"by": "operator-7"})
+        ok, _ = verify_safety_evidence(s["evidence"], s["robot_pub"], entries=s["rec"].entries())
+        self.assertFalse(ok)
+
+    def test_reordered_entries_rejected(self):
+        s = _scenario()
+        entries = s["rec"].entries()
+        entries[0], entries[2] = entries[2], entries[0]
+        ok, _ = verify_safety_evidence(s["evidence"], s["robot_pub"], entries=entries)
+        self.assertFalse(ok)
+
+    def test_wrong_robot_key_rejected(self):
+        s = _scenario()
+        other = generate_did_key_identity()
+        ok, _ = verify_safety_evidence(
+            s["evidence"], other.public_key_jwk, entries=s["rec"].entries()
+        )
+        self.assertFalse(ok)
+
+    def test_forged_evidence_not_attributable_to_robot(self):
+        # An attacker seals the robot's real head under its own key. Verifying with
+        # the robot's key fails, so the evidence cannot be attributed to the robot.
+        s = _scenario()
+        attacker = _robot()
+        forged = build_safety_evidence(
+            attacker,
+            halos_stack=HALOS_STACK,
+            window=WINDOW,
+            blackbox_head=s["rec"].head(),
+            entry_count=s["rec"].count(),
+        )
+        ok, _ = verify_safety_evidence(forged, s["robot_pub"], entries=s["rec"].entries())
+        self.assertFalse(ok)
+
+    def test_head_mismatch_rejected(self):
+        s = _scenario()
+        bad = build_safety_evidence(
+            s["robot"],
+            halos_stack=HALOS_STACK,
+            window=WINDOW,
+            blackbox_head="uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            entry_count=s["rec"].count(),
+        )
+        ok, _ = verify_safety_evidence(bad, s["robot_pub"], entries=s["rec"].entries())
+        self.assertFalse(ok)
+
+    def test_missing_stack_or_window_rejected(self):
+        robot = _robot()
+        with self.assertRaises(HalosError):
+            build_safety_evidence(
+                robot, halos_stack={}, window=WINDOW, blackbox_head="u", entry_count=0
+            )
+        with self.assertRaises(HalosError):
+            build_safety_evidence(
+                robot, halos_stack=HALOS_STACK, window={}, blackbox_head="u", entry_count=0
+            )
+
+    def test_payloads_confidential_but_chain_public(self):
+        # The chain verifies from the encrypted entries without the key, while the
+        # payloads open only with the black-box key.
+        s = _scenario()
+        entries = s["rec"].entries()
+        self.assertNotIn("operator-7", str(entries))  # payload is encrypted
+        opened = s["rec"].open_entry(entries[3])
+        self.assertEqual(opened["source"], "estop")
+        self.assertEqual(opened["detail"]["by"], "operator-7")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/vouch/robotics/__init__.py
+++ b/vouch/robotics/__init__.py
@@ -30,6 +30,7 @@ robots and embodied agents:
   - swarm: multi-robot swarm membership and collective-action attribution.
   - handover: safe robot-to-human handover with an envelope attestation and receipt.
   - root_identity: bind a hardware-rooted robot to a recognized manufacturer under a pinned root.
+  - halos: signed, tamper-evident safety-evidence record for an NVIDIA Halos-certified stack.
 """
 
 from .capability import (
@@ -228,6 +229,14 @@ from .root_identity import (
     build_robot_identity,
     verify_robot_identity_chain,
 )
+from .halos import (
+    HALOS_EVENT_SOURCES,
+    HALOS_SAFETY_EVIDENCE_TYPE,
+    HalosError,
+    SafetyEventRecorder,
+    build_safety_evidence,
+    verify_safety_evidence,
+)
 
 __all__ = [
     # identity
@@ -391,6 +400,13 @@ __all__ = [
     "RobotIdentityChainResult",
     "build_robot_identity",
     "verify_robot_identity_chain",
+    # halos safety evidence (signed tamper-evident record for a Halos-certified stack)
+    "HALOS_SAFETY_EVIDENCE_TYPE",
+    "HALOS_EVENT_SOURCES",
+    "HalosError",
+    "SafetyEventRecorder",
+    "build_safety_evidence",
+    "verify_safety_evidence",
     # safety record (incident/near-miss ledger + portable record)
     "SafetyEventLog",
     "verify_safety_log",

--- a/vouch/robotics/halos.py
+++ b/vouch/robotics/halos.py
@@ -1,0 +1,231 @@
+"""
+Halos safety-evidence recorder (NVIDIA Halos integration).
+
+NVIDIA Halos certifies that a robot's stack is functionally safe and secure by
+design. It does not, on its own, produce a verifiable record of what a specific
+robot did, or bind that record to the robot's identity. This module is the
+evidence layer that sits under a Halos-certified stack.
+
+A `SafetyEventRecorder` captures the safety-relevant event stream produced by the
+Halos Outside-In Safety Blueprint components (the Safety AI Monitor, the Safety
+Event Integrator, the Safety Decision Maker, and the sensor input pipeline), plus
+emergency stops and operator actions, into the tamper-evident, encrypted black-box
+(the robot flight recorder). The robot then signs a `HalosSafetyEvidenceCredential`
+that seals the black-box chain head and entry count and binds them to the robot's
+identity and to the exact Halos stack elements it ran on (the IGX system-on-module,
+the Halos Core version, and the Blueprint applications).
+
+A verifier that holds the sealed credential and the entries confirms four things
+without needing the black-box key: the record is unaltered, it has not been
+truncated or extended since it was sealed, it is attributable to that specific
+robot, and it names the certified Halos configuration it was produced on. Only a
+holder of the black-box key can read the payloads, so the record stays confidential
+while remaining verifiable.
+
+This ships the formats and the reference recorder. It composes the existing
+black-box and robot-identity primitives and adds no new cryptography.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from .blackbox import GENESIS_PREV_HASH, BlackBoxLog, verify_blackbox_chain
+from ._signing import attach_proof
+
+VC_CONTEXT_V2 = "https://www.w3.org/ns/credentials/v2"
+VOUCH_CONTEXT_V1 = "https://vouch-protocol.com/contexts/v1"
+HALOS_SAFETY_EVIDENCE_TYPE = "HalosSafetyEvidenceCredential"
+
+# The safety-relevant event producers in a Halos-certified stack: the four
+# Outside-In Safety Blueprint components, plus an emergency stop and an operator
+# action. A recorder rejects any event from a source outside this set, so the
+# record maps to a known part of the certified stack.
+HALOS_EVENT_SOURCES = frozenset(
+    {
+        "SIPP",  # Sensor Input Processing Pipeline
+        "SAIM",  # Safety AI Monitor
+        "SEI",  # Safety Event Integrator
+        "SDM",  # Safety Decision Maker (runs on the IGX Functional Safety Island)
+        "estop",  # emergency stop
+        "operator",  # human operator action
+    }
+)
+
+
+class HalosError(Exception):
+    """Raised on invalid Halos safety-evidence input."""
+
+
+class SafetyEventRecorder:
+    """
+    Records the Halos safety-event stream into the tamper-evident black-box.
+
+    Wraps a `BlackBoxLog`: each recorded event is encrypted and hash-linked, so
+    the stream is confidential yet tamper-evident. `key` is 32 bytes (AES-256).
+    """
+
+    def __init__(self, key: bytes) -> None:
+        self._log = BlackBoxLog(key=key)
+
+    def record(
+        self,
+        source: str,
+        event: str,
+        detail: Optional[Dict[str, Any]] = None,
+        *,
+        timestamp: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Record one safety event from a named Halos stack source."""
+        if source not in HALOS_EVENT_SOURCES:
+            raise HalosError(f"unknown Halos event source: {source!r}")
+        payload = {"source": source, "detail": detail or {}}
+        return self._log.append(event, payload, timestamp=timestamp)
+
+    def head(self) -> str:
+        return self._log.head()
+
+    def count(self) -> int:
+        return len(self._log.entries())
+
+    def entries(self) -> List[Dict[str, Any]]:
+        return self._log.entries()
+
+    def open_entry(self, entry: Dict[str, Any]) -> Dict[str, Any]:
+        """Decrypt one entry with this recorder's black-box key."""
+        return self._log.open_entry(entry)
+
+
+def build_safety_evidence(
+    robot_signer: Any,
+    *,
+    halos_stack: Dict[str, Any],
+    window: Dict[str, str],
+    recorder: Optional[SafetyEventRecorder] = None,
+    blackbox_head: Optional[str] = None,
+    entry_count: Optional[int] = None,
+    robot_identity: Optional[str] = None,
+    valid_seconds: Optional[int] = None,
+    valid_from: Optional[datetime] = None,
+    created: Optional[datetime] = None,
+) -> Dict[str, Any]:
+    """
+    Seal a robot's Halos safety-event record into a signed HalosSafetyEvidenceCredential.
+
+    The robot signs a credential that binds the black-box chain head and entry
+    count to its identity, to the Halos stack elements it ran on, and to the time
+    window. Pass either a `recorder` or an explicit `blackbox_head` + `entry_count`.
+
+    Args:
+      halos_stack: the certified Halos configuration, for example
+        {"igxSom": "...", "halosCore": "...", "blueprint": ["SAIM", "SEI", "SDM"]}.
+      window: {"from": iso, "to": iso} covering the recorded events.
+      robot_identity: optional reference (credential id or hash) to the robot's
+        hardware-rooted identity credential, tying the evidence to it.
+      created: overrides the proof timestamp for reproducible test vectors.
+    """
+    if not halos_stack:
+        raise HalosError("halos_stack is required")
+    if not window or "from" not in window or "to" not in window:
+        raise HalosError("window with 'from' and 'to' is required")
+
+    if recorder is not None:
+        head = recorder.head()
+        count = recorder.count()
+    else:
+        if blackbox_head is None or entry_count is None:
+            raise HalosError("pass a recorder, or both blackbox_head and entry_count")
+        head = blackbox_head
+        count = entry_count
+    if count < 0:
+        raise HalosError("entry_count cannot be negative")
+
+    robot_did = robot_signer.get_did()
+    issued = (valid_from or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    subject: Dict[str, Any] = {
+        "id": robot_did,
+        "blackboxHead": head,
+        "entryCount": count,
+        "halosStack": halos_stack,
+        "window": {"from": window["from"], "to": window["to"]},
+    }
+    if robot_identity is not None:
+        subject["robotIdentity"] = robot_identity
+
+    credential: Dict[str, Any] = {
+        "@context": [VC_CONTEXT_V2, VOUCH_CONTEXT_V1],
+        "type": ["VerifiableCredential", HALOS_SAFETY_EVIDENCE_TYPE],
+        "issuer": robot_did,
+        "validFrom": _iso(issued),
+        "credentialSubject": subject,
+    }
+    if valid_seconds is not None:
+        credential["validUntil"] = _iso(issued + timedelta(seconds=valid_seconds))
+    return attach_proof(credential, robot_signer, created=created)
+
+
+def verify_safety_evidence(
+    credential: Dict[str, Any],
+    robot_public_key: Any,
+    *,
+    entries: Optional[List[Dict[str, Any]]] = None,
+) -> "tuple[bool, Optional[Dict[str, Any]]]":
+    """
+    Verify a HalosSafetyEvidenceCredential.
+
+    Checks the robot's proof and that the issuer is the robot. When `entries` are
+    supplied, also checks that the black-box chain is intact, that its length
+    matches the sealed entry count, and that its head matches the sealed head, so a
+    truncated, extended, reordered, or tampered record is rejected. Returns
+    (ok, credentialSubject).
+    """
+    from vouch import data_integrity
+    from vouch.verifier import _coerce_ed25519_public_key
+
+    type_field = credential.get("type") or []
+    if isinstance(type_field, str):
+        type_field = [type_field]
+    if HALOS_SAFETY_EVIDENCE_TYPE not in type_field:
+        return False, None
+
+    resolved = (
+        _coerce_ed25519_public_key(robot_public_key) if robot_public_key is not None else None
+    )
+    if resolved is None:
+        return False, None
+    try:
+        if not data_integrity.verify_proof(credential, resolved):
+            return False, None
+    except ValueError:
+        return False, None
+
+    subject = credential.get("credentialSubject") or {}
+    if subject.get("id") != credential.get("issuer"):
+        return False, None
+
+    if entries is not None:
+        ok, _ = verify_blackbox_chain(entries)
+        if not ok:
+            return False, None
+        if len(entries) != subject.get("entryCount"):
+            return False, None
+        head = entries[-1]["entryHash"] if entries else GENESIS_PREV_HASH
+        if head != subject.get("blackboxHead"):
+            return False, None
+
+    return True, subject
+
+
+def _iso(dt: datetime) -> str:
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+__all__ = [
+    "HALOS_SAFETY_EVIDENCE_TYPE",
+    "HALOS_EVENT_SOURCES",
+    "HalosError",
+    "SafetyEventRecorder",
+    "build_safety_evidence",
+    "verify_safety_evidence",
+]


### PR DESCRIPTION
This adds the Halos safety-evidence recorder: the identity and evidence layer for a robot running an NVIDIA Halos-certified stack. Halos certifies that a robot's stack is safe and secure by design. This records what a specific robot actually did and binds it to the robot's identity and the certified configuration.

## What it adds

- `SafetyEventRecorder` (`vouch/robotics/halos.py`): captures the Halos Outside-In Safety Blueprint event stream (SIPP, SAIM, SEI, SDM, plus emergency stops and operator actions) into the tamper-evident, encrypted black-box.
- `build_safety_evidence` / `verify_safety_evidence`: the robot signs a `HalosSafetyEvidenceCredential` that seals the black-box chain head and entry count and binds them to its identity and to the Halos stack elements it ran on (IGX system-on-module, Halos Core, Blueprint applications). A verifier confirms, without the black-box key, that the record is unaltered, untruncated, attributable to that robot, and tied to the certified configuration, while the payloads stay confidential.

## Cross-language and C ABI

The build and verify functions are ported to the Rust core and exposed through two curated `vouch_robotics_` C ABI functions with the regenerated `sdks/cpp/include/vouch_core.h`, so a C or C++ Halos application links the header and calls them directly. A `HalosSafetyEvidenceCredential` produced by the Python reference verifies through the Rust path.

## Tests and disclosure

Twelve adversarial tests cover tampering, truncation, extension after sealing, reordering, a wrong key, forged evidence, and the confidentiality of payloads. `PAD-105` discloses the mechanism.
