### PR TITLE
Move disconnected edge/space section above "One core, every platform"

### DIFF
--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -2718,17 +2718,17 @@ Run the whole thing: \`examples/disconnected_exchange_demo.py\` completes an off
 
 The complete portfolio (disclosed PAD-106 to PAD-124) ships as open-layer modules, each an eddsa-jcs-2022 credential or a deterministic verifier predicate, with hardware acquisition (ranging, TPM, orbital propagators) left to the platform:
 
-- \`vouch.robotics.freshness\` — presenter freshness token bound to a network epoch, plus a graded trust-decay weight (PAD-107, 119)
-- \`vouch.robotics.presence\` — channel-geometry (range/Doppler) proof of presence (PAD-108)
-- \`vouch.robotics.geoscope\` — ephemeris/geometric-scoped authority with shrink-only regions (PAD-109)
-- \`vouch.robotics.quorum_trust\` — swarm-consensus quarantine, quorum-of-orbits update acceptance, offline threshold key continuity (PAD-110, 111, 116)
-- \`vouch.robotics.dtn_revocation\` — conditional dead-man revocation and a carried validity witness (PAD-112, 120)
-- \`vouch.robotics.localization\` — triangulated proof-of-location, kinematic-plausibility filtering, narrow-beam presence (PAD-113, 114, 121)
-- \`vouch.robotics.edge_trust\` — attested time-quality, connectivity-scaled autonomy envelope, integrity-risk authority narrowing (PAD-115, 117, 118)
-- \`vouch.robotics.perception_consensus\` — Byzantine sensor agreement, mutual-attestation mesh standing (PAD-122, 123)
-- \`vouch.robotics.bundle\` — DTN Bundle Protocol custody and credential/freshness binding (PAD-124)
+- \`vouch.robotics.freshness\`: presenter freshness token bound to a network epoch, plus a graded trust-decay weight (PAD-107, 119)
+- \`vouch.robotics.presence\`: channel-geometry (range/Doppler) proof of presence (PAD-108)
+- \`vouch.robotics.geoscope\`: ephemeris/geometric-scoped authority with shrink-only regions (PAD-109)
+- \`vouch.robotics.quorum_trust\`: swarm-consensus quarantine, quorum-of-orbits update acceptance, offline threshold key continuity (PAD-110, 111, 116)
+- \`vouch.robotics.dtn_revocation\`: conditional dead-man revocation and a carried validity witness (PAD-112, 120)
+- \`vouch.robotics.localization\`: triangulated proof-of-location, kinematic-plausibility filtering, narrow-beam presence (PAD-113, 114, 121)
+- \`vouch.robotics.edge_trust\`: attested time-quality, connectivity-scaled autonomy envelope, integrity-risk authority narrowing (PAD-115, 117, 118)
+- \`vouch.robotics.perception_consensus\`: Byzantine sensor agreement, mutual-attestation mesh standing (PAD-122, 123)
+- \`vouch.robotics.bundle\`: DTN Bundle Protocol custody and credential/freshness binding (PAD-124)
 
-Real hardware plugs in through \`vouch.robotics.hardware\`: typed sensor Protocols (\`NavigationSource\`, \`RangeSensor\`, \`DopplerSensor\`, \`PointingSource\`, \`ClockSource\`, \`EpochSource\`, \`IntegrityMonitor\`), \`Simulated*\` reference implementations, and capture/verify-live adapters that feed the predicates unchanged — see \`examples/hardware_seam_demo.py\` and the driver skeleton \`examples/hardware_drivers/\`. Two predicates ship production algorithms rather than the conservative reference bound: kinematic plausibility does real two-body orbital propagation (\`vouch.robotics.orbital\`), and the carried non-revocation witness uses a dynamic sparse-Merkle accumulator (\`vouch.robotics.accumulator\`).
+Real hardware plugs in through \`vouch.robotics.hardware\`: typed sensor Protocols (\`NavigationSource\`, \`RangeSensor\`, \`DopplerSensor\`, \`PointingSource\`, \`ClockSource\`, \`EpochSource\`, \`IntegrityMonitor\`), \`Simulated*\` reference implementations, and capture/verify-live adapters that feed the predicates unchanged. See \`examples/hardware_seam_demo.py\` and the driver skeleton \`examples/hardware_drivers/\`. Two predicates ship production algorithms rather than the conservative reference bound: kinematic plausibility does real two-body orbital propagation (\`vouch.robotics.orbital\`), and the carried non-revocation witness uses a dynamic sparse-Merkle accumulator (\`vouch.robotics.accumulator\`).
 `,
       },
       {

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -235,11 +235,67 @@ export default function HomePage() {
         </div>
       </section>
 
-      {/* One core, every platform */}
+      {/* Disconnected edge / space */}
       <section className="border-b border-rule">
         <div className="container-wide py-20">
           <div className="section-heading">
             <span className="num">§ II</span>
+            <h2>At the disconnected edge, including space</h2>
+          </div>
+          <p className="text-ink-soft max-w-prose mb-6 leading-relaxed">
+            In orbit, on the lunar surface, deep underground, under water, in a jammed or
+            infrastructure-poor theater, a round trip to a home server is impossible or too slow to be
+            part of a trust decision. Because a Vouch credential verifies entirely offline against
+            pre-distributed anchors, two nodes can authenticate each other and exchange authority at
+            the edge with no live connection home. Space is simply the most demanding instance of a
+            general capability for denied, degraded, intermittent, and limited-connectivity (DDIL)
+            environments, so the same primitives cover a satellite constellation, an ocean glider, an
+            underground mine, and a tactical edge node alike.
+          </p>
+          <p className="text-ink-soft max-w-prose mb-12 leading-relaxed text-[0.9rem]">
+            One honest caveat: offline trust is <em>enabled</em> by distributing trust anchors during a
+            contact window, not by removing that step. Vouch makes the offline exchange sound and makes
+            staleness explicit; it does not pretend a node can trust a peer it has never had any prior
+            root for.
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-10">
+            {DISCONNECTED_EDGE.map((item) => (
+              <div key={item.title} className="feature-card">
+                <div className="eyebrow-faint mb-2">{item.num}</div>
+                <h3 className="font-serif font-semibold text-[1.25rem] mb-3 tracking-tight">{item.title}</h3>
+                <p className="text-ink-soft text-[0.95rem] leading-relaxed">{item.body}</p>
+              </div>
+            ))}
+          </div>
+          <div className="mt-10 flex flex-wrap gap-x-6 gap-y-2 items-baseline">
+            <Link href="/robotics/" className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline">
+              ROBOTICS PRIMITIVES &rarr;
+            </Link>
+            <a
+              href="https://github.com/vouch-protocol/vouch/blob/main/docs/dtn-bounded-staleness-revocation.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline"
+            >
+              DTN BOUNDED-STALENESS SPEC &rarr;
+            </a>
+            <a
+              href="https://github.com/vouch-protocol/vouch/blob/main/examples/disconnected_exchange_demo.py"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline"
+            >
+              OFFLINE-EXCHANGE EXAMPLE &rarr;
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* One core, every platform */}
+      <section className="border-b border-rule">
+        <div className="container-wide py-20">
+          <div className="section-heading">
+            <span className="num">§ III</span>
             <h2>One core, every platform</h2>
           </div>
           <p className="text-ink-soft max-w-prose mb-12 leading-relaxed">
@@ -259,7 +315,7 @@ export default function HomePage() {
           </div>
 
           <div className="section-heading mt-20">
-            <span className="num">§ II.b</span>
+            <span className="num">§ III.b</span>
             <h2>An assistant that knows the protocol</h2>
           </div>
           <p className="text-ink-soft max-w-prose mb-12 leading-relaxed">
@@ -281,7 +337,7 @@ export default function HomePage() {
       <section className="border-b border-rule">
         <div className="container-wide py-20">
           <div className="section-heading">
-            <span className="num">§ III</span>
+            <span className="num">§ IV</span>
             <h2>Built on open standards</h2>
           </div>
           <p className="text-ink-soft max-w-prose mb-10 leading-relaxed">
@@ -308,7 +364,7 @@ export default function HomePage() {
       <section className="border-b border-rule">
         <div className="container-wide py-20">
           <div className="section-heading">
-            <span className="num">§ IV</span>
+            <span className="num">§ V</span>
             <h2>A quick taste</h2>
           </div>
           <p className="text-ink-soft max-w-prose mb-8 leading-relaxed">
@@ -482,62 +538,6 @@ const ok = core.verifyProof(signed, kp.public_b64);   // true
                 </Link>
               ))}
             </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Disconnected edge / space */}
-      <section className="border-b border-rule">
-        <div className="container-wide py-20">
-          <div className="section-heading">
-            <span className="num">§ V</span>
-            <h2>At the disconnected edge, including space</h2>
-          </div>
-          <p className="text-ink-soft max-w-prose mb-6 leading-relaxed">
-            In orbit, on the lunar surface, deep underground, under water, in a jammed or
-            infrastructure-poor theater, a round trip to a home server is impossible or too slow to be
-            part of a trust decision. Because a Vouch credential verifies entirely offline against
-            pre-distributed anchors, two nodes can authenticate each other and exchange authority at
-            the edge with no live connection home. Space is simply the most demanding instance of a
-            general capability for denied, degraded, intermittent, and limited-connectivity (DDIL)
-            environments, so the same primitives cover a satellite constellation, an ocean glider, an
-            underground mine, and a tactical edge node alike.
-          </p>
-          <p className="text-ink-soft max-w-prose mb-12 leading-relaxed text-[0.9rem]">
-            One honest caveat: offline trust is <em>enabled</em> by distributing trust anchors during a
-            contact window, not by removing that step. Vouch makes the offline exchange sound and makes
-            staleness explicit; it does not pretend a node can trust a peer it has never had any prior
-            root for.
-          </p>
-          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-10">
-            {DISCONNECTED_EDGE.map((item) => (
-              <div key={item.title} className="feature-card">
-                <div className="eyebrow-faint mb-2">{item.num}</div>
-                <h3 className="font-serif font-semibold text-[1.25rem] mb-3 tracking-tight">{item.title}</h3>
-                <p className="text-ink-soft text-[0.95rem] leading-relaxed">{item.body}</p>
-              </div>
-            ))}
-          </div>
-          <div className="mt-10 flex flex-wrap gap-x-6 gap-y-2 items-baseline">
-            <Link href="/robotics/" className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline">
-              ROBOTICS PRIMITIVES &rarr;
-            </Link>
-            <a
-              href="https://github.com/vouch-protocol/vouch/blob/main/docs/dtn-bounded-staleness-revocation.md"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline"
-            >
-              DTN BOUNDED-STALENESS SPEC &rarr;
-            </a>
-            <a
-              href="https://github.com/vouch-protocol/vouch/blob/main/examples/disconnected_exchange_demo.py"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-mono text-burgundy text-[0.7rem] tracking-wider no-underline hover:underline"
-            >
-              OFFLINE-EXCHANGE EXAMPLE &rarr;
-            </a>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Description

Reorders the homepage (`website/src/app/page.tsx`) so the "At the disconnected edge, including space" section appears earlier in the page, right after "What the protocol provides" and before "One core, every platform", instead of near the bottom after the quick taste.

## Type of Change

- [x] Refactoring (no functional changes)
- [x] Documentation update

## Related Issues



## Changes Made

- Moved the "At the disconnected edge, including space" section from the bottom (previously §V, after "A quick taste") to directly after "What the protocol provides".
- Renumbered the `§` section markers so they stay sequential:
  - §II: At the disconnected edge, including space (moved up)
  - §III: One core, every platform (+ §III.b assistant)
  - §IV: Built on open standards
  - §V: A quick taste

## Testing

- [x] Manual testing performed: type-checked the website; no new errors introduced (only a pre-existing tsconfig `baseUrl` deprecation warning unrelated to this change).

## Checklist

- [x] My code follows the project's code style
- [x] My commits are signed off (DCO)

## Screenshots (if applicable)

Section order is now: What the protocol provides → **At the disconnected edge, including space** → One core, every platform → Built on open standards → A quick taste.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgSU1EsxzhDRq6Eo5dBUMY)_