### PR TITLE
Pin the ruff version in CI linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: "3.11"
       
       - name: Install ruff
-        run: pip install ruff
+        run: pip install ruff==0.15.17
       
       - name: Run ruff check
         run: ruff check vouch/ tests/ examples/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
     
     - name: Install linters
       run: |
-        pip install ruff black mypy
+        pip install ruff==0.15.17 black mypy
     
     - name: Check formatting with black
       run: |


### PR DESCRIPTION
The lint job installed ruff without a version, so it used whichever ruff was newest at run time. A newer ruff can format code that an older one leaves alone, which makes the lint result depend on the release date rather than on the code.

This pins ruff to a fixed version in the two workflows that install it, so the lint job is reproducible and only changes when the version is bumped on purpose. The pinned version is the one the codebase is already formatted against, so no source files change.
