### PR TITLE
Group GitHub Actions dependabot updates and auto-merge safe bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -38,3 +38,7 @@ updates:
       # Stay on v1 until the workflow is migrated to the newer input names.
       - dependency-name: "actions/first-interaction"
         update-types: ["version-update:semver-major"]
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge
+        if: ${{ steps.metadata.outputs.package-ecosystem == 'github_actions' || steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Two changes to cut down the weekly dependabot noise.

Grouping: the github-actions ecosystem now groups all action updates into a single pull request, the way the pip dev-dependencies are already grouped. Instead of one PR per action each week, there is one PR for all of them.

Auto-merge: a workflow enables auto-merge on dependabot pull requests once their checks pass. GitHub Actions updates auto-merge for any version bump (they are low-risk CI tooling and CI gates them), and other ecosystems auto-merge for patch and minor bumps only, so a major dependency bump still waits for a human.

Auto-merge only takes effect once the repository has "Allow auto-merge" turned on and main requires status checks, so the merge waits for CI rather than landing immediately.
