### PR TITLE
Update paper 1 (Vouch Protocol umbrella)

### DIFF
--- a/papers/paper-1-vouch-protocol/paper-1-vouch-protocol.md
+++ b/papers/paper-1-vouch-protocol/paper-1-vouch-protocol.md
@@ -1,141 +1,464 @@
-# Vouch Protocol: Cryptographic Identity and Continuous State Verifiability for Autonomous AI Agents
+---
+abstract: |
+  Autonomous AI agents now make decisions that matter: they move money,
+  submit regulated filings, read clinical records, commit code. The
+  credentials those agents use to do this (API keys, OAuth bearer
+  tokens, shared service accounts) were designed for a human clicking
+  through a session. They prove access. They do not prove who authorized
+  that action, what the agent intends to do, or whether the agent is
+  still trustworthy by the time it acts.
 
-**Author:** Ramprasad Anandam Gaddam
-**Affiliation:** Independent (open-source maintainer, Vouch Protocol)
-**Contact:** groups.rampy1@gmail.com  ·  https://github.com/vouch-protocol/vouch
-**Version:** Pre-print draft, 14 May 2026
-**License:** This paper is released under CC BY 4.0. The Vouch Protocol reference implementations are released under Apache 2.0. The fifty-eight defensive disclosures cited herein are released under CC0.
-**Repository:** https://github.com/vouch-protocol/vouch
-**Specification:** Spec v0.1-draft, Vouch Protocol CG Report (https://github.com/vouch-protocol/vouch/blob/main/docs/specs/w3c-cg-report.md)
+  We present the **Vouch Protocol**: an open specification with a
+  byte-exact Rust core and software development kits in seven languages
+  (Python, TypeScript, Go, C++, .NET, JVM, and Swift) for
+  cryptographically identifying autonomous AI agents and binding every
+  action they take to a signed Verifiable Credential. Each credential
+  carries the agent's identity, the specific intent (action, target,
+  resource), the delegation chain from the original human principal down
+  to the agent, and a freshness window after which the credential stops
+  being valid.
 
+  Per-action signing is necessary but not sufficient. Once an agent has
+  been admitted, the next question is whether it is still behaving
+  correctly *right now*, after we let it through the door. The
+  protocol's *State Verifiability layer* answers that with four
+  mechanisms: (1) trust entropy decay, where credential trust falls
+  exponentially over time and must be renewed before consequential
+  actions; (2) behavioral attestation digests, lightweight per-interval
+  summaries of the agent's API calls, resources accessed, and intent
+  drift; (3) canary commit/reveal chains, providing cryptographic
+  detection of silent agent failure or substitution; and (4) $M$-of-$N$
+  validator quorum, distributing trust evaluation across
+  role-specialized validators (policy, behavior, budget).
+
+  A cluster of recent systems enforces *pre-action authorization*: they
+  intercept an agent's tool call and evaluate it against a declarative
+  policy before execution (Uchibeke 2026; Fatmi 2026; Errico 2026; Lavi
+  2026; Palumbo et al. 2026). Vouch addresses the complementary and
+  broader problem. Rather than checking an action against a finite
+  authored allow-list, it verifies the action against the principal's
+  cryptographically signed *intent*, traced through a delegation chain
+  to the root human author, which covers the open-ended space of
+  legitimate actions that a finite policy cannot enumerate. Because the
+  credential format is standards-native (W3C Verifiable Credentials
+  secured by Data Integrity, the `eddsa-jcs-2022` cryptosuite), any
+  conforming verifier can consume it, and the protocol extends
+  verification with a correctness layer (reasoning-faithfulness and
+  retrieval-grounding) that policy enforcement alone does not provide.
+
+  The protocol is built on W3C Verifiable Credentials Data Model 2.0
+  with Data Integrity proofs: the `eddsa-jcs-2022` cryptosuite, which
+  signs Ed25519 over RFC 8785 JCS-canonicalized payloads. For the
+  post-quantum transition, the protocol defines a *dual-proof profile*
+  in which a credential carries two independent Data Integrity proofs on
+  the same JCS-canonicalized bytes: one `eddsa-jcs-2022` proof
+  (classical Ed25519) and one `mldsa44-jcs-2026` proof (ML-DSA-44, FIPS
+  204). Verifiers can downgrade gracefully, and the wire format requires
+  no Vouch-specific composite cryptosuite identifier.
+
+  This paper covers the credential format, the Identity Sidecar pattern
+  that isolates an agent's signing key from the LLM process,
+  delegation-chain construction with resource narrowing and
+  depth-limited validation, the BitstringStatusList revocation
+  mechanism, the Heartbeat Protocol's renewal cycle, the dual-proof
+  post-quantum profile and its same-canonical-bytes property, and the
+  State Verifiability runtime. We then work through the adversarial
+  cases that motivated the design (prompt injection, key exfiltration,
+  replay across resources, post-quantum cryptographic obsolescence) and
+  what the protocol does about each. Because all seven language SDKs
+  bind to a single Rust core, credentials produced through any SDK are
+  byte-identical, and a published RFC 8785 JCS test-vector battery
+  verifies this on every release.
+
+  The implementation is open-source under Apache 2.0. Sixty defensive
+  prior-art disclosures accompany the specification under CC0 to keep
+  design innovations openly available.
+
+  **Index Terms:** AI agent identity, Verifiable Credentials,
+  decentralized identifiers, intent-bound authorization, pre-action
+  authorization, reasoning faithfulness, retrieval grounding,
+  post-quantum cryptography, dual-proof signatures, JCS
+  canonicalization, prompt injection, delegation, continuous
+  attestation, behavioral provenance.
+author:
+- Ramprasad Anandam Gaddam
+bibliography: "C:/Users/rampy/AppData/Local/Temp/references.bib"
+date: |
+  Version v0.1 May 2026\
+  *This paper is released under CC BY 4.0; the reference implementations
+  under Apache 2.0; the defensive disclosures under CC0.*\
+  Vouch-signed by Vouch Protocol: <https://vch.sh/arxiv-1>
+title: " Vouch Protocol: Cryptographic Identity and Continuous State
+  Verifiability for Autonomous AI Agents "
 ---
 
-## Abstract
+# Introduction
 
-Autonomous AI agents are increasingly delegated decisions with real-world consequences: financial transfers, regulated submissions, clinical record access, code commits. The credentials those agents use today — API keys, OAuth bearer tokens, shared service accounts — were designed for human-driven sessions. They prove *access*. They do not prove *intent*, do not bind *who authorized what*, and offer no operational mechanism to continuously verify that an agent is still behaving correctly while running.
+## The Accountability Gap
 
-We present the **Vouch Protocol**: an open specification and reference implementation in Python, TypeScript, and Go for cryptographically identifying autonomous AI agents and binding every action they take to a signed Verifiable Credential whose payload includes the agent's identity, the specific intent (action, target, resource), the chain of principals who delegated authority down to the agent, and a freshness window beyond which the credential expires.
-
-Beyond per-action signing, the protocol defines a **State Verifiability layer** that addresses operational questions arising after an agent has been identified and authorized: is the agent still behaving correctly *right now*, after we let it through the door? The mechanisms are (1) **trust entropy decay**, where credential trust falls exponentially over time and must be renewed before consequential actions; (2) **behavioral attestation digests**, lightweight per-interval summaries of the agent's API calls, resources accessed, and intent drift; (3) **canary commit/reveal chains**, providing cryptographic detection of silent agent failure or substitution; and (4) **M-of-N validator quorum**, distributing trust evaluation across role-specialized validators (policy, behavior, budget).
-
-The protocol is built on W3C Verifiable Credentials Data Model 2.0 with Data Integrity proofs (the `eddsa-jcs-2022` cryptosuite for Ed25519 over RFC 8785 JCS-canonicalized payloads). For the post-quantum transition, an optional hybrid cryptosuite `hybrid-eddsa-mldsa44-jcs-2026` binds an Ed25519 signature and an ML-DSA-44 signature (FIPS 204) to the same canonical bytes, allowing graceful verifier downgrade and forward migration without changing the canonical payload.
-
-We describe the credential format, the Identity Sidecar pattern for isolating agent signing keys from the LLM process, the delegation-chain construction with resource narrowing and depth-limited validation, the BitstringStatusList revocation mechanism, the Heartbeat Protocol's renewal cycle, the hybrid post-quantum profile and its byte-identical-canonicalization construction, and the State Verifiability runtime. We discuss adversarial threats (prompt injection, key exfiltration, replay across resources, post-quantum cryptographic obsolescence) and the protocol's defenses. We provide cross-language test vectors verifying byte-identical credentials across three independent implementations.
-
-The implementation is open-source under Apache 2.0. Fifty-eight defensive prior-art disclosures accompany the specification under CC0 to keep design innovations openly available.
-
-**Index Terms:** AI agent identity, Verifiable Credentials, decentralized identifiers, post-quantum cryptography, hybrid signatures, JCS canonicalization, prompt injection, delegation, continuous attestation, behavioral provenance.
-
----
-
-## 1. Introduction
-
-### 1.1 The Accountability Gap
-
-Modern AI agents — LangChain pipelines, CrewAI swarms, AutoGPT-style autonomous workers, Model Context Protocol-driven assistants — increasingly take actions that human-level credentials were never designed to authorize. An LLM-driven agent submitting an insurance claim, placing a stock order, querying a patient's electronic health record, or auto-committing code to a production branch is performing a real action with real consequences. When that action requires audit, dispute resolution, or regulatory review, the only artefact available is a log entry naming an API key. The key is shared, was rotated three months ago, and gives no insight into which specific agent generation, which orchestration layer, which prompt, or which user-level principal authorized the action.
+Modern AI agents (LangChain pipelines, CrewAI swarms, AutoGPT-style
+autonomous workers, Model Context Protocol-driven assistants)
+increasingly take actions that human-level credentials were never
+designed to authorize. An LLM-driven agent submitting an insurance
+claim, placing a stock order, querying a patient's electronic health
+record, or auto-committing code to a production branch is performing a
+real action with real consequences. When that action requires audit,
+dispute resolution, or regulatory review, the only artefact available is
+a log entry naming an API key. The key is shared, was rotated three
+months ago, and gives no insight into which specific agent generation,
+which orchestration layer, which prompt, or which user-level principal
+authorized the action.
 
 The accountability gap has three structural sources:
 
-1. **Identity opacity.** Bearer credentials (API keys, JWTs, OAuth access tokens) prove access by possession, not by signature over an intent. An entity in possession of the bearer can take any action the bearer permits; nothing in the credential reflects which specific entity, in which specific context, with which specific upstream authorization, did so.
+1.  **Identity opacity.** Bearer credentials (API keys, JWTs, OAuth
+    access tokens) prove access by possession, not by signature over an
+    intent. An entity in possession of the bearer can take any action
+    the bearer permits; nothing in the credential reflects which
+    specific entity, in which specific context, with which specific
+    upstream authorization, did so.
 
-2. **Intent omission.** Even when an action is logged, the intent it represented is recorded in application-specific log formats with no cryptographic binding. A log entry "agent-prod-2 called `submit_claim`" can be forged by anyone with access to the log writer. The action's parameters, the resource it targeted, and the authorization chain are not cryptographically bound to the agent's identity.
+2.  **Intent omission.** Even when an action is logged, the intent it
+    represented is recorded in application-specific log formats with no
+    cryptographic binding. A log entry
+    "`agent-prod-2 called submit_claim`" can be forged by anyone with
+    access to the log writer. The action's parameters, the resource it
+    targeted, and the authorization chain are not cryptographically
+    bound to the agent's identity.
 
-3. **Trust monotonicity.** Existing identity systems trust credentials until they are explicitly revoked. A compromised agent continues operating until a human detects misbehavior and pushes a revocation. For autonomous agents — which may operate in regulated, latency-sensitive, or sparsely-monitored contexts — the gap between compromise and revocation may span hours or days, during which the compromised agent has uninterrupted authority.
+3.  **Trust monotonicity.** Existing identity systems trust credentials
+    until they are explicitly revoked. A compromised agent continues
+    operating until a human detects misbehavior and pushes a revocation.
+    For autonomous agents, which may operate in regulated,
+    latency-sensitive, or sparsely-monitored contexts, the gap between
+    compromise and revocation may span hours or days, during which the
+    compromised agent has uninterrupted authority.
 
-### 1.2 The Vouch Protocol Approach
+## The Vouch Protocol Approach
 
 The Vouch Protocol addresses these failures with three composing layers:
 
-1. A **credential layer** in which every agent action is issued as a W3C Verifiable Credential signed by the agent's Decentralized Identifier (DID) via a Data Integrity proof. The credential's `credentialSubject.intent` field carries the action verb, the target identifier, and the resource URI bound together. The credential's `validUntil` is short (commonly 5 minutes). The proof is `eddsa-jcs-2022` over the JCS-canonicalized credential bytes, or optionally the hybrid post-quantum cryptosuite.
+1.  A **credential layer** in which every agent action is issued as a
+    W3C Verifiable Credential signed by the agent's Decentralized
+    Identifier (DID) via a Data Integrity proof. The credential's
+    `credentialSubject.intent` field carries the action verb, the target
+    identifier, and the resource URI bound together. The credential's
+    `validUntil` is short (commonly 5 minutes). The proof is
+    `eddsa-jcs-2022` over the JCS-canonicalized credential bytes,
+    optionally paired with a second `mldsa44-jcs-2026` proof on the same
+    credential for the dual-proof post-quantum profile.
 
-2. A **delegation layer** in which credentials chain together, each link cryptographically attesting to a principal-to-sub-principal authorization. Resource scope must narrow at each link; chain depth is bounded; the root principal is verifiable. Multi-agent systems gain end-to-end attribution: "the patient authorized the clinician, who authorized their EHR agent, who authorized the prior-auth sub-agent, who submitted this credential" is a single auditable chain.
+2.  A **delegation layer** in which credentials chain together, each
+    link cryptographically attesting to a principal-to-sub-principal
+    authorization. Resource scope must narrow at each link; chain depth
+    is bounded; the root principal is verifiable. Multi-agent systems
+    gain end-to-end attribution: "the patient authorized the clinician,
+    who authorized their EHR agent, who authorized the prior-auth
+    sub-agent, who submitted this credential" is a single auditable
+    chain.
 
-3. A **state verifiability layer** in which long-running agents renew their credentials on a heartbeat schedule. Trust decays exponentially over time; behavioral attestation digests are computed per interval; canary commit/reveal chains detect silent failures; an M-of-N validator quorum distributes trust evaluation across role-specialized policy / behavior / budget validators. An agent that cannot heartbeat — because it crashed, is compromised, or has drifted out of policy — loses authority by entropy decay; a missed heartbeat is cryptographically detectable.
+3.  A **state verifiability layer** in which long-running agents renew
+    their credentials on a heartbeat schedule. Trust decays
+    exponentially over time; behavioral attestation digests are computed
+    per interval; canary commit/reveal chains detect silent failures; an
+    $M$-of-$N$ validator quorum distributes trust evaluation across
+    role-specialized policy / behavior / budget validators. An agent
+    that cannot heartbeat, because it crashed, is compromised, or has
+    drifted out of policy, loses authority by entropy decay; a missed
+    heartbeat is cryptographically detectable.
 
-Together, the three layers move from "the agent had a key" to "the agent issued a signed credential at time T, declaring action A on resource R, with the authorization of principals P₁ → P₂ → P_n, verifiable against the agent's published DID Document and the issuer's revocation registry, with a freshness window of 300 seconds and a running behavioral attestation showing the agent is operating within its declared scope."
+Together, the three layers move from "the agent had a key" to "the agent
+issued a signed credential at time $T$, declaring action $A$ on resource
+$R$, with the authorization of principals $P_1 \to P_2 \to P_n$,
+verifiable against the agent's published DID Document and the issuer's
+revocation registry, with a freshness window of 300 seconds and a
+running behavioral attestation showing the agent is operating within its
+declared scope."
 
-### 1.3 Design Goals
+The protocol's central claim is one of *intent verification* rather than
+*policy authorization*. A recent and active line of work intercepts an
+agent's tool call and checks it against an authored declarative policy
+before execution (Uchibeke 2026; Fatmi 2026; Errico 2026; Lavi 2026;
+Palumbo et al. 2026). A declarative policy is a finite allow-list and
+can admit only the actions its author anticipated; the space of
+legitimate actions an agent may need to take for a principal is
+open-ended. Vouch instead verifies each action against the principal's
+cryptographically signed intent, carried down a delegation chain to the
+root human author (§[5](#sec:delegation){reference-type="ref"
+reference="sec:delegation"}), and adds a correctness layer that checks
+reasoning-faithfulness (Gaddam 2026d) and retrieval-grounding (Gaddam
+2026e). The two approaches compose: a policy gate can bound capability
+type while Vouch establishes identity, intent, and correctness for each
+admitted action. §[2](#sec:related){reference-type="ref"
+reference="sec:related"} develops this positioning against the specific
+systems in that cluster.
+
+## Design Goals
 
 Six design goals shaped the protocol:
 
-- **Standards alignment over invention.** Where existing open standards suffice — W3C VC 2.0, Data Integrity, DIDs, BitstringStatusList, RFC 8785 JCS, NIST FIPS 204 — the protocol composes with them and does not introduce new primitives.
-- **LLM-isolated key material.** The agent's private signing key must never appear in the LLM's context window. The Identity Sidecar pattern isolates the key in a separate process that the LLM cannot reach.
-- **Byte-identical canonicalization across languages.** Credentials signed by the Python SDK must verify against credentials signed by the TypeScript or Go SDK with the same input. JCS (RFC 8785) is the canonical form.
-- **Cryptographic agility.** The protocol must accommodate the post-quantum transition without changing the canonical payload format. The hybrid cryptosuite signs the same bytes with two algorithms; verifiers select the trust level they require.
-- **Continuous verifiability, not point-in-time authentication.** Trust must be renewed under observation; an agent that goes silent must lose authority automatically.
-- **Open prior art.** Every novel design pattern is published as a defensive disclosure (Apache 2.0 code, CC0 disclosure) to keep the design space open.
+- **Standards alignment over invention.** Where existing open standards
+  suffice (W3C VC 2.0, Data Integrity, DIDs, BitstringStatusList, RFC
+  8785 JCS, NIST FIPS 204), the protocol composes with them and does not
+  introduce new primitives.
 
-### 1.4 Contribution Summary
+- **LLM-isolated key material.** The agent's private signing key must
+  never appear in the LLM's context window. The Identity Sidecar pattern
+  isolates the key in a separate process that the LLM cannot reach.
+
+- **Byte-identical canonicalization across languages.** All seven
+  language SDKs bind to a single Rust core (`vouch-core`); a credential
+  produced through any SDK verifies against any other. JCS (RFC 8785) is
+  the canonical form (Gaddam 2026b).
+
+- **Cryptographic agility.** The protocol must accommodate the
+  post-quantum transition without changing the canonical payload format.
+  The dual-proof profile attaches two independent Data Integrity proofs
+  on the same JCS-canonicalized bytes; verifiers select the trust level
+  they require.
+
+- **Continuous verifiability, not point-in-time authentication.** Trust
+  must be renewed under observation; an agent that goes silent must lose
+  authority automatically.
+
+- **Open prior art.** Every novel design pattern is published as a
+  defensive disclosure (Apache 2.0 code, CC0 disclosure) to keep the
+  design space open.
+
+## Contribution Summary
 
 This paper contributes:
 
-1. The Vouch Credential format and its Data Integrity proof construction (`eddsa-jcs-2022`).
-2. The Identity Sidecar pattern with intent allow-list enforcement at the sidecar layer, defended against prompt injection by construction.
-3. The delegation chain mechanism with resource narrowing, depth-limit, and trusted-principal anchoring.
-4. The BitstringStatusList integration for per-credential revocation, plus DID-level revocation for issuer-key compromise.
-5. The hybrid post-quantum cryptosuite `hybrid-eddsa-mldsa44-jcs-2026`, with concatenated signatures bound to the same JCS canonical bytes.
-6. The State Verifiability runtime: trust entropy decay, behavioral attestation digests, canary commit/reveal chains, M-of-N validator quorum.
-7. Cross-language test vectors and three reference implementations (Python, TypeScript, Go).
+1.  The Vouch Credential format and its Data Integrity proof
+    construction (`eddsa-jcs-2022`).
 
-### 1.5 Paper Organization
+2.  The Identity Sidecar pattern with intent allow-list enforcement at
+    the sidecar layer, defended against prompt injection by
+    construction.
 
-Section 2 reviews related work and clarifies Vouch's position in the agent-identity landscape. Section 3 defines the credential format. Section 4 presents the Identity Sidecar architecture. Section 5 develops the delegation chain construction and its verification. Section 6 details the revocation mechanisms. Section 7 presents the hybrid post-quantum cryptosuite. Section 8 introduces the State Verifiability layer. Section 9 analyses the protocol's security properties against an adversarial threat model. Section 10 reports cross-language interoperability results. Section 11 discusses limitations and future work. Section 12 concludes.
+3.  The delegation chain mechanism with resource narrowing, depth-limit,
+    and trusted-principal anchoring.
 
----
+4.  The BitstringStatusList integration for per-credential revocation,
+    plus DID-level revocation for issuer-key compromise.
 
-## 2. Related Work and Positioning
+5.  The dual-proof post-quantum profile, in which a credential carries
+    two independent Data Integrity proofs (`eddsa-jcs-2022` and
+    `mldsa44-jcs-2026`) on the same JCS-canonicalized bytes.
 
-### 2.1 Workload Identity Systems
+6.  The State Verifiability runtime: trust entropy decay, behavioral
+    attestation digests, canary commit/reveal chains, $M$-of-$N$
+    validator quorum.
 
-SPIFFE and SPIRE [Strong2018] define workload identity for service-to-service communication in cloud environments. SPIFFE issues short-lived X.509 SVIDs or JWT-SVIDs to workloads via attestation against the host platform. SPIFFE establishes *that* a workload is who it claims to be (via attestation against the runtime), but does not bind the workload's actions to the identity at the per-action level. A SPIFFE-authenticated workload making an HTTP call to a downstream service authenticates the call via mutual TLS; the call's intent (target resource, requested action, authorization chain) is not part of the authenticated payload.
+7.  A byte-exact Rust core (`vouch-core`) with SDKs in seven languages
+    (Python, TypeScript, Go, C++, .NET, JVM, Swift) that produce
+    byte-identical credentials, backed by a published cross-language JCS
+    test-vector battery (Gaddam 2026b).
 
-Vouch composes with SPIFFE: a SPIFFE-attested workload may also be a Vouch issuer, holding a Vouch DID whose verification methods are bootstrapped from the SVID. The Vouch credential then provides the per-action binding that SPIFFE does not.
+8.  A positioning of intent verification as distinct from, and broader
+    than, policy-based pre-action authorization, extended with a
+    correctness layer (reasoning-faithfulness (Gaddam 2026d),
+    retrieval-grounding (Gaddam 2026e)) absent from that body of work.
 
-### 2.2 OAuth 2.0 / OAuth 2.1 and Token-Based Access
+## Paper Organization
 
-OAuth 2.x [RFC 6749, RFC 9700] is the dominant access-grant protocol for HTTP APIs. Access tokens are bearer credentials authorizing the client to call defined scopes on the resource server. OAuth makes no claim about which specific agent within a client used the token, what the agent intended, or whether the agent's runtime state remains within policy.
+Section [2](#sec:related){reference-type="ref" reference="sec:related"}
+reviews related work and clarifies Vouch's position in the
+agent-identity landscape.
+Section [3](#sec:credential){reference-type="ref"
+reference="sec:credential"} defines the credential format.
+Section [4](#sec:sidecar){reference-type="ref" reference="sec:sidecar"}
+presents the Identity Sidecar architecture.
+Section [5](#sec:delegation){reference-type="ref"
+reference="sec:delegation"} develops the delegation chain construction
+and its verification. Section [6](#sec:revocation){reference-type="ref"
+reference="sec:revocation"} details the revocation mechanisms.
+Section [7](#sec:hybrid){reference-type="ref" reference="sec:hybrid"}
+presents the dual-proof post-quantum profile.
+Section [8](#sec:state){reference-type="ref" reference="sec:state"}
+introduces the State Verifiability layer.
+Section [9](#sec:security){reference-type="ref"
+reference="sec:security"} analyses the protocol's security properties
+against an adversarial threat model.
+Section [10](#sec:interop){reference-type="ref" reference="sec:interop"}
+reports cross-language interoperability results.
+Section [11](#sec:discussion){reference-type="ref"
+reference="sec:discussion"} discusses limitations and future work.
+Section [12](#sec:conclusion){reference-type="ref"
+reference="sec:conclusion"} concludes.
 
-Vouch is complementary to OAuth at the application layer. A Vouch credential may accompany an OAuth-authorized HTTP request, providing the agent-identity, intent, and delegation that OAuth's bearer model omits. Resource servers may verify both — OAuth for coarse access authorization and Vouch for action-specific identity and intent — or may use Vouch alone for agent-to-agent communication where OAuth's session model does not fit.
+# Related Work and Positioning {#sec:related}
 
-### 2.3 Decentralized Identifiers and Verifiable Credentials
+## Workload Identity Systems
 
-The W3C Decentralized Identifiers (DID) Core [DID-CORE] and Verifiable Credentials Data Model 2.0 [VC-DM-2.0] specifications define the underlying identity and credential primitives Vouch uses. Vouch issues VCs as defined by VC-DM-2.0, with DIDs as the issuer identifier. Vouch does not introduce a new identity primitive; it specifies a credential subtype (`VouchCredential`) and a per-action issuance pattern.
+SPIFFE and SPIRE (Strong and SPIFFE Project 2018) define workload
+identity for service-to-service communication in cloud environments.
+SPIFFE issues short-lived X.509 SVIDs or JWT-SVIDs to workloads via
+attestation against the host platform. SPIFFE establishes *that* a
+workload is who it claims to be (via attestation against the runtime),
+but does not bind the workload's actions to the identity at the
+per-action level. A SPIFFE-authenticated workload making an HTTP call to
+a downstream service authenticates the call via mutual TLS; the call's
+intent (target resource, requested action, authorization chain) is not
+part of the authenticated payload.
 
-Among the many credential subtypes the VC ecosystem has produced — student transcripts, professional certifications, vaccination records, employment letters — Vouch occupies a distinct niche: per-action, short-validity, agent-issued credentials describing what the agent is about to do, not what it has been authorized to be.
+Vouch composes with SPIFFE: a SPIFFE-attested workload may also be a
+Vouch issuer, holding a Vouch DID whose verification methods are
+bootstrapped from the SVID. The Vouch credential then provides the
+per-action binding that SPIFFE does not.
 
-### 2.4 ZCAP-LD and Capability-Based Authorization
+## OAuth 2.0 / OAuth 2.1 and Token-Based Access
 
-ZCAP-LD [ZCAP-LD] is a JSON-LD capability authorization format that supports attenuation through delegation. ZCAP capabilities are attenuated at each delegation: a parent capability is restricted as it is delegated downward. The result is similar in shape to a Vouch delegation chain.
+OAuth 2.x (Hardt 2012; Lodderstedt et al. 2025) is the dominant
+access-grant protocol for HTTP APIs. Access tokens are bearer
+credentials authorizing the client to call defined scopes on the
+resource server. OAuth makes no claim about which specific agent within
+a client used the token, what the agent intended, or whether the agent's
+runtime state remains within policy.
+
+Vouch is complementary to OAuth at the application layer. A Vouch
+credential may accompany an OAuth-authorized HTTP request, providing the
+agent-identity, intent, and delegation that OAuth's bearer model omits.
+Resource servers may verify both (OAuth for coarse access authorization
+and Vouch for action-specific identity and intent), or may use Vouch
+alone for agent-to-agent communication where OAuth's session model does
+not fit.
+
+## Decentralized Identifiers and Verifiable Credentials
+
+The W3C Decentralized Identifiers (DID) Core (World Wide Web Consortium
+2022) and Verifiable Credentials Data Model 2.0 (World Wide Web
+Consortium 2024b) specifications define the underlying identity and
+credential primitives Vouch uses. Vouch issues VCs as defined by
+VC-DM-2.0, with DIDs as the issuer identifier. Vouch does not introduce
+a new identity primitive; it specifies a credential subtype
+(`VouchCredential`) and a per-action issuance pattern.
+
+Among the many credential subtypes the VC ecosystem has produced
+(student transcripts, professional certifications, vaccination records,
+employment letters), Vouch occupies a distinct niche: per-action,
+short-validity, agent-issued credentials describing what the agent is
+about to do, not what it has been authorized to be.
+
+## ZCAP-LD and Capability-Based Authorization
+
+ZCAP-LD (W3C Credentials Community Group 2024) is a JSON-LD capability
+authorization format that supports attenuation through delegation. ZCAP
+capabilities are attenuated at each delegation: a parent capability is
+restricted as it is delegated downward. The result is similar in shape
+to a Vouch delegation chain.
 
 Vouch's delegation differs in three respects:
 
-1. **Canonicalization**: Vouch uses RFC 8785 JCS, not JSON-LD canonicalization. JCS is simpler, has no external context dependencies, and produces byte-identical output across implementations more reliably.
-2. **Resource binding**: Each Vouch delegation link explicitly binds a `resource` URI. The chain validator enforces that child resources be sub-paths of parent resources, preventing capability widening at any link.
-3. **Chain semantics**: Vouch delegations are credentials in their own right (each link is a VC); ZCAP capabilities are stand-alone documents with their own data model.
+1.  **Canonicalization**: Vouch uses RFC 8785 JCS, not JSON-LD
+    canonicalization. JCS is simpler, has no external context
+    dependencies, and produces byte-identical output across
+    implementations more reliably.
 
-Vouch's chain construction is documented as defensive disclosure PAD-002 (Chain of Custody Delegation).
+2.  **Resource binding**: Each Vouch delegation link explicitly binds a
+    `resource` URI. The chain validator enforces that child resources be
+    sub-paths of parent resources, preventing capability widening at any
+    link.
 
-### 2.5 C2PA Content Credentials
+3.  **Chain semantics**: Vouch delegations are credentials in their own
+    right (each link is a VC); ZCAP capabilities are stand-alone
+    documents with their own data model.
 
-The Coalition for Content Provenance and Authenticity (C2PA) defines content-binding credentials for media assets [C2PA-1.4]. C2PA Content Credentials embed signed provenance into media files (images, audio, video). Vouch is complementary: a content-creation agent may sign a Vouch credential authorizing the act of generating an image, then bind the image's C2PA manifest to the same agent identity. PAD-014 (Vouch Sonic) and PAD-024 (Temporal Video Fingerprinting) detail content-bound applications.
+## C2PA Content Credentials
 
-### 2.6 Post-Quantum Signature Migration Frameworks
+The Coalition for Content Provenance and Authenticity (C2PA) defines
+content-binding credentials for media assets (Coalition for Content
+Provenance and Authenticity 2024). C2PA Content Credentials embed signed
+provenance into media files (images, audio, video). Vouch is
+complementary: a content-creation agent may sign a Vouch credential
+authorizing the act of generating an image, then bind the image's C2PA
+manifest to the same agent identity.
 
-NIST's selection of ML-DSA-44 (FIPS 204) and SLH-DSA (FIPS 205) as standardized post-quantum digital signature algorithms creates the migration pressure Vouch addresses. The IETF's `draft-ietf-jose-pq-composite-sigs` defines composite signatures for JOSE; the W3C Data Integrity community has discussed parallel constructions. Vouch's `hybrid-eddsa-mldsa44-jcs-2026` cryptosuite is a Data-Integrity-native realization: a single Vouch credential carries a `proofValue` that is the byte-concatenation of the Ed25519 signature and the ML-DSA-44 signature, both computed over the same JCS canonical bytes. Verifiers in classical-only mode validate the first 64 bytes; verifiers in PQ-aware mode validate both. The construction is documented as PAD-040 (Hybrid Composite Signature Bound to Same Canonical Bytes).
+## Post-Quantum Signature Migration Frameworks
 
-### 2.7 Honeypot and Adversarial-Detection Approaches
+NIST's selection of ML-DSA-44 (FIPS 204) and SLH-DSA (FIPS 205) as
+standardized post-quantum digital signature algorithms (National
+Institute of Standards and Technology 2024) creates the migration
+pressure Vouch addresses. The IETF's *draft-ietf-jose-pq-composite-sigs*
+defines composite signatures for JOSE; the W3C Data Integrity community
+has parallel work in progress, including Digital Bazaar's
+`mldsa44-rdfc-2024-cryptosuite` family (Digital Bazaar, Inc. 2026) and
+an upcoming JCS variant. Vouch's *dual-proof profile* is a
+Data-Integrity-native realization that avoids inventing a composite
+cryptosuite identifier: a single Vouch credential carries two
+independent Data Integrity proofs in its `proof` array, one
+`eddsa-jcs-2022` proof and one `mldsa44-jcs-2026` proof, both computed
+over the same JCS canonical credential bytes. Verifiers in
+classical-only mode validate the `eddsa-jcs-2022` proof and ignore the
+rest; verifiers in PQ-aware mode validate the `mldsa44-jcs-2026` proof;
+verifiers in both-required mode iterate the proof array and accept only
+when every proof verifies.
 
-Several adjacent works treat agent and identity systems defensively rather than only protectively. Vouch's design includes adversarial-detection mechanisms (PAD-031 Canary Provenance Honeypots, PAD-047 VDF-rate-limited actions, PAD-058 Auto-Rotation on Leak Detection) that compose with the core protocol. These are referenced in this paper where relevant but treated in greater depth in the accompanying defensive-disclosure portfolio.
+## Pre-Action Authorization Systems {#sec:related-preaction}
 
----
+A cluster of systems published between January and April 2026
+establishes *pre-action authorization* as a distinct primitive for agent
+safety. Uchibeke's Open Agent Passport intercepts an agent's tool calls
+and evaluates them against a declarative policy before execution,
+emitting a signed audit record for each decision (Uchibeke 2026).
+Faramesh places a mandatory, transport-independent authorization
+checkpoint ahead of any action that changes external state,
+standardizing actions into a canonical representation and returning
+permit, defer, or deny artifacts that executors must honor (Fatmi 2026).
+AARM specifies a runtime that intercepts actions, evaluates them against
+policy and intent alignment, and maintains tamper-evident records, with
+a threat taxonomy covering prompt injection and confused-deputy
+attacks (Errico 2026). Right-to-Act formalizes a pre-execution
+admissibility boundary in which any unmet required condition halts or
+defers execution, separating compensatory from non-compensatory decision
+regimes (Lavi 2026). FORGE compiles declarative policies, written in a
+Datalog-derived language over abstract predicates, into a reference
+monitor that enforces them at each agent decision point (Palumbo et al.
+2026).
 
-## 3. The Vouch Credential
+These systems share an architecture: an enforcement point admits or
+denies an action against an authored policy. They differ from Vouch in
+three respects that this paper treats as the central distinction. First,
+they are *policy-bound*: the admission decision is made against a
+finite, declaratively authored rule set, which can only cover the
+actions an author anticipated. Vouch is *intent-bound*: the decision is
+made against the principal's cryptographically signed intent, traced
+through a delegation chain to the root human author
+(§[5](#sec:delegation){reference-type="ref"
+reference="sec:delegation"}), covering the open-ended space of
+legitimate actions a finite policy cannot enumerate. Second, none of
+these systems anchors its decision in a standards-defined credential;
+their audit records and decision artifacts are system-specific, whereas
+a Vouch credential is a W3C Verifiable Credential secured by Data
+Integrity (§[3](#sec:credential){reference-type="ref"
+reference="sec:credential"}) that any conforming verifier can consume.
+Third, none adds a correctness layer: Vouch additionally verifies
+whether the agent's reasoning was faithful to the stated intent (Gaddam
+2026d) and whether its outputs were grounded in retrieved evidence
+rather than confabulated (Gaddam 2026e).
 
-### 3.1 Format
+The two approaches are complementary rather than competing. A deployment
+can run a pre-action policy gate and Vouch together: the policy gate
+bounds capability *type*, and Vouch establishes who acted, under whose
+signed intent, with what delegated authority, and whether the action was
+reasoned faithfully. As a matter of record, the foundational primitives
+Vouch builds on were placed in the public domain as dated defensive
+disclosures contemporaneously with this cluster: the cryptographic
+binding of agent identity to signed intent in December 2025 (Gaddam
+2025), and the recursive, intent-bound delegation chain anchored to a
+root human author in January 2026 (Gaddam 2026c).
 
-A Vouch Credential is a W3C Verifiable Credential 2.0 with a `VouchCredential` type tag, a `credentialSubject` carrying the agent's intent, and a Data Integrity proof over the JCS-canonicalized credential bytes. The format is defined in Section 5 of the Vouch Protocol specification.
+# The Vouch Credential {#sec:credential}
 
-```json
+## Format
+
+A Vouch Credential is a W3C Verifiable Credential 2.0 with a
+`VouchCredential` type tag, a `credentialSubject` carrying the agent's
+intent, and a Data Integrity proof over the JCS-canonicalized credential
+bytes. The format is defined in Section 5 of the Vouch Protocol
+specification.
+
+``` {.json language="json"}
 {
   "@context": [
     "https://www.w3.org/ns/credentials/v2",
@@ -161,646 +484,1011 @@ A Vouch Credential is a W3C Verifiable Credential 2.0 with a `VouchCredential` t
     "created": "2026-05-13T05:41:10Z",
     "verificationMethod": "did:web:agent.example.com#key-1",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z77CAhFw1rKB1wLQ541oZ55WD1rVcmkiHFnF8EcVs2A4zX6Y4rYwcdxY5To2YDkNusLdkXYX8EgXVrLcZyTpPGxh"
+    "proofValue": "z77CAhFw1rKB1wLQ541oZ55WD1rVcmkiHFnF8EcVs2A4..."
   }
 }
 ```
 
-The required fields, beyond the VC 2.0 baseline:
+The required fields beyond the VC 2.0 baseline:
 
 - `type` MUST include `VouchCredential`.
-- `credentialSubject.vouchVersion` MUST be present and equal to the protocol version this credential conforms to.
-- `credentialSubject.intent.action`, `intent.target`, `intent.resource` MUST all be non-empty strings. Empty strings are treated as missing.
-- `validFrom` MUST be in RFC 3339 form with `Z` UTC indicator (not `+00:00`).
-- `validUntil` SHOULD be set to a short window (default 300 seconds from `validFrom`); credentials with no `validUntil` are accepted but operationally discouraged.
 
-### 3.2 The eddsa-jcs-2022 Cryptosuite
+- `credentialSubject.vouchVersion` MUST be present and equal to the
+  protocol version this credential conforms to.
 
-The default cryptosuite is `eddsa-jcs-2022` (W3C Data Integrity registered identifier). The signing procedure:
+- `credentialSubject.intent.action`, `intent.target`, `intent.resource`
+  MUST all be non-empty strings. Empty strings are treated as missing.
 
-1. Construct the credential dictionary with all required fields, including the `proof` object except `proofValue`.
-2. Canonicalize the entire credential using RFC 8785 JCS. JCS specifies a strict deterministic ordering, escaping, and number formatting; the output is byte-identical across conforming implementations.
-3. Compute the Ed25519 signature over the canonical bytes using the issuer's private key.
-4. Encode the signature in multibase base58btc form (the `z` prefix), producing approximately 88 characters.
-5. Set `proof.proofValue` to the multibase-encoded signature.
+- `validFrom` MUST be in RFC 3339 form with `Z` UTC indicator (not
+  `+00:00`).
+
+- `validUntil` SHOULD be set to a short window (default 300 seconds from
+  `validFrom`).
+
+## The eddsa-jcs-2022 Cryptosuite
+
+The default cryptosuite is `eddsa-jcs-2022` (W3C Data Integrity
+registered identifier). The signing procedure:
+
+1.  Construct the credential dictionary with all required fields,
+    including the `proof` object except `proofValue`.
+
+2.  Canonicalize the entire credential using RFC 8785 JCS. JCS specifies
+    a strict deterministic ordering, escaping, and number formatting;
+    the output is byte-identical across conforming implementations.
+
+3.  Compute the SHA-256 digest of the canonical bytes.
+
+4.  Compute the Ed25519 signature over the digest using the issuer's
+    private key.
+
+5.  Encode the signature in multibase base58btc form (the `z` prefix),
+    producing approximately 88 characters.
+
+6.  Set `proof.proofValue` to the multibase-encoded signature.
 
 Verification reverses the process:
-1. Extract `proof.proofValue`, decode from multibase base58btc.
-2. Reconstruct the credential dictionary excluding `proof.proofValue` (other proof fields are part of the signed payload).
-3. JCS-canonicalize.
-4. Resolve the issuer's DID Document, locate the verification method indicated by `proof.verificationMethod`, extract the Ed25519 public key (encoded as Multikey in the DID Document).
-5. Verify the Ed25519 signature.
 
-### 3.3 JCS Determinism Across Languages
+1.  Extract `proof.proofValue`, decode from multibase base58btc.
 
-JSON Canonicalization Scheme (RFC 8785) fixes the serialization that Ed25519 signs. The protocol's three reference implementations (Python, TypeScript, Go) produce byte-identical JCS output given byte-identical inputs. Cross-language test vectors in `test-vectors/jcs/` verify the property on every release. PAD-039 (Cross-Implementation Deterministic Multi-Party Trust State via JCS-Canonicalized Verifiable Credentials) documents the design choice and its rationale.
+2.  Reconstruct the credential dictionary excluding `proof.proofValue`
+    (other proof fields are part of the signed payload).
 
-The byte-identity property is foundational: without it, a credential signed by Python and a credential with the same logical content signed by TypeScript would have different signatures, breaking interoperability and federation across implementations.
+3.  JCS-canonicalize.
 
-### 3.4 Verification Method Resolution
+4.  Compute the SHA-256 digest of the canonical bytes.
 
-`proof.verificationMethod` is a URI of the form `did:web:agent.example.com#key-1`. The verifier resolves this:
+5.  Resolve the issuer's DID Document, locate the verification method
+    indicated by `proof.verificationMethod`, extract the Ed25519 public
+    key (encoded as Multikey in the DID Document).
 
-1. Fetch the DID Document at `https://agent.example.com/.well-known/did.json`.
-2. Locate the `verificationMethod` array entry with id `did:web:agent.example.com#key-1`.
-3. Confirm the entry is referenced from the appropriate verification relationship (for credential issuance, `assertionMethod`).
-4. Extract `publicKeyMultibase` and decode to obtain the Ed25519 public key.
+6.  Verify the Ed25519 signature over the digest.
 
-The verifier caches DID Documents with a configurable TTL. On verification failure, the verifier forces refresh, ensuring rotation is detected within the operator's chosen latency window.
+## JCS Determinism Across Languages
 
-### 3.5 Intent Replay Resistance
+JSON Canonicalization Scheme (RFC 8785) fixes the serialization that
+Ed25519 signs. Rather than maintaining several independent
+implementations in sync, the protocol exposes a single Rust core
+(`vouch-core`) to seven languages (Python, TypeScript, Go, C++, .NET,
+JVM, Swift) through WebAssembly and UniFFI bindings, so byte-identical
+JCS output is a property of the shared core rather than of
+cross-implementation discipline. A published JCS test-vector
+battery (Gaddam 2026b) pins the canonical form, and any conforming
+binding must reproduce it.
 
-Each credential carries a unique `id` (typically a UUID URN). Verifiers maintain a nonce store keyed on `id`. A credential whose `id` has previously been seen is rejected (`nonce_replay`). The nonce store's TTL must be at least the longest plausible credential `validUntil` to prevent a credential from being replayed after the nonce store has forgotten it.
+The byte-identity property is foundational: without it, a credential
+produced through one SDK and a credential with the same logical content
+produced through another would have different signatures, breaking
+interoperability and federation across languages.
 
-Replay resistance is also enforced at the intent level: `intent.target` and `intent.resource` are part of the signed payload. A credential authorizing `submit_claim` on `claim:HC-001` cannot be replayed against `claim:HC-002` without re-signing — the JCS canonical bytes differ.
+## Intent Replay Resistance
 
----
+Each credential carries a unique `id` (typically a UUID URN). Verifiers
+maintain a nonce store keyed on `id`. A credential whose `id` has
+previously been seen is rejected (`nonce_replay`). The nonce store's TTL
+must be at least the longest plausible credential `validUntil` to
+prevent a credential from being replayed after the nonce store has
+forgotten it.
 
-## 4. The Identity Sidecar Pattern
+Replay resistance is also enforced at the intent level: `intent.target`
+and `intent.resource` are part of the signed payload. A credential
+authorizing `submit_claim` on `claim:HC-001` cannot be replayed against
+`claim:HC-002` without re-signing; the JCS canonical bytes differ.
 
-### 4.1 Motivation
+# The Identity Sidecar Pattern {#sec:sidecar}
 
-Modern AI agents are typically built around a Large Language Model. The LLM is stochastic, non-deterministic, and vulnerable to prompt injection. Exposing the agent's private signing key to the LLM's context window creates three failure modes:
+## Motivation
 
-- **Key leak via prompt injection.** Adversarial content in retrieved documents, tool outputs, or user input can instruct the LLM to print the key as part of its output.
-- **Unauthorized signing via jailbreak.** A jailbroken LLM may use the key to sign arbitrary intents, including intents not authorized by the principal.
-- **Persistence in training data and logs.** Key material that passed through the LLM may end up in logged conversation transcripts, fine-tuning corpora, or vendor-side analytics.
+Modern AI agents are typically built around a Large Language Model. The
+LLM is stochastic, non-deterministic, and vulnerable to prompt
+injection. Exposing the agent's private signing key to the LLM's context
+window creates three failure modes:
 
-Direct key exposure to the LLM is incompatible with the protocol's security model.
+- **Key leak via prompt injection.** Adversarial content in retrieved
+  documents, tool outputs, or user input can instruct the LLM to print
+  the key as part of its output.
 
-### 4.2 Architecture
+- **Unauthorized signing via jailbreak.** A jailbroken LLM may use the
+  key to sign arbitrary intents, including intents not authorized by the
+  principal.
 
-The Identity Sidecar pattern (defensive disclosure PAD-003) separates the agent into two processes:
+- **Persistence in training data and logs.** Key material that passed
+  through the LLM may end up in logged conversation transcripts,
+  fine-tuning corpora, or vendor-side analytics.
 
-1. **The Brain (stochastic).** The LLM. Holds zero cryptographic secrets. Reasons about which action to take and proposes intents to the Sidecar.
-2. **The Passport (deterministic).** A small, auditable process holding the private signing keys in its address space. Receives intent proposals from the Brain, applies a deterministic policy check, and issues credentials only when policy passes.
+Direct key exposure to the LLM is incompatible with the protocol's
+security model.
 
-The Brain and the Passport communicate over a local IPC channel — typically localhost HTTP, a UNIX domain socket, or an MCP transport. The IPC boundary is the trust boundary.
+## Architecture
 
-### 4.3 Just-In-Time Signing Flow
+The Identity Sidecar pattern separates the agent into two processes:
+
+1.  **The Brain (stochastic).** The LLM. Holds zero cryptographic
+    secrets. Reasons about which action to take and proposes intents to
+    the Sidecar.
+
+2.  **The Passport (deterministic).** A small, auditable process holding
+    the private signing keys in its address space. Receives intent
+    proposals from the Brain, applies a deterministic policy check, and
+    issues credentials only when policy passes.
+
+The Brain and the Passport communicate over a local IPC channel:
+typically localhost HTTP, a UNIX domain socket, or an MCP transport. The
+IPC boundary is the trust boundary.
+
+## Just-In-Time Signing Flow
 
 A signing operation proceeds:
 
-1. The Brain decides an action is appropriate. It constructs a proposed intent.
-2. The Brain submits the intent to the Sidecar over IPC.
-3. The Sidecar applies its policy: structural validation (required fields present), allow-list check (PAD-056: action type is in the deployed allow-list), and rate-limit check.
-4. If policy passes, the Sidecar constructs the full credential, signs it with the held private key, and returns the credential to the Brain.
-5. If policy fails, the Sidecar returns a structured error. No credential is produced.
+1.  The Brain decides an action is appropriate. It constructs a proposed
+    intent.
 
-The Sidecar's policy check is the **last line of defence** against a compromised Brain. A prompt-injected LLM may propose any intent it likes; the Sidecar refuses to sign anything outside the allow-list. The capability bound on a compromised Brain is therefore structural (PAD-056), not behavioural.
+2.  The Brain submits the intent to the Sidecar over IPC.
 
-### 4.4 Reference Implementations and Tier Hierarchy
+3.  The Sidecar applies its policy: structural validation (required
+    fields present), allow-list check (action type is in the deployed
+    allow-list), and rate-limit check.
+
+4.  If policy passes, the Sidecar constructs the full credential, signs
+    it with the held private key, and returns the credential to the
+    Brain.
+
+5.  If policy fails, the Sidecar returns a structured error. No
+    credential is produced.
+
+The Sidecar's policy check is the *last line of defence* against a
+compromised Brain. A prompt-injected LLM may propose any intent it
+likes; the Sidecar refuses to sign anything outside the allow-list. The
+capability bound on a compromised Brain is therefore structural, not
+behavioural.
+
+## Reference Implementations and Tier Hierarchy
 
 Three reference Sidecar implementations accompany the protocol:
 
-- **Go** (`go-sidecar/`): production-tier, KMS/HSM-backed, hybrid PQ supported, sensitive-mode JWE wrapping, multi-tenant.
-- **Python** (`vouch.sidecar.*`): lightweight tier for self-hosted Python stacks. File or environment keys. Intentionally omits KMS, hybrid PQ, JWE, and multi-tenancy.
-- **TypeScript** (`packages/sdk-ts/sidecar/`): lightweight tier for Node stacks. Same omissions as Python.
+- **Go** (`go-sidecar/`): production-tier, KMS/HSM-backed, dual-proof PQ
+  supported, sensitive-mode JWE wrapping, multi-tenant.
 
-The HTTP wire contract is identical across all three:
-- `GET /health` — liveness probe
-- `GET /did` — the sidecar's configured DID
-- `GET /.well-known/did.json` — optional DID Document serving
-- `POST /sign` — sign a Vouch credential for an intent
+- **Python** (`vouch.sidecar.*`): lightweight tier for self-hosted
+  Python stacks. File or environment keys. Intentionally omits KMS,
+  dual-proof PQ, JWE, and multi-tenancy.
 
-A shared contract test suite (`test-vectors/sidecar-contract/`) verifies that all three implementations accept and reject the same inputs and emit semantically equivalent credentials. The tier hierarchy is informative guidance: deployers requiring KMS, FIPS, hybrid PQ, or multi-tenancy run the Go sidecar; deployers with simpler requirements may run Python or TypeScript.
+- **TypeScript** (`packages/sdk-ts/sidecar/`): lightweight tier for Node
+  stacks. Same omissions as Python.
 
-### 4.5 MCP Integration
+The HTTP wire contract is identical across all three. A shared contract
+test suite verifies that all three implementations accept and reject the
+same inputs and emit semantically equivalent credentials. The tier
+hierarchy is informative guidance: deployers requiring KMS, FIPS,
+dual-proof PQ, or multi-tenancy run the Go sidecar; deployers with
+simpler requirements may run Python or TypeScript.
 
-The Model Context Protocol (MCP) [MCP-2025] is a standard for exposing tools and resources to LLM clients. A Vouch Sidecar may expose its signing capability as an MCP tool:
+# Delegation Chains {#sec:delegation}
 
-```json
+## Motivation
+
+Multi-agent systems present an attribution problem: an action taken by a
+leaf agent may have been authorized by a chain of principals: a user
+authorized an assistant, which authorized a research agent, which
+authorized a web-scraping sub-agent. When the action requires audit, the
+leaf-only signing model loses the chain.
+
+Vouch delegations are themselves Verifiable Credentials. Each link in a
+chain is a credential signed by the delegating principal and identifying
+the delegate. A leaf-action credential includes the full chain (or a
+reference to it) so a verifier can reconstruct the authorization path
+from root principal to leaf agent.
+
+## Delegation Link Structure
+
+A delegation link is a Vouch credential whose `credentialSubject` is
+shaped:
+
+``` {.json language="json"}
 {
-  "name": "vouch_sign",
-  "description": "Issue a Vouch Credential for an intent payload.",
-  "inputSchema": {
-    "type": "object",
-    "properties": {
-      "intent": {
-        "type": "object",
-        "required": ["action", "target", "resource"]
-      }
-    },
-    "required": ["intent"]
-  }
+  "issuer": "did:web:assistant.example.com",
+  "subject": "did:web:research-agent.example.com",
+  "intent": {
+    "action": "web_search",
+    "target": "topic:climate-2026",
+    "resource": "https://research-agent.example.com/agents/research-agent/scope/2026"
+  },
+  "validFrom": "2026-05-14T06:00:00Z",
+  "validUntil": "2026-05-14T08:00:00Z",
+  "proof": { "...DataIntegrityProof..." }
 }
 ```
 
-An MCP-aware LLM client invokes `vouch_sign` exactly as it would any other tool. The Sidecar's allow-list and rate-limit policies are unchanged; the MCP layer is transport, not authority.
+The link's `issuer` is the delegating principal; `subject` is the
+delegate. The `intent` object (`action`, `target`, `resource`) describes
+the authorized action and the resource URI under which it must fall;
+`validFrom` and `validUntil` bound the delegation in time. Each link is
+itself signed by its `issuer`.
 
----
+## Chain Construction and the Resource Narrowing Rule
 
-## 5. Delegation Chains
+A chain is a list of delegation-link credentials, ordered from root
+principal to leaf agent. At each link, the child's `intent.resource`
+MUST be a sub-URI of, or equal to, the parent's `intent.resource`. The
+narrowing rule prevents capability widening at any link: a delegate
+cannot grant a sub-delegate more authority than it itself holds.
 
-### 5.1 Motivation
+## Depth Limit
 
-Multi-agent systems present an attribution problem: an action taken by a leaf agent may have been authorized by a chain of principals — a user authorized an assistant, which authorized a research agent, which authorized a web-scraping sub-agent. When the action requires audit, the leaf-only signing model loses the chain.
+Chain depth is bounded to **five links maximum**. This limit prevents
+pathological chains from inflating verification cost and from obscuring
+the actual authorization path.
 
-Vouch delegations are themselves Verifiable Credentials. Each link in a chain is a credential signed by the delegating principal and identifying the delegate. A leaf-action credential includes the full chain (or a reference to it) so a verifier can reconstruct the authorization path from root principal to leaf agent.
-
-### 5.2 Delegation Link Structure
-
-A delegation link is a Vouch credential whose `credentialSubject` is shaped:
-
-```json
-{
-  "credentialSubject": {
-    "id": "did:web:research-agent.example.com",
-    "delegatedBy": "did:web:assistant.example.com",
-    "scope": {
-      "actions": ["web_search", "scrape_page"],
-      "resource": "https://research-agent.example.com/agents/research-agent/scope/2026"
-    },
-    "validUntil": "2026-05-14T08:00:00Z"
-  }
-}
-```
-
-The link's `issuer` is the delegating principal. The link's `credentialSubject.id` is the delegate. `scope.actions` enumerates which actions are delegated; `scope.resource` is the resource URI under which all delegated actions must fall.
-
-### 5.3 Chain Construction and the Resource Narrowing Rule
-
-A chain is a list of delegation-link credentials, ordered from root principal to leaf agent. At each link, the child's `scope.resource` MUST be a sub-URI of the parent's `scope.resource`. Concretely, with parent resource `https://x.example.com/department/finance/` and child resource `https://x.example.com/department/finance/accounts-payable/`, the narrowing is valid. With child resource `https://x.example.com/department/legal/`, narrowing is violated and the chain is rejected.
-
-The narrowing rule prevents capability widening at any link. A delegate cannot grant a sub-delegate more authority than it itself holds.
-
-### 5.4 Depth Limit
-
-Chain depth is bounded to **five links maximum** (specification §9.4). This limit prevents pathological chains from inflating verification cost and from obscuring the actual authorization path. Deployments requiring deeper chains MUST restructure (e.g., introduce a single mid-level principal acting on behalf of multiple sub-principals).
-
-### 5.5 Chain Validation
+## Chain Validation
 
 A verifier validating a leaf credential with an attached chain:
 
-1. Verifies the leaf credential's signature as in §3.2.
-2. Identifies the chain root: the first link's `issuer` MUST be in the verifier's set of **trusted principals** for the leaf action. If not, validation fails with `untrusted_principal`.
-3. For each adjacent pair (parent, child) in the chain, verifies the child's `scope.resource` is a sub-URI of the parent's.
-4. Verifies each link's `delegatedBy` matches the previous link's `credentialSubject.id`.
-5. Verifies each link's signature.
-6. Verifies the leaf credential's `intent.action` is in the deepest link's `scope.actions`.
-7. Verifies the leaf credential's `intent.resource` is a sub-URI of the deepest link's `scope.resource`.
+1.  Verifies the leaf credential's signature.
 
-Any failure produces a structured rejection reason: `untrusted_principal`, `chain_depth_exceeded`, `resource_not_narrowed`, `link_signature_invalid`, `parent_proof_mismatch`, or `action_not_in_scope`.
+2.  Verifies the root link's `issuer` is in the verifier's set of
+    trusted principals for the leaf action.
 
-### 5.6 Trusted Principal Anchoring
+3.  For each adjacent pair (parent, child), verifies the parent link's
+    `subject` equals the child link's `issuer`.
 
-The chain root is the only link not validated by signature alone — the verifier must know to trust the root principal independently. This anchoring is part of deployment policy: a verifier for a healthcare claim system may anchor at the patient's verified-identity DID; a verifier for a corporate spending agent may anchor at the CFO's DID; a verifier for general public services may anchor at the user's federated identity provider.
+4.  For each link, verifies its `intent.resource` is a sub-URI of, or
+    equal to, the parent link's `intent.resource`.
 
-Trust-set bootstrap is out of scope of the protocol itself. PAD-008 (Hybrid Identity Bootstrapping) describes one common approach: use existing identity infrastructure (GitHub SSH, mobile-phone identity providers, employer SSO) as the source of trusted-principal DIDs.
+5.  For each link, verifies its `validFrom` and `validUntil` fall within
+    the parent link's temporal bounds.
 
----
+6.  Verifies each link's Data Integrity proof.
 
-## 6. Revocation
+7.  Verifies the leaf credential's `intent.resource` is a sub-URI of the
+    deepest link's `intent.resource`.
 
-### 6.1 Two Mechanisms
+Any failure produces a structured rejection reason:
+`untrusted_principal`, `chain_depth_exceeded`, `resource_not_narrowed`,
+`temporal_bounds_exceeded`, `subject_issuer_mismatch`, or
+`link_signature_invalid`.
+
+# Revocation {#sec:revocation}
+
+## Two Mechanisms
 
 Vouch supports two complementary revocation mechanisms:
 
-- **DID-level revocation**: revoke an entire DID, invalidating all credentials it has issued or ever will issue.
-- **Credential-level revocation**: revoke a specific credential without affecting other credentials from the same issuer.
+- **DID-level revocation**: revoke an entire DID, invalidating all
+  credentials it has issued or ever will issue.
 
-Most production deployments run both. DID-level revocation is appropriate for blanket kill switches (key compromise, agent decommissioning); credential-level revocation is appropriate for surgical retraction (regulatory hold on a specific transaction, suspension pending review).
+- **Credential-level revocation**: revoke a specific credential without
+  affecting other credentials from the same issuer.
 
-### 6.2 DID-Level Revocation Registry
+Most production deployments run both. DID-level revocation is
+appropriate for blanket kill switches (key compromise, agent
+decommissioning); credential-level revocation is appropriate for
+surgical retraction (regulatory hold on a specific transaction,
+suspension pending review).
 
-The protocol defines a revocation registry interface (`RevocationStoreInterface`). A revoked DID is recorded as a `RevocationRecord` with `did`, `revoked_at`, `reason`, and `revoked_by`. Reference implementations include in-memory, file, and Redis backends.
+## DID-Level Revocation Registry
 
-Verifiers consult the registry on every credential verification. If the issuing DID is in the registry, the credential is rejected with `issuer_revoked`. The registry's cache TTL is operator-configurable; a typical default is 60 seconds.
+The protocol defines a revocation registry interface
+(`RevocationStoreInterface`). A revoked DID is recorded as a
+`RevocationRecord` with `did`, `revoked_at`, `reason`, and `revoked_by`.
+Reference implementations include in-memory, file, and Redis backends.
 
-### 6.3 BitstringStatusList for Per-Credential Revocation
+Verifiers consult the registry on every credential verification. If the
+issuing DID is in the registry, the credential is rejected with
+`issuer_revoked`. The registry's cache TTL is operator-configurable; a
+typical default is 60 seconds.
 
-For per-credential revocation, Vouch uses W3C BitstringStatusList [VC-BITSTRING-STATUS-LIST]. The issuer maintains a published `BitstringStatusListCredential` whose `credentialSubject.encodedList` is a gzip-compressed, base64url-encoded bitstring. Each Vouch credential includes a `credentialStatus` property:
+## BitstringStatusList for Per-Credential Revocation
 
-```json
-"credentialStatus": {
-  "id": "https://issuer.example/status/1#42",
-  "type": "BitstringStatusListEntry",
-  "statusPurpose": "revocation",
-  "statusListIndex": "42",
-  "statusListCredential": "https://issuer.example/status/1"
-}
-```
+For per-credential revocation, Vouch uses W3C BitstringStatusList (World
+Wide Web Consortium 2024a). The issuer maintains a published
+`BitstringStatusListCredential` whose `credentialSubject.encodedList` is
+a gzip-compressed, base64url-encoded bitstring. Each Vouch credential
+includes a `credentialStatus` property pointing at its index. A verifier
+fetches the status list, decompresses, reads the indicated bit; if the
+bit is set, the credential is revoked.
 
-A verifier fetches the status list, decompresses, reads bit 42; if the bit is set, the credential is revoked. The protocol's `StatusListFetcher` caches the status list with a configurable TTL and supports conditional GETs (`If-None-Match`, `If-Modified-Since`) for efficient re-validation.
+The protocol's `StatusListFetcher` caches the status list with a
+configurable TTL and supports conditional GETs (`If-None-Match`,
+`If-Modified-Since`) for efficient re-validation.
 
-### 6.4 Cross-Language Equivalence
+# Dual-Proof Post-Quantum Profile {#sec:hybrid}
 
-The three reference implementations produce semantically equivalent BitstringStatusList credentials:
+## Motivation
 
-- **Python and TypeScript**: byte-identical encoded output. Both use zlib DEFLATE through their language's standard library.
-- **Go**: produces a valid DEFLATE stream from `compress/flate`. The bytes differ slightly from Python/TypeScript (different DEFLATE encoder choices), but the decompressed bitstring is identical. The spec mandates equivalence of the decompressed bitstring, not byte-identity of the gzip envelope.
+NIST's selection of ML-DSA-44 (FIPS 204) as a standardized post-quantum
+digital signature (National Institute of Standards and Technology 2024)
+places a known cryptographic transition on the protocol's horizon.
+Ed25519 will not survive a sufficiently large fault-tolerant quantum
+computer. The transition window is uncertain but real, and credentials
+with multi-year audit retention requirements (regulated healthcare,
+financial settlement) cannot afford to be signed with an algorithm that
+will be broken before the retention window expires.
 
-All three implementations are verified against a cross-language test vector at `test-vectors/bitstring-status-list/vector.json`.
+The protocol's response is the *dual-proof profile*: a credential
+carries two independent W3C Data Integrity proofs on the same
+JCS-canonicalized credential bytes, one `eddsa-jcs-2022` proof
+(classical Ed25519) and one `mldsa44-jcs-2026` proof (ML-DSA-44). The
+Data Integrity specification already defines the `proof` field as an
+array, so the dual-proof construction is a natural use of existing
+primitives and requires no Vouch-specific composite cryptosuite
+identifier.
 
-### 6.5 Sizing and Cursor Persistence
+## Construction
 
-The W3C BitstringStatusList minimum length is 131,072 bits (16 KiB uncompressed; tens of bytes compressed when sparse). One status list accommodates 131,072 credentials. For larger issuers, a fresh status list is allocated as exhaustion approaches; the `credentialStatus.statusListCredential` URL on each credential identifies its list.
+The credential's `proof` field is an array of two Data Integrity proof
+objects:
 
-The issuer's allocation cursor (next free index) must persist across restarts; it is **not recoverable** from the bitstring alone. The reference implementations expose a `to_state_dict`/`from_state_dict` pattern for durable storage in Redis, Postgres, or S3.
+    "proof": [
+      {
+        "type": "DataIntegrityProof",
+        "cryptosuite": "eddsa-jcs-2022",
+        "verificationMethod": "...#key-ed25519",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z<base58btc(ed25519_sig)>"
+      },
+      {
+        "type": "DataIntegrityProof",
+        "cryptosuite": "mldsa44-jcs-2026",
+        "verificationMethod": "...#key-mldsa44",
+        "proofPurpose": "assertionMethod",
+        "proofValue": "z<base58btc(mldsa44_sig)>"
+      }
+    ]
 
----
+Both proofs are computed over the same JCS-canonical credential bytes
+(the credential minus the `proofValue` field of each proof,
+JCS-canonicalized). The same-canonical-bytes property is preserved by
+construction: both cryptosuites use JCS canonicalization on the same
+credential body. Each proof's `proofValue` is independently multibase
+base58btc-encoded.
 
-## 7. Hybrid Post-Quantum Cryptosuite
+The Ed25519 signature is exactly 64 bytes; the ML-DSA-44 signature is
+exactly 2,420 bytes. Each appears in its own proof object's `proofValue`
+rather than being concatenated into a single field.
 
-### 7.1 Motivation
+## Verifier Modes
 
-NIST's selection of ML-DSA-44 (FIPS 204) as a standardized post-quantum digital signature [NIST-FIPS-204] places a known cryptographic transition on the protocol's horizon. Ed25519 will not survive a sufficiently large fault-tolerant quantum computer. The transition window is uncertain but real, and credentials with multi-year audit retention requirements (regulated healthcare, financial settlement) cannot afford to be signed with an algorithm that will be broken before the retention window expires.
+A verifier iterates the credential's `proof` array and applies one of
+three local policies:
 
-The protocol's response is `hybrid-eddsa-mldsa44-jcs-2026`: a cryptosuite that binds an Ed25519 signature and an ML-DSA-44 signature to the same JCS-canonicalized payload, allowing graceful verifier downgrade and forward migration.
+1.  **Classical-only**: validate the `eddsa-jcs-2022` proof; ignore the
+    rest. Useful when ML-DSA-44 libraries are unavailable or
+    computationally expensive.
 
-### 7.2 Construction
+2.  **Post-quantum-only**: validate the `mldsa44-jcs-2026` proof. Useful
+    when classical signatures are no longer trusted under the verifier's
+    compliance regime.
 
-The hybrid `proofValue` is the byte-concatenation:
+3.  **Both-required**: validate every proof in the array; reject if any
+    one fails. The cautious mode, recommended for long-retention
+    credentials.
 
-```
-proofValue = base58btc( ed25519_signature || mldsa44_signature )
-            (64 bytes)    (2,420 bytes)
-            ───────────── 2,484 bytes total
-```
+The verifier's mode is policy, not part of the credential. The same
+credential is verifiable under any verifier mode without re-signing.
 
-Both signatures are computed over the same JCS-canonical credential bytes (the credential minus `proof.proofValue`, JCS-canonicalized). The Ed25519 signature is exactly 64 bytes; the ML-DSA-44 signature is exactly 2,420 bytes. The concatenation is then multibase base58btc-encoded for the `proofValue` string.
+## DID Document Representation
 
-The construction is documented as PAD-040 (Hybrid Composite Signature Bound to Same Canonical Bytes).
+A signing DID supporting the dual-proof profile publishes two
+verification methods in its DID Document: one Ed25519 Multikey, one
+ML-DSA-44 Multikey. The Multikey multicodec prefix distinguishes the two
+algorithms, and each proof's `verificationMethod` field points at its
+own key.
 
-### 7.3 Verifier Modes
+## Migration Path
 
-A verifier may operate in any of three modes:
+A deployment migrates from classical to dual-proof in three steps:
 
-1. **Classical-only**: validate only the first 64 bytes (Ed25519). Useful when ML-DSA-44 libraries are unavailable or computationally expensive.
-2. **PQ-aware single**: validate either signature; accept the credential if either verifies. Useful during transition periods when not all verifiers support both algorithms.
-3. **Both-required**: validate both signatures; reject if either fails. The cautious mode, recommended for long-retention credentials.
+1.  **Adopt dual-proof signing**: the signer issues credentials with two
+    proofs in the array. Existing classical-only verifiers continue
+    working (they see a familiar `eddsa-jcs-2022` proof and ignore the
+    second one they don't recognize).
 
-The verifier's mode is policy, not part of the credential. The same credential is verifiable under any verifier mode without re-signing.
+2.  **Update verifiers**: deploy a verifier release that supports
+    ML-DSA-44. Configure the verifier's mode (classical-only, PQ-only,
+    or both-required) based on the deployment's risk tolerance.
 
-### 7.4 DID Document Representation
+3.  **Retire classical signing**: once all verifiers are PQ-aware,
+    switch the signer to issue only the `mldsa44-jcs-2026` proof. The
+    dual-proof profile is the migration vehicle, not the destination.
 
-A signing DID supporting the hybrid cryptosuite publishes two verification methods in its DID Document — one Ed25519 Multikey, one ML-DSA-44 Multikey:
+## Performance and Size
 
-```json
-"verificationMethod": [
-  {
-    "id": "did:web:agent.example.com#key-1",
-    "type": "Multikey",
-    "controller": "did:web:agent.example.com",
-    "publicKeyMultibase": "z6Mki..."        // Ed25519
-  },
-  {
-    "id": "did:web:agent.example.com#pq-key-1",
-    "type": "Multikey",
-    "controller": "did:web:agent.example.com",
-    "publicKeyMultibase": "uMIIH..."        // ML-DSA-44 (multicodec discrimination)
-  }
-]
-```
+Per-credential signing cost (Apple M3 Max, reference Python
+implementation):
 
-The Multikey multicodec prefix distinguishes the two algorithms; PAD-041 (Multikey Algorithm-Agnostic Verification Method Resolution) defines the discrimination rules.
+- Ed25519 alone: $\sim$`<!-- -->`{=html}50 $\mu$s
 
-### 7.5 Migration Path
+- ML-DSA-44 alone: $\sim$`<!-- -->`{=html}3 ms
 
-A deployment migrates from classical to hybrid in three steps:
+- Dual-proof (both): $\sim$`<!-- -->`{=html}3 ms (dominated by
+  ML-DSA-44)
 
-1. **Adopt hybrid signing**: the signer issues hybrid-cryptosuite credentials alongside or in place of classical credentials. Existing classical-only verifiers continue working (they read the first 64 bytes).
-2. **Update verifiers**: deploy a verifier release that supports ML-DSA-44. Configure the verifier's mode (classical-only, PQ-aware-single, or both-required) based on the deployment's risk tolerance.
-3. **Retire classical signing**: once all verifiers are PQ-aware, switch the signer to ML-DSA-44-only (a future cryptosuite). The hybrid cryptosuite is the migration vehicle, not the destination.
+Per-credential credential size (multibase-encoded proofs):
 
-### 7.6 Performance and Size
+- Classical only: $\sim$`<!-- -->`{=html}700 bytes total
 
-Per-credential signing cost (Apple M3 Max, reference Python implementation):
+- Dual-proof: $\sim$`<!-- -->`{=html}3,200 bytes total
 
-- Ed25519 alone: ~50 µs
-- ML-DSA-44 alone: ~3 ms
-- Hybrid (concatenated): ~3 ms (dominated by ML-DSA-44)
+The size delta matters for HTTP-header-conveyed credentials and for
+credentials embedded in QR codes. For application-body conveyance the
+overhead is negligible.
 
-Per-credential signature size (base58btc-encoded `proofValue`):
+## Relationship to Concurrent Work
 
-- Ed25519 alone: ~88 characters
-- Hybrid: ~3,400 characters
+The dual-proof construction converges with Digital Bazaar's
+`mldsa44-rdfc-2024-cryptosuite` family (Digital Bazaar, Inc. 2026),
+which defines an ML-DSA-44 Data Integrity cryptosuite using RDFC
+canonicalization, and with that family's forthcoming JCS variant. The
+cryptosuite identifier `mldsa44-jcs-2026` used in this paper is
+provisional and is being aligned with that upstream registration.
+Earlier Vouch reference implementations (v1.6.x) emit a single composite
+cryptosuite (`hybrid-eddsa-mldsa44-jcs-2026`) with a concatenated
+`proofValue`; this composite identifier is retained as a transitional
+alias for backward compatibility only, and new implementations emit the
+dual-proof form described above.
 
-The size delta matters for HTTP-header-conveyed credentials and for credentials embedded in QR codes. For application-body conveyance the overhead is negligible.
+# The State Verifiability Layer {#sec:state}
 
----
+## Motivation: From Point-in-Time to Continuous
 
-## 8. The State Verifiability Layer
+The credential layer addresses "did the agent claim authorization at
+time $T$." The State Verifiability layer addresses operational questions
+arising *after* that: is the agent still behaving correctly *now*? Has
+it drifted out of policy? Has it been substituted? Has it crashed
+silently and been replayed by an adversary?
 
-### 8.1 Motivation: From Point-in-Time to Continuous
+A long-running agent without continuous attestation accumulates risk.
+The longer it runs, the wider the window during which a compromise or
+substitution may go undetected. Heartbeat-style renewal makes that
+window bounded.
 
-The credential layer addresses *did the agent claim authorization at time T*. The State Verifiability layer addresses operational questions arising *after* that: is the agent still behaving correctly *now*? Has it drifted out of policy? Has it been substituted? Has it crashed silently and been replayed by an adversary?
+## The Heartbeat Protocol
 
-A long-running agent without continuous attestation accumulates risk. The longer it runs, the wider the window during which a compromise or substitution may go undetected. Heartbeat-style renewal makes that window bounded: the agent must demonstrate, on a schedule, that it is still the agent it was at credential issuance and that its behaviour is within policy.
+The Heartbeat Protocol defines a periodic renewal cycle:
 
-### 8.2 The Heartbeat Protocol
+1.  The agent's `HeartbeatSession` records actions and behavioural
+    signals during each interval.
 
-The Heartbeat Protocol (defensive disclosure PAD-016) defines a periodic renewal cycle:
+2.  At the heartbeat boundary (default 60 seconds), the session
+    constructs a `HeartbeatRequest`: it includes a behavioural digest,
+    the running Merkle root of actions performed since the last
+    heartbeat, the canary commit/reveal pair, and an interval index.
 
-1. The agent's `HeartbeatSession` records actions and behavioural signals during each interval.
-2. At the heartbeat boundary (default 60 seconds), the session constructs a `HeartbeatRequest`: it includes a behavioural digest, the running Merkle root of actions performed since the last heartbeat (PAD computed via RFC 6962 domain separation, see §8.4), the canary commit/reveal pair, and an interval index.
-3. The agent submits the request to a validator (or quorum of validators).
-4. The validator(s) check schema, behavioural digest structure, canary chain integrity, interval-index monotonicity, and trust policy.
-5. On success, the validator returns a fresh `SessionVoucher` credential with the agent's renewed trust parameters.
-6. On failure (broken canary, stale interval index, behavioural drift), no voucher is issued; the agent's existing voucher expires; the agent loses authority.
+3.  The agent submits the request to a validator (or quorum of
+    validators).
 
-The Heartbeat Protocol inverts the traditional PKI trust model from "trusted until revoked" to **"untrusted until renewed."**
+4.  The validator(s) check schema, behavioural digest structure, canary
+    chain integrity, interval-index monotonicity, and trust policy.
 
-### 8.3 Trust Entropy Decay
+5.  On success, the validator returns a fresh `SessionVoucher`
+    credential with the agent's renewed trust parameters.
 
-Each SessionVoucher carries `initialTrust` and `decayLambda`. The effective trust at time `t` after the voucher's `issuedAt`:
+6.  On failure (broken canary, stale interval index, behavioural drift),
+    no voucher is issued; the agent's existing voucher expires; the
+    agent loses authority.
 
-$$\text{trust}(t) = \text{initialTrust} \cdot e^{-\lambda(t - t_0)}$$
+The Heartbeat Protocol inverts the traditional PKI trust model from
+"trusted until revoked" to *"untrusted until renewed"* (Gaddam 2026a).
 
-Sensitive actions are gated by current trust. The protocol defines three reference thresholds:
+## Trust Entropy Decay
 
-- `TRUST_THRESHOLD_HIGH_STAKES = 0.9` — financial transfers, code deployment, regulated submissions.
-- `TRUST_THRESHOLD_MEDIUM_STAKES = 0.75` — protected-health-information read, customer-data access.
-- `TRUST_THRESHOLD_LOW_STAKES = 0.5` — status queries, idle activity.
+Each SessionVoucher carries `initialTrust` and `decayLambda`. The
+effective trust at time $t$ after the voucher's `issuedAt`:
 
-Operators choose thresholds per deployment. The protocol's trust-entropy primitives (`compute_trust_at`, `check_trust_threshold`, `half_life_seconds`) provide the mathematical machinery; the threshold values are policy.
+$$\textsf{trust}(t) = \textsf{initialTrust} \cdot e^{-\lambda (t - t_0)}$$
 
-Heartbeat interval should be set to less than half the half-life so renewal stays ahead of decay. For $\lambda = 0.01$, half-life is approximately 69 seconds; a 30-second heartbeat is appropriate.
+Sensitive actions are gated by current trust. The specification defines
+five reference thresholds by operation category:
 
-### 8.4 Behavioural Attestation
+- Financial transaction: $\theta = 0.95$ (transfers, settlement,
+  regulated submissions).
+
+- API write: $\theta = 0.80$ (state-changing calls, code deployment).
+
+- API read: $\theta = 0.50$ (PHI read, customer-data access, status
+  queries).
+
+- Health check: $\theta = 0.20$ (liveness, idle activity).
+
+- Logging: $\theta = 0.05$ (telemetry, audit emission).
+
+Heartbeat interval should be set to less than half the half-life so
+renewal stays ahead of decay. For $\lambda = 0.01$, half-life is
+approximately 69 seconds; a 30-second heartbeat is appropriate.
+
+## Behavioural Attestation
 
 Per-interval, the `BehavioralCollector` records:
 
-- API calls made by the agent (URL, token count, optional intent-drift score)
+- API calls made by the agent (URL, token count, optional intent-drift
+  score)
+
 - Resources accessed
+
 - Any policy-defined custom signals
 
-At each heartbeat, the collector produces a `behavioralDigest`:
+At each heartbeat, the collector produces a `behavioralDigest`. Three
+reference intent-drift scorers ship with the SDK: arithmetic mean,
+maximum-of-samples, and exponential-weighted moving average. The drift
+score quantifies the divergence of the agent's recent activity from a
+baseline; a sharp rise across consecutive intervals signals a potential
+prompt-injection or policy-drift event.
 
-```json
-{
-  "apiCalls": 7,
-  "tokensConsumed": 1340,
-  "resourcesAccessed": ["order:42", "order:51"],
-  "intentDriftScore": 0.13
-}
-```
+## Canary Commitments
 
-Three reference intent-drift scorers ship with the SDK: arithmetic mean (`mean_drift_scorer`), maximum-of-samples (`max_drift_scorer`), and exponential-weighted moving average (`ewma_drift_scorer`). The drift score quantifies the divergence of the agent's recent activity from a baseline; a sharp rise across consecutive intervals signals a potential prompt-injection or policy-drift event.
+The canary commit/reveal chain provides cryptographic detection of
+silent agent failure. Each heartbeat commits to a fresh 256-bit secret
+hash; the next heartbeat reveals the prior secret. A missed heartbeat
+means the prior secret is never revealed; no subsequent heartbeat can
+resume the chain because the validator expects the missing reveal.
 
-To prevent unbounded growth, the collector caps the resources list at a configurable maximum (default 64); beyond the cap, the `apiCalls` count is still accurate but individual URIs are not enumerated.
+The validator state per agent is one string (the last commitment). The
+state is cheap to persist and survives validator restarts.
 
-### 8.5 Canary Commitments
+## Action Merkle Roots
 
-The canary commit/reveal chain (PAD-032) provides cryptographic detection of silent agent failure. Each heartbeat commits to a fresh 256-bit secret hash; the next heartbeat reveals the prior secret. A missed heartbeat means the prior secret is never revealed; no subsequent heartbeat can resume the chain because the validator expects the missing reveal.
+A `HeartbeatRequest` includes the Merkle root of actions performed since
+the last heartbeat, computed over RFC 6962-domain-separated Merkle
+trees (Laurie et al. 2013). Each action is hashed with `0x00` prefix
+(leaf); internal nodes are hashed with `0x01` prefix. This prevents the
+classical second-preimage attack on Merkle trees.
 
-```python
-# Agent side, managed by HeartbeatSession
-chain = CanaryChain()
-msg = chain.next_heartbeat()
-# msg.commitment is included in this heartbeat
-# msg.reveal is the previous secret (None on first interval)
+## Validator Quorum
 
-# Validator side, managed by HeartbeatValidator
-verifier = CanaryVerifier()
-ok = verifier.observe(msg.commitment, msg.reveal)
-if not ok:
-    revoke_session_voucher()
-```
+Single validators are single points of failure. The `HeartbeatQuorum`
+distributes trust evaluation across multiple validators with different
+responsibilities:
 
-The validator state per agent is one string (the last commitment). The state is cheap to persist (`MemoryHeartbeatStore`, `RedisHeartbeatStore`) and survives validator restarts.
-
-### 8.6 Action Merkle Roots
-
-A `HeartbeatRequest` includes the Merkle root of actions performed since the last heartbeat, computed over RFC 6962-domain-separated Merkle trees. Each action is hashed with `0x00` prefix (leaf); internal nodes are hashed with `0x01` prefix. This prevents the classical second-preimage attack on Merkle trees.
-
-The validator does not validate every action — it cannot, the actions are application-specific — but it records the root. If an action is later disputed, the agent can produce an inclusion proof against the recorded root. The Merkle root is a tamper-evident commitment to the agent's claimed activity per interval.
-
-### 8.7 Validator Quorum
-
-Single validators are single points of failure. The `HeartbeatQuorum` distributes trust evaluation across multiple validators with different responsibilities:
-
-```python
+``` {.python language="Python"}
 quorum = HeartbeatQuorum(
     validators=[
         QuorumValidator(validator=policy_validator,     role=ROLE_POLICY),
         QuorumValidator(validator=behavioral_validator, role=ROLE_BEHAVIORAL),
         QuorumValidator(validator=budget_validator,     role=ROLE_BUDGET),
     ],
-    threshold=2,                  # 2-of-3
+    threshold=2,
 )
 ```
 
-Roles are reference tags; deployments choose their own role taxonomy. The quorum threshold is M-of-N. Trust parameter aggregation across approving validators is configurable; the defaults (`initial_trust` takes minimum, `decay_lambda` takes maximum, `scope` is intersection) bias toward caution.
+Roles are reference tags; deployments choose their own role taxonomy.
+The quorum threshold is $M$-of-$N$. Trust parameter aggregation across
+approving validators is configurable; the defaults bias toward caution.
 
-Weighted voting is supported: a senior validator may carry weight 2, a junior weight 1; the threshold is then evaluated against the weighted sum. PAD-046 (Algorithm Quorum Verification) describes the M-of-N machinery; the State Verifiability layer uses the same construction at the validator level.
+# Security Analysis {#sec:security}
 
-### 8.8 Pluggable Persistence
-
-`HeartbeatValidator` accepts an injected `HeartbeatStoreInterface` backend. The reference implementation ships `MemoryHeartbeatStore` (in-process, suitable for tests) and demonstrates the contract via tests. Production backends (Redis, Postgres, S3 with optimistic concurrency) are implementor-supplied. The state per agent is a JSON-serializable dictionary (`last_commitment`, `expecting_reveal`, `last_interval`); the schema is stable across the validator's lifetime.
-
----
-
-## 9. Security Analysis
-
-### 9.1 Threat Model
+## Threat Model
 
 The protocol assumes:
 
-- The cryptographic primitives (Ed25519, ML-DSA-44, SHA-256) are sound under their respective security assumptions.
-- The verifier can resolve the issuer's DID Document via the agent's chosen DID method (`did:web` via HTTPS, `did:key` via decoding).
-- The verifier has access to the revocation registry and to BitstringStatusList endpoints.
-- The Identity Sidecar's process boundary is enforced by the host operating system: a malicious LLM process cannot read the Sidecar's memory.
+- The cryptographic primitives (Ed25519, ML-DSA-44, SHA-256) are sound
+  under their respective security assumptions.
+
+- The verifier can resolve the issuer's DID Document via the agent's
+  chosen DID method (`did:web` via HTTPS, `did:key` via decoding).
+
+- The verifier has access to the revocation registry and to
+  BitstringStatusList endpoints.
+
+- The Identity Sidecar's process boundary is enforced by the host
+  operating system: a malicious LLM process cannot read the Sidecar's
+  memory.
+
+The protocol does *not* assume:
+
+- The LLM is trustworthy. Prompt injection, jailbreak, and model
+  substitution attacks are within the threat model.
+
+- The transport layer is confidential. Credentials are designed to be
+  exposed in transit (the signature establishes authenticity even when
+  an adversary observes the credential).
+
+- The agent's host platform is uncompromised. Root-level compromise of
+  the host defeats any application-level defence, including this one.
+
+## Defended Threats
+
+**Bearer-credential theft.** Vouch credentials are bound to the issuer's
+DID by signature; an adversary who copies a credential cannot reuse it
+to issue new credentials. The original credential is bound to its
+`intent.target` and `intent.resource`; it cannot be replayed against a
+different resource.
+
+**Prompt injection causing key exfiltration.** The Identity Sidecar
+makes this attack class structurally impossible: the LLM process has no
+access to the private key.
+
+**Prompt injection causing unauthorized credential issuance.** The
+Sidecar's intent allow-list makes this attack class capability-bounded:
+the LLM may propose any intent it likes, but the Sidecar refuses to sign
+intents outside the deployment's allow-list.
+
+**Injected or untrustworthy intent.** A natural objection is that
+verifying an action against "signed intent" only relocates the trust
+problem upstream: what if the captured intent is itself a product of
+prompt injection? Vouch closes this in two places. First, intent is
+signed at the human-principal boundary before any agent processing. The
+root of every delegation chain is a credential signed by the human
+principal's key (§[5](#sec:delegation){reference-type="ref"
+reference="sec:delegation"}), establishing a chain of custody from the
+original authorization down to the acting agent (Gaddam 2026c); an
+intent fabricated inside a compromised agent carries no valid root
+signature and fails chain validation. Second, the faithfulness of the
+agent's reasoning relative to that signed intent is itself verifiable:
+the reasoning trace is evidence-anchored and checked for causal
+consistency with the chosen action (Gaddam 2026d), and outputs can be
+bound to retrieved evidence rather than confabulated (Gaddam 2026e).
+Intent an agent invents for itself is therefore neither rooted in a
+principal's signature nor reconcilable with a faithful reasoning trace.
+
+**Replay across resources.** Each credential's `intent.resource` is part
+of the signed payload. Replaying against a different resource
+invalidates the signature.
+
+**Delegation chain forgery.** Each link is a signed credential; forging
+a link requires possessing the delegating principal's key.
+Trusted-principal anchoring ensures the chain root is known to the
+verifier independently.
+
+**Resource widening at delegation.** The chain validator's
+resource-narrowing rule rejects chains where any link grants access
+beyond its parent's scope.
+
+**Long-running agent silent failure.** The Heartbeat Protocol's canary
+chain detects missed heartbeats: the next heartbeat cannot produce the
+expected reveal, the chain breaks, and the validator refuses to renew.
+
+**Key compromise.** DID-level revocation invalidates all credentials
+issued by the compromised key. The auto-rotation pipeline automates
+rotation when leak detection fires.
+
+**Post-quantum cryptanalysis.** The dual-proof profile carries an
+ML-DSA-44 Data Integrity proof in addition to the Ed25519 proof,
+allowing the credential to be re-verified against the PQ proof once
+Ed25519 is broken. Verifiers in both-required mode are immune to
+single-algorithm cryptanalysis.
+
+## Residual Threats
+
+**Within-allow-list abuse.** The Sidecar's allow-list bounds capability
+*type*, not *abuse within type*. Mitigations: pattern strictness, rate
+limits, downstream verifier policy, and human-in-the-loop confirmation
+for ambiguous cases.
+
+**DID resolution failures.** If the issuer's DID Document is
+unreachable, the credential cannot be verified. Verifiers MUST fail
+closed rather than accept unverified credentials.
+
+**Trusted-principal anchor compromise.** If a trusted-principal DID is
+compromised, the adversary can construct delegation chains rooted at
+that DID that authorize arbitrary leaf actions within the principal's
+scope. Defence: rotate trusted-principal keys regularly; require
+multi-key signing at the root for high-stakes deployments.
 
-The protocol does **not** assume:
+# Cross-Language Interoperability {#sec:interop}
 
-- The LLM is trustworthy. Prompt injection, jailbreak, and model substitution attacks are within the threat model.
-- The transport layer is confidential. Credentials are designed to be exposed in transit (the signature establishes authenticity even when an adversary observes the credential).
-- The agent's host platform is uncompromised. Root-level compromise of the host defeats any application-level defence, including this one.
+## Test Vectors
 
-### 9.2 Defended Threats
+The protocol ships cross-language test vectors verifying that every
+language SDK, each bound to the shared Rust core, produces
+byte-identical credentials given identical inputs:
 
-**Bearer-credential theft.** Vouch credentials are bound to the issuer's DID by signature; an adversary who copies a credential cannot reuse it to issue new credentials. The original credential is bound to its `intent.target` and `intent.resource`; it cannot be replayed against a different resource. Within its `validUntil` it could be replayed against the same resource, but the nonce store rejects repeat `id`s. After `validUntil`, the credential is no longer accepted.
+- `test-vectors/jcs/`: JSON Canonicalization Scheme reference outputs.
 
-**Prompt injection causing key exfiltration.** The Identity Sidecar (PAD-003) makes this attack class structurally impossible: the LLM process has no access to the private key.
+- `test-vectors/eddsa-jcs-2022/`: full credential signing test vectors
+  for the classical cryptosuite.
 
-**Prompt injection causing unauthorized credential issuance.** The Sidecar's intent allow-list (PAD-056) makes this attack class capability-bounded: the LLM may propose any intent it likes, but the Sidecar refuses to sign intents outside the deployment's allow-list.
+- `test-vectors/hybrid-eddsa-mldsa44/`: full credential signing test
+  vectors for the dual-proof post-quantum profile (and, for v1.6.x
+  interop, the transitional composite cryptosuite).
 
-**Replay across resources.** Each credential's `intent.resource` is part of the signed payload. Replaying against a different resource invalidates the signature.
+- `test-vectors/bitstring-status-list/`: BitstringStatusList encoding
+  test vectors.
 
-**Delegation chain forgery.** Each link is a signed credential; forging a link requires possessing the delegating principal's key. Trusted-principal anchoring ensures the chain root is known to the verifier independently.
+- `test-vectors/sidecar-contract/`: HTTP wire-contract test suite for
+  the three sidecar implementations.
 
-**Resource widening at delegation.** The chain validator's resource-narrowing rule rejects chains where any link grants access beyond its parent's scope.
+## Reference Implementation Properties
 
-**Long-running agent silent failure.** The Heartbeat Protocol's canary chain detects missed heartbeats: the next heartbeat cannot produce the expected reveal, the chain breaks, and the validator refuses to renew.
+  Component       Language / runtime
+  --------------- ---------------------
+  `vouch-core`    Rust (shared core)
+  `sdk-py`        Python 3.10+
+  `sdk-ts`        TypeScript 5+
+  `go-sidecar`    Go 1.21+
+  `sdks/cpp`      C++
+  `sdks/dotnet`   .NET
+  `sdks/jvm`      Java / Kotlin (JVM)
+  `sdks/swift`    Swift
 
-**Key compromise.** DID-level revocation invalidates all credentials issued by the compromised key. The auto-rotation pipeline (PAD-058) automates rotation when leak detection fires.
+  : The Vouch reference architecture: one Rust core (`vouch-core`)
+  exposed to seven language SDKs through WebAssembly and UniFFI
+  bindings, so every SDK produces byte-identical credentials by
+  construction.
 
-**Post-quantum cryptanalysis.** The hybrid cryptosuite carries an ML-DSA-44 signature in addition to Ed25519, allowing the credential to be re-verified against the PQ signature once Ed25519 is broken. Verifiers in `both-required` mode are immune to single-algorithm cryptanalysis.
+All SDKs pass the cross-language test vectors. CI runs the vectors on
+every commit and rejects merges that introduce divergence.
 
-### 9.3 Residual Threats and Mitigations
+## Known Implementation Divergences
 
-**Within-allow-list abuse.** The Sidecar's allow-list bounds capability *type*, not *abuse within type*. A `send_email` capability granted to the assistant can be invoked against legitimate or illegitimate recipients within the operator's regex constraints. Mitigations: pattern strictness, rate limits, downstream verifier policy, and human-in-the-loop confirmation for ambiguous cases.
+The one documented divergence is in BitstringStatusList byte-encoding:
+different DEFLATE encoders across language runtimes produce valid but
+non-identical compressed streams for the same bitstring. The
+specification requires equivalence of the *decompressed* bitstring,
+which every implementation satisfies; revocation status is therefore
+identical across all SDKs, and verifiers and issuers interoperate.
 
-**DID resolution failures.** If the issuer's DID Document is unreachable (DNS issue, server outage, expired TLS certificate), the credential cannot be verified. Verifiers MUST fail closed (`did_resolution_failed`) rather than accept unverified credentials. Operators SHOULD monitor DID Document availability.
+# Discussion {#sec:discussion}
 
-**Trusted-principal anchor compromise.** If a trusted-principal DID is compromised, the adversary can construct delegation chains rooted at that DID that authorize arbitrary leaf actions within the principal's scope. Defence: rotate trusted-principal keys regularly; require multi-key signing at the root for high-stakes deployments.
+## Limitations
 
-**Side-channel attacks on the Sidecar.** Timing, power, or cache-side channels could in principle extract key material from the Sidecar process. Defence is implementation-dependent: KMS/HSM backends with side-channel-protected hardware are appropriate for high-assurance deployments.
+**State Verifiability is Python-only at the runtime level.** The data
+formats (SessionVoucher, behavioural digest, canary commitment,
+heartbeat request) are cross-language and verifiable in any of the three
+implementations. The runtime orchestration (`HeartbeatSession`,
+`HeartbeatScheduler`, `HeartbeatValidator`, `HeartbeatQuorum`) is
+implemented in Python only. TypeScript and Go ports are work in progress
+at the time of publication.
 
----
+**Trusted-principal anchoring is deployment-specific.** The protocol
+does not standardize how a verifier discovers its trusted principals.
+Each deployment configures this independently.
 
-## 10. Cross-Language Interoperability
+**Confidentiality of sensitive intents is not addressed in v0.1-draft.**
+Vouch credentials are non-confidential. For deployments handling
+regulated content, the next minor revision will add an optional
+confidentiality profile using post-quantum key encapsulation.
 
-### 10.1 Test Vectors
+**The Identity Sidecar's allow-list is static configuration.** Dynamic
+capability adjustment is achievable through the protocol's normal
+credential validity windows but requires care to compose with the
+Sidecar's static allow-list.
 
-The protocol ships cross-language test vectors verifying that Python, TypeScript, and Go implementations produce byte-identical credentials given identical inputs:
+## Adoption Path
 
-- `test-vectors/jcs/` — JSON Canonicalization Scheme reference outputs.
-- `test-vectors/eddsa-jcs-2022/` — full credential signing test vectors for the classical cryptosuite.
-- `test-vectors/hybrid-eddsa-mldsa44/` — full credential signing test vectors for the hybrid cryptosuite.
-- `test-vectors/bitstring-status-list/vector.json` — BitstringStatusList encoding test vector. Python and TypeScript produce byte-identical output; Go produces a semantically equivalent DEFLATE stream (different encoder, identical decompressed bitstring).
-- `test-vectors/sidecar-contract/` — HTTP wire-contract test suite covering `/health`, `/did`, `/sign` endpoints; verifies all three sidecar implementations accept and reject the same inputs.
+The protocol has been validated against three reference implementations
+and a cross-language test-vector battery. Adoption requirements for a
+new deployment:
 
-### 10.2 Reference Implementation Properties
+1.  Generate an issuer DID and publish its DID Document.
 
-| Implementation | Language | Lines of code | Tests | Cryptosuites | Sidecar tier |
-|---|---|---|---|---|---|
-| `vouch/` | Python 3.10+ | ~4,500 | 350 | classical + hybrid | Lightweight + Dev |
-| `packages/sdk-ts/` | TypeScript 5+ | ~3,200 | 120 | classical + hybrid | Lightweight |
-| `go-sidecar/` | Go 1.21+ | ~2,800 | 75 | classical + hybrid | Production |
+2.  Choose a Sidecar tier (Go for production, Python or TypeScript for
+    lighter deployments).
 
-All three pass the cross-language test vectors. CI runs the vectors on every commit, and rejects merges that introduce divergence.
+3.  Configure the Sidecar's allow-list with the deployment's action
+    vocabulary.
 
-### 10.3 Known Implementation Divergences
+4.  Wire the agent's tool-call layer to call the Sidecar's `/sign`
+    endpoint instead of directly calling external APIs.
 
-The only documented divergence is in BitstringStatusList byte-encoding: Python and TypeScript use `zlib`'s DEFLATE encoder, which produces byte-identical output for identical bitstrings; Go's `compress/flate` produces a valid but different DEFLATE stream. The spec requires equivalence of the **decompressed** bitstring; all three implementations agree on the decompressed bitstring and therefore on every credential's revocation status. Verifiers and issuers interoperate across all three.
+5.  Deploy a verifier (either as a library at the API boundary, or as a
+    separate service) for the deployment's external services.
 
----
+6.  For long-running agents, deploy at least one Heartbeat validator (or
+    a quorum of three for regulated deployments).
 
-## 11. Discussion
+End-to-end onboarding effort is on the order of one to two engineering
+days for the credential layer alone, and another two to four days for
+state verifiability and quorum.
 
-### 11.1 Limitations
+## Future Work
 
-**State Verifiability is Python-only at the runtime level.** The data formats (SessionVoucher, behavioural digest, canary commitment, heartbeat request) are cross-language and verifiable in any of the three implementations. The runtime orchestration (`HeartbeatSession`, `HeartbeatScheduler`, `HeartbeatValidator`, `HeartbeatQuorum`) is implemented in Python only. TypeScript and Go ports are work in progress at the time of publication.
+Four directions are actively under development:
 
-**Trusted-principal anchoring is deployment-specific.** The protocol does not standardize how a verifier discovers its trusted principals. Each deployment configures this independently. Standardization here would benefit cross-deployment federation but is outside this paper's scope.
+1.  **TypeScript and Go ports of the State Verifiability runtime.**
 
-**Confidentiality of sensitive intents is not addressed in v0.1-draft.** Vouch credentials are non-confidential; an observer in the credential's transit path reads its intent. For deployments handling regulated content (PHI, financial routing instructions), the next minor revision will add an optional confidentiality profile using post-quantum key encapsulation (ML-KEM-768). This is reserved future work.
+2.  **Confidentiality profile for sensitive intents** using ML-KEM-768
+    key encapsulation.
 
-**The Identity Sidecar's allow-list is a static configuration.** Dynamic capability adjustment (granting `send_money` for a specific 60-second window, then auto-revoking) is achievable through the protocol's normal credential validity windows but requires care to compose with the Sidecar's static allow-list. PAD-053 (Time-Bounded Ephemeral Rules) describes one approach for related contexts.
-
-### 11.2 Adoption Path
-
-The protocol has been validated against three reference implementations and a cross-language test-vector battery. Adoption requirements for a new deployment:
-
-1. Generate an issuer DID and publish its DID Document.
-2. Choose a Sidecar tier (Go for production, Python or TypeScript for lighter deployments).
-3. Configure the Sidecar's allow-list with the deployment's action vocabulary.
-4. Wire the agent's tool-call layer to call the Sidecar's `/sign` endpoint instead of directly calling external APIs.
-5. Deploy a verifier — either as a library at the API boundary, or as a separate service — for the deployment's external services.
-6. For long-running agents, deploy at least one Heartbeat validator (or a quorum of three for regulated deployments).
-
-End-to-end onboarding effort is on the order of one to two engineering days for the credential layer alone, and another two to four days for state verifiability and quorum.
-
-### 11.3 Standards Alignment
-
-The protocol is currently in W3C Credentials Community Group incubation as of the publication date. The W3C CG Report (Spec v0.1-draft) is available at the URL given in the front matter. The protocol composes with — does not replace — existing standards (VC 2.0, DID Core, Data Integrity, Controlled Identifiers, BitstringStatusList, JCS, FIPS 204).
-
-### 11.4 Open Prior Art
-
-Fifty-eight defensive prior-art disclosures (PAD-001 through PAD-058) accompany the protocol. The full disclosure portfolio is available at `https://github.com/vouch-protocol/vouch/tree/main/docs/disclosures/`. Each disclosure is licensed under CC0 (the disclosure document itself) and Apache 2.0 (the corresponding reference implementation, where applicable).
-
-The disclosure portfolio establishes that the design choices documented in this paper are public prior art, not patentable claims. We invite the community to build, fork, and extend the protocol; we expect that the spec will continue to evolve as deployment experience accumulates.
-
-### 11.5 Future Work
-
-Four directions are actively under development at the time of publication:
-
-1. **TypeScript and Go ports of the State Verifiability runtime.** The data formats are cross-language; the orchestration is currently Python-only.
-2. **Confidentiality profile for sensitive intents** using ML-KEM-768 key encapsulation.
-3. **Hosted continuous leak monitor** that closes the loop from PAD-058: webhook-driven repository scanning, automated DID rotation, dual-signed migration credentials, verifier broadcast. Open-source CLI scanner and Gatekeeper extension; hosted continuous component as a commercial extension.
-4. **AI-assisted developer tooling distributed as Claude Skills / Custom GPTs / Gemini Gems** (PAD-057), allowing developers to receive Vouch integration guidance through their own AI tool subscriptions with zero protocol-vendor inference cost.
-
-The protocol's State Verifiability runtime, the hybrid post-quantum cryptosuite, the dual-signed migration credential format of PAD-058, and the validator-quorum composition each merit follow-up papers; outlines are in preparation.
-
----
-
-## 12. Conclusion
-
-We have presented the Vouch Protocol, an open standard for cryptographic identity and continuous state verifiability of autonomous AI agents. The protocol composes Verifiable Credentials, Decentralized Identifiers, Data Integrity proofs, and post-quantum cryptosuites with two novel layers: an Identity Sidecar pattern that isolates the agent's key from the LLM and bounds the agent's capabilities by an enforced allow-list, and a State Verifiability layer that renews trust continuously via heartbeat, decays trust exponentially in the interval, attests behaviour cryptographically, and detects silent failure through canary commit/reveal chains.
-
-Three reference implementations (Python, TypeScript, Go) interoperate at the credential-byte level. The protocol is open under Apache 2.0; fifty-eight defensive disclosures keep the design space open under CC0.
-
-The accountability gap in agent identity is solvable today. The cryptographic primitives are sound, the standards exist, and the implementation effort is bounded. Vouch is one realization of a path the open agent-identity ecosystem will increasingly need: from "the bearer has access" to "this specific agent issued this specific intent under this specific authorization chain, verifiable in seconds, with cryptographic rather than logbook evidence."
-
----
-
-## Acknowledgements
-
-The author thanks Manu Sporny and the W3C Verifiable Credentials Working Group for foundational work on Verifiable Credentials, Data Integrity, and the eddsa-jcs-2022 cryptosuite; the W3C Credentials Community Group for hosting and reviewing the incubation; the IETF JOSE working group for ongoing work on PQ/T composite signatures; the C2PA technical committee for content-provenance complementarity; and the open-source community of contributors and reviewers whose feedback shaped many of the choices documented here.
-
----
-
-## References
-
-[C2PA-1.4] Coalition for Content Provenance and Authenticity. *C2PA Technical Specification 1.4*. 2024.
-
-[DID-CORE] World Wide Web Consortium. *Decentralized Identifiers (DIDs) v1.0.* W3C Recommendation, 19 July 2022.
-
-[MCP-2025] Anthropic. *Model Context Protocol Specification.* 2025.
-
-[NIST-FIPS-204] National Institute of Standards and Technology. *Module-Lattice-Based Digital Signature Standard.* FIPS 204, August 2024.
-
-[RFC 6749] Hardt, D. *The OAuth 2.0 Authorization Framework.* IETF RFC 6749, 2012.
-
-[RFC 6962] Laurie, B., Langley, A., and Kasper, E. *Certificate Transparency.* IETF RFC 6962, 2013.
-
-[RFC 8785] Rundgren, A., Jordan, B., Erdtman, S. *JSON Canonicalization Scheme (JCS).* IETF RFC 8785, June 2020.
-
-[RFC 9700] Lodderstedt, T., Bradley, J., Labunets, A., Fett, D. *OAuth 2.0 Security Best Current Practice.* IETF RFC 9700, 2025.
-
-[Strong2018] Strong, J. *SPIFFE: Universal Workload Identity.* Linux Foundation, 2018.
-
-[VC-BITSTRING-STATUS-LIST] World Wide Web Consortium. *Bitstring Status List v1.0.* W3C Candidate Recommendation, 2024.
-
-[VC-DATA-INTEGRITY] World Wide Web Consortium. *Verifiable Credential Data Integrity 1.0.* W3C Candidate Recommendation, 2024.
-
-[VC-DM-2.0] World Wide Web Consortium. *Verifiable Credentials Data Model v2.0.* W3C Candidate Recommendation, 2024.
-
-[ZCAP-LD] World Wide Web Consortium Credentials Community Group. *Authorization Capabilities for Linked Data v0.3.* Draft Community Group Report.
-
-### Defensive Disclosures Cited
-
-[PAD-001] Cryptographic Agent Identity. Gaddam, December 2025.
-[PAD-002] Chain of Custody Delegation. Gaddam, January 2026.
-[PAD-003] Identity Sidecar Pattern. Gaddam, January 2026.
-[PAD-008] Hybrid Identity Bootstrapping. Gaddam, January 2026.
-[PAD-014] Vouch Sonic: Robust Acoustic Provenance. Gaddam, January 2026.
-[PAD-016] Dynamic Credential Renewal / Heartbeat Protocol. Gaddam, February 2026.
-[PAD-024] Temporal Video Fingerprinting. Gaddam, February 2026.
-[PAD-031] Adversarial Provenance Honeypots. Gaddam, April 2026.
-[PAD-032] Cryptographic Mortality Protocol. Gaddam, April 2026.
-[PAD-039] JCS Deterministic Multi-Party Trust State. Gaddam, April 2026.
-[PAD-040] Hybrid Composite Signature Bound to Same Canonical Bytes. Gaddam, April 2026.
-[PAD-041] Multikey Algorithm-Agnostic Verification. Gaddam, April 2026.
-[PAD-042] Standardized Metadata Schema. Gaddam, April 2026.
-[PAD-045] Proof of Non-Hallucination via Cryptographic Retrieval Anchoring. Gaddam, April 2026.
-[PAD-046] Algorithm Quorum Verification. Gaddam, April 2026.
-[PAD-047] Verifiable Delay Functions for Rate-Limited Agent Actions. Gaddam, April 2026.
-[PAD-053] Time-Bounded Ephemeral Rules. Gaddam, April 2026.
-[PAD-056] Capability-Bounded AI Assistant Output via Intent Allow-List. Gaddam, May 2026.
-[PAD-057] BYO-LLM Distribution of Protocol Capabilities. Gaddam, May 2026.
-[PAD-058] Automated DID Rotation on Leak Detection. Gaddam, May 2026.
-
-Full disclosure portfolio: https://github.com/vouch-protocol/vouch/tree/main/docs/disclosures/
-
----
-
-## Appendix A: Reference Implementations
-
-- **Python**: `pip install vouch-protocol`. Source: https://github.com/vouch-protocol/vouch/tree/main/vouch/
-- **TypeScript**: `npm install @vouch-protocol/core`. Source: https://github.com/vouch-protocol/vouch/tree/main/packages/sdk-ts/
-- **Go**: `go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest`. Source: https://github.com/vouch-protocol/vouch/tree/main/go-sidecar/
-
-## Appendix B: Test Vectors
-
-All test vectors are at https://github.com/vouch-protocol/vouch/tree/main/test-vectors/. The set covers JCS canonicalization (`jcs/`), eddsa-jcs-2022 cryptosuite (`eddsa-jcs-2022/`), hybrid-eddsa-mldsa44-jcs-2026 cryptosuite (`hybrid-eddsa-mldsa44/`), BitstringStatusList encoding (`bitstring-status-list/`), and sidecar HTTP contract (`sidecar-contract/`).
-
-## Appendix C: Specification Document
-
-The full Vouch Protocol Specification, currently Spec v0.1-draft in W3C Credentials Community Group incubation, is at https://github.com/vouch-protocol/vouch/blob/main/docs/specs/w3c-cg-report.md.
-
----
-
-*End of paper.*
+3.  **Hosted continuous leak monitor** that closes the loop from
+    automated detection to DID rotation with dual-signed migration
+    credentials and verifier broadcast.
+
+4.  **AI-assisted developer tooling** distributed as Claude Skills /
+    Custom GPTs / Gemini Gems, allowing developers to receive Vouch
+    integration guidance through their own AI tool subscriptions with
+    zero protocol-vendor inference cost.
+
+5.  **Embodied and robotics extension**: applying per-action intent
+    credentials and the State Verifiability layer to physical actuation,
+    where an action is a movement or a manipulation rather than an API
+    call.
+
+The protocol's State Verifiability runtime, the dual-proof post-quantum
+profile, and the migration story from classical to dual-proof to pure-PQ
+each merit follow-up papers; outlines are in preparation.
+
+# Conclusion {#sec:conclusion}
+
+We have presented the Vouch Protocol, an open standard for cryptographic
+identity and continuous state verifiability of autonomous AI agents. The
+protocol composes Verifiable Credentials, Decentralized Identifiers,
+Data Integrity proofs, and post-quantum cryptosuites with two novel
+layers: an Identity Sidecar pattern that isolates the agent's key from
+the LLM and bounds the agent's capabilities by an enforced allow-list,
+and a State Verifiability layer that renews trust continuously via
+heartbeat, decays trust exponentially in the interval, attests behaviour
+cryptographically, and detects silent failure through canary
+commit/reveal chains.
+
+A single Rust core (`vouch-core`), exposed to seven language SDKs
+through WebAssembly and UniFFI bindings, makes credentials
+byte-identical across languages by construction. The protocol is open
+under Apache 2.0; sixty defensive disclosures keep the design space open
+under CC0.
+
+The accountability gap in agent identity is solvable today. The
+cryptographic primitives are sound, the standards exist, and the
+implementation effort is bounded. Vouch is one realization of a path the
+open agent-identity ecosystem will increasingly need: from "the bearer
+has access" to "this specific agent issued this specific intent under
+this specific authorization chain, verifiable in seconds, with
+cryptography rather than logbook evidence."
+
+# Acknowledgements {#acknowledgements .unnumbered}
+
+The author thanks Manu Sporny and the W3C Verifiable Credentials Working
+Group for foundational work on Verifiable Credentials, Data Integrity,
+and the eddsa-jcs-2022 cryptosuite; the W3C Credentials Community Group
+for hosting and reviewing the incubation; the IETF JOSE working group
+for ongoing work on PQ/T composite signatures; the C2PA technical
+committee for content-provenance complementarity; and the open-source
+community of contributors and reviewers whose feedback shaped many of
+the choices documented here.
+
+# Reference Implementations
+
+- **Python**: `pip install vouch-protocol`. Source:
+  <https://github.com/vouch-protocol/vouch/tree/main/vouch/>
+
+- **TypeScript**: `npm install @vouch-protocol/core`. Source:
+  <https://github.com/vouch-protocol/vouch/tree/main/packages/sdk-ts/>
+
+- **Go**: install with `go install` from
+  [github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar](github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar){.uri}.
+  Source:
+  <https://github.com/vouch-protocol/vouch/tree/main/go-sidecar/>
+
+- **Rust core and further SDKs**: the `vouch-core` crate is under
+  <https://github.com/vouch-protocol/vouch/tree/main/core/>; SDKs for
+  C++, .NET, JVM, and Swift are under
+  <https://github.com/vouch-protocol/vouch/tree/main/sdks/>.
+
+# Test Vectors
+
+All test vectors are at
+<https://github.com/vouch-protocol/vouch/tree/main/test-vectors/>.
+
+# Specification Document
+
+The full Vouch Protocol Specification, currently Spec v0.1-draft in W3C
+Credentials Community Group incubation, is at
+<https://github.com/vouch-protocol/vouch/blob/main/docs/specs/w3c-cg-report.md>.
+
+::::::::::::::::::::::::: {#refs .references .csl-bib-body .hanging-indent}
+::: {#ref-c2pa14 .csl-entry}
+Coalition for Content Provenance and Authenticity. 2024. *C2PA Technical
+Specification 1.4*.
+<https://c2pa.org/specifications/specifications/1.4/index.html>.
+:::
+
+::: {#ref-db-mldsa44 .csl-entry}
+Digital Bazaar, Inc. 2026. *Mldsa44-Rdfc-2024-Cryptosuite: ML-DSA-44
+Data Integrity Cryptosuite (RDFC Canonicalization)*.
+<https://github.com/digitalbazaar/mldsa44-rdfc-2024-cryptosuite>.
+:::
+
+::: {#ref-aarm2026 .csl-entry}
+Errico, Herman. 2026. *Autonomous Action Runtime Management (AARM): A
+System Specification for Securing AI-Driven Actions at Runtime*.
+<https://arxiv.org/abs/2602.09433>.
+:::
+
+::: {#ref-faramesh2026 .csl-entry}
+Fatmi, Amjad. 2026. *Faramesh: A Protocol-Agnostic Execution Control
+Plane for Autonomous Agent Systems*. <https://arxiv.org/abs/2601.17744>.
+:::
+
+::: {#ref-pad001 .csl-entry}
+Gaddam, Ramprasad Anandam. 2025. *Cryptographic Binding of AI Agent
+Identity*.
+<https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-001-cryptographic-agent-identity.md>.
+:::
+
+::: {#ref-pad016 .csl-entry}
+Gaddam, Ramprasad Anandam. 2026a. *Continuous Trust Maintenance via
+Dynamic Credential Renewal (the Heartbeat Protocol)*.
+<https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-016-dynamic-credential-renewal.md>.
+:::
+
+::: {#ref-pad039 .csl-entry}
+Gaddam, Ramprasad Anandam. 2026b. *Cross-Implementation Deterministic
+Multi-Party Trust State via JCS-Canonicalized Verifiable Credentials*.
+<https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-039-jcs-deterministic-multi-party-trust-state.md>.
+:::
+
+::: {#ref-pad002 .csl-entry}
+Gaddam, Ramprasad Anandam. 2026c. *Cryptographic Binding of AI Agent
+Intent via Recursive Delegation (Chain of Custody)*.
+<https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-002-chain-of-custody.md>.
+:::
+
+::: {#ref-pad017 .csl-entry}
+Gaddam, Ramprasad Anandam. 2026d. *Cryptographic Proof of Reasoning with
+Adaptive Commitment Depth*.
+<https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-017-cryptographic-proof-of-reasoning.md>.
+:::
+
+::: {#ref-pad045 .csl-entry}
+Gaddam, Ramprasad Anandam. 2026e. *Proof of Non-Hallucination via
+Cryptographic Retrieval Anchoring*.
+<https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-045-proof-of-non-hallucination-retrieval-anchoring.md>.
+:::
+
+::: {#ref-rfc6749 .csl-entry}
+Hardt, D. 2012. *The OAuth 2.0 Authorization Framework*. RFC 6749.
+Internet Engineering Task Force.
+<https://datatracker.ietf.org/doc/html/rfc6749>.
+:::
+
+::: {#ref-rfc6962 .csl-entry}
+Laurie, B., A. Langley, and E. Kasper. 2013. *Certificate Transparency*.
+RFC 6962. Internet Engineering Task Force.
+<https://datatracker.ietf.org/doc/html/rfc6962>.
+:::
+
+::: {#ref-righttoact2026 .csl-entry}
+Lavi, Gadi. 2026. *Right-to-Act: A Pre-Execution Non-Compensatory
+Decision Protocol for AI Systems*. <https://arxiv.org/abs/2604.24153>.
+:::
+
+::: {#ref-rfc9700 .csl-entry}
+Lodderstedt, T., J. Bradley, A. Labunets, and D. Fett. 2025. *OAuth 2.0
+Security Best Current Practice*. RFC 9700. Internet Engineering Task
+Force. <https://datatracker.ietf.org/doc/html/rfc9700>.
+:::
+
+::: {#ref-nistfips204 .csl-entry}
+National Institute of Standards and Technology. 2024.
+*Module-Lattice-Based Digital Signature Standard*. FIPS 204. U.S.
+Department of Commerce. <https://csrc.nist.gov/pubs/fips/204/final>.
+:::
+
+::: {#ref-forge2026 .csl-entry}
+Palumbo, Nils, Sarthak Choudhary, Jihye Choi, Guy Amir, Prasad
+Chalasani, and Somesh Jha. 2026. *Formal Policy Enforcement for
+Real-World Agentic Systems*. <https://arxiv.org/abs/2602.16708>.
+:::
+
+::: {#ref-strong2018spiffe .csl-entry}
+Strong, J., and SPIFFE Project. 2018. *SPIFFE: Universal Workload
+Identity*. Linux Foundation. <https://spiffe.io/>.
+:::
+
+::: {#ref-oap2026 .csl-entry}
+Uchibeke, Uchi. 2026. *Before the Tool Call: Deterministic Pre-Action
+Authorization for Autonomous AI Agents*.
+<https://arxiv.org/abs/2603.20953>.
+:::
+
+::: {#ref-zcapld .csl-entry}
+W3C Credentials Community Group. 2024. *Authorization Capabilities for
+Linked Data V0.3 (ZCAP-LD)*. <https://w3c-ccg.github.io/zcap-spec/>.
+:::
+
+::: {#ref-w3cdidcore .csl-entry}
+World Wide Web Consortium. 2022. *Decentralized Identifiers (DIDs)
+V1.0*. W3C Recommendation. <https://www.w3.org/TR/did-core/>.
+:::
+
+::: {#ref-w3cbsl .csl-entry}
+World Wide Web Consortium. 2024a. *Bitstring Status List V1.0*. W3C
+Candidate Recommendation.
+<https://www.w3.org/TR/vc-bitstring-status-list/>.
+:::
+
+::: {#ref-w3cvcdm2 .csl-entry}
+World Wide Web Consortium. 2024b. *Verifiable Credentials Data Model
+V2.0*. W3C Candidate Recommendation.
+<https://www.w3.org/TR/vc-data-model-2.0/>.
+:::
+:::::::::::::::::::::::::

--- a/papers/paper-1-vouch-protocol/paper-1-vouch-protocol.tex
+++ b/papers/paper-1-vouch-protocol/paper-1-vouch-protocol.tex
@@ -9,6 +9,8 @@
 \usepackage{authblk}
 \usepackage{abstract}
 \usepackage{amsmath,amssymb}
+\usepackage{tikz}
+\usetikzlibrary{positioning, arrows.meta, shapes.geometric, fit, backgrounds, calc}
 \usepackage{booktabs}
 \usepackage{tabularx}
 \usepackage{enumitem}
@@ -89,7 +91,7 @@
 \texttt{ram@vouch-protocol.com} \\
 \url{https://github.com/vouch-protocol/vouch}}
 \date{Version v0.1 \quad May 2026 \\
-\emph{Licensed under CC BY 4.0} \\[4pt]
+\emph{This paper is released under CC BY 4.0; the reference implementations under Apache 2.0; the defensive disclosures under CC0.} \\[4pt]
 \small Vouch-signed by Vouch Protocol: \url{https://vch.sh/arxiv-1}}
 
 % ====================================================================
@@ -100,18 +102,20 @@
 \begin{abstract}
 Autonomous AI agents now make decisions that matter: they move money, submit regulated filings, read clinical records, commit code. The credentials those agents use to do this (API keys, OAuth bearer tokens, shared service accounts) were designed for a human clicking through a session. They prove access. They do not prove who authorized that action, what the agent intends to do, or whether the agent is still trustworthy by the time it acts.
 
-We present the \textbf{Vouch Protocol}: an open specification and a reference implementation in Python, TypeScript, and Go for cryptographically identifying autonomous AI agents and binding every action they take to a signed Verifiable Credential. Each credential carries the agent's identity, the specific intent (action, target, resource), the delegation chain from the original human principal down to the agent, and a freshness window after which the credential stops being valid.
+We present the \textbf{Vouch Protocol}: an open specification with a byte-exact Rust core and software development kits in seven languages (Python, TypeScript, Go, C++, .NET, JVM, and Swift) for cryptographically identifying autonomous AI agents and binding every action they take to a signed Verifiable Credential. Each credential carries the agent's identity, the specific intent (action, target, resource), the delegation chain from the original human principal down to the agent, and a freshness window after which the credential stops being valid.
 
 Per-action signing is necessary but not sufficient. Once an agent has been admitted, the next question is whether it is still behaving correctly \emph{right now}, after we let it through the door. The protocol's \emph{State Verifiability layer} answers that with four mechanisms: (1) trust entropy decay, where credential trust falls exponentially over time and must be renewed before consequential actions; (2) behavioral attestation digests, lightweight per-interval summaries of the agent's API calls, resources accessed, and intent drift; (3) canary commit/reveal chains, providing cryptographic detection of silent agent failure or substitution; and (4) $M$-of-$N$ validator quorum, distributing trust evaluation across role-specialized validators (policy, behavior, budget).
 
-The protocol is built on W3C Verifiable Credentials Data Model 2.0 with Data Integrity proofs: the \texttt{eddsa-jcs-2022} cryptosuite, which signs Ed25519 over RFC 8785 JCS-canonicalized payloads. For the post-quantum transition, the protocol defines a \emph{dual-proof profile} in which a credential carries two independent Data Integrity proofs on the same JCS-canonicalized bytes: one \texttt{eddsa-jcs-2022} proof (classical Ed25519) and one \texttt{mldsa44-jcs-2026} proof (ML-DSA-44, FIPS 204). Verifiers can downgrade gracefully, and the wire format requires no Vouch-specific composite cryptosuite identifier.
+A cluster of recent systems enforces \emph{pre-action authorization}: they intercept an agent's tool call and evaluate it against a declarative policy before execution~\cite{oap2026,faramesh2026,aarm2026,righttoact2026,forge2026}. Vouch addresses the complementary and broader problem. Rather than checking an action against a finite authored allow-list, it verifies the action against the principal's cryptographically signed \emph{intent}, traced through a delegation chain to the root human author, which covers the open-ended space of legitimate actions that a finite policy cannot enumerate. Because the credential format is standards-native (W3C Verifiable Credentials secured by Data Integrity, the \texttt{eddsa-jcs-2022} cryptosuite), any conforming verifier can consume it, and the protocol extends verification with a correctness layer (reasoning-faithfulness and retrieval-grounding) that policy enforcement alone does not provide.
 
-This paper covers the credential format, the Identity Sidecar pattern that isolates an agent's signing key from the LLM process, delegation-chain construction with resource narrowing and depth-limited validation, the BitstringStatusList revocation mechanism, the Heartbeat Protocol's renewal cycle, the dual-proof post-quantum profile and its same-canonical-bytes property, and the State Verifiability runtime. We then work through the adversarial cases that motivated the design (prompt injection, key exfiltration, replay across resources, post-quantum cryptographic obsolescence) and what the protocol does about each. Cross-language test vectors show that three independent implementations produce byte-identical credentials.
+The protocol is built on W3C Verifiable Credentials Data Model 2.0 with Data Integrity proofs: the \texttt{eddsa-jcs-2022} cryptosuite, which signs Ed25519 over RFC 8785 JCS-canonicalized payloads. For the post-quantum transition, the protocol defines a \emph{dual-proof profile} in which a credential carries two independent Data Integrity proofs over the same JCS-canonicalized credential body: one \texttt{eddsa-jcs-2022} proof (classical Ed25519) and one \texttt{mldsa44-jcs-2024} proof (ML-DSA-44, FIPS 204). Verifiers can downgrade gracefully, and the wire format requires no Vouch-specific composite cryptosuite identifier.
 
-The implementation is open-source under Apache 2.0. Sixty defensive prior-art disclosures accompany the specification under CC0 to keep design innovations openly available.
+This paper covers the credential format, the Identity Sidecar pattern that isolates an agent's signing key from the LLM process, delegation-chain construction with resource narrowing and capability attenuation, the BitstringStatusList revocation mechanism, the Heartbeat Protocol's renewal cycle, the dual-proof post-quantum profile and its shared-canonical-document construction, and the State Verifiability runtime. We then work through the adversarial cases that motivated the design (prompt injection, key exfiltration, replay across resources, post-quantum cryptographic obsolescence) and what the protocol does about each. Because all seven language SDKs bind to a single Rust core, credentials produced through any SDK are byte-identical, and a published RFC 8785 JCS test-vector battery verifies this on every release.
+
+The implementation is open-source under Apache 2.0. More than 120 defensive prior-art disclosures accompany the specification under CC0 to keep design innovations openly available.
 
 \smallskip
-\noindent\textbf{Index Terms:} AI agent identity, Verifiable Credentials, decentralized identifiers, post-quantum cryptography, dual-proof signatures, JCS canonicalization, prompt injection, delegation, continuous attestation, behavioral provenance.
+\noindent\textbf{Index Terms:} AI agent identity, Verifiable Credentials, decentralized identifiers, intent-bound authorization, pre-action authorization, reasoning faithfulness, retrieval grounding, post-quantum cryptography, dual-proof signatures, JCS canonicalization, prompt injection, delegation, continuous attestation, behavioral provenance.
 \end{abstract}
 
 % ====================================================================
@@ -136,14 +140,16 @@ The accountability gap has three structural sources:
 The Vouch Protocol addresses these failures with three composing layers:
 
 \begin{enumerate}[label=\textbf{\arabic*.},leftmargin=*]
-\item A \textbf{credential layer} in which every agent action is issued as a W3C Verifiable Credential signed by the agent's Decentralized Identifier (DID) via a Data Integrity proof. The credential's \verb|credentialSubject.intent| field carries the action verb, the target identifier, and the resource URI bound together. The credential's \verb|validUntil| is short (commonly 5 minutes). The proof is \texttt{eddsa-jcs-2022} over the JCS-canonicalized credential bytes, optionally paired with a second \texttt{mldsa44-jcs-2026} proof on the same credential for the dual-proof post-quantum profile.
+\item A \textbf{credential layer} in which every agent action is issued as a W3C Verifiable Credential signed by the agent's Decentralized Identifier (DID) via a Data Integrity proof. The credential's \verb|credentialSubject.intent| field carries the action verb, the target identifier, and the resource URI bound together. The credential's \verb|validUntil| is short (commonly 5 minutes). The proof is \texttt{eddsa-jcs-2022} over the JCS-canonicalized credential bytes, optionally paired with a second \texttt{mldsa44-jcs-2024} proof on the same credential for the dual-proof post-quantum profile.
 
-\item A \textbf{delegation layer} in which credentials chain together, each link cryptographically attesting to a principal-to-sub-principal authorization. Resource scope must narrow at each link; chain depth is bounded; the root principal is verifiable. Multi-agent systems gain end-to-end attribution: ``the patient authorized the clinician, who authorized their EHR agent, who authorized the prior-auth sub-agent, who submitted this credential'' is a single auditable chain.
+\item A \textbf{delegation layer} in which credentials chain together, each link cryptographically attesting to a principal-to-sub-principal authorization. Each delegated capability must be a proper subset of its parent, so authority strictly narrows at each hop (capability attenuation); the root principal is verifiable. Multi-agent systems gain end-to-end attribution: ``the patient authorized the clinician, who authorized their EHR agent, who authorized the prior-auth sub-agent, who submitted this credential'' is a single auditable chain.
 
 \item A \textbf{state verifiability layer} in which long-running agents renew their credentials on a heartbeat schedule. Trust decays exponentially over time; behavioral attestation digests are computed per interval; canary commit/reveal chains detect silent failures; an $M$-of-$N$ validator quorum distributes trust evaluation across role-specialized policy / behavior / budget validators. An agent that cannot heartbeat, because it crashed, is compromised, or has drifted out of policy, loses authority by entropy decay; a missed heartbeat is cryptographically detectable.
 \end{enumerate}
 
 Together, the three layers move from ``the agent had a key'' to ``the agent issued a signed credential at time $T$, declaring action $A$ on resource $R$, with the authorization of principals $P_1 \to P_2 \to P_n$, verifiable against the agent's published DID Document and the issuer's revocation registry, with a freshness window of 300 seconds and a running behavioral attestation showing the agent is operating within its declared scope.''
+
+The protocol's central claim is one of \emph{intent verification} rather than \emph{policy authorization}. A recent and active line of work intercepts an agent's tool call and checks it against an authored declarative policy before execution~\cite{oap2026,faramesh2026,aarm2026,righttoact2026,forge2026}. A declarative policy is a finite allow-list and can admit only the actions its author anticipated; the space of legitimate actions an agent may need to take for a principal is open-ended. Vouch instead verifies each action against the principal's cryptographically signed intent, carried down a delegation chain to the root human author (\S\ref{sec:delegation}), and adds a correctness layer that checks reasoning-faithfulness~\cite{pad017} and retrieval-grounding~\cite{pad045}. The two approaches compose: a policy gate can bound capability type while Vouch establishes identity, intent, and correctness for each admitted action. \S\ref{sec:related} develops this positioning against the specific systems in that cluster.
 
 \subsection{Design Goals}
 
@@ -152,8 +158,8 @@ Six design goals shaped the protocol:
 \begin{itemize}[leftmargin=*]
 \item \textbf{Standards alignment over invention.} Where existing open standards suffice (W3C VC 2.0, Data Integrity, DIDs, BitstringStatusList, RFC 8785 JCS, NIST FIPS 204), the protocol composes with them and does not introduce new primitives.
 \item \textbf{LLM-isolated key material.} The agent's private signing key must never appear in the LLM's context window. The Identity Sidecar pattern isolates the key in a separate process that the LLM cannot reach.
-\item \textbf{Byte-identical canonicalization across languages.} Credentials signed by the Python SDK must verify against credentials signed by the TypeScript or Go SDK with the same input. JCS (RFC 8785) is the canonical form.
-\item \textbf{Cryptographic agility.} The protocol must accommodate the post-quantum transition without changing the canonical payload format. The dual-proof profile attaches two independent Data Integrity proofs on the same JCS-canonicalized bytes; verifiers select the trust level they require.
+\item \textbf{Byte-identical canonicalization across languages.} All seven language SDKs bind to a single Rust core (\texttt{vouch-core}); a credential produced through any SDK verifies against any other. JCS (RFC 8785) is the canonical form~\cite{pad039}.
+\item \textbf{Cryptographic agility.} The protocol must accommodate the post-quantum transition without changing the canonical payload format. The dual-proof profile attaches two independent Data Integrity proofs over the same JCS-canonicalized credential body; verifiers select the trust level they require.
 \item \textbf{Continuous verifiability, not point-in-time authentication.} Trust must be renewed under observation; an agent that goes silent must lose authority automatically.
 \item \textbf{Open prior art.} Every novel design pattern is published as a defensive disclosure (Apache 2.0 code, CC0 disclosure) to keep the design space open.
 \end{itemize}
@@ -165,11 +171,12 @@ This paper contributes:
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item The Vouch Credential format and its Data Integrity proof construction (\texttt{eddsa-jcs-2022}).
 \item The Identity Sidecar pattern with intent allow-list enforcement at the sidecar layer, defended against prompt injection by construction.
-\item The delegation chain mechanism with resource narrowing, depth-limit, and trusted-principal anchoring.
+\item The delegation chain mechanism with capability attenuation (proper-subset narrowing), verifier-side cost budgets, and trusted-principal anchoring.
 \item The BitstringStatusList integration for per-credential revocation, plus DID-level revocation for issuer-key compromise.
-\item The dual-proof post-quantum profile, in which a credential carries two independent Data Integrity proofs (\texttt{eddsa-jcs-2022} and \texttt{mldsa44-jcs-2026}) on the same JCS-canonicalized bytes.
+\item The dual-proof post-quantum profile, in which a credential carries two independent Data Integrity proofs (\texttt{eddsa-jcs-2022} and \texttt{mldsa44-jcs-2024}) over the same JCS-canonicalized credential body.
 \item The State Verifiability runtime: trust entropy decay, behavioral attestation digests, canary commit/reveal chains, $M$-of-$N$ validator quorum.
-\item Cross-language test vectors and three reference implementations (Python, TypeScript, Go).
+\item A byte-exact Rust core (\texttt{vouch-core}) with SDKs in seven languages (Python, TypeScript, Go, C++, .NET, JVM, Swift) that produce byte-identical credentials, backed by a published cross-language JCS test-vector battery~\cite{pad039}.
+\item A positioning of intent verification as distinct from, and broader than, policy-based pre-action authorization, extended with a correctness layer (reasoning-faithfulness~\cite{pad017}, retrieval-grounding~\cite{pad045}) absent from that body of work.
 \end{enumerate}
 
 \subsection{Paper Organization}
@@ -216,7 +223,16 @@ The Coalition for Content Provenance and Authenticity (C2PA) defines content-bin
 
 \subsection{Post-Quantum Signature Migration Frameworks}
 
-NIST's selection of ML-DSA-44 (FIPS 204) and SLH-DSA (FIPS 205) as standardized post-quantum digital signature algorithms~\cite{nistfips204} creates the migration pressure Vouch addresses. The IETF's \emph{draft-ietf-jose-pq-composite-sigs} defines composite signatures for JOSE; the W3C Data Integrity community has parallel work in progress, including Digital Bazaar's \texttt{mldsa44-rdfc-2024-cryptosuite} family~\cite{db-mldsa44} and an upcoming JCS variant. Vouch's \emph{dual-proof profile} is a Data-Integrity-native realization that avoids inventing a composite cryptosuite identifier: a single Vouch credential carries two independent Data Integrity proofs in its \verb|proof| array, one \texttt{eddsa-jcs-2022} proof and one \texttt{mldsa44-jcs-2026} proof, both computed over the same JCS canonical credential bytes. Verifiers in classical-only mode validate the \texttt{eddsa-jcs-2022} proof and ignore the rest; verifiers in PQ-aware mode validate the \texttt{mldsa44-jcs-2026} proof; verifiers in both-required mode iterate the proof array and accept only when every proof verifies.
+NIST's selection of ML-DSA-44 (FIPS 204) and SLH-DSA (FIPS 205) as standardized post-quantum digital signature algorithms~\cite{nistfips204} creates the migration pressure Vouch addresses. The IETF's \emph{draft-ietf-jose-pq-composite-sigs} defines composite signatures for JOSE; the W3C Data Integrity community has parallel work in progress, including Digital Bazaar's \texttt{mldsa44-rdfc-2024-cryptosuite} family~\cite{db-mldsa44} and an upcoming JCS variant. Vouch's \emph{dual-proof profile} is a Data-Integrity-native realization that avoids inventing a composite cryptosuite identifier: a single Vouch credential carries two independent Data Integrity proofs in its \verb|proof| array, one \texttt{eddsa-jcs-2022} proof and one \texttt{mldsa44-jcs-2024} proof, both computed over the same JCS-canonicalized credential body, each with its own proof configuration. Verifiers in classical-only mode validate the \texttt{eddsa-jcs-2022} proof and ignore the rest; verifiers in PQ-aware mode validate the \texttt{mldsa44-jcs-2024} proof; verifiers in both-required mode iterate the proof array and accept only when every proof verifies.
+
+\subsection{Pre-Action Authorization Systems}
+\label{sec:related-preaction}
+
+A cluster of systems published between January and April 2026 establishes \emph{pre-action authorization} as a distinct primitive for agent safety. Uchibeke's Open Agent Passport intercepts an agent's tool calls and evaluates them against a declarative policy before execution, emitting a signed audit record for each decision~\cite{oap2026}. Faramesh places a mandatory, transport-independent authorization checkpoint ahead of any action that changes external state, standardizing actions into a canonical representation and returning permit, defer, or deny artifacts that executors must honor~\cite{faramesh2026}. AARM specifies a runtime that intercepts actions, evaluates them against policy and intent alignment, and maintains tamper-evident records, with a threat taxonomy covering prompt injection and confused-deputy attacks~\cite{aarm2026}. Right-to-Act formalizes a pre-execution admissibility boundary in which any unmet required condition halts or defers execution, separating compensatory from non-compensatory decision regimes~\cite{righttoact2026}. FORGE compiles declarative policies, written in a Datalog-derived language over abstract predicates, into a reference monitor that enforces them at each agent decision point~\cite{forge2026}.
+
+These systems share an architecture: an enforcement point admits or denies an action against an authored policy. They differ from Vouch in three respects that this paper treats as the central distinction. First, they are \emph{policy-bound}: the admission decision is made against a finite, declaratively authored rule set, which can only cover the actions an author anticipated. Vouch is \emph{intent-bound}: the decision is made against the principal's cryptographically signed intent, traced through a delegation chain to the root human author (\S\ref{sec:delegation}), covering the open-ended space of legitimate actions a finite policy cannot enumerate. Second, none of these systems anchors its decision in a standards-defined credential; their audit records and decision artifacts are system-specific, whereas a Vouch credential is a W3C Verifiable Credential secured by Data Integrity (\S\ref{sec:credential}) that any conforming verifier can consume. Third, none adds a correctness layer: Vouch additionally verifies whether the agent's reasoning was faithful to the stated intent~\cite{pad017} and whether its outputs were grounded in retrieved evidence rather than confabulated~\cite{pad045}.
+
+The two approaches are complementary rather than competing. A deployment can run a pre-action policy gate and Vouch together: the policy gate bounds capability \emph{type}, and Vouch establishes who acted, under whose signed intent, with what delegated authority, and whether the action was reasoned faithfully. As a matter of record, the foundational primitives Vouch builds on were placed in the public domain as dated defensive disclosures contemporaneously with this cluster: the cryptographic binding of agent identity to signed intent in December 2025~\cite{pad001}, and the recursive, intent-bound delegation chain anchored to a root human author in January 2026~\cite{pad002}.
 
 % ====================================================================
 \section{The Vouch Credential}
@@ -272,28 +288,32 @@ The required fields beyond the VC 2.0 baseline:
 The default cryptosuite is \texttt{eddsa-jcs-2022} (W3C Data Integrity registered identifier). The signing procedure:
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
-\item Construct the credential dictionary with all required fields, including the \verb|proof| object except \verb|proofValue|.
-\item Canonicalize the entire credential using RFC 8785 JCS. JCS specifies a strict deterministic ordering, escaping, and number formatting; the output is byte-identical across conforming implementations.
-\item Compute the Ed25519 signature over the canonical bytes using the issuer's private key.
-\item Encode the signature in multibase base58btc form (the \texttt{z} prefix), producing approximately 88 characters.
-\item Set \verb|proof.proofValue| to the multibase-encoded signature.
+\item Construct the credential with all required fields, and separately construct the \emph{proof configuration}: the \verb|proof| object without \verb|proofValue|.
+\item Canonicalize the proof configuration and the credential body (the credential without its \verb|proof|) independently, each using RFC 8785 JCS. JCS specifies a strict deterministic ordering, escaping, and number formatting; the output is byte-identical across conforming implementations.
+\item Compute \verb|proofConfigHash|, the SHA-256 hash of the canonical proof configuration, and \verb|transformedDocumentHash|, the SHA-256 hash of the canonical credential body. Each is 32 bytes.
+\item Form \verb|hashData| by concatenating \verb|proofConfigHash| first and \verb|transformedDocumentHash| second, yielding 64 bytes.
+\item Compute the Ed25519 signature over \verb|hashData| using the issuer's private key.
+\item Encode the signature in multibase base58btc form (the \texttt{z} prefix), producing approximately 88 characters, and set \verb|proof.proofValue|.
 \end{enumerate}
 
 Verification reverses the process:
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
-\item Extract \verb|proof.proofValue|, decode from multibase base58btc.
-\item Reconstruct the credential dictionary excluding \verb|proof.proofValue| (other proof fields are part of the signed payload).
-\item JCS-canonicalize.
+\item Extract \verb|proof.proofValue| and decode it from multibase base58btc.
+\item Separate the proof configuration (the \verb|proof| object without \verb|proofValue|) from the credential body.
+\item JCS-canonicalize each independently and compute the SHA-256 hash of each.
+\item Reassemble \verb|hashData| as \verb|proofConfigHash| followed by \verb|transformedDocumentHash|.
 \item Resolve the issuer's DID Document, locate the verification method indicated by \verb|proof.verificationMethod|, extract the Ed25519 public key (encoded as Multikey in the DID Document).
-\item Verify the Ed25519 signature.
+\item Verify the Ed25519 signature over \verb|hashData|.
 \end{enumerate}
+
+\paragraph{Conformance note.} Earlier Vouch reference implementations computed a single SHA-256 digest over the JCS canonicalization of the credential with its unsigned proof merged in, and signed those 32 bytes. That is a different function of the same inputs, and a credential carrying such a proof is not verifiable by a conforming \texttt{eddsa-jcs-2022} implementation even though it declares that cryptosuite identifier. The two-hash construction above is the normative one, and the reference implementations are being corrected to it. Because Vouch has no external deployments relying on the earlier bytes, the correction is a direct replacement rather than a compatibility-preserving migration.
 
 \subsection{JCS Determinism Across Languages}
 
-JSON Canonicalization Scheme (RFC 8785) fixes the serialization that Ed25519 signs. The protocol's three reference implementations (Python, TypeScript, Go) produce byte-identical JCS output given byte-identical inputs. Cross-language test vectors verify the property on every release.
+JSON Canonicalization Scheme (RFC 8785) fixes the serialization that Ed25519 signs. Rather than maintaining several independent implementations in sync, the protocol exposes a single Rust core (\texttt{vouch-core}) to seven languages (Python, TypeScript, Go, C++, .NET, JVM, Swift) through WebAssembly and UniFFI bindings, so byte-identical JCS output is a property of the shared core rather than of cross-implementation discipline. A published JCS test-vector battery~\cite{pad039} pins the canonical form, and any conforming binding must reproduce it.
 
-The byte-identity property is foundational: without it, a credential signed by Python and a credential with the same logical content signed by TypeScript would have different signatures, breaking interoperability and federation across implementations.
+The byte-identity property is foundational: without it, a credential produced through one SDK and a credential with the same logical content produced through another would have different signatures, breaking interoperability and federation across languages.
 
 \subsection{Intent Replay Resistance}
 
@@ -319,7 +339,7 @@ Direct key exposure to the LLM is incompatible with the protocol's security mode
 
 \subsection{Architecture}
 
-The Identity Sidecar pattern separates the agent into two processes:
+The Identity Sidecar pattern separates the agent into two processes (Figure~\ref{fig:sidecar}):
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item \textbf{The Brain (stochastic).} The LLM. Holds zero cryptographic secrets. Reasons about which action to take and proposes intents to the Sidecar.
@@ -327,6 +347,33 @@ The Identity Sidecar pattern separates the agent into two processes:
 \end{enumerate}
 
 The Brain and the Passport communicate over a local IPC channel: typically localhost HTTP, a UNIX domain socket, or an MCP transport. The IPC boundary is the trust boundary.
+
+\begin{figure}[h]
+\centering
+\begin{tikzpicture}[
+    box/.style={draw, thick, minimum width=2.8cm, minimum height=1.9cm, align=center, font=\small},
+    brain/.style={box, fill=red!5, draw=red!50!black},
+    passport/.style={box, fill=teal!5, draw=teal!60!black},
+    resource/.style={draw, thick, fill=gray!5, minimum width=2.6cm, minimum height=1.9cm, align=center, font=\small},
+    arr/.style={-{Stealth[length=2.2mm]}, thick},
+    boundary/.style={draw, dashed, thick, gray!60!black, rounded corners=3pt, inner sep=12pt},
+    lbl/.style={font=\footnotesize\itshape, text=gray!60!black, align=center},
+    annot/.style={font=\scriptsize\ttfamily, fill=white, inner sep=2pt}
+]
+\node[brain] (brain) at (0, 0) {\textbf{Brain}\\(LLM)\\[2pt]\footnotesize stochastic\\\footnotesize \emph{no keys}};
+\node[passport, right=3.3cm of brain] (passport) {\textbf{Passport}\\(Sidecar)\\[2pt]\footnotesize deterministic\\\footnotesize \emph{holds keys}};
+\begin{scope}[on background layer]
+  \node[boundary, fit=(brain) (passport), label={[lbl,anchor=south]above:trust boundary $=$ IPC channel}] {};
+\end{scope}
+\draw[arr] ($(brain.east) + (0, 0.45)$) -- node[annot, above]{intent proposal} ($(passport.west) + (0, 0.45)$);
+\draw[arr] ($(passport.west) + (0, -0.45)$) -- node[annot, below]{signed VC or rejection} ($(brain.east) + (0, -0.45)$);
+\node[resource, right=2.3cm of passport] (rs) {Resource\\server\\(Verifier)};
+\draw[arr] (brain.south) ++ (0, -0.1) -- ++(0, -1.2) coordinate (b1) -| node[annot, pos=0.25, below]{VC + request} (rs.south);
+\node[lbl, below=1.4cm of passport] {policy: structural $+$ allow-list $+$ rate limit};
+\end{tikzpicture}
+\caption{Identity Sidecar pattern. The Brain (LLM) holds no cryptographic secrets and proposes intents over a local IPC channel. The Passport applies a deterministic allow-list policy and signs only intents that pass. A compromised Brain cannot exceed the Passport's enforced scope.}
+\label{fig:sidecar}
+\end{figure}
 
 \subsection{Just-In-Time Signing Flow}
 
@@ -342,17 +389,19 @@ A signing operation proceeds:
 
 The Sidecar's policy check is the \emph{last line of defence} against a compromised Brain. A prompt-injected LLM may propose any intent it likes; the Sidecar refuses to sign anything outside the allow-list. The capability bound on a compromised Brain is therefore structural, not behavioural.
 
+It is worth distinguishing this allow-list from the declarative policies of the pre-action authorization systems discussed in \S\ref{sec:related-preaction}, because the resemblance is superficial. The Sidecar allow-list is a coarse bound on which \emph{classes} of action an agent may even propose: a defense-in-depth rail against a fully compromised model, not the mechanism that decides whether a given action is legitimate. Legitimacy in Vouch is established separately, by verifying each action against the principal's signed intent, its delegation chain to the human principal, and the correctness layer. In a policy-bound system the authored rule set \emph{is} the admission decision, so it can admit only what its author anticipated; in Vouch the allow-list only fences capability type, while the open-ended space of legitimate actions is covered by intent verification rather than by enumeration. A deployment may even omit the allow-list where the signed-intent and delegation checks suffice.
+
 \subsection{Reference Implementations and Tier Hierarchy}
 
-Three reference Sidecar implementations accompany the protocol:
+Three of the seven language SDKs additionally ship a signing sidecar daemon:
 
 \begin{itemize}[leftmargin=*]
-\item \textbf{Go} (\verb|go-sidecar/|): production-tier, KMS/HSM-backed, hybrid PQ supported, sensitive-mode JWE wrapping, multi-tenant.
-\item \textbf{Python} (\verb|vouch.sidecar.*|): lightweight tier for self-hosted Python stacks. File or environment keys. Intentionally omits KMS, hybrid PQ, JWE, and multi-tenancy.
+\item \textbf{Go} (\verb|go-sidecar/|): production-tier, KMS/HSM-backed, dual-proof PQ supported, sensitive-mode JWE wrapping, multi-tenant.
+\item \textbf{Python} (\verb|vouch.sidecar.*|): lightweight tier for self-hosted Python stacks. File or environment keys. Intentionally omits KMS, dual-proof PQ, JWE, and multi-tenancy.
 \item \textbf{TypeScript} (\verb|packages/sdk-ts/sidecar/|): lightweight tier for Node stacks. Same omissions as Python.
 \end{itemize}
 
-The HTTP wire contract is identical across all three. A shared contract test suite verifies that all three implementations accept and reject the same inputs and emit semantically equivalent credentials. The tier hierarchy is informative guidance: deployers requiring KMS, FIPS, hybrid PQ, or multi-tenancy run the Go sidecar; deployers with simpler requirements may run Python or TypeScript.
+The HTTP wire contract is identical across all three sidecars. A shared contract test suite verifies that the three sidecar implementations accept and reject the same inputs and emit semantically equivalent credentials. The tier hierarchy is informative guidance: deployers requiring KMS, FIPS, dual-proof PQ, or multi-tenancy run the Go sidecar; deployers with simpler requirements may run Python or TypeScript.
 
 % ====================================================================
 \section{Delegation Chains}
@@ -370,27 +419,54 @@ A delegation link is a Vouch credential whose \verb|credentialSubject| is shaped
 
 \begin{lstlisting}[language=json]
 {
-  "credentialSubject": {
-    "id": "did:web:research-agent.example.com",
-    "delegatedBy": "did:web:assistant.example.com",
-    "scope": {
-      "actions": ["web_search", "scrape_page"],
-      "resource": "https://research-agent.example.com/agents/research-agent/scope/2026"
-    },
-    "validUntil": "2026-05-14T08:00:00Z"
-  }
+  "issuer": "did:web:assistant.example.com",
+  "subject": "did:web:research-agent.example.com",
+  "intent": {
+    "action": "web_search",
+    "target": "topic:climate-2026",
+    "resource": "https://research-agent.example.com/agents/research-agent/scope/2026"
+  },
+  "validFrom": "2026-05-14T06:00:00Z",
+  "validUntil": "2026-05-14T08:00:00Z",
+  "proof": { "...DataIntegrityProof..." }
 }
 \end{lstlisting}
 
-The link's \verb|issuer| is the delegating principal. The link's \verb|credentialSubject.id| is the delegate. \verb|scope.actions| enumerates which actions are delegated; \verb|scope.resource| is the resource URI under which all delegated actions must fall.
+The link's \verb|issuer| is the delegating principal; \verb|subject| is the delegate. The \verb|intent| object (\verb|action|, \verb|target|, \verb|resource|) describes the authorized action and the resource URI under which it must fall; \verb|validFrom| and \verb|validUntil| bound the delegation in time. Each link is itself signed by its \verb|issuer|.
 
 \subsection{Chain Construction and the Resource Narrowing Rule}
 
-A chain is a list of delegation-link credentials, ordered from root principal to leaf agent. At each link, the child's \verb|scope.resource| MUST be a sub-URI of the parent's \verb|scope.resource|. The narrowing rule prevents capability widening at any link. A delegate cannot grant a sub-delegate more authority than it itself holds.
+A chain is a list of delegation-link credentials, ordered from root principal to leaf agent (Figure~\ref{fig:delegation}). At each link, the child's \verb|intent.resource| MUST be a sub-URI of, or equal to, the parent's \verb|intent.resource|. The narrowing rule prevents capability widening at any link: a delegate cannot grant a sub-delegate more authority than it itself holds.
 
-\subsection{Depth Limit}
+\begin{figure}[h]
+\centering
+\begin{tikzpicture}[
+    principal/.style={draw, thick, rounded corners=2pt, fill=teal!5, minimum width=2.6cm, minimum height=0.95cm, align=center, font=\small},
+    link/.style={font=\scriptsize\ttfamily, align=center, fill=white, inner sep=2pt},
+    arr/.style={-{Stealth[length=2.5mm]}, thick},
+    annot/.style={font=\footnotesize\itshape, text=gray!60!black, align=center}
+]
+\node[principal] (user)   at (0, 0)   {User\\\scriptsize did:web:alice};
+\node[principal] (asst)   at (3.4, 0) {Assistant\\\scriptsize did:web:asst};
+\node[principal] (res)    at (6.8, 0) {Research agent\\\scriptsize did:web:rsch};
+\node[principal] (leaf)   at (10.2, 0){Web scraper\\\scriptsize did:web:scrp};
+\draw[arr] (user)   -- node[link, above]{delegates}     (asst);
+\draw[arr] (asst)   -- node[link, above]{delegates}     (res);
+\draw[arr] (res)    -- node[link, above]{delegates}     (leaf);
+\node[annot, below=0.1cm of user]   {resource:\\\texttt{/*}};
+\node[annot, below=0.1cm of asst]   {\texttt{/research/*}};
+\node[annot, below=0.1cm of res]    {\texttt{/research/papers/*}};
+\node[annot, below=0.1cm of leaf]   {\texttt{/research/papers/x.pdf}};
+\draw[arr, dashed] (leaf.south) ++ (0, -1.15) -- node[link, right, xshift=2pt]{leaf intent + chain}+(0, -0.7);
+\node[principal, fill=gray!8, below=2.5cm of leaf, minimum width=3.2cm] (rs){Resource server\\\scriptsize (verifies whole chain)};
+\end{tikzpicture}
+\caption{Delegation chain. Each link records the parent's DID (\texttt{issuer}), the child's DID (\texttt{subject}), the intent handed down (action, target, resource), and a Data Integrity proof. The resource narrows at each link; a link that broadens its parent's resource triggers \texttt{resource\_not\_narrowed}. The resource server validates the whole chain on every request: signatures, capability attenuation, temporal bounds, and verifier-side budgets.}
+\label{fig:delegation}
+\end{figure}
 
-Chain depth is bounded to \textbf{five links maximum}. This limit prevents pathological chains from inflating verification cost and from obscuring the actual authorization path.
+\subsection{Capability Attenuation}
+
+Rather than capping the chain at a fixed number of links, each delegated capability MUST be a proper subset of its parent along at least one dimension (action, target, resource, time, rate, or policy) and broader along none. Authority therefore strictly narrows at every hop and cannot grow, which bounds the chain by construction: a link that fails to attenuate is rejected with \verb|capability_not_attenuated|. This rule replaces the earlier fixed depth limit, adopted following capability-security feedback from Alan Karp. Verification cost is bounded separately by verifier-side budgets (maximum depth, verification time, and cumulative time-to-live), which the verifier declares and enforces, returning \verb|verifier_budget_exceeded| when a chain exceeds them.
 
 \subsection{Chain Validation}
 
@@ -398,15 +474,15 @@ A verifier validating a leaf credential with an attached chain:
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item Verifies the leaf credential's signature.
-\item Identifies the chain root: the first link's \verb|issuer| MUST be in the verifier's set of trusted principals for the leaf action.
-\item For each adjacent pair (parent, child) in the chain, verifies the child's \verb|scope.resource| is a sub-URI of the parent's.
-\item Verifies each link's \verb|delegatedBy| matches the previous link's \verb|credentialSubject.id|.
-\item Verifies each link's signature.
-\item Verifies the leaf credential's \verb|intent.action| is in the deepest link's \verb|scope.actions|.
-\item Verifies the leaf credential's \verb|intent.resource| is a sub-URI of the deepest link's \verb|scope.resource|.
+\item Verifies the root link's \verb|issuer| is in the verifier's set of trusted principals for the leaf action.
+\item For each adjacent pair (parent, child), verifies the parent link's \verb|subject| equals the child link's \verb|issuer|.
+\item For each link, verifies its \verb|intent.resource| is a sub-URI of, or equal to, the parent link's \verb|intent.resource|.
+\item For each link, verifies its \verb|validFrom| and \verb|validUntil| fall within the parent link's temporal bounds.
+\item Verifies each link's Data Integrity proof.
+\item Verifies the leaf credential's \verb|intent.resource| is a sub-URI of the deepest link's \verb|intent.resource|.
 \end{enumerate}
 
-Any failure produces a structured rejection reason: \verb|untrusted_principal|, \verb|chain_depth_exceeded|, \verb|resource_not_narrowed|, \verb|link_signature_invalid|, \verb|parent_proof_mismatch|, or \verb|action_not_in_scope|.
+Any failure produces a structured rejection reason: \verb|untrusted_principal|, \verb|capability_not_attenuated|, \verb|resource_not_narrowed|, \verb|verifier_budget_exceeded|, \verb|temporal_bounds_exceeded|, \verb|subject_issuer_mismatch|, or \verb|link_signature_invalid|.
 
 % ====================================================================
 \section{Revocation}
@@ -443,7 +519,7 @@ The protocol's \verb|StatusListFetcher| caches the status list with a configurab
 
 NIST's selection of ML-DSA-44 (FIPS 204) as a standardized post-quantum digital signature~\cite{nistfips204} places a known cryptographic transition on the protocol's horizon. Ed25519 will not survive a sufficiently large fault-tolerant quantum computer. The transition window is uncertain but real, and credentials with multi-year audit retention requirements (regulated healthcare, financial settlement) cannot afford to be signed with an algorithm that will be broken before the retention window expires.
 
-The protocol's response is the \emph{dual-proof profile}: a credential carries two independent W3C Data Integrity proofs on the same JCS-canonicalized credential bytes, one \texttt{eddsa-jcs-2022} proof (classical Ed25519) and one \texttt{mldsa44-jcs-2026} proof (ML-DSA-44). The Data Integrity specification already defines the \verb|proof| field as an array, so the dual-proof construction is a natural use of existing primitives and requires no Vouch-specific composite cryptosuite identifier.
+The protocol's response is the \emph{dual-proof profile}: a credential carries two independent W3C Data Integrity proofs over the same JCS-canonicalized credential body, one \texttt{eddsa-jcs-2022} proof (classical Ed25519) and one \texttt{mldsa44-jcs-2024} proof (ML-DSA-44). The Data Integrity specification already defines the \verb|proof| field as an array, so the dual-proof construction is a natural use of existing primitives and requires no Vouch-specific composite cryptosuite identifier.
 
 \subsection{Construction}
 
@@ -460,15 +536,15 @@ The credential's \verb|proof| field is an array of two Data Integrity proof obje
   },
   {
     "type": "DataIntegrityProof",
-    "cryptosuite": "mldsa44-jcs-2026",
+    "cryptosuite": "mldsa44-jcs-2024",
     "verificationMethod": "...#key-mldsa44",
     "proofPurpose": "assertionMethod",
-    "proofValue": "z<base58btc(mldsa44_sig)>"
+    "proofValue": "u<base64url(mldsa44_sig)>"
   }
 ]
 \end{verbatim}
 
-Both proofs are computed over the same JCS-canonical credential bytes (the credential minus the \verb|proofValue| field of each proof, JCS-canonicalized). The same-canonical-bytes property is preserved by construction: both cryptosuites use JCS canonicalization on the same credential body. Each proof's \verb|proofValue| is independently multibase base58btc-encoded.
+Both proofs are anchored to the same canonical credential body: the credential is JCS-canonicalized and hashed once, and that \verb|transformedDocumentHash| is shared by both proofs. Each proof contributes its own \verb|proofConfigHash|, since the cryptosuite identifier and verification method differ between them, so the 64-byte \verb|hashData| each algorithm signs differs only in its leading 32 bytes.\footnote{Two conformant Data Integrity proofs on one credential cannot sign byte-identical input: each proof binds its own proof configuration (the cryptosuite identifier and verification method), which necessarily differs between the classical and post-quantum suites. What the two proofs share, and what matters, is the canonical document body. Identical-byte signing across suites is therefore neither possible nor required.} The two suites encode their signatures differently: the Ed25519 \verb|proofValue| uses multibase base58btc (the \texttt{z} prefix), while the ML-DSA-44 \verb|proofValue| uses multibase base64url (the \texttt{u} prefix), as the quantum-resistant cryptosuite specifies.
 
 The Ed25519 signature is exactly 64 bytes; the ML-DSA-44 signature is exactly 2,420 bytes. Each appears in its own proof object's \verb|proofValue| rather than being concatenated into a single field.
 
@@ -478,7 +554,7 @@ A verifier iterates the credential's \verb|proof| array and applies one of three
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item \textbf{Classical-only}: validate the \texttt{eddsa-jcs-2022} proof; ignore the rest. Useful when ML-DSA-44 libraries are unavailable or computationally expensive.
-\item \textbf{Post-quantum-only}: validate the \texttt{mldsa44-jcs-2026} proof. Useful when classical signatures are no longer trusted under the verifier's compliance regime.
+\item \textbf{Post-quantum-only}: validate the \texttt{mldsa44-jcs-2024} proof. Useful when classical signatures are no longer trusted under the verifier's compliance regime.
 \item \textbf{Both-required}: validate every proof in the array; reject if any one fails. The cautious mode, recommended for long-retention credentials.
 \end{enumerate}
 
@@ -495,7 +571,7 @@ A deployment migrates from classical to dual-proof in three steps:
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item \textbf{Adopt dual-proof signing}: the signer issues credentials with two proofs in the array. Existing classical-only verifiers continue working (they see a familiar \texttt{eddsa-jcs-2022} proof and ignore the second one they don't recognize).
 \item \textbf{Update verifiers}: deploy a verifier release that supports ML-DSA-44. Configure the verifier's mode (classical-only, PQ-only, or both-required) based on the deployment's risk tolerance.
-\item \textbf{Retire classical signing}: once all verifiers are PQ-aware, switch the signer to issue only the \texttt{mldsa44-jcs-2026} proof. The dual-proof profile is the migration vehicle, not the destination.
+\item \textbf{Retire classical signing}: once all verifiers are PQ-aware, switch the signer to issue only the \texttt{mldsa44-jcs-2024} proof. The dual-proof profile is the migration vehicle, not the destination.
 \end{enumerate}
 
 \subsection{Performance and Size}
@@ -519,7 +595,7 @@ The size delta matters for HTTP-header-conveyed credentials and for credentials 
 
 \subsection{Relationship to Concurrent Work}
 
-The dual-proof construction converges with Digital Bazaar's \texttt{mldsa44-rdfc-2024-cryptosuite} family~\cite{db-mldsa44}, which defines an ML-DSA-44 Data Integrity cryptosuite using RDFC canonicalization, and with that family's forthcoming JCS variant. The cryptosuite identifier \texttt{mldsa44-jcs-2026} used in this paper is provisional and is being aligned with that upstream registration. Earlier Vouch reference implementations (v1.6.x) emit a single composite cryptosuite (\texttt{hybrid-eddsa-mldsa44-jcs-2026}) with a concatenated \verb|proofValue|; this composite identifier is retained as a transitional alias for backward compatibility only, and new implementations emit the dual-proof form described above.
+The post-quantum proof uses \texttt{mldsa44-jcs-2024}, the ML-DSA-44 cryptosuite with JCS canonicalization defined in the W3C Quantum-Resistant Cryptosuites specification~\cite{w3cqr}. That specification declares itself experimental and not intended for production use, so a deployment should treat the post-quantum proof as a forward-looking migration vehicle rather than a production assurance; the classical proof carries the security of the credential today. Related work includes Digital Bazaar's \texttt{mldsa44-rdfc-2024-cryptosuite} family~\cite{db-mldsa44}, which defines an ML-DSA-44 cryptosuite over RDFC canonicalization rather than JCS. Earlier Vouch reference implementations (v1.6.x) emitted a single composite cryptosuite (\texttt{hybrid-eddsa-mldsa44-jcs-2026}) with a concatenated \verb|proofValue|; that identifier and its concatenated encoding are deprecated and removed, and current implementations emit the dual-proof form described above.
 
 % ====================================================================
 \section{The State Verifiability Layer}
@@ -533,7 +609,7 @@ A long-running agent without continuous attestation accumulates risk. The longer
 
 \subsection{The Heartbeat Protocol}
 
-The Heartbeat Protocol defines a periodic renewal cycle:
+The Heartbeat Protocol defines a periodic renewal cycle (Figure~\ref{fig:heartbeat}):
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item The agent's \verb|HeartbeatSession| records actions and behavioural signals during each interval.
@@ -544,7 +620,40 @@ The Heartbeat Protocol defines a periodic renewal cycle:
 \item On failure (broken canary, stale interval index, behavioural drift), no voucher is issued; the agent's existing voucher expires; the agent loses authority.
 \end{enumerate}
 
-The Heartbeat Protocol inverts the traditional PKI trust model from ``trusted until revoked'' to \emph{``untrusted until renewed.''}
+The Heartbeat Protocol inverts the traditional PKI trust model from ``trusted until revoked'' to \emph{``untrusted until renewed''}~\cite{pad016}.
+
+\begin{figure}[h]
+\centering
+\begin{tikzpicture}[
+    agentbox/.style={draw, thick, rounded corners=2pt, fill=teal!5, minimum width=2.8cm, minimum height=0.9cm, align=center, font=\small},
+    valbox/.style={draw, thick, rounded corners=2pt, fill=red!5, minimum width=2.8cm, minimum height=0.9cm, align=center, font=\small},
+    rsbox/.style={draw, thick, rounded corners=2pt, fill=gray!10, minimum width=2.8cm, minimum height=0.9cm, align=center, font=\small},
+    arr/.style={-{Stealth[length=2.2mm]}, thick},
+    msg/.style={font=\scriptsize\ttfamily, fill=white, inner sep=2pt},
+    annot/.style={font=\scriptsize\itshape, text=gray!55!black, align=left}
+]
+\node[agentbox] (a0) at (0, 0) {Agent};
+\node[valbox]   (v0) at (5, 0) {Validator};
+\node[rsbox]    (r0) at (10, 0){Resource server};
+\draw[gray!40, dashed] (a0.south) -- ++(0, -7.5);
+\draw[gray!40, dashed] (v0.south) -- ++(0, -7.5);
+\draw[gray!40, dashed] (r0.south) -- ++(0, -7.5);
+\node[annot, anchor=west] at (-1.8, -0.7) {$t_0$: voucher issued};
+\draw[arr] (a0.south |- 0, -1.1) -- node[msg, above]{action + VC + voucher} ($(r0.south) + (0, -1.1)$);
+\node[annot, anchor=west] at (10.4, -1.1) {trust $=$ initial};
+\node[annot, anchor=west, text=red!60!black] at (-1.8, -2.0) {$t_1$: decay $T(t)=T_0 e^{-\lambda(t-t_0)}$};
+\draw[arr] (a0.south |- 0, -3.0) -- node[msg, above]{HeartbeatRequest} ($(v0.south) + (0, -3.0)$);
+\node[annot, anchor=west] at (-1.8, -3.0) {$t_{h}$};
+\node[annot, anchor=west] at (5.4, -3.4) {digest, Merkle root,\\canary reveal/commit};
+\node[annot, anchor=west, fill=red!5, draw=red!50, rounded corners=2pt, inner sep=3pt] at (4.0, -4.5) {validator: schema, drift,\\canary, monotonicity};
+\draw[arr] ($(v0.south) + (0, -5.5)$) -- node[msg, above]{SessionVoucher (renewed)} ($(a0.south) + (0, -5.5)$);
+\node[annot, anchor=west] at (-1.8, -5.5) {trust $\leftarrow$ initial};
+\node[annot, anchor=west, text=red!70!black] at (-1.8, -6.6) {if validator refuses or heartbeat missed:};
+\node[annot, anchor=west, text=red!70!black] at (-1.0, -7.1) {voucher expires; trust $\to 0$; resource server denies subsequent actions.};
+\end{tikzpicture}
+\caption{Heartbeat lifecycle. Each interval the agent's voucher trust decays exponentially. At the heartbeat boundary the agent submits a digest, an action Merkle root, and a canary commit/reveal to the validator. A renewed voucher resets trust. A missed or rejected heartbeat lets the existing voucher expire, and trust drives below the action's threshold within seconds.}
+\label{fig:heartbeat}
+\end{figure}
 
 \subsection{Trust Entropy Decay}
 
@@ -554,12 +663,14 @@ Each SessionVoucher carries \texttt{initialTrust} and \texttt{decayLambda}. The 
 \textsf{trust}(t) = \textsf{initialTrust} \cdot e^{-\lambda (t - t_0)}
 \]
 
-Sensitive actions are gated by current trust. The protocol defines three reference thresholds:
+Sensitive actions are gated by current trust. The specification defines five reference thresholds by operation category:
 
 \begin{itemize}[leftmargin=*]
-\item \verb|TRUST_THRESHOLD_HIGH_STAKES = 0.9|: financial transfers, code deployment, regulated submissions.
-\item \verb|TRUST_THRESHOLD_MEDIUM_STAKES = 0.75|: PHI read, customer-data access.
-\item \verb|TRUST_THRESHOLD_LOW_STAKES = 0.5|: status queries, idle activity.
+\item Financial transaction: $\theta = 0.95$ (transfers, settlement, regulated submissions).
+\item API write: $\theta = 0.80$ (state-changing calls, code deployment).
+\item API read: $\theta = 0.50$ (PHI read, customer-data access, status queries).
+\item Health check: $\theta = 0.20$ (liveness, idle activity).
+\item Logging: $\theta = 0.05$ (telemetry, audit emission).
 \end{itemize}
 
 Heartbeat interval should be set to less than half the half-life so renewal stays ahead of decay. For $\lambda = 0.01$, half-life is approximately 69 seconds; a 30-second heartbeat is appropriate.
@@ -634,6 +745,8 @@ The protocol does \emph{not} assume:
 
 \noindent\textbf{Prompt injection causing unauthorized credential issuance.} The Sidecar's intent allow-list makes this attack class capability-bounded: the LLM may propose any intent it likes, but the Sidecar refuses to sign intents outside the deployment's allow-list.
 
+\noindent\textbf{Injected or untrustworthy intent.} A natural objection is that verifying an action against ``signed intent'' only relocates the trust problem upstream: what if the captured intent is itself a product of prompt injection? Vouch closes this in two places. First, intent is signed at the human-principal boundary before any agent processing. The root of every delegation chain is a credential signed by the human principal's key (\S\ref{sec:delegation}), establishing a chain of custody from the original authorization down to the acting agent~\cite{pad002}; an intent fabricated inside a compromised agent carries no valid root signature and fails chain validation. Second, the faithfulness of the agent's reasoning relative to that signed intent is itself verifiable: the reasoning trace is evidence-anchored and checked for causal consistency with the chosen action~\cite{pad017}, and outputs can be bound to retrieved evidence rather than confabulated~\cite{pad045}. Intent an agent invents for itself is therefore neither rooted in a principal's signature nor reconcilable with a faithful reasoning trace.
+
 \noindent\textbf{Replay across resources.} Each credential's \verb|intent.resource| is part of the signed payload. Replaying against a different resource invalidates the signature.
 
 \noindent\textbf{Delegation chain forgery.} Each link is a signed credential; forging a link requires possessing the delegating principal's key. Trusted-principal anchoring ensures the chain root is known to the verifier independently.
@@ -660,12 +773,12 @@ The protocol does \emph{not} assume:
 
 \subsection{Test Vectors}
 
-The protocol ships cross-language test vectors verifying that Python, TypeScript, and Go implementations produce byte-identical credentials given identical inputs:
+The protocol ships cross-language test vectors verifying that every language SDK, each bound to the shared Rust core, produces byte-identical credentials given identical inputs:
 
 \begin{itemize}[leftmargin=*]
 \item \verb|test-vectors/jcs/|: JSON Canonicalization Scheme reference outputs.
 \item \verb|test-vectors/eddsa-jcs-2022/|: full credential signing test vectors for the classical cryptosuite.
-\item \verb|test-vectors/hybrid-eddsa-mldsa44/|: full credential signing test vectors for the dual-proof post-quantum profile (and, for v1.6.x interop, the transitional composite cryptosuite).
+\item \verb|test-vectors/hybrid-eddsa-mldsa44/|: full credential signing test vectors for the dual-proof post-quantum profile.
 \item \verb|test-vectors/bitstring-status-list/|: BitstringStatusList encoding test vectors.
 \item \verb|test-vectors/sidecar-contract/|: HTTP wire-contract test suite for the three sidecar implementations.
 \end{itemize}
@@ -675,23 +788,28 @@ The protocol ships cross-language test vectors verifying that Python, TypeScript
 \begin{table}[h]
 \centering
 \small
-\begin{tabular}{lllrrl}
+\begin{tabular}{ll}
 \toprule
-Implementation & Language & LOC & Tests & Cryptosuites & Sidecar tier \\
+Component & Language / runtime \\
 \midrule
-\verb|vouch/| & Python 3.10+ & 4{,}500 & 350 & classical + hybrid & Lightweight + Dev \\
-\verb|packages/sdk-ts/| & TypeScript 5+ & 3{,}200 & 120 & classical + hybrid & Lightweight \\
-\verb|go-sidecar/| & Go 1.21+ & 2{,}800 & 75 & classical + hybrid & Production \\
+\verb|vouch-core| & Rust (shared core) \\
+\verb|sdk-py| & Python 3.10+ \\
+\verb|sdk-ts| & TypeScript 5+ \\
+\verb|go-sidecar| & Go 1.21+ \\
+\verb|sdks/cpp| & C++ \\
+\verb|sdks/dotnet| & .NET \\
+\verb|sdks/jvm| & Java / Kotlin (JVM) \\
+\verb|sdks/swift| & Swift \\
 \bottomrule
 \end{tabular}
-\caption{Reference implementations of the Vouch Protocol.}
+\caption{The Vouch reference architecture: one Rust core (\texttt{vouch-core}) exposed to seven language SDKs through WebAssembly and UniFFI bindings, so every SDK produces byte-identical credentials by construction.}
 \end{table}
 
-All three pass the cross-language test vectors. CI runs the vectors on every commit, and rejects merges that introduce divergence.
+All SDKs pass the cross-language test vectors. CI runs the vectors on every commit and rejects merges that introduce divergence. Concretely, the same credential signed through any of the seven SDKs is byte-for-byte identical, classical proof and post-quantum proof alike, because every SDK binds to one Rust core operating over JCS canonical bytes. This cross-language identity is a separate property from the relationship between the two proofs \emph{within} a dual-proof credential, which sign different \verb|hashData| because each binds its own cryptosuite and key (\S\ref{sec:hybrid}).
 
 \subsection{Known Implementation Divergences}
 
-The only documented divergence is in BitstringStatusList byte-encoding: Python and TypeScript use \texttt{zlib}'s DEFLATE encoder, which produces byte-identical output for identical bitstrings; Go's \texttt{compress/flate} produces a valid but different DEFLATE stream. The spec requires equivalence of the \emph{decompressed} bitstring; all three implementations agree on the decompressed bitstring and therefore on every credential's revocation status. Verifiers and issuers interoperate across all three.
+The one documented divergence is in BitstringStatusList byte-encoding: different DEFLATE encoders across language runtimes produce valid but non-identical compressed streams for the same bitstring. The specification requires equivalence of the \emph{decompressed} bitstring, which every implementation satisfies; revocation status is therefore identical across all SDKs, and verifiers and issuers interoperate.
 
 % ====================================================================
 \section{Discussion}
@@ -699,7 +817,7 @@ The only documented divergence is in BitstringStatusList byte-encoding: Python a
 
 \subsection{Limitations}
 
-\noindent\textbf{State Verifiability is Python-only at the runtime level.} The data formats (SessionVoucher, behavioural digest, canary commitment, heartbeat request) are cross-language and verifiable in any of the three implementations. The runtime orchestration (\verb|HeartbeatSession|, \verb|HeartbeatScheduler|, \verb|HeartbeatValidator|, \verb|HeartbeatQuorum|) is implemented in Python only. TypeScript and Go ports are work in progress at the time of publication.
+\noindent\textbf{State Verifiability is Python-only at the runtime level.} The data formats (SessionVoucher, behavioural digest, canary commitment, heartbeat request) are cross-language and verifiable in any of the seven language SDKs. The runtime orchestration (\verb|HeartbeatSession|, \verb|HeartbeatScheduler|, \verb|HeartbeatValidator|, \verb|HeartbeatQuorum|) is implemented in Python only. TypeScript and Go ports are work in progress at the time of publication.
 
 \noindent\textbf{Trusted-principal anchoring is deployment-specific.} The protocol does not standardize how a verifier discovers its trusted principals. Each deployment configures this independently.
 
@@ -709,7 +827,7 @@ The only documented divergence is in BitstringStatusList byte-encoding: Python a
 
 \subsection{Adoption Path}
 
-The protocol has been validated against three reference implementations and a cross-language test-vector battery. Adoption requirements for a new deployment:
+The protocol has been validated against the Rust core, its seven language SDKs, and a cross-language test-vector battery. Adoption requirements for a new deployment:
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item Generate an issuer DID and publish its DID Document.
@@ -724,14 +842,15 @@ End-to-end onboarding effort is on the order of one to two engineering days for 
 
 \subsection{Future Work}
 
-Four directions are actively under development:
+Three directions remain actively under development:
 
 \begin{enumerate}[label=\arabic*.,leftmargin=*]
 \item \textbf{TypeScript and Go ports of the State Verifiability runtime.}
 \item \textbf{Confidentiality profile for sensitive intents} using ML-KEM-768 key encapsulation.
 \item \textbf{Hosted continuous leak monitor} that closes the loop from automated detection to DID rotation with dual-signed migration credentials and verifier broadcast.
-\item \textbf{AI-assisted developer tooling} distributed as Claude Skills / Custom GPTs / Gemini Gems, allowing developers to receive Vouch integration guidance through their own AI tool subscriptions with zero protocol-vendor inference cost.
 \end{enumerate}
+
+Two capabilities that earlier roadmaps listed as future work already ship: an embodied and robotics extension (hardware-rooted robot identity, physical capability attenuation, custody chains, and kill-switch and safety-evidence credentials), and AI-assisted developer tooling distributed as Claude Skills, Custom GPTs, and Gemini Gems. Both are documented in companion material rather than developed further in this paper.
 
 The protocol's State Verifiability runtime, the dual-proof post-quantum profile, and the migration story from classical to dual-proof to pure-PQ each merit follow-up papers; outlines are in preparation.
 
@@ -741,14 +860,14 @@ The protocol's State Verifiability runtime, the dual-proof post-quantum profile,
 
 We have presented the Vouch Protocol, an open standard for cryptographic identity and continuous state verifiability of autonomous AI agents. The protocol composes Verifiable Credentials, Decentralized Identifiers, Data Integrity proofs, and post-quantum cryptosuites with two novel layers: an Identity Sidecar pattern that isolates the agent's key from the LLM and bounds the agent's capabilities by an enforced allow-list, and a State Verifiability layer that renews trust continuously via heartbeat, decays trust exponentially in the interval, attests behaviour cryptographically, and detects silent failure through canary commit/reveal chains.
 
-Three reference implementations (Python, TypeScript, Go) interoperate at the credential-byte level. The protocol is open under Apache 2.0; sixty defensive disclosures keep the design space open under CC0.
+A single Rust core (\texttt{vouch-core}), exposed to seven language SDKs through WebAssembly and UniFFI bindings, makes credentials byte-identical across languages by construction. The protocol is open under Apache 2.0; more than 120 defensive disclosures keep the design space open under CC0.
 
 The accountability gap in agent identity is solvable today. The cryptographic primitives are sound, the standards exist, and the implementation effort is bounded. Vouch is one realization of a path the open agent-identity ecosystem will increasingly need: from ``the bearer has access'' to ``this specific agent issued this specific intent under this specific authorization chain, verifiable in seconds, with cryptography rather than logbook evidence.''
 
 % ====================================================================
 \section*{Acknowledgements}
 
-The author thanks Manu Sporny and the W3C Verifiable Credentials Working Group for foundational work on Verifiable Credentials, Data Integrity, and the eddsa-jcs-2022 cryptosuite; the W3C Credentials Community Group for hosting and reviewing the incubation; the IETF JOSE working group for ongoing work on PQ/T composite signatures; the C2PA technical committee for content-provenance complementarity; and the open-source community of contributors and reviewers whose feedback shaped many of the choices documented here.
+The author thanks Manu Sporny and the W3C Verifiable Credentials Working Group for foundational work on Verifiable Credentials, Data Integrity, and the eddsa-jcs-2022 cryptosuite; Alan Karp for the capability-attenuation model that shaped the delegation design, and Amir Hameed Mir for scope-framing feedback; the W3C Credentials Community Group for hosting and reviewing the incubation; the IETF JOSE working group for ongoing work on PQ/T composite signatures; the C2PA technical committee for content-provenance complementarity; and the open-source community of contributors and reviewers whose feedback shaped many of the choices documented here.
 
 % ====================================================================
 \bibliographystyle{plain}
@@ -763,6 +882,7 @@ The author thanks Manu Sporny and the W3C Verifiable Credentials Working Group f
 \item \textbf{Python}: \verb|pip install vouch-protocol|. Source: \url{https://github.com/vouch-protocol/vouch/tree/main/vouch/}
 \item \textbf{TypeScript}: \verb|npm install @vouch-protocol/core|. Source: \url{https://github.com/vouch-protocol/vouch/tree/main/packages/sdk-ts/}
 \item \textbf{Go}: install with \verb|go install| from \url{github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar}. Source: \url{https://github.com/vouch-protocol/vouch/tree/main/go-sidecar/}
+\item \textbf{Rust core and further SDKs}: the \texttt{vouch-core} crate is under \url{https://github.com/vouch-protocol/vouch/tree/main/core/}; SDKs for C++, .NET, JVM, and Swift are under \url{https://github.com/vouch-protocol/vouch/tree/main/sdks/}.
 \end{itemize}
 
 \section{Test Vectors}

--- a/papers/paper-1-vouch-protocol/references.bib
+++ b/papers/paper-1-vouch-protocol/references.bib
@@ -129,10 +129,117 @@
   url    = {https://modelcontextprotocol.io/}
 }
 
+@techreport{w3cqr,
+  title       = {Quantum-Resistant Cryptosuites v1.0},
+  author      = {{World Wide Web Consortium}},
+  year        = {2026},
+  institution = {W3C Draft Specification},
+  note        = {Declared experimental; not intended for production use},
+  url         = {https://www.w3.org/TR/vc-di-quantum-resistant-1.0/}
+}
+
 @misc{db-mldsa44,
   title  = {mldsa44-rdfc-2024-cryptosuite: ML-DSA-44 Data Integrity Cryptosuite (RDFC canonicalization)},
   author = {{Digital Bazaar, Inc.}},
   year   = {2026},
   note   = {JCS variant in preparation},
   url    = {https://github.com/digitalbazaar/mldsa44-rdfc-2024-cryptosuite}
+}
+
+% ---- Pre-action authorization cluster (Jan--Apr 2026) ----
+
+@misc{oap2026,
+  title  = {Before the Tool Call: Deterministic Pre-Action Authorization for Autonomous {AI} Agents},
+  author = {Uchibeke, Uchi},
+  year   = {2026},
+  note   = {arXiv preprint arXiv:2603.20953},
+  url    = {https://arxiv.org/abs/2603.20953}
+}
+
+@misc{faramesh2026,
+  title  = {Faramesh: A Protocol-Agnostic Execution Control Plane for Autonomous Agent Systems},
+  author = {Fatmi, Amjad},
+  year   = {2026},
+  note   = {arXiv preprint arXiv:2601.17744},
+  url    = {https://arxiv.org/abs/2601.17744}
+}
+
+@misc{aarm2026,
+  title  = {Autonomous Action Runtime Management ({AARM}): A System Specification for Securing {AI}-Driven Actions at Runtime},
+  author = {Errico, Herman},
+  year   = {2026},
+  note   = {arXiv preprint arXiv:2602.09433},
+  url    = {https://arxiv.org/abs/2602.09433}
+}
+
+@misc{righttoact2026,
+  title  = {Right-to-Act: A Pre-Execution Non-Compensatory Decision Protocol for {AI} Systems},
+  author = {Lavi, Gadi},
+  year   = {2026},
+  note   = {arXiv preprint arXiv:2604.24153},
+  url    = {https://arxiv.org/abs/2604.24153}
+}
+
+@misc{forge2026,
+  title  = {Formal Policy Enforcement for Real-World Agentic Systems},
+  author = {Palumbo, Nils and Choudhary, Sarthak and Choi, Jihye and Amir, Guy and Chalasani, Prasad and Jha, Somesh},
+  year   = {2026},
+  note   = {arXiv preprint arXiv:2602.16708},
+  url    = {https://arxiv.org/abs/2602.16708}
+}
+
+% ---- Vouch defensive disclosures cited individually ----
+
+@misc{pad001,
+  title  = {Cryptographic Binding of {AI} Agent Identity},
+  author = {Gaddam, Ramprasad Anandam},
+  year   = {2025},
+  month  = dec,
+  note   = {Vouch Protocol Defensive Disclosure PAD-001, 28 December 2025},
+  url    = {https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-001-cryptographic-agent-identity.md}
+}
+
+@misc{pad002,
+  title  = {Cryptographic Binding of {AI} Agent Intent via Recursive Delegation (Chain of Custody)},
+  author = {Gaddam, Ramprasad Anandam},
+  year   = {2026},
+  month  = jan,
+  note   = {Vouch Protocol Defensive Disclosure PAD-002, 3 January 2026},
+  url    = {https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-002-chain-of-custody.md}
+}
+
+@misc{pad016,
+  title  = {Continuous Trust Maintenance via Dynamic Credential Renewal (The Heartbeat Protocol)},
+  author = {Gaddam, Ramprasad Anandam},
+  year   = {2026},
+  month  = feb,
+  note   = {Vouch Protocol Defensive Disclosure PAD-016, 14 February 2026},
+  url    = {https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-016-dynamic-credential-renewal.md}
+}
+
+@misc{pad017,
+  title  = {Cryptographic Proof of Reasoning with Adaptive Commitment Depth},
+  author = {Gaddam, Ramprasad Anandam},
+  year   = {2026},
+  month  = feb,
+  note   = {Vouch Protocol Defensive Disclosure PAD-017, 14 February 2026},
+  url    = {https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-017-cryptographic-proof-of-reasoning.md}
+}
+
+@misc{pad039,
+  title  = {Cross-Implementation Deterministic Multi-Party Trust State via {JCS}-Canonicalized Verifiable Credentials},
+  author = {Gaddam, Ramprasad Anandam},
+  year   = {2026},
+  month  = apr,
+  note   = {Vouch Protocol Defensive Disclosure PAD-039, 27 April 2026},
+  url    = {https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-039-jcs-deterministic-multi-party-trust-state.md}
+}
+
+@misc{pad045,
+  title  = {Proof of Non-Hallucination via Cryptographic Retrieval Anchoring},
+  author = {Gaddam, Ramprasad Anandam},
+  year   = {2026},
+  month  = apr,
+  note   = {Vouch Protocol Defensive Disclosure PAD-045, 29 April 2026},
+  url    = {https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-045-proof-of-non-hallucination-retrieval-anchoring.md}
 }


### PR DESCRIPTION
This updates the paper-1 source for the current design: the standards-conformant dual-proof construction (two Data Integrity proofs over the same canonical document body, using `mldsa44-jcs-2024` with base64url encoding), capability attenuation in place of a fixed delegation-depth limit, and a related-work section positioning intent verification against recent pre-action authorization systems. It also incorporates review feedback across the abstract, introduction, delegation, and interoperability sections, updates the acknowledgements and the disclosure count, and adds the three architecture figures.
