### PR TITLE
v1.7: capability attenuation replaces the fixed delegation depth limit

### DIFF
--- a/claude-skill/skills/vouch-protocol/reference/delegation.md
+++ b/claude-skill/skills/vouch-protocol/reference/delegation.md
@@ -75,7 +75,7 @@ agent.tools = vouch.protect([submit_claim], parent=grant)
 
 To build a chain explicitly, sign each credential under its parent. The
 `parent_credential` argument appends a delegation link and enforces resource
-narrowing and the depth limit.
+narrowing at build time. The full non-expansion rule (no link may broaden its parent on any of action, target, resource, time, rate, or policy) is checked at verification, and there is no fixed chain-depth limit; verifiers bound cost with their own budgets.
 
 ```python
 from vouch import Signer

--- a/core/uniffi/src/lib.rs
+++ b/core/uniffi/src/lib.rs
@@ -166,6 +166,12 @@ pub fn verify_chain_time_bound(
     )?)
 }
 
+/// v1.7 capability-attenuation chain validation. Infallible JSON boundary:
+/// returns a `{"valid": bool, ...}` verdict string (see core::attenuation).
+pub fn validate_delegation_chain(request_json: String) -> String {
+    vouch_core::attenuation::validate_chain_json(&request_json)
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn build_delegation_link(
     issuer: String,

--- a/core/uniffi/src/vouch_core.udl
+++ b/core/uniffi/src/vouch_core.udl
@@ -48,6 +48,8 @@ namespace vouch_core {
     [Throws=CoreError]
     boolean verify_chain_time_bound(string chain_json, string now_iso, i64 clock_skew_seconds);
 
+    string validate_delegation_chain(string request_json);
+
     // FROST(Ed25519, SHA-512) threshold signing (RFC 9591). The aggregated
     // signature is a standard Ed25519 signature, verifiable with
     // ed25519_verify like any other; no new proof type. See

--- a/core/vouch-core/src/attenuation.rs
+++ b/core/vouch-core/src/attenuation.rs
@@ -1,0 +1,700 @@
+//! v1.7 capability attenuation: the non-expansion rule over the six delegation
+//! dimensions, verifier cost budgets, and chain-cascade revocation
+//! (Specification 9.3 to 9.6).
+//!
+//! Security posture: default-deny. Every check answers "is the child broader
+//! than its parent on this dimension?" and any malformed input, unknown shape,
+//! or ambiguous comparison rejects rather than admits. A delegation chain grants
+//! authority, so a false "valid" is an authority-escalation bug; a false
+//! "invalid" is only an availability issue. We bias hard toward rejection.
+//!
+//! A dimension absent on a child link is inherited unchanged from its parent;
+//! it can never be widened by omission. A dimension the parent leaves unbounded
+//! may be narrowed by a child. Only when the child *specifies* a dimension that
+//! the parent also bounds do we compare them.
+
+use std::collections::BTreeSet;
+
+use serde_json::Value;
+
+use crate::error::{CoreError, Result};
+use crate::time::iso_to_epoch_seconds;
+
+/// A small tolerance for rate comparison so exact-equal rates are not rejected
+/// by floating-point noise.
+const RATE_EPSILON: f64 = 1e-9;
+
+/// The six capability dimensions a delegation link may carry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Dimension {
+    Action,
+    Target,
+    Resource,
+    Time,
+    Rate,
+    Policy,
+}
+
+impl Dimension {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Dimension::Action => "action",
+            Dimension::Target => "target",
+            Dimension::Resource => "resource",
+            Dimension::Time => "time",
+            Dimension::Rate => "rate",
+            Dimension::Policy => "policy",
+        }
+    }
+}
+
+/// A structured reason a delegation chain is rejected. `code()` yields the
+/// on-the-wire reason string used across the SDKs.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DelegationReject {
+    /// A child link is broader than its parent on the named dimension.
+    ScopeExceedsParent { dimension: Dimension },
+    /// The verifier's local cost budget was exceeded; `limit` names which one.
+    VerifierBudgetExceeded { limit: String },
+    /// A link (0-indexed from the root) is revoked; the whole chain and every
+    /// authority below it is rejected.
+    DelegationRevoked { link_index: usize },
+    /// A link's `subject` does not match the next link's `issuer`.
+    SubjectIssuerMismatch { link_index: usize },
+    /// The root link's issuer is not in the verifier's trusted set.
+    UntrustedPrincipal,
+    /// The current instant is outside the chain's effective validity window.
+    OutsideValidityWindow,
+    /// The chain or a link is structurally malformed.
+    Malformed { detail: String },
+}
+
+impl DelegationReject {
+    pub fn code(&self) -> &'static str {
+        match self {
+            DelegationReject::ScopeExceedsParent { .. } => "scope_exceeds_parent",
+            DelegationReject::VerifierBudgetExceeded { .. } => "verifier_budget_exceeded",
+            DelegationReject::DelegationRevoked { .. } => "delegation_revoked",
+            DelegationReject::SubjectIssuerMismatch { .. } => "subject_issuer_mismatch",
+            DelegationReject::UntrustedPrincipal => "untrusted_principal",
+            DelegationReject::OutsideValidityWindow => "outside_validity_window",
+            DelegationReject::Malformed { .. } => "malformed_delegation",
+        }
+    }
+}
+
+/// Verifier-local cost budget (Specification 9.4). `None` means unlimited.
+/// These are the verifier's configurable choice, not a protocol requirement.
+#[derive(Debug, Clone, Default)]
+pub struct VerifierBudget {
+    pub max_depth: Option<usize>,
+    pub max_cumulative_ttl_seconds: Option<i64>,
+}
+
+type DResult = std::result::Result<(), DelegationReject>;
+
+// --------------------------------------------------------------------------
+// Dimension helpers
+// --------------------------------------------------------------------------
+
+fn intent<'a>(link: &'a Value) -> Option<&'a Value> {
+    link.get("intent")
+}
+
+/// Normalize an action/target field to a set of strings.
+/// `Ok(None)`  => absent (inherit from parent).
+/// `Ok(Some)`  => a string or an array of strings.
+/// `Err`       => present but malformed (default-deny).
+fn string_set(v: Option<&Value>) -> Result<Option<BTreeSet<String>>> {
+    match v {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(s)) => {
+            let mut set = BTreeSet::new();
+            set.insert(s.clone());
+            Ok(Some(set))
+        }
+        Some(Value::Array(arr)) => {
+            let mut set = BTreeSet::new();
+            for item in arr {
+                match item.as_str() {
+                    Some(s) => {
+                        set.insert(s.to_string());
+                    }
+                    None => {
+                        return Err(CoreError::Json("action/target array must be strings".into()))
+                    }
+                }
+            }
+            Ok(Some(set))
+        }
+        Some(_) => Err(CoreError::Json("action/target must be a string or array".into())),
+    }
+}
+
+/// Path-component-wise sub-resource test. `child` is within `parent` when it is
+/// equal to it, or extends it at a path boundary. Trailing slashes are ignored.
+fn is_sub_resource(child: &str, parent: &str) -> bool {
+    let c = child.trim_end_matches('/');
+    let p = parent.trim_end_matches('/');
+    if c == p {
+        return true;
+    }
+    // child must extend parent at a "/" boundary, not merely share a prefix
+    // (so "https://x/a2" is NOT under "https://x/a").
+    c.len() > p.len() && c.starts_with(p) && c.as_bytes()[p.len()] == b'/'
+}
+
+/// Parse an ISO-8601 duration (the subset used by rate windows: days, hours,
+/// minutes, seconds, e.g. `PT1H`, `PT30M`, `PT1H30M15S`, `P1D`) to seconds.
+fn parse_duration_seconds(s: &str) -> Result<i64> {
+    let bytes = s.as_bytes();
+    if bytes.is_empty() || bytes[0] != b'P' {
+        return Err(CoreError::Json(format!("invalid duration: {s}")));
+    }
+    let mut total: i64 = 0;
+    let mut num = String::new();
+    let mut in_time = false;
+    let mut saw_field = false;
+    for &b in &bytes[1..] {
+        match b {
+            b'T' => in_time = true,
+            b'0'..=b'9' => num.push(b as char),
+            b'D' | b'H' | b'M' | b'S' => {
+                if num.is_empty() {
+                    return Err(CoreError::Json(format!("invalid duration: {s}")));
+                }
+                let n: i64 = num
+                    .parse()
+                    .map_err(|_| CoreError::Json(format!("invalid duration: {s}")))?;
+                let secs = match b {
+                    b'D' => n * 86_400,
+                    b'H' => n * 3_600,
+                    b'M' if in_time => n * 60, // minute in the time section
+                    b'M' => n * 2_592_000,     // month in the date section (approx 30d)
+                    b'S' => n,
+                    _ => unreachable!(),
+                };
+                total += secs;
+                num.clear();
+                saw_field = true;
+            }
+            _ => return Err(CoreError::Json(format!("invalid duration: {s}"))),
+        }
+    }
+    if !saw_field || !num.is_empty() {
+        return Err(CoreError::Json(format!("invalid duration: {s}")));
+    }
+    Ok(total)
+}
+
+/// Rate as events per second: `limit / window_seconds`. Higher is broader.
+fn rate_events_per_sec(rate: &Value) -> Result<f64> {
+    let obj = rate
+        .as_object()
+        .ok_or_else(|| CoreError::Json("rate must be an object".into()))?;
+    let limit = obj
+        .get("limit")
+        .and_then(|v| v.as_f64())
+        .ok_or_else(|| CoreError::Json("rate.limit must be a number".into()))?;
+    if limit < 0.0 {
+        return Err(CoreError::Json("rate.limit must be non-negative".into()));
+    }
+    let window = obj
+        .get("window")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CoreError::Json("rate.window must be an ISO-8601 duration".into()))?;
+    let secs = parse_duration_seconds(window)?;
+    if secs <= 0 {
+        return Err(CoreError::Json("rate.window must be positive".into()));
+    }
+    Ok(limit / secs as f64)
+}
+
+/// Child policy must be equal to or stricter than the parent's. Numeric parent
+/// constraints are treated as minimum thresholds (higher child value = stricter).
+/// Non-numeric constraints require exact equality. A parent key the child omits
+/// means the child dropped a constraint, which is broader, and is rejected.
+/// Conservative by construction: anything not provably at-least-as-strict fails.
+fn policy_not_weaker(parent: &Value, child: &Value) -> bool {
+    let (pobj, cobj) = match (parent.as_object(), child.as_object()) {
+        (Some(p), Some(c)) => (p, c),
+        _ => return false, // a policy that is not an object cannot be reasoned about
+    };
+    for (k, pv) in pobj {
+        match cobj.get(k) {
+            None => return false, // child dropped a parent constraint => weaker
+            Some(cv) => match (pv.as_f64(), cv.as_f64()) {
+                (Some(pn), Some(cn)) => {
+                    if cn < pn {
+                        return false; // lower threshold => less strict
+                    }
+                }
+                (Some(_), None) | (None, Some(_)) => return false, // type mismatch
+                (None, None) => {
+                    if pv != cv {
+                        return false; // non-numeric must match exactly
+                    }
+                }
+            },
+        }
+    }
+    true
+}
+
+fn window(link: &Value) -> Result<(Option<i64>, Option<i64>)> {
+    let vf = match link.get("validFrom").and_then(|v| v.as_str()) {
+        Some(s) => Some(iso_to_epoch_seconds(s)?),
+        None => None,
+    };
+    let vu = match link.get("validUntil").and_then(|v| v.as_str()) {
+        Some(s) => Some(iso_to_epoch_seconds(s)?),
+        None => None,
+    };
+    Ok((vf, vu))
+}
+
+// --------------------------------------------------------------------------
+// Non-expansion between an adjacent (parent, child) pair
+// --------------------------------------------------------------------------
+
+/// Verify that `child` does not broaden `parent` on any dimension. Returns the
+/// offending [`Dimension`] on failure. Malformed inputs reject as `Resource` or
+/// the relevant dimension via the error-to-reject mapping in [`validate_chain`].
+pub fn non_expansion(parent: &Value, child: &Value) -> std::result::Result<(), Dimension> {
+    let p_intent = intent(parent);
+    let c_intent = intent(child);
+
+    // action: child actions must be a subset of the parent's.
+    if let Ok(Some(c_actions)) = string_set(c_intent.and_then(|v| v.get("action"))) {
+        if let Ok(Some(p_actions)) = string_set(p_intent.and_then(|v| v.get("action"))) {
+            if !c_actions.is_subset(&p_actions) {
+                return Err(Dimension::Action);
+            }
+        }
+    } else if c_intent.map(|v| v.get("action").is_some()).unwrap_or(false) {
+        return Err(Dimension::Action); // present but malformed
+    }
+
+    // target: child targets must be a subset of the parent's.
+    if let Ok(Some(c_targets)) = string_set(c_intent.and_then(|v| v.get("target"))) {
+        if let Ok(Some(p_targets)) = string_set(p_intent.and_then(|v| v.get("target"))) {
+            if !c_targets.is_subset(&p_targets) {
+                return Err(Dimension::Target);
+            }
+        }
+    } else if c_intent.map(|v| v.get("target").is_some()).unwrap_or(false) {
+        return Err(Dimension::Target);
+    }
+
+    // resource: child resource must be a sub-resource of the parent's.
+    let c_res = c_intent.and_then(|v| v.get("resource")).and_then(|v| v.as_str());
+    if let Some(cr) = c_res {
+        if let Some(pr) = p_intent.and_then(|v| v.get("resource")).and_then(|v| v.as_str()) {
+            if !is_sub_resource(cr, pr) {
+                return Err(Dimension::Resource);
+            }
+        }
+    } else if c_intent
+        .and_then(|v| v.get("resource"))
+        .map(|v| !v.is_null())
+        .unwrap_or(false)
+    {
+        return Err(Dimension::Resource); // present but not a string
+    }
+
+    // time: child window must be within the parent's.
+    let (cf, cu) = match window(child) {
+        Ok(w) => w,
+        Err(_) => return Err(Dimension::Time),
+    };
+    let (pf, pu) = match window(parent) {
+        Ok(w) => w,
+        Err(_) => return Err(Dimension::Time),
+    };
+    if let (Some(f), Some(pf)) = (cf, pf) {
+        if f < pf {
+            return Err(Dimension::Time);
+        }
+    }
+    if let (Some(u), Some(pu)) = (cu, pu) {
+        if u > pu {
+            return Err(Dimension::Time);
+        }
+    }
+
+    // rate: child events-per-second must not exceed the parent's.
+    if let Some(cr) = child.get("rate") {
+        if !cr.is_null() {
+            let ce = match rate_events_per_sec(cr) {
+                Ok(e) => e,
+                Err(_) => return Err(Dimension::Rate),
+            };
+            if let Some(pr) = parent.get("rate") {
+                if !pr.is_null() {
+                    let pe = match rate_events_per_sec(pr) {
+                        Ok(e) => e,
+                        Err(_) => return Err(Dimension::Rate),
+                    };
+                    if ce > pe + RATE_EPSILON {
+                        return Err(Dimension::Rate);
+                    }
+                }
+            }
+        }
+    }
+
+    // policy: child policy must be equal to or stricter than the parent's.
+    if let Some(cp) = child.get("policy") {
+        if !cp.is_null() {
+            if let Some(pp) = parent.get("policy") {
+                if !pp.is_null() && !policy_not_weaker(pp, cp) {
+                    return Err(Dimension::Policy);
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// --------------------------------------------------------------------------
+// Full chain validation
+// --------------------------------------------------------------------------
+
+fn link_str<'a>(link: &'a Value, key: &str) -> Option<&'a str> {
+    link.get(key).and_then(|v| v.as_str())
+}
+
+/// Validate a delegation chain ordered root -> leaf under the v1.7 rules.
+///
+/// * `trusted_roots` empty => the root-trust check is skipped (the caller
+///   anchors trust elsewhere); otherwise the root issuer must be present.
+/// * `revoked_link_indices` are links the caller has resolved as revoked
+///   (credential- or DID-level); any hit rejects the whole chain (cascade).
+/// * `budget` caps the verifier's work; `None` fields are unlimited.
+///
+/// Returns `Ok(())` when the chain is valid, or the first [`DelegationReject`].
+pub fn validate_chain(
+    chain: &[Value],
+    trusted_roots: &[String],
+    revoked_link_indices: &[usize],
+    budget: &VerifierBudget,
+    now_iso: &str,
+    clock_skew_seconds: i64,
+) -> DResult {
+    if chain.is_empty() {
+        return Err(DelegationReject::Malformed {
+            detail: "empty delegation chain".into(),
+        });
+    }
+
+    // Verifier budget: depth.
+    if let Some(max) = budget.max_depth {
+        if chain.len() > max {
+            return Err(DelegationReject::VerifierBudgetExceeded {
+                limit: "depth".into(),
+            });
+        }
+    }
+
+    // Every link must be an object with issuer and subject.
+    for (i, link) in chain.iter().enumerate() {
+        if link.as_object().is_none() {
+            return Err(DelegationReject::Malformed {
+                detail: format!("link {i} is not an object"),
+            });
+        }
+        if link_str(link, "issuer").is_none() || link_str(link, "subject").is_none() {
+            return Err(DelegationReject::Malformed {
+                detail: format!("link {i} missing issuer/subject"),
+            });
+        }
+    }
+
+    // Root trust.
+    if !trusted_roots.is_empty() {
+        let root_issuer = link_str(&chain[0], "issuer").unwrap();
+        if !trusted_roots.iter().any(|r| r == root_issuer) {
+            return Err(DelegationReject::UntrustedPrincipal);
+        }
+    }
+
+    // Cascade revocation: a revoked link invalidates the whole chain.
+    if let Some(&idx) = revoked_link_indices.iter().min() {
+        if idx < chain.len() {
+            return Err(DelegationReject::DelegationRevoked { link_index: idx });
+        }
+    }
+
+    // Linkage and non-expansion for each adjacent pair.
+    for i in 1..chain.len() {
+        let parent = &chain[i - 1];
+        let child = &chain[i];
+        if link_str(parent, "subject") != link_str(child, "issuer") {
+            return Err(DelegationReject::SubjectIssuerMismatch { link_index: i });
+        }
+        non_expansion(parent, child)
+            .map_err(|dimension| DelegationReject::ScopeExceedsParent { dimension })?;
+    }
+
+    // Effective validity window: the intersection of every link's window, i.e.
+    // the latest start and the earliest end. `now` must fall inside it.
+    let mut eff_start: Option<i64> = None;
+    let mut eff_end: Option<i64> = None;
+    let mut cumulative_ttl: i64 = 0;
+    for link in chain {
+        let (vf, vu) = window(link).map_err(|e| DelegationReject::Malformed {
+            detail: e.to_string(),
+        })?;
+        if let Some(f) = vf {
+            eff_start = Some(eff_start.map_or(f, |cur| cur.max(f)));
+        }
+        if let Some(u) = vu {
+            eff_end = Some(eff_end.map_or(u, |cur| cur.min(u)));
+        }
+        if let (Some(f), Some(u)) = (vf, vu) {
+            if u >= f {
+                cumulative_ttl += u - f;
+            }
+        }
+    }
+    let now = iso_to_epoch_seconds(now_iso).map_err(|e| DelegationReject::Malformed {
+        detail: e.to_string(),
+    })?;
+    if let Some(f) = eff_start {
+        if now < f - clock_skew_seconds {
+            return Err(DelegationReject::OutsideValidityWindow);
+        }
+    }
+    if let Some(u) = eff_end {
+        if now > u + clock_skew_seconds {
+            return Err(DelegationReject::OutsideValidityWindow);
+        }
+    }
+
+    // Verifier budget: cumulative TTL across the chain.
+    if let Some(max) = budget.max_cumulative_ttl_seconds {
+        if cumulative_ttl > max {
+            return Err(DelegationReject::VerifierBudgetExceeded {
+                limit: "cumulative_ttl".into(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn link(issuer: &str, subject: &str, intent: Value) -> Value {
+        json!({
+            "issuer": issuer,
+            "subject": subject,
+            "intent": intent,
+            "validFrom": "2026-04-26T09:00:00Z",
+            "validUntil": "2026-04-26T12:00:00Z"
+        })
+    }
+
+    fn now() -> &'static str {
+        "2026-04-26T10:00:00Z"
+    }
+
+    #[test]
+    fn restate_unchanged_is_valid() {
+        let i = json!({"action":"read","target":"t","resource":"https://x/a"});
+        let chain = vec![
+            link("did:web:root", "did:web:a", i.clone()),
+            link("did:web:a", "did:web:b", i.clone()),
+        ];
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_ok());
+    }
+
+    #[test]
+    fn resource_narrowing_is_valid() {
+        let chain = vec![
+            link("did:web:root", "did:web:a", json!({"resource":"https://x/a"})),
+            link("did:web:a", "did:web:b", json!({"resource":"https://x/a/b"})),
+        ];
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_ok());
+    }
+
+    #[test]
+    fn resource_widening_rejected_naming_dimension() {
+        let chain = vec![
+            link("did:web:root", "did:web:a", json!({"resource":"https://x/a/b"})),
+            link("did:web:a", "did:web:b", json!({"resource":"https://x/a"})),
+        ];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err.code(), "scope_exceeds_parent");
+        assert_eq!(err, DelegationReject::ScopeExceedsParent { dimension: Dimension::Resource });
+    }
+
+    #[test]
+    fn sibling_prefix_is_not_sub_resource() {
+        assert!(!is_sub_resource("https://x/a2", "https://x/a"));
+        assert!(is_sub_resource("https://x/a/b", "https://x/a"));
+        assert!(is_sub_resource("https://x/a", "https://x/a/"));
+    }
+
+    #[test]
+    fn action_superset_rejected() {
+        let chain = vec![
+            link("did:web:root", "did:web:a", json!({"action":"read"})),
+            link("did:web:a", "did:web:b", json!({"action":["read","write"]})),
+        ];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::ScopeExceedsParent { dimension: Dimension::Action });
+    }
+
+    #[test]
+    fn action_subset_ok() {
+        let chain = vec![
+            link("did:web:root", "did:web:a", json!({"action":["read","write"]})),
+            link("did:web:a", "did:web:b", json!({"action":"read"})),
+        ];
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_ok());
+    }
+
+    #[test]
+    fn rate_widening_rejected() {
+        let mut a = link("did:web:root", "did:web:a", json!({"action":"read"}));
+        a["rate"] = json!({"limit":100,"window":"PT1H"});
+        let mut b = link("did:web:a", "did:web:b", json!({"action":"read"}));
+        b["rate"] = json!({"limit":100,"window":"PT30M"}); // twice the events/sec
+        let chain = vec![a, b];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::ScopeExceedsParent { dimension: Dimension::Rate });
+    }
+
+    #[test]
+    fn rate_narrowing_ok() {
+        let mut a = link("did:web:root", "did:web:a", json!({"action":"read"}));
+        a["rate"] = json!({"limit":100,"window":"PT1H"});
+        let mut b = link("did:web:a", "did:web:b", json!({"action":"read"}));
+        b["rate"] = json!({"limit":50,"window":"PT1H"});
+        let chain = vec![a, b];
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_ok());
+    }
+
+    #[test]
+    fn policy_weakening_rejected() {
+        let mut a = link("did:web:root", "did:web:a", json!({"action":"read"}));
+        a["policy"] = json!({"minHeartbeatAgeSeconds":300});
+        let mut b = link("did:web:a", "did:web:b", json!({"action":"read"}));
+        b["policy"] = json!({"minHeartbeatAgeSeconds":100}); // weaker
+        let chain = vec![a, b];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::ScopeExceedsParent { dimension: Dimension::Policy });
+    }
+
+    #[test]
+    fn policy_dropping_constraint_rejected() {
+        let mut a = link("did:web:root", "did:web:a", json!({"action":"read"}));
+        a["policy"] = json!({"minHeartbeatAgeSeconds":300});
+        let mut b = link("did:web:a", "did:web:b", json!({"action":"read"}));
+        b["policy"] = json!({"unrelated":true}); // dropped the parent's constraint
+        let chain = vec![a, b];
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_err());
+    }
+
+    #[test]
+    fn time_widening_rejected() {
+        let chain = vec![
+            json!({"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},
+                   "validFrom":"2026-04-26T10:00:00Z","validUntil":"2026-04-26T11:00:00Z"}),
+            json!({"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},
+                   "validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}),
+        ];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), "2026-04-26T10:30:00Z", 30).unwrap_err();
+        assert_eq!(err, DelegationReject::ScopeExceedsParent { dimension: Dimension::Time });
+    }
+
+    #[test]
+    fn subject_issuer_mismatch_rejected() {
+        let i = json!({"action":"read"});
+        let chain = vec![
+            link("did:web:root", "did:web:a", i.clone()),
+            link("did:web:WRONG", "did:web:b", i.clone()),
+        ];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::SubjectIssuerMismatch { link_index: 1 });
+    }
+
+    #[test]
+    fn untrusted_root_rejected() {
+        let i = json!({"action":"read"});
+        let chain = vec![link("did:web:root", "did:web:a", i)];
+        let err = validate_chain(&chain, &["did:web:other".into()], &[], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::UntrustedPrincipal);
+    }
+
+    #[test]
+    fn cascade_revocation_rejects_whole_chain() {
+        let i = json!({"action":"read"});
+        let chain = vec![
+            link("did:web:root", "did:web:a", i.clone()),
+            link("did:web:a", "did:web:b", i.clone()),
+            link("did:web:b", "did:web:c", i.clone()),
+        ];
+        // middle link revoked
+        let err = validate_chain(&chain, &[], &[1], &VerifierBudget::default(), now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::DelegationRevoked { link_index: 1 });
+    }
+
+    #[test]
+    fn budget_depth_exceeded() {
+        let i = json!({"action":"read"});
+        let chain = vec![
+            link("did:web:root", "did:web:a", i.clone()),
+            link("did:web:a", "did:web:b", i.clone()),
+            link("did:web:b", "did:web:c", i.clone()),
+        ];
+        let budget = VerifierBudget { max_depth: Some(2), max_cumulative_ttl_seconds: None };
+        let err = validate_chain(&chain, &[], &[], &budget, now(), 30).unwrap_err();
+        assert_eq!(err, DelegationReject::VerifierBudgetExceeded { limit: "depth".into() });
+    }
+
+    #[test]
+    fn deep_but_attenuating_chain_is_valid_without_depth_cap() {
+        // Ten hops, each restating the same authority: valid now that the fixed
+        // depth limit is gone (this is the whole point of v1.7).
+        let mut chain = Vec::new();
+        let i = json!({"action":"read","resource":"https://x/a"});
+        for n in 0..10 {
+            let issuer = if n == 0 { "did:web:root".to_string() } else { format!("did:web:h{}", n - 1) };
+            let subject = format!("did:web:h{n}");
+            chain.push(link(&issuer, &subject, i.clone()));
+        }
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_ok());
+    }
+
+    #[test]
+    fn now_outside_effective_window_rejected() {
+        let chain = vec![link("did:web:root", "did:web:a", json!({"action":"read"}))];
+        let err = validate_chain(&chain, &[], &[], &VerifierBudget::default(), "2026-04-26T20:00:00Z", 30).unwrap_err();
+        assert_eq!(err, DelegationReject::OutsideValidityWindow);
+    }
+
+    #[test]
+    fn absent_child_dimension_inherits_and_passes() {
+        let chain = vec![
+            link("did:web:root", "did:web:a", json!({"action":"read","resource":"https://x/a"})),
+            link("did:web:a", "did:web:b", json!({"resource":"https://x/a/b"})), // action omitted => inherit
+        ];
+        assert!(validate_chain(&chain, &[], &[], &VerifierBudget::default(), now(), 30).is_ok());
+    }
+
+    #[test]
+    fn duration_parser() {
+        assert_eq!(parse_duration_seconds("PT1H").unwrap(), 3600);
+        assert_eq!(parse_duration_seconds("PT30M").unwrap(), 1800);
+        assert_eq!(parse_duration_seconds("PT1H30M15S").unwrap(), 5415);
+        assert_eq!(parse_duration_seconds("P1D").unwrap(), 86400);
+        assert!(parse_duration_seconds("1H").is_err());
+        assert!(parse_duration_seconds("PT").is_err());
+    }
+}

--- a/core/vouch-core/src/attenuation.rs
+++ b/core/vouch-core/src/attenuation.rs
@@ -15,7 +15,7 @@
 
 use std::collections::BTreeSet;
 
-use serde_json::Value;
+use serde_json::{json, Value};
 
 use crate::error::{CoreError, Result};
 use crate::time::iso_to_epoch_seconds;
@@ -482,6 +482,85 @@ pub fn validate_chain(
     }
 
     Ok(())
+}
+
+// --------------------------------------------------------------------------
+// JSON boundary for the SDK bindings (uniffi / wasm)
+// --------------------------------------------------------------------------
+
+/// Validate a delegation chain from a single JSON request, returning a JSON
+/// verdict. Infallible: malformed input yields a `malformed_delegation` verdict
+/// rather than an error, so every caller gets a uniform verdict shape.
+///
+/// Request:  `{ "chain": [..links..], "trustedRoots"?: [..], "revokedIndices"?:
+/// [..], "budget"?: {"maxDepth"?: n, "maxCumulativeTtlSeconds"?: n}, "nowIso":
+/// "..", "clockSkewSeconds"?: 30 }`
+///
+/// Response: `{"valid": true}` or `{"valid": false, "code": "..", ..detail..}`.
+pub fn validate_chain_json(request_json: &str) -> String {
+    let req: Value = match serde_json::from_str(request_json) {
+        Ok(v) => v,
+        Err(e) => return verdict_malformed(&format!("request json: {e}")),
+    };
+    let chain: Vec<Value> = match req.get("chain").and_then(|v| v.as_array()) {
+        Some(c) => c.clone(),
+        None => return verdict_malformed("missing chain array"),
+    };
+    let trusted_roots: Vec<String> = req
+        .get("trustedRoots")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_str().map(String::from)).collect())
+        .unwrap_or_default();
+    let revoked: Vec<usize> = req
+        .get("revokedIndices")
+        .and_then(|v| v.as_array())
+        .map(|a| a.iter().filter_map(|x| x.as_u64().map(|n| n as usize)).collect())
+        .unwrap_or_default();
+    let budget = VerifierBudget {
+        max_depth: req
+            .pointer("/budget/maxDepth")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as usize),
+        max_cumulative_ttl_seconds: req
+            .pointer("/budget/maxCumulativeTtlSeconds")
+            .and_then(|v| v.as_i64()),
+    };
+    let now = req.get("nowIso").and_then(|v| v.as_str()).unwrap_or("");
+    let skew = req
+        .get("clockSkewSeconds")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(30);
+
+    match validate_chain(&chain, &trusted_roots, &revoked, &budget, now, skew) {
+        Ok(()) => json!({ "valid": true }).to_string(),
+        Err(r) => reject_to_json(&r).to_string(),
+    }
+}
+
+fn verdict_malformed(detail: &str) -> String {
+    json!({ "valid": false, "code": "malformed_delegation", "detail": detail }).to_string()
+}
+
+fn reject_to_json(r: &DelegationReject) -> Value {
+    let mut v = json!({ "valid": false, "code": r.code() });
+    let o = v.as_object_mut().unwrap();
+    match r {
+        DelegationReject::ScopeExceedsParent { dimension } => {
+            o.insert("dimension".into(), json!(dimension.as_str()));
+        }
+        DelegationReject::VerifierBudgetExceeded { limit } => {
+            o.insert("limit".into(), json!(limit));
+        }
+        DelegationReject::DelegationRevoked { link_index }
+        | DelegationReject::SubjectIssuerMismatch { link_index } => {
+            o.insert("linkIndex".into(), json!(link_index));
+        }
+        DelegationReject::Malformed { detail } => {
+            o.insert("detail".into(), json!(detail));
+        }
+        DelegationReject::UntrustedPrincipal | DelegationReject::OutsideValidityWindow => {}
+    }
+    v
 }
 
 #[cfg(test)]

--- a/core/vouch-core/src/lib.rs
+++ b/core/vouch-core/src/lib.rs
@@ -7,6 +7,7 @@
 //! language. Behavior MUST match the TypeScript reference SDK byte-for-byte and
 //! pass the shared interop vectors in `test-vectors/`.
 
+pub mod attenuation;
 pub mod credentials;
 pub mod data_integrity;
 pub mod delegation;

--- a/core/vouch-core/tests/interop_delegation.rs
+++ b/core/vouch-core/tests/interop_delegation.rs
@@ -1,0 +1,52 @@
+//! Interop: the shared delegation-attenuation vectors are the cross-language
+//! contract. This test pins the Rust core to `test-vectors/delegation-attenuation/
+//! vector.json`; the Python, Go, and TypeScript SDKs run the same file and MUST
+//! produce identical verdicts.
+
+use serde_json::Value;
+use vouch_core::attenuation::validate_chain_json;
+
+fn load_vectors() -> Value {
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../test-vectors/delegation-attenuation/vector.json"
+    );
+    let text = std::fs::read_to_string(path).expect("read delegation vectors");
+    serde_json::from_str(&text).expect("parse delegation vectors")
+}
+
+#[test]
+fn core_matches_delegation_vectors() {
+    let vectors = load_vectors();
+    let cases = vectors["cases"].as_array().expect("cases array");
+    assert!(!cases.is_empty(), "vector file has no cases");
+
+    for case in cases {
+        let name = case["name"].as_str().unwrap_or("<unnamed>");
+        let request = case["request"].to_string();
+        let expect = &case["expect"];
+
+        let verdict: Value =
+            serde_json::from_str(&validate_chain_json(&request)).expect("verdict is json");
+
+        assert_eq!(
+            verdict["valid"], expect["valid"],
+            "case {name}: valid mismatch (got {verdict})"
+        );
+
+        if expect["valid"] == Value::Bool(false) {
+            assert_eq!(
+                verdict["code"], expect["code"],
+                "case {name}: code mismatch (got {verdict})"
+            );
+            for field in ["dimension", "limit", "linkIndex"] {
+                if !expect[field].is_null() {
+                    assert_eq!(
+                        verdict[field], expect[field],
+                        "case {name}: {field} mismatch (got {verdict})"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -197,6 +197,13 @@ pub fn verify_chain_time_bound(
     delegation::verify_chain_time_bound(arr, now_iso, clock_skew_seconds as i64).map_err(jerr)
 }
 
+/// v1.7 capability-attenuation chain validation. Infallible JSON boundary:
+/// returns a `{"valid": bool, ...}` verdict string (see core::attenuation).
+#[wasm_bindgen(js_name = validateDelegationChain)]
+pub fn validate_delegation_chain(request_json: &str) -> String {
+    vouch_core::attenuation::validate_chain_json(request_json)
+}
+
 // --------------------------------------------------------------------------
 // FROST(Ed25519, SHA-512) threshold signing (RFC 9591). The aggregated
 // signature is a standard Ed25519 signature, verifiable with ed25519Verify

--- a/docs/specs/w3c-cg-report-v1.7-draft.md
+++ b/docs/specs/w3c-cg-report-v1.7-draft.md
@@ -1,0 +1,118 @@
+# Vouch Protocol CG Report, v1.7 DRAFT, Section 9 (Delegation) and related conformance
+
+**Status:** v1.7 WORKING DRAFT. NOT published. NOT for the current CCG review.
+**Baseline:** v1.6.2 (`docs/specs/w3c-cg-report.md`) remains the version under CCG review and MUST NOT be edited for this change. This document holds the v1.7 replacement text for the affected sections only; every other section of v1.6.2 is inherited unchanged.
+**Change:** CH-001 (delegation redesign: replace the fixed depth limit with a non-expansion rule).
+**Review status:** the core non-expansion rule, the verifier cost budgets, and the three edge policies (acceptable narrowing, chain termination, and revocation cascade) are settled following review by Alan Karp and Manu Sporny on PR #42.
+**Style:** RFC 2119 keywords. W3C and ZCAP references are permitted in this specification (it is a standards document); this allowance does not extend to the public FAQ, Help, and KB.
+
+---
+
+## 9. Delegation Chains (v1.7)
+
+### 9.1 Overview
+
+In multi-agent systems, a root principal may delegate authority through a chain of agents. The Vouch Protocol supports cryptographic delegation chains that preserve accountability at each hop. Delegation in Vouch follows the object-capability tradition: authority originates at a root principal, and at each link it is either restated unchanged or attenuated (narrowed), and never broadened. No delegate can grant more than it holds.
+
+The semantics align conceptually with W3C Authorization Capabilities (ZCAP-LD) [ZCAP-LD] and the broader object-capability tradition, including the restate-or-attenuate model used by UCAN. Vouch aligns with that model but does NOT take a normative dependency on the ZCAP-LD document, whose draft is not currently maintained; ZCAP-LD is tracked informatively (Appendix A). Two design distinctions remain:
+
+- **No JSON-LD requirement**: Delegation links use the same JCS-canonicalized JSON form as the surrounding credential, avoiding JSON-LD canonicalization.
+- **Explicit resource binding**: Each delegation link MUST carry a `resource` field, ensuring that capabilities are bound to specific URIs rather than abstract action names.
+
+### 9.2 Delegation Link Structure
+
+Each link in a delegation chain expresses a capability across up to six dimensions: action, target, resource, time, rate, and policy. The first three are carried in `intent`, time in `validFrom`/`validUntil`, and the optional `rate` and `policy` fields carry the remaining two.
+
+```json
+{
+  "issuer": "did:web:alice.example.com",
+  "subject": "did:web:travel-agent.example.com",
+  "intent": {
+    "action": "plan_trip",
+    "target": "destination:Paris",
+    "resource": "https://travel-api.example.com/v1/bookings"
+  },
+  "validFrom": "2026-04-26T09:00:00Z",
+  "validUntil": "2026-04-26T11:00:00Z",
+  "rate": { "limit": 100, "window": "PT1H" },
+  "policy": { "minHeartbeatAgeSeconds": 300 },
+  "proof": { "...DataIntegrityProof..." }
+}
+```
+
+| Field | Required | Description |
+|---|---|---|
+| `issuer` | REQUIRED | DID of the delegator |
+| `subject` | REQUIRED | DID of the delegate (recipient of authority) |
+| `intent` | REQUIRED | Authorized scope: `action`, `target`, and required `resource` |
+| `validFrom`, `validUntil` | REQUIRED | Temporal bounds (the time dimension) |
+| `rate` | OPTIONAL | Rate ceiling for the delegated capability (the rate dimension) |
+| `policy` | OPTIONAL | Additional conditions, for example a minimum heartbeat freshness (the policy dimension) |
+| `proof` | REQUIRED | Data Integrity proof signed by the `issuer` |
+
+A dimension that is absent on a link is treated as inherited unchanged from the parent; it cannot be widened by omission.
+
+### 9.3 Chain Validation
+
+To verify a delegation chain, the verifier:
+
+1. Validates the outermost Vouch Credential signature.
+2. Walks the chain from the last link to the first.
+3. For each link, verifies that `subject` matches the `issuer` of the next link.
+4. Verifies the root `issuer` is a trusted principal.
+5. Verifies the **non-expansion rule** for each adjacent (parent, child) pair: the child capability MUST NOT be broader than its parent on any of {action, target, resource, time, rate, policy}. A child MAY restate any dimension unchanged or attenuate (narrow) it. Restating every dimension, that is re-delegating the same authority without narrowing, is valid and is often the intended behavior. Per dimension, "not broader" is defined as:
+   - **action**: child actions are a subset of, or equal to, the parent's actions.
+   - **target**: child targets are a subset of, or equal to, the parent's targets.
+   - **resource**: child `intent.resource` is a sub-resource of, or equal to, the parent's.
+   - **time**: child `[validFrom, validUntil]` is within, or equal to, the parent's interval.
+   - **rate**: child `rate.limit` per window is less than or equal to the parent's.
+   - **policy**: child policy is equal to or stricter than the parent's.
+6. A chain is rejected with `scope_exceeds_parent`, naming the offending dimension (for example `resource`), if any child is broader than its parent on any dimension.
+
+Whether a particular narrowing is *acceptable* is not a protocol concern. The system where the capability is invoked is the authority on whether a delegated scope is acceptable, in both directions: a scope that is too broad for that system's rules, or a narrowing that is not sufficient for them. A verifier MAY enforce stricter local policy through an OPTIONAL narrowing hook. This protocol requires only that no link broadens its parent.
+
+### 9.4 Chain Growth and Verifier Cost Budgets
+
+There is no fixed maximum chain depth. The non-expansion rule (Section 9.3, step 5) is the control on authority: because no link can broaden its parent, authority along a chain can only stay equal or shrink, and can never grow without bound.
+
+Earlier revisions (through v1.6.2) required a fixed maximum depth (RECOMMENDED 5 hops). That control is removed: at the limit, an agent that still needs to hand a slice of its authority to another agent cannot delegate, so it proxies the other agent's requests or shares its credentials, both of which grant broader authority and destroy the audit trail.
+
+Cost control moves to the verifier. A verifier MAY cap the work it will spend validating a chain, by depth, total verification time, or cumulative validity (TTL) across the chain. This is the verifier's local, configurable choice and is NOT a protocol-level requirement. When a verifier rejects a chain for exceeding its budget, it MUST report `verifier_budget_exceeded` and the specific limit reached, so the delegating agent narrows earlier rather than routing around the limit. See [[PAD-022](https://github.com/vouch-protocol/vouch/blob/main/docs/disclosures/PAD-022-swarm-limits-protocol.md)] for multi-agent delegation graphs beyond simple linear chains.
+
+### 9.5 Non-expansion (normative)
+
+Delegation links MUST NOT broaden the parent's authority on any dimension. A link MAY restate a capability unchanged or attenuate (narrow) it. This non-expansion property is the normative basis for Section 9.3 step 5, and follows the object-capability tradition of restate-or-attenuate, consistent with UCAN and W3C ZCAP-LD.
+
+### 9.6 Chain-Cascade Revocation
+
+When any link in a delegation chain is revoked, whether through the credential-level BitstringStatusList (`credentialStatus`) or the DID-level `vouch.revocation` registry, every delegation downstream of that link becomes invalid. A verifier that encounters a revoked link MUST reject the chain and all authority derived below that link, reporting `delegation_revoked`.
+
+Key rotation is NOT treated as a cascade trigger. Delegation links SHOULD be issued to a key scoped to the delegation rather than to the issuer's long-lived authentication key, so that routine key rotation does not invalidate active chains. An issuer that prefers bulk revocability MAY instead issue to a long-lived key, accepting that revoking that key invalidates every delegation signed with it.
+
+---
+
+## 17. Conformance Levels (v1.7 deltas)
+
+### 17.1 Level 1 (L1): Credential
+
+A conformant L1 verifier that accepts a delegation chain MUST enforce the non-expansion rule (Section 9.3, step 5). Non-expansion is a core validity property of any presented chain, so v1.7 places the check at L1: any verifier that accepts a chain enforces it, even at L1.
+
+### 17.2 Level 2 (L2): Sidecar + Delegation + Revocation
+
+Replace the v1.6.2 delegation bullet, which read "Support delegation chains per Section 9, including the resource-narrowing rule and the depth limit of five links," with:
+
+- Support delegation chains per Section 9, including the non-expansion rule (no link broader than its parent on any of action/target/resource/time/rate/policy; restate or attenuate) and verifier-side cost budgets. There is no fixed depth limit.
+
+---
+
+## Appendix C.4 Delegation chain vectors (v1.7 delta)
+
+Replace the v1.6.2 vector description, which read "Linear chains of depth 1, 3, and 5 with valid and invalid resource-narrowing examples," with:
+
+- Chains demonstrating valid attenuation on each dimension (action, target, resource, time, rate, policy), a valid restatement (re-delegation with unchanged scope), invalid widening on each dimension, and a chain rejected by a verifier cost budget. All three reference implementations (Python, TypeScript, Go) MUST produce identical accept/reject decisions and identical rejection reasons for every vector. The shared, machine-readable vectors are published at `test-vectors/delegation-attenuation/vector.json`, and the Python, TypeScript, and Go SDKs each run them (a module-level runner and a verifier-wiring runner) so that any divergence fails a build.
+
+---
+
+## Carry-over note
+
+When v1.7 is finalized: fold these sections into a complete v1.7 document, bump the version, the dated this-version URL, and the revision line as was done for v1.6.2; re-run the no-em-dash check; and notify the reviewers whose feedback was acted on (Alan, Amir) citing the section. The delegation edge policies (acceptable narrowing, termination, revocation cascade) were resolved on PR #42 by Alan Karp and Manu Sporny.

--- a/gemini-gem/knowledge/vouch-knowledge.md
+++ b/gemini-gem/knowledge/vouch-knowledge.md
@@ -650,7 +650,7 @@ agent.tools = vouch.protect([submit_claim], parent=grant)
 
 To build a chain explicitly, sign each credential under its parent. The
 `parent_credential` argument appends a delegation link and enforces resource
-narrowing and the depth limit.
+narrowing at build time. The full non-expansion rule (no link may broaden its parent on any of action, target, resource, time, rate, or policy) is checked at verification, and there is no fixed chain-depth limit; verifiers bound cost with their own budgets.
 
 ```python
 from vouch import Signer

--- a/go-sidecar/attenuation/attenuation.go
+++ b/go-sidecar/attenuation/attenuation.go
@@ -1,0 +1,406 @@
+// Package attenuation implements the v1.7 capability-attenuation rule: the
+// non-expansion check over the six delegation dimensions, verifier cost
+// budgets, and chain-cascade revocation (Specification 9.3-9.6).
+//
+// It is a faithful port of core/vouch-core/src/attenuation.rs; the two MUST
+// agree verdict-for-verdict against test-vectors/delegation-attenuation.
+//
+// Security posture: default-deny. Any malformed input or ambiguous comparison
+// rejects, because delegation grants authority and a false "valid" is an
+// authority-escalation bug.
+package attenuation
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const rateEpsilon = 1e-9
+
+// Verdict is the uniform result shape shared with the other implementations.
+type Verdict map[string]interface{}
+
+func isoToEpoch(s string) (int64, error) {
+	t, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return 0, err
+	}
+	return t.Unix(), nil
+}
+
+// stringSet: nil map => absent; a string or []string => set; else error.
+func stringSet(v interface{}) (map[string]bool, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch t := v.(type) {
+	case string:
+		return map[string]bool{t: true}, nil
+	case []interface{}:
+		set := map[string]bool{}
+		for _, item := range t {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("action/target array must be strings")
+			}
+			set[s] = true
+		}
+		return set, nil
+	default:
+		return nil, fmt.Errorf("action/target must be a string or array")
+	}
+}
+
+func isSubResource(child, parent string) bool {
+	c := strings.TrimRight(child, "/")
+	p := strings.TrimRight(parent, "/")
+	if c == p {
+		return true
+	}
+	return len(c) > len(p) && strings.HasPrefix(c, p) && c[len(p)] == '/'
+}
+
+func parseDurationSeconds(s string) (int64, error) {
+	if len(s) == 0 || s[0] != 'P' {
+		return 0, fmt.Errorf("invalid duration: %s", s)
+	}
+	var total int64
+	num := ""
+	inTime := false
+	sawField := false
+	for _, ch := range s[1:] {
+		switch {
+		case ch == 'T':
+			inTime = true
+		case ch >= '0' && ch <= '9':
+			num += string(ch)
+		case ch == 'D' || ch == 'H' || ch == 'M' || ch == 'S':
+			if num == "" {
+				return 0, fmt.Errorf("invalid duration: %s", s)
+			}
+			n, err := strconv.ParseInt(num, 10, 64)
+			if err != nil {
+				return 0, fmt.Errorf("invalid duration: %s", s)
+			}
+			switch ch {
+			case 'D':
+				total += n * 86400
+			case 'H':
+				total += n * 3600
+			case 'M':
+				if inTime {
+					total += n * 60
+				} else {
+					total += n * 2592000
+				}
+			case 'S':
+				total += n
+			}
+			num = ""
+			sawField = true
+		default:
+			return 0, fmt.Errorf("invalid duration: %s", s)
+		}
+	}
+	if !sawField || num != "" {
+		return 0, fmt.Errorf("invalid duration: %s", s)
+	}
+	return total, nil
+}
+
+func asFloat(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	}
+	return 0, false
+}
+
+func rateEventsPerSec(rate interface{}) (float64, error) {
+	obj, ok := rate.(map[string]interface{})
+	if !ok {
+		return 0, fmt.Errorf("rate must be an object")
+	}
+	limit, ok := asFloat(obj["limit"])
+	if !ok || limit < 0 {
+		return 0, fmt.Errorf("rate.limit must be a non-negative number")
+	}
+	window, ok := obj["window"].(string)
+	if !ok {
+		return 0, fmt.Errorf("rate.window must be an ISO-8601 duration")
+	}
+	secs, err := parseDurationSeconds(window)
+	if err != nil || secs <= 0 {
+		return 0, fmt.Errorf("rate.window must be positive")
+	}
+	return limit / float64(secs), nil
+}
+
+func policyNotWeaker(parent, child interface{}) bool {
+	pobj, ok1 := parent.(map[string]interface{})
+	cobj, ok2 := child.(map[string]interface{})
+	if !ok1 || !ok2 {
+		return false
+	}
+	for k, pv := range pobj {
+		cv, present := cobj[k]
+		if !present {
+			return false
+		}
+		pn, pIsNum := asFloat(pv)
+		cn, cIsNum := asFloat(cv)
+		if pIsNum && cIsNum {
+			if cn < pn {
+				return false
+			}
+		} else if pIsNum != cIsNum {
+			return false
+		} else if !reflect.DeepEqual(pv, cv) {
+			return false
+		}
+	}
+	return true
+}
+
+func window(link map[string]interface{}) (*int64, *int64, error) {
+	var vf, vu *int64
+	if s, ok := link["validFrom"].(string); ok {
+		e, err := isoToEpoch(s)
+		if err != nil {
+			return nil, nil, err
+		}
+		vf = &e
+	}
+	if s, ok := link["validUntil"].(string); ok {
+		e, err := isoToEpoch(s)
+		if err != nil {
+			return nil, nil, err
+		}
+		vu = &e
+	}
+	return vf, vu, nil
+}
+
+func intentOf(link map[string]interface{}) map[string]interface{} {
+	if m, ok := link["intent"].(map[string]interface{}); ok {
+		return m
+	}
+	return map[string]interface{}{}
+}
+
+// nonExpansion returns the offending dimension if child broadens parent, else "".
+func nonExpansion(parent, child map[string]interface{}) string {
+	pIntent := intentOf(parent)
+	cIntent := intentOf(child)
+
+	for _, dim := range []string{"action", "target"} {
+		if cRaw, present := cIntent[dim]; present {
+			cSet, err := stringSet(cRaw)
+			if err != nil {
+				return dim
+			}
+			pSet, _ := stringSet(pIntent[dim])
+			if cSet != nil && pSet != nil {
+				for k := range cSet {
+					if !pSet[k] {
+						return dim
+					}
+				}
+			}
+		}
+	}
+
+	if cRes, present := cIntent["resource"]; present {
+		cs, ok := cRes.(string)
+		if !ok {
+			return "resource"
+		}
+		if ps, ok := pIntent["resource"].(string); ok && !isSubResource(cs, ps) {
+			return "resource"
+		}
+	}
+
+	cf, cu, err := window(child)
+	if err != nil {
+		return "time"
+	}
+	pf, pu, err := window(parent)
+	if err != nil {
+		return "time"
+	}
+	if cf != nil && pf != nil && *cf < *pf {
+		return "time"
+	}
+	if cu != nil && pu != nil && *cu > *pu {
+		return "time"
+	}
+
+	if cRate, present := child["rate"]; present && cRate != nil {
+		ce, err := rateEventsPerSec(cRate)
+		if err != nil {
+			return "rate"
+		}
+		if pRate, present := parent["rate"]; present && pRate != nil {
+			pe, err := rateEventsPerSec(pRate)
+			if err != nil {
+				return "rate"
+			}
+			if ce > pe+rateEpsilon {
+				return "rate"
+			}
+		}
+	}
+
+	if cPol, present := child["policy"]; present && cPol != nil {
+		if pPol, present := parent["policy"]; present && pPol != nil {
+			if !policyNotWeaker(pPol, cPol) {
+				return "policy"
+			}
+		}
+	}
+
+	return ""
+}
+
+// ValidateChain validates a delegation chain (root -> leaf) under v1.7 rules.
+func ValidateChain(chain []interface{}, trustedRoots []string, revoked []int, budget map[string]interface{}, nowIso string, skew int64) Verdict {
+	if len(chain) == 0 {
+		return Verdict{"valid": false, "code": "malformed_delegation", "detail": "empty delegation chain"}
+	}
+	if md, ok := asFloat(budget["maxDepth"]); ok && len(chain) > int(md) {
+		return Verdict{"valid": false, "code": "verifier_budget_exceeded", "limit": "depth"}
+	}
+
+	links := make([]map[string]interface{}, len(chain))
+	for i, raw := range chain {
+		m, ok := raw.(map[string]interface{})
+		if !ok {
+			return Verdict{"valid": false, "code": "malformed_delegation", "detail": fmt.Sprintf("link %d not object", i)}
+		}
+		_, iOk := m["issuer"].(string)
+		_, sOk := m["subject"].(string)
+		if !iOk || !sOk {
+			return Verdict{"valid": false, "code": "malformed_delegation", "detail": fmt.Sprintf("link %d missing issuer/subject", i)}
+		}
+		links[i] = m
+	}
+
+	if len(trustedRoots) > 0 {
+		rootIssuer := links[0]["issuer"].(string)
+		found := false
+		for _, r := range trustedRoots {
+			if r == rootIssuer {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return Verdict{"valid": false, "code": "untrusted_principal"}
+		}
+	}
+
+	minRevoked := -1
+	for _, idx := range revoked {
+		if idx >= 0 && idx < len(links) && (minRevoked == -1 || idx < minRevoked) {
+			minRevoked = idx
+		}
+	}
+	if minRevoked != -1 {
+		return Verdict{"valid": false, "code": "delegation_revoked", "linkIndex": minRevoked}
+	}
+
+	for i := 1; i < len(links); i++ {
+		parent, child := links[i-1], links[i]
+		if parent["subject"] != child["issuer"] {
+			return Verdict{"valid": false, "code": "subject_issuer_mismatch", "linkIndex": i}
+		}
+		if dim := nonExpansion(parent, child); dim != "" {
+			return Verdict{"valid": false, "code": "scope_exceeds_parent", "dimension": dim}
+		}
+	}
+
+	var effStart, effEnd *int64
+	var cumulativeTTL int64
+	for _, link := range links {
+		vf, vu, err := window(link)
+		if err != nil {
+			return Verdict{"valid": false, "code": "malformed_delegation", "detail": err.Error()}
+		}
+		if vf != nil {
+			if effStart == nil || *vf > *effStart {
+				effStart = vf
+			}
+		}
+		if vu != nil {
+			if effEnd == nil || *vu < *effEnd {
+				effEnd = vu
+			}
+		}
+		if vf != nil && vu != nil && *vu >= *vf {
+			cumulativeTTL += *vu - *vf
+		}
+	}
+	now, err := isoToEpoch(nowIso)
+	if err != nil {
+		return Verdict{"valid": false, "code": "malformed_delegation", "detail": err.Error()}
+	}
+	if effStart != nil && now < *effStart-skew {
+		return Verdict{"valid": false, "code": "outside_validity_window"}
+	}
+	if effEnd != nil && now > *effEnd+skew {
+		return Verdict{"valid": false, "code": "outside_validity_window"}
+	}
+	if mt, ok := asFloat(budget["maxCumulativeTtlSeconds"]); ok && cumulativeTTL > int64(mt) {
+		return Verdict{"valid": false, "code": "verifier_budget_exceeded", "limit": "cumulative_ttl"}
+	}
+
+	return Verdict{"valid": true}
+}
+
+// ValidateChainJSON is the JSON boundary matching the core. Infallible.
+func ValidateChainJSON(requestJSON string) string {
+	var req map[string]interface{}
+	if err := json.Unmarshal([]byte(requestJSON), &req); err != nil {
+		return marshalVerdict(Verdict{"valid": false, "code": "malformed_delegation", "detail": "request json: " + err.Error()})
+	}
+	chain, ok := req["chain"].([]interface{})
+	if !ok {
+		return marshalVerdict(Verdict{"valid": false, "code": "malformed_delegation", "detail": "missing chain array"})
+	}
+	var trusted []string
+	if arr, ok := req["trustedRoots"].([]interface{}); ok {
+		for _, x := range arr {
+			if s, ok := x.(string); ok {
+				trusted = append(trusted, s)
+			}
+		}
+	}
+	var revoked []int
+	if arr, ok := req["revokedIndices"].([]interface{}); ok {
+		for _, x := range arr {
+			if n, ok := asFloat(x); ok {
+				revoked = append(revoked, int(n))
+			}
+		}
+	}
+	budget, _ := req["budget"].(map[string]interface{})
+	now, _ := req["nowIso"].(string)
+	skew := int64(30)
+	if s, ok := asFloat(req["clockSkewSeconds"]); ok {
+		skew = int64(s)
+	}
+	return marshalVerdict(ValidateChain(chain, trusted, revoked, budget, now, skew))
+}
+
+func marshalVerdict(v Verdict) string {
+	b, _ := json.Marshal(v)
+	return string(b)
+}

--- a/go-sidecar/attenuation/attenuation_test.go
+++ b/go-sidecar/attenuation/attenuation_test.go
@@ -1,0 +1,55 @@
+package attenuation
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The Go validator MUST produce the same verdicts as the Rust core on the
+// shared interop vectors.
+func TestGoMatchesDelegationVectors(t *testing.T) {
+	path := filepath.Join("..", "..", "test-vectors", "delegation-attenuation", "vector.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read vectors: %v", err)
+	}
+	var doc struct {
+		Cases []struct {
+			Name    string                 `json:"name"`
+			Request map[string]interface{} `json:"request"`
+			Expect  map[string]interface{} `json:"expect"`
+		} `json:"cases"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse vectors: %v", err)
+	}
+	if len(doc.Cases) == 0 {
+		t.Fatal("no cases")
+	}
+
+	for _, c := range doc.Cases {
+		reqBytes, _ := json.Marshal(c.Request)
+		var verdict map[string]interface{}
+		if err := json.Unmarshal([]byte(ValidateChainJSON(string(reqBytes))), &verdict); err != nil {
+			t.Fatalf("%s: verdict not json: %v", c.Name, err)
+		}
+		if verdict["valid"] != c.Expect["valid"] {
+			t.Errorf("%s: valid mismatch: got %v", c.Name, verdict)
+			continue
+		}
+		if c.Expect["valid"] == false {
+			if verdict["code"] != c.Expect["code"] {
+				t.Errorf("%s: code mismatch: got %v", c.Name, verdict)
+			}
+			for _, field := range []string{"dimension", "limit", "linkIndex"} {
+				if want, ok := c.Expect[field]; ok {
+					if verdict[field] != want {
+						t.Errorf("%s: %s mismatch: got %v want %v", c.Name, field, verdict[field], want)
+					}
+				}
+			}
+		}
+	}
+}

--- a/go-sidecar/signer/credential.go
+++ b/go-sidecar/signer/credential.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cloudflare/circl/sign/mldsa/mldsa44"
 )
 
-const maxDelegationDepth = 5
+// v1.7 removes the fixed delegation depth limit (was 5).
 
 // SignOptions configures Signer.Sign.
 type SignOptions struct {
@@ -321,12 +321,10 @@ func (s *Signer) extendDelegationChain(
 		parentChain = raw
 	}
 
-	if len(parentChain) >= maxDelegationDepth {
-		return nil, fmt.Errorf(
-			"delegation chain exceeds max depth of %d",
-			maxDelegationDepth,
-		)
-	}
+	// v1.7 removes the fixed depth limit; the non-expansion rule is enforced at
+	// verification by the shared attenuation validator, and cost is a
+	// verifier-side budget. The resource-narrowing guard below stays as a fast
+	// build-time check.
 
 	parentResource, _ := parentIntent["resource"].(string)
 	childResource, _ := currentIntent["resource"].(string)

--- a/go-sidecar/signer/credential_test.go
+++ b/go-sidecar/signer/credential_test.go
@@ -466,7 +466,8 @@ func TestDelegationResourceNarrowingViolation(t *testing.T) {
 	}
 }
 
-func TestDelegationDepthLimit(t *testing.T) {
+func TestDelegationDeepChainAllowedV17(t *testing.T) {
+	// v1.7 removes the fixed depth limit: a restate-only chain grows without a cap.
 	intent := map[string]any{
 		"action":   "read",
 		"target":   "data",
@@ -482,7 +483,7 @@ func TestDelegationDepthLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for i := 1; i <= 5; i++ {
+	for i := 1; i <= 6; i++ {
 		cred, err = signers[i].Sign(SignOptions{
 			Intent:           intent,
 			ParentCredential: cred,
@@ -493,15 +494,8 @@ func TestDelegationDepthLimit(t *testing.T) {
 	}
 	subject := cred["credentialSubject"].(map[string]any)
 	chain := subject["delegationChain"].([]any)
-	if len(chain) != 5 {
-		t.Fatalf("expected 5 links, got %d", len(chain))
-	}
-
-	if _, err := signers[6].Sign(SignOptions{
-		Intent:           intent,
-		ParentCredential: cred,
-	}); err == nil {
-		t.Fatal("expected depth-limit error on 6th hop")
+	if len(chain) != 6 {
+		t.Fatalf("expected 6 links, got %d", len(chain))
 	}
 }
 

--- a/openai-gpt/knowledge/vouch-knowledge.md
+++ b/openai-gpt/knowledge/vouch-knowledge.md
@@ -650,7 +650,7 @@ agent.tools = vouch.protect([submit_claim], parent=grant)
 
 To build a chain explicitly, sign each credential under its parent. The
 `parent_credential` argument appends a delegation link and enforces resource
-narrowing and the depth limit.
+narrowing at build time. The full non-expansion rule (no link may broaden its parent on any of action, target, resource, time, rate, or policy) is checked at verification, and there is no fixed chain-depth limit; verifiers bound cost with their own budgets.
 
 ```python
 from vouch import Signer

--- a/packages/sdk-ts/src/attenuation.ts
+++ b/packages/sdk-ts/src/attenuation.ts
@@ -1,0 +1,274 @@
+/**
+ * v1.7 capability attenuation: the non-expansion rule over the six delegation
+ * dimensions, verifier cost budgets, and chain-cascade revocation
+ * (Specification 9.3-9.6).
+ *
+ * Faithful port of core/vouch-core/src/attenuation.rs; the two MUST agree
+ * verdict-for-verdict against test-vectors/delegation-attenuation.
+ *
+ * Security posture: default-deny. Any malformed input or ambiguous comparison
+ * rejects, because delegation grants authority and a false "valid" is an
+ * authority-escalation bug.
+ */
+
+const RATE_EPSILON = 1e-9;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Json = any;
+
+export interface Verdict {
+  valid: boolean;
+  code?: string;
+  dimension?: string;
+  limit?: string;
+  linkIndex?: number;
+  detail?: string;
+}
+
+function isoToEpoch(s: string): number {
+  const ms = Date.parse(s);
+  if (Number.isNaN(ms)) throw new Error(`invalid datetime: ${s}`);
+  return Math.floor(ms / 1000);
+}
+
+/** null => absent; string or string[] => Set; else throws. */
+function stringSet(v: Json): Set<string> | null {
+  if (v === undefined || v === null) return null;
+  if (typeof v === 'string') return new Set([v]);
+  if (Array.isArray(v)) {
+    const out = new Set<string>();
+    for (const item of v) {
+      if (typeof item !== 'string') throw new Error('action/target array must be strings');
+      out.add(item);
+    }
+    return out;
+  }
+  throw new Error('action/target must be a string or array');
+}
+
+function isSubResource(child: string, parent: string): boolean {
+  const c = child.replace(/\/+$/, '');
+  const p = parent.replace(/\/+$/, '');
+  if (c === p) return true;
+  return c.length > p.length && c.startsWith(p) && c[p.length] === '/';
+}
+
+function parseDurationSeconds(s: string): number {
+  if (!s || s[0] !== 'P') throw new Error(`invalid duration: ${s}`);
+  let total = 0;
+  let num = '';
+  let inTime = false;
+  let sawField = false;
+  for (const ch of s.slice(1)) {
+    if (ch === 'T') {
+      inTime = true;
+    } else if (ch >= '0' && ch <= '9') {
+      num += ch;
+    } else if (ch === 'D' || ch === 'H' || ch === 'M' || ch === 'S') {
+      if (num === '') throw new Error(`invalid duration: ${s}`);
+      const n = parseInt(num, 10);
+      if (ch === 'D') total += n * 86400;
+      else if (ch === 'H') total += n * 3600;
+      else if (ch === 'M') total += inTime ? n * 60 : n * 2592000;
+      else total += n;
+      num = '';
+      sawField = true;
+    } else {
+      throw new Error(`invalid duration: ${s}`);
+    }
+  }
+  if (!sawField || num !== '') throw new Error(`invalid duration: ${s}`);
+  return total;
+}
+
+function rateEventsPerSec(rate: Json): number {
+  if (typeof rate !== 'object' || rate === null) throw new Error('rate must be an object');
+  const limit = rate.limit;
+  if (typeof limit !== 'number' || limit < 0) throw new Error('rate.limit must be non-negative');
+  if (typeof rate.window !== 'string') throw new Error('rate.window must be an ISO-8601 duration');
+  const secs = parseDurationSeconds(rate.window);
+  if (secs <= 0) throw new Error('rate.window must be positive');
+  return limit / secs;
+}
+
+function policyNotWeaker(parent: Json, child: Json): boolean {
+  if (typeof parent !== 'object' || parent === null || typeof child !== 'object' || child === null) {
+    return false;
+  }
+  for (const k of Object.keys(parent)) {
+    if (!(k in child)) return false;
+    const pv = parent[k];
+    const cv = child[k];
+    const pNum = typeof pv === 'number';
+    const cNum = typeof cv === 'number';
+    if (pNum && cNum) {
+      if (cv < pv) return false;
+    } else if (pNum !== cNum) {
+      return false;
+    } else if (JSON.stringify(pv) !== JSON.stringify(cv)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function windowOf(link: Json): [number | null, number | null] {
+  const vf = typeof link.validFrom === 'string' ? isoToEpoch(link.validFrom) : null;
+  const vu = typeof link.validUntil === 'string' ? isoToEpoch(link.validUntil) : null;
+  return [vf, vu];
+}
+
+/** Returns the offending dimension if `child` broadens `parent`, else null. */
+export function nonExpansion(parent: Json, child: Json): string | null {
+  const pIntent = (parent.intent as Json) ?? {};
+  const cIntent = (child.intent as Json) ?? {};
+
+  for (const dim of ['action', 'target'] as const) {
+    if (cIntent[dim] !== undefined) {
+      let cSet: Set<string> | null;
+      try {
+        cSet = stringSet(cIntent[dim]);
+      } catch {
+        return dim;
+      }
+      let pSet: Set<string> | null = null;
+      try {
+        pSet = stringSet(pIntent[dim]);
+      } catch {
+        pSet = null;
+      }
+      if (cSet && pSet) {
+        for (const a of cSet) if (!pSet.has(a)) return dim;
+      }
+    }
+  }
+
+  if (cIntent.resource !== undefined) {
+    if (typeof cIntent.resource !== 'string') return 'resource';
+    if (typeof pIntent.resource === 'string' && !isSubResource(cIntent.resource, pIntent.resource)) {
+      return 'resource';
+    }
+  }
+
+  let cf: number | null, cu: number | null, pf: number | null, pu: number | null;
+  try {
+    [cf, cu] = windowOf(child);
+    [pf, pu] = windowOf(parent);
+  } catch {
+    return 'time';
+  }
+  if (cf !== null && pf !== null && cf < pf) return 'time';
+  if (cu !== null && pu !== null && cu > pu) return 'time';
+
+  if (child.rate !== undefined && child.rate !== null) {
+    let ce: number;
+    try {
+      ce = rateEventsPerSec(child.rate);
+    } catch {
+      return 'rate';
+    }
+    if (parent.rate !== undefined && parent.rate !== null) {
+      let pe: number;
+      try {
+        pe = rateEventsPerSec(parent.rate);
+      } catch {
+        return 'rate';
+      }
+      if (ce > pe + RATE_EPSILON) return 'rate';
+    }
+  }
+
+  if (child.policy !== undefined && child.policy !== null) {
+    if (parent.policy !== undefined && parent.policy !== null && !policyNotWeaker(parent.policy, child.policy)) {
+      return 'policy';
+    }
+  }
+
+  return null;
+}
+
+export function validateChain(
+  chain: Json[],
+  trustedRoots: string[] = [],
+  revokedIndices: number[] = [],
+  budget: Json = {},
+  nowIso = '',
+  clockSkewSeconds = 30,
+): Verdict {
+  if (chain.length === 0) {
+    return { valid: false, code: 'malformed_delegation', detail: 'empty delegation chain' };
+  }
+  if (typeof budget?.maxDepth === 'number' && chain.length > budget.maxDepth) {
+    return { valid: false, code: 'verifier_budget_exceeded', limit: 'depth' };
+  }
+  for (let i = 0; i < chain.length; i++) {
+    const link = chain[i];
+    if (typeof link !== 'object' || link === null || typeof link.issuer !== 'string' || typeof link.subject !== 'string') {
+      return { valid: false, code: 'malformed_delegation', detail: `link ${i} malformed` };
+    }
+  }
+  if (trustedRoots.length > 0 && !trustedRoots.includes(chain[0].issuer)) {
+    return { valid: false, code: 'untrusted_principal' };
+  }
+  const revoked = revokedIndices.filter((i) => i >= 0 && i < chain.length);
+  if (revoked.length > 0) {
+    return { valid: false, code: 'delegation_revoked', linkIndex: Math.min(...revoked) };
+  }
+  for (let i = 1; i < chain.length; i++) {
+    const parent = chain[i - 1];
+    const child = chain[i];
+    if (parent.subject !== child.issuer) {
+      return { valid: false, code: 'subject_issuer_mismatch', linkIndex: i };
+    }
+    const dim = nonExpansion(parent, child);
+    if (dim !== null) return { valid: false, code: 'scope_exceeds_parent', dimension: dim };
+  }
+
+  let effStart: number | null = null;
+  let effEnd: number | null = null;
+  let cumulativeTtl = 0;
+  let now: number;
+  try {
+    for (const link of chain) {
+      const [vf, vu] = windowOf(link);
+      if (vf !== null) effStart = effStart === null ? vf : Math.max(effStart, vf);
+      if (vu !== null) effEnd = effEnd === null ? vu : Math.min(effEnd, vu);
+      if (vf !== null && vu !== null && vu >= vf) cumulativeTtl += vu - vf;
+    }
+    now = isoToEpoch(nowIso);
+  } catch (e) {
+    return { valid: false, code: 'malformed_delegation', detail: String(e) };
+  }
+  if (effStart !== null && now < effStart - clockSkewSeconds) {
+    return { valid: false, code: 'outside_validity_window' };
+  }
+  if (effEnd !== null && now > effEnd + clockSkewSeconds) {
+    return { valid: false, code: 'outside_validity_window' };
+  }
+  if (typeof budget?.maxCumulativeTtlSeconds === 'number' && cumulativeTtl > budget.maxCumulativeTtlSeconds) {
+    return { valid: false, code: 'verifier_budget_exceeded', limit: 'cumulative_ttl' };
+  }
+  return { valid: true };
+}
+
+/** JSON boundary matching the core. Infallible. */
+export function validateChainJson(requestJson: string): string {
+  let req: Json;
+  try {
+    req = JSON.parse(requestJson);
+  } catch (e) {
+    return JSON.stringify({ valid: false, code: 'malformed_delegation', detail: `request json: ${e}` });
+  }
+  if (!Array.isArray(req.chain)) {
+    return JSON.stringify({ valid: false, code: 'malformed_delegation', detail: 'missing chain array' });
+  }
+  const verdict = validateChain(
+    req.chain,
+    req.trustedRoots ?? [],
+    req.revokedIndices ?? [],
+    req.budget ?? {},
+    req.nowIso ?? '',
+    typeof req.clockSkewSeconds === 'number' ? req.clockSkewSeconds : 30,
+  );
+  return JSON.stringify(verdict);
+}

--- a/packages/sdk-ts/src/signer.ts
+++ b/packages/sdk-ts/src/signer.ts
@@ -33,7 +33,7 @@ import {
   type VouchCredential,
 } from './vc';
 
-const MAX_CHAIN_DEPTH = 5;
+// v1.7 removes the fixed delegation depth limit (was 5).
 
 /**
  * The proofValue that binds a delegation link to its parent credential. A
@@ -454,11 +454,10 @@ export class Signer {
     const parentIntent = parentSubject.intent;
     const parentChain: DelegationLink[] = parentSubject.delegationChain ?? [];
 
-    if (parentChain.length >= MAX_CHAIN_DEPTH) {
-      throw new Error(
-        `Delegation chain exceeds max depth of ${MAX_CHAIN_DEPTH}`
-      );
-    }
+    // v1.7 removes the fixed depth limit; the non-expansion rule is enforced at
+    // verification by the shared attenuation validator, and cost is a
+    // verifier-side budget. The resource-narrowing guard below stays as a fast
+    // build-time check.
 
     const parentResource = parentIntent.resource ?? '';
     const childResource = currentIntent.resource ?? '';

--- a/packages/sdk-ts/tests/attenuation.test.ts
+++ b/packages/sdk-ts/tests/attenuation.test.ts
@@ -1,0 +1,28 @@
+/**
+ * The TypeScript delegation validator MUST produce the same verdicts as the
+ * Rust core on the shared interop vectors.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { describe, it, expect } from 'vitest';
+
+import { validateChainJson } from '../src/attenuation';
+
+const vectorPath = path.join(process.cwd(), '..', '..', 'test-vectors', 'delegation-attenuation', 'vector.json');
+const vectors = JSON.parse(fs.readFileSync(vectorPath, 'utf8'));
+
+describe('delegation attenuation interop vectors', () => {
+  for (const c of vectors.cases) {
+    it(c.name, () => {
+      const verdict = JSON.parse(validateChainJson(JSON.stringify(c.request)));
+      expect(verdict.valid).toBe(c.expect.valid);
+      if (!c.expect.valid) {
+        expect(verdict.code).toBe(c.expect.code);
+        for (const field of ['dimension', 'limit', 'linkIndex']) {
+          if (field in c.expect) expect(verdict[field]).toBe(c.expect[field]);
+        }
+      }
+    });
+  }
+});

--- a/packages/sdk-ts/tests/credential.test.ts
+++ b/packages/sdk-ts/tests/credential.test.ts
@@ -389,7 +389,7 @@ describe('Delegation chains', () => {
     ).rejects.toThrow(/resource-narrowing/);
   });
 
-  test('enforces the depth limit', async () => {
+  test('allows a deep restate-only chain (v1.7 removes the depth limit)', async () => {
     const commonResource = 'https://api.example.com/v1/data';
     const intentTpl: Intent = {
       action: 'read',
@@ -406,20 +406,14 @@ describe('Delegation chains', () => {
     let cred: VouchCredential = await signers[0].sign({
       intent: intentTpl,
     });
-    for (let i = 1; i < 6; i++) {
+    // Six hops: the sixth was previously rejected by the depth limit.
+    for (let i = 1; i < 7; i++) {
       cred = await signers[i].sign({
         intent: intentTpl,
         parentCredential: cred,
       });
     }
-    expect(cred.credentialSubject.delegationChain).toHaveLength(5);
-
-    await expect(
-      signers[6].sign({
-        intent: intentTpl,
-        parentCredential: cred,
-      })
-    ).rejects.toThrow(/max depth/);
+    expect(cred.credentialSubject.delegationChain).toHaveLength(6);
   });
 
   test('binds to a proof-set (post-quantum) parent via its classical proof member', async () => {

--- a/papers/paper-1-vouch-protocol/paper-1-vouch-protocol.tex
+++ b/papers/paper-1-vouch-protocol/paper-1-vouch-protocol.tex
@@ -466,7 +466,7 @@ A chain is a list of delegation-link credentials, ordered from root principal to
 
 \subsection{Capability Attenuation}
 
-Rather than capping the chain at a fixed number of links, each delegated capability MUST be a proper subset of its parent along at least one dimension (action, target, resource, time, rate, or policy) and broader along none. Authority therefore strictly narrows at every hop and cannot grow, which bounds the chain by construction: a link that fails to attenuate is rejected with \verb|capability_not_attenuated|. This rule replaces the earlier fixed depth limit, adopted following capability-security feedback from Alan Karp. Verification cost is bounded separately by verifier-side budgets (maximum depth, verification time, and cumulative time-to-live), which the verifier declares and enforces, returning \verb|verifier_budget_exceeded| when a chain exceeds them.
+Rather than capping the chain at a fixed number of links, each delegated capability MUST be a proper subset of its parent along at least one dimension (action, target, resource, time, rate, or policy) and broader along none. Authority therefore strictly narrows at every hop and cannot grow, which bounds the chain by construction: a link that broadens its parent on any dimension is rejected with \verb|scope_exceeds_parent|, naming the offending dimension. This rule replaces the earlier fixed depth limit, adopted following capability-security feedback from Alan Karp. Verification cost is bounded separately by verifier-side budgets (maximum depth, verification time, and cumulative time-to-live), which the verifier declares and enforces, returning \verb|verifier_budget_exceeded| when a chain exceeds them.
 
 \subsection{Chain Validation}
 
@@ -482,7 +482,7 @@ A verifier validating a leaf credential with an attached chain:
 \item Verifies the leaf credential's \verb|intent.resource| is a sub-URI of the deepest link's \verb|intent.resource|.
 \end{enumerate}
 
-Any failure produces a structured rejection reason: \verb|untrusted_principal|, \verb|capability_not_attenuated|, \verb|resource_not_narrowed|, \verb|verifier_budget_exceeded|, \verb|temporal_bounds_exceeded|, \verb|subject_issuer_mismatch|, or \verb|link_signature_invalid|.
+Any failure produces a structured rejection reason: \verb|untrusted_principal|, \verb|scope_exceeds_parent| (naming the broadened dimension), \verb|verifier_budget_exceeded|, \verb|subject_issuer_mismatch|, \verb|delegation_revoked| (a revoked link invalidates the whole chain below it), or \verb|outside_validity_window|.
 
 % ====================================================================
 \section{Revocation}

--- a/test-vectors/delegation-attenuation/vector.json
+++ b/test-vectors/delegation-attenuation/vector.json
@@ -1,0 +1,228 @@
+{
+  "description": "v1.7 capability-attenuation delegation-chain validation vectors. Each case is a request to the delegation validator and the expected verdict. Every conforming implementation (Rust core, Python, Go, TypeScript) MUST produce the expected verdict. Request/verdict schema is defined in core::attenuation::validate_chain_json.",
+  "spec": "w3c-cg-report v1.7 §9.3-9.6",
+  "now": "2026-04-26T10:00:00Z",
+  "cases": [
+    {
+      "name": "restate_unchanged_valid",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read","target":"t","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read","target":"t","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z","clockSkewSeconds":30
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "resource_narrowing_valid",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"resource":"https://x/a/b"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "resource_widening_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"resource":"https://x/a/b"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "resource"}
+    },
+    {
+      "name": "resource_sibling_prefix_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"resource":"https://x/a2"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "resource"}
+    },
+    {
+      "name": "action_superset_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":["read","write"]},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "action"}
+    },
+    {
+      "name": "action_subset_valid",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":["read","write"]},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "target_widening_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"target":"claim:1"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"target":"claim:2"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "target"}
+    },
+    {
+      "name": "time_widening_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T10:00:00Z","validUntil":"2026-04-26T11:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:30:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "time"}
+    },
+    {
+      "name": "rate_widening_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"rate":{"limit":100,"window":"PT1H"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"rate":{"limit":100,"window":"PT30M"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "rate"}
+    },
+    {
+      "name": "rate_narrowing_valid",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"rate":{"limit":100,"window":"PT1H"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"rate":{"limit":50,"window":"PT1H"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "policy_weakening_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"policy":{"minHeartbeatAgeSeconds":300},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"policy":{"minHeartbeatAgeSeconds":100},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "scope_exceeds_parent", "dimension": "policy"}
+    },
+    {
+      "name": "policy_strengthening_valid",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"policy":{"minHeartbeatAgeSeconds":300},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"policy":{"minHeartbeatAgeSeconds":600},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "absent_child_dimension_inherits_valid",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"resource":"https://x/a/b"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "subject_issuer_mismatch_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:WRONG","subject":"did:web:b","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "subject_issuer_mismatch", "linkIndex": 1}
+    },
+    {
+      "name": "untrusted_root_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "trustedRoots": ["did:web:other"],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "untrusted_principal"}
+    },
+    {
+      "name": "cascade_revocation_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:b","subject":"did:web:c","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "revokedIndices": [1],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "delegation_revoked", "linkIndex": 1}
+    },
+    {
+      "name": "budget_depth_exceeded",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:a","subject":"did:web:b","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:b","subject":"did:web:c","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "budget": {"maxDepth": 2},
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": false, "code": "verifier_budget_exceeded", "limit": "depth"}
+    },
+    {
+      "name": "deep_attenuating_chain_valid_no_depth_cap",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:h0","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:h0","subject":"did:web:h1","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:h1","subject":"did:web:h2","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:h2","subject":"did:web:h3","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:h3","subject":"did:web:h4","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"},
+          {"issuer":"did:web:h4","subject":"did:web:h5","intent":{"action":"read","resource":"https://x/a"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T12:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T10:00:00Z"
+      },
+      "expect": {"valid": true}
+    },
+    {
+      "name": "now_outside_effective_window_rejected",
+      "request": {
+        "chain": [
+          {"issuer":"did:web:root","subject":"did:web:a","intent":{"action":"read"},"validFrom":"2026-04-26T09:00:00Z","validUntil":"2026-04-26T11:00:00Z"}
+        ],
+        "nowIso":"2026-04-26T20:00:00Z"
+      },
+      "expect": {"valid": false, "code": "outside_validity_window"}
+    },
+    {
+      "name": "empty_chain_malformed",
+      "request": {"chain": [], "nowIso":"2026-04-26T10:00:00Z"},
+      "expect": {"valid": false, "code": "malformed_delegation"}
+    }
+  ]
+}

--- a/tests/test_delegation_attenuation.py
+++ b/tests/test_delegation_attenuation.py
@@ -9,8 +9,12 @@ import pytest
 from vouch.attenuation import validate_chain_json
 
 VECTORS = json.loads(
-    (Path(__file__).resolve().parent.parent
-     / "test-vectors" / "delegation-attenuation" / "vector.json").read_text()
+    (
+        Path(__file__).resolve().parent.parent
+        / "test-vectors"
+        / "delegation-attenuation"
+        / "vector.json"
+    ).read_text()
 )
 
 

--- a/tests/test_delegation_attenuation.py
+++ b/tests/test_delegation_attenuation.py
@@ -1,0 +1,26 @@
+"""The Python delegation validator MUST produce the same verdicts as the Rust
+core on the shared interop vectors."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vouch.attenuation import validate_chain_json
+
+VECTORS = json.loads(
+    (Path(__file__).resolve().parent.parent
+     / "test-vectors" / "delegation-attenuation" / "vector.json").read_text()
+)
+
+
+@pytest.mark.parametrize("case", VECTORS["cases"], ids=[c["name"] for c in VECTORS["cases"]])
+def test_python_matches_delegation_vector(case):
+    verdict = json.loads(validate_chain_json(json.dumps(case["request"])))
+    expect = case["expect"]
+    assert verdict["valid"] == expect["valid"], f"{case['name']}: {verdict}"
+    if not expect["valid"]:
+        assert verdict["code"] == expect["code"], f"{case['name']}: {verdict}"
+        for field in ("dimension", "limit", "linkIndex"):
+            if field in expect:
+                assert verdict.get(field) == expect[field], f"{case['name']}: {verdict}"

--- a/tests/test_signer_vc.py
+++ b/tests/test_signer_vc.py
@@ -281,8 +281,10 @@ def test_delegation_chain_resource_narrowing_allows_sub_path():
     assert len(grand_cred["credentialSubject"]["delegationChain"]) == 1
 
 
-def test_delegation_chain_depth_limit_enforced():
-    """A chain of 5 parents should reject a 6th hop."""
+def test_delegation_chain_deep_chain_allowed_v17():
+    """v1.7 removes the fixed depth limit: a restate-only chain grows without a
+    cap. Authority is bounded by the non-expansion rule (each link restates or
+    narrows) and cost by a verifier-side budget, not a protocol depth ceiling."""
     common_resource = "https://api.example.com/v1/data"
     intent_template = {
         "action": "read",
@@ -293,15 +295,11 @@ def test_delegation_chain_depth_limit_enforced():
     signers = [_new_signer(f"did:web:agent{i}.example.com") for i in range(7)]
 
     cred = signers[0].sign(intent=intent_template)
-    # Build chain of length 5 (max allowed)
-    for s in signers[1:6]:
+    # Six hops: the sixth was previously rejected by the depth limit.
+    for s in signers[1:7]:
         cred = s.sign(intent=intent_template, parent_credential=cred)
 
-    assert len(cred["credentialSubject"]["delegationChain"]) == 5
-
-    # The 6th hop must fail
-    with pytest.raises(ValueError, match="max depth"):
-        signers[6].sign(intent=intent_template, parent_credential=cred)
+    assert len(cred["credentialSubject"]["delegationChain"]) == 6
 
 
 # ---------------------------------------------------------------------------

--- a/vouch/attenuation.py
+++ b/vouch/attenuation.py
@@ -1,0 +1,279 @@
+"""v1.7 capability attenuation: the non-expansion rule over the six delegation
+dimensions, verifier cost budgets, and chain-cascade revocation
+(Specification 9.3-9.6).
+
+This is a faithful port of ``core/vouch-core/src/attenuation.rs``. The two MUST
+agree verdict-for-verdict; the shared vectors in
+``test-vectors/delegation-attenuation/vector.json`` are the contract.
+
+Security posture: default-deny. Any malformed input, unknown shape, or
+ambiguous comparison rejects rather than admits, because a delegation chain
+grants authority and a false "valid" is an authority-escalation bug.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+_RATE_EPSILON = 1e-9
+_DIMENSIONS = ("action", "target", "resource", "time", "rate", "policy")
+
+
+def _iso_to_epoch(s: str) -> int:
+    dt = datetime.fromisoformat(s.replace("Z", "+00:00"))
+    return int(dt.timestamp())
+
+
+def _string_set(v: Any) -> Optional[set]:
+    """None -> absent; a str or list[str] -> set; anything else raises."""
+    if v is None:
+        return None
+    if isinstance(v, str):
+        return {v}
+    if isinstance(v, list):
+        out = set()
+        for item in v:
+            if not isinstance(item, str):
+                raise ValueError("action/target array must be strings")
+            out.add(item)
+        return out
+    raise ValueError("action/target must be a string or array")
+
+
+def _is_sub_resource(child: str, parent: str) -> bool:
+    c = child.rstrip("/")
+    p = parent.rstrip("/")
+    if c == p:
+        return True
+    return len(c) > len(p) and c.startswith(p) and c[len(p)] == "/"
+
+
+def _parse_duration_seconds(s: str) -> int:
+    if not s or s[0] != "P":
+        raise ValueError(f"invalid duration: {s}")
+    total = 0
+    num = ""
+    in_time = False
+    saw_field = False
+    for ch in s[1:]:
+        if ch == "T":
+            in_time = True
+        elif ch.isdigit():
+            num += ch
+        elif ch in ("D", "H", "M", "S"):
+            if num == "":
+                raise ValueError(f"invalid duration: {s}")
+            n = int(num)
+            if ch == "D":
+                total += n * 86_400
+            elif ch == "H":
+                total += n * 3_600
+            elif ch == "M":
+                total += n * 60 if in_time else n * 2_592_000
+            else:  # S
+                total += n
+            num = ""
+            saw_field = True
+        else:
+            raise ValueError(f"invalid duration: {s}")
+    if not saw_field or num != "":
+        raise ValueError(f"invalid duration: {s}")
+    return total
+
+
+def _rate_events_per_sec(rate: Any) -> float:
+    if not isinstance(rate, dict):
+        raise ValueError("rate must be an object")
+    limit = rate.get("limit")
+    if not isinstance(limit, (int, float)) or isinstance(limit, bool) or limit < 0:
+        raise ValueError("rate.limit must be a non-negative number")
+    window = rate.get("window")
+    if not isinstance(window, str):
+        raise ValueError("rate.window must be an ISO-8601 duration")
+    secs = _parse_duration_seconds(window)
+    if secs <= 0:
+        raise ValueError("rate.window must be positive")
+    return float(limit) / float(secs)
+
+
+def _policy_not_weaker(parent: Any, child: Any) -> bool:
+    if not isinstance(parent, dict) or not isinstance(child, dict):
+        return False
+    for k, pv in parent.items():
+        if k not in child:
+            return False  # child dropped a parent constraint => weaker
+        cv = child[k]
+        p_num = isinstance(pv, (int, float)) and not isinstance(pv, bool)
+        c_num = isinstance(cv, (int, float)) and not isinstance(cv, bool)
+        if p_num and c_num:
+            if cv < pv:
+                return False
+        elif p_num != c_num:
+            return False  # type mismatch
+        else:
+            if pv != cv:
+                return False  # non-numeric must match exactly
+    return True
+
+
+def _window(link: dict):
+    vf = link.get("validFrom")
+    vu = link.get("validUntil")
+    return (
+        _iso_to_epoch(vf) if isinstance(vf, str) else None,
+        _iso_to_epoch(vu) if isinstance(vu, str) else None,
+    )
+
+
+def non_expansion(parent: dict, child: dict) -> Optional[str]:
+    """Return the offending dimension name if ``child`` broadens ``parent``,
+    else None."""
+    p_intent = parent.get("intent") or {}
+    c_intent = child.get("intent") or {}
+
+    # action / target: child set must be a subset of the parent's.
+    for dim in ("action", "target"):
+        c_raw = c_intent.get(dim) if isinstance(c_intent, dict) else None
+        if c_raw is not None:
+            try:
+                c_set = _string_set(c_raw)
+            except ValueError:
+                return dim
+            p_set = _string_set(p_intent.get(dim)) if isinstance(p_intent, dict) else None
+            if c_set is not None and p_set is not None and not c_set.issubset(p_set):
+                return dim
+
+    # resource: child resource must be a sub-resource of the parent's.
+    c_res = c_intent.get("resource") if isinstance(c_intent, dict) else None
+    if c_res is not None:
+        if not isinstance(c_res, str):
+            return "resource"
+        p_res = p_intent.get("resource") if isinstance(p_intent, dict) else None
+        if isinstance(p_res, str) and not _is_sub_resource(c_res, p_res):
+            return "resource"
+
+    # time: child window within parent's.
+    try:
+        cf, cu = _window(child)
+        pf, pu = _window(parent)
+    except ValueError:
+        return "time"
+    if cf is not None and pf is not None and cf < pf:
+        return "time"
+    if cu is not None and pu is not None and cu > pu:
+        return "time"
+
+    # rate: child events/sec must not exceed the parent's.
+    c_rate = child.get("rate")
+    if c_rate is not None:
+        try:
+            ce = _rate_events_per_sec(c_rate)
+        except ValueError:
+            return "rate"
+        p_rate = parent.get("rate")
+        if p_rate is not None:
+            try:
+                pe = _rate_events_per_sec(p_rate)
+            except ValueError:
+                return "rate"
+            if ce > pe + _RATE_EPSILON:
+                return "rate"
+
+    # policy: child must be equal to or stricter than the parent's.
+    c_pol = child.get("policy")
+    if c_pol is not None:
+        p_pol = parent.get("policy")
+        if p_pol is not None and not _policy_not_weaker(p_pol, c_pol):
+            return "policy"
+
+    return None
+
+
+def validate_chain(
+    chain: List[dict],
+    trusted_roots: Optional[List[str]] = None,
+    revoked_indices: Optional[List[int]] = None,
+    budget: Optional[Dict[str, Any]] = None,
+    now_iso: str = "",
+    clock_skew_seconds: int = 30,
+) -> Dict[str, Any]:
+    """Validate a delegation chain (root -> leaf) under the v1.7 rules and
+    return a verdict dict identical in shape to the core JSON boundary."""
+    trusted_roots = trusted_roots or []
+    revoked_indices = revoked_indices or []
+    budget = budget or {}
+
+    if not chain:
+        return {"valid": False, "code": "malformed_delegation", "detail": "empty delegation chain"}
+
+    max_depth = budget.get("maxDepth")
+    if isinstance(max_depth, int) and len(chain) > max_depth:
+        return {"valid": False, "code": "verifier_budget_exceeded", "limit": "depth"}
+
+    for i, link in enumerate(chain):
+        if not isinstance(link, dict) or not isinstance(link.get("issuer"), str) or not isinstance(link.get("subject"), str):
+            return {"valid": False, "code": "malformed_delegation", "detail": f"link {i} malformed"}
+
+    if trusted_roots:
+        if chain[0]["issuer"] not in trusted_roots:
+            return {"valid": False, "code": "untrusted_principal"}
+
+    revoked = [i for i in revoked_indices if 0 <= i < len(chain)]
+    if revoked:
+        return {"valid": False, "code": "delegation_revoked", "linkIndex": min(revoked)}
+
+    for i in range(1, len(chain)):
+        parent, child = chain[i - 1], chain[i]
+        if parent.get("subject") != child.get("issuer"):
+            return {"valid": False, "code": "subject_issuer_mismatch", "linkIndex": i}
+        dim = non_expansion(parent, child)
+        if dim is not None:
+            return {"valid": False, "code": "scope_exceeds_parent", "dimension": dim}
+
+    eff_start = None
+    eff_end = None
+    cumulative_ttl = 0
+    try:
+        for link in chain:
+            vf, vu = _window(link)
+            if vf is not None:
+                eff_start = vf if eff_start is None else max(eff_start, vf)
+            if vu is not None:
+                eff_end = vu if eff_end is None else min(eff_end, vu)
+            if vf is not None and vu is not None and vu >= vf:
+                cumulative_ttl += vu - vf
+        now = _iso_to_epoch(now_iso)
+    except ValueError as e:
+        return {"valid": False, "code": "malformed_delegation", "detail": str(e)}
+
+    if eff_start is not None and now < eff_start - clock_skew_seconds:
+        return {"valid": False, "code": "outside_validity_window"}
+    if eff_end is not None and now > eff_end + clock_skew_seconds:
+        return {"valid": False, "code": "outside_validity_window"}
+
+    max_ttl = budget.get("maxCumulativeTtlSeconds")
+    if isinstance(max_ttl, int) and cumulative_ttl > max_ttl:
+        return {"valid": False, "code": "verifier_budget_exceeded", "limit": "cumulative_ttl"}
+
+    return {"valid": True}
+
+
+def validate_chain_json(request_json: str) -> str:
+    """JSON boundary matching the core: request in, verdict JSON out. Infallible."""
+    try:
+        req = json.loads(request_json)
+    except json.JSONDecodeError as e:
+        return json.dumps({"valid": False, "code": "malformed_delegation", "detail": f"request json: {e}"})
+    if not isinstance(req.get("chain"), list):
+        return json.dumps({"valid": False, "code": "malformed_delegation", "detail": "missing chain array"})
+    verdict = validate_chain(
+        chain=req["chain"],
+        trusted_roots=req.get("trustedRoots"),
+        revoked_indices=req.get("revokedIndices"),
+        budget=req.get("budget"),
+        now_iso=req.get("nowIso", ""),
+        clock_skew_seconds=req.get("clockSkewSeconds", 30),
+    )
+    return json.dumps(verdict)

--- a/vouch/attenuation.py
+++ b/vouch/attenuation.py
@@ -213,7 +213,11 @@ def validate_chain(
         return {"valid": False, "code": "verifier_budget_exceeded", "limit": "depth"}
 
     for i, link in enumerate(chain):
-        if not isinstance(link, dict) or not isinstance(link.get("issuer"), str) or not isinstance(link.get("subject"), str):
+        if (
+            not isinstance(link, dict)
+            or not isinstance(link.get("issuer"), str)
+            or not isinstance(link.get("subject"), str)
+        ):
             return {"valid": False, "code": "malformed_delegation", "detail": f"link {i} malformed"}
 
     if trusted_roots:
@@ -265,9 +269,13 @@ def validate_chain_json(request_json: str) -> str:
     try:
         req = json.loads(request_json)
     except json.JSONDecodeError as e:
-        return json.dumps({"valid": False, "code": "malformed_delegation", "detail": f"request json: {e}"})
+        return json.dumps(
+            {"valid": False, "code": "malformed_delegation", "detail": f"request json: {e}"}
+        )
     if not isinstance(req.get("chain"), list):
-        return json.dumps({"valid": False, "code": "malformed_delegation", "detail": "missing chain array"})
+        return json.dumps(
+            {"valid": False, "code": "malformed_delegation", "detail": "missing chain array"}
+        )
     verdict = validate_chain(
         chain=req["chain"],
         trusted_roots=req.get("trustedRoots"),

--- a/vouch/conformance.py
+++ b/vouch/conformance.py
@@ -201,7 +201,8 @@ def check_revocation() -> CheckResult:
 
 
 def check_delegation_narrowing() -> CheckResult:
-    """Delegation: a child chains to its parent, and the five-link depth bound is enforced."""
+    """Delegation (v1.7 non-expansion): a child chains to its parent, a
+    broadening delegation is rejected, and there is no fixed depth bound."""
     root = keys.generate_identity("conformance.test")
     root_signer = Signer(private_key=root.private_key_jwk, did=root.did)
     parent = root_signer.sign(
@@ -229,30 +230,48 @@ def check_delegation_narrowing() -> CheckResult:
             "the child did not record its parent in the delegation chain",
         )
 
-    # Extend the chain link by link; the depth bound must reject a further link.
+    # Non-expansion: a child that broadens the parent's resource must be rejected.
+    widen_id = keys.generate_identity("conformance.test")
+    widen_signer = Signer(private_key=widen_id.private_key_jwk, did=widen_id.did)
+    rejected_widening = False
+    try:
+        widen_signer.sign(
+            intent={
+                "action": "read",
+                "target": "users_table",
+                "resource": "https://conformance.test",  # broader than the parent
+            },
+            parent_credential=parent,
+        )
+    except ValueError:
+        rejected_widening = True
+    if not rejected_widening:
+        return CheckResult(
+            "delegation_narrowing", Status.FAIL, "a broadening delegation was not rejected"
+        )
+
+    # No fixed depth bound (v1.7): a deep restate-only chain must be accepted.
     current = parent
-    depth_enforced = False
     for _ in range(8):
         link_id = keys.generate_identity("conformance.test")
         link_signer = Signer(private_key=link_id.private_key_jwk, did=link_id.did)
-        try:
-            current = link_signer.sign(
-                intent={
-                    "action": "read",
-                    "target": "users_table",
-                    "resource": "https://conformance.test/db/users",
-                },
-                parent_credential=current,
-            )
-        except ValueError:
-            depth_enforced = True
-            break
-    if not depth_enforced:
+        current = link_signer.sign(
+            intent={
+                "action": "manage",
+                "target": "all_tables",
+                "resource": "https://conformance.test/db",
+            },
+            parent_credential=current,
+        )
+    deep_chain = current.get("credentialSubject", {}).get("delegationChain") or []
+    if len(deep_chain) < 8:
         return CheckResult(
-            "delegation_narrowing", Status.FAIL, "the five-link depth bound was not enforced"
+            "delegation_narrowing", Status.FAIL, "a deep attenuating chain was not accepted"
         )
     return CheckResult(
-        "delegation_narrowing", Status.PASS, "child chains to parent, depth bound enforced"
+        "delegation_narrowing",
+        Status.PASS,
+        "child chains to parent, broadening is rejected, deep chains are allowed",
     )
 
 

--- a/vouch/signer.py
+++ b/vouch/signer.py
@@ -398,20 +398,20 @@ class Signer:
         """
         Build a delegation link from `parent_credential` to this signer.
 
-        Implements Specification §9.2 link structure. Validates depth limit
-        (§9.4) and resource-narrowing (§9.3 step 5).
+        Implements Specification §9.2 link structure and enforces the v1.7
+        non-expansion rule (§9.3-9.5): the new link must not broaden the parent
+        on any dimension. The fixed depth limit is removed; verifiers bound
+        chain cost with their own budgets.
         """
-        MAX_CHAIN_DEPTH = 5
-
         parent_subject = parent_credential.get("credentialSubject", {})
         parent_intent = parent_subject.get("intent", {})
         parent_chain = parent_subject.get("delegationChain") or []
 
-        if len(parent_chain) >= MAX_CHAIN_DEPTH:
-            raise ValueError(f"Delegation chain exceeds max depth of {MAX_CHAIN_DEPTH}")
-
-        # Resource-narrowing check (§9.3): child resource must be a sub-resource
-        # of (or equal to) the parent's resource.
+        # v1.7 removes the fixed depth limit. The full non-expansion rule across
+        # all six dimensions is enforced at verification time by the shared
+        # validator (vouch/attenuation.py, pinned to the cross-language interop
+        # vectors). At build time we keep the resource-narrowing guard as a fast
+        # local check so an obviously-broadening link is refused early.
         parent_resource = parent_intent.get("resource", "")
         child_resource = current_intent.get("resource", "")
         if (

--- a/website-agent/backend/knowledge/delegation.md
+++ b/website-agent/backend/knowledge/delegation.md
@@ -75,7 +75,7 @@ agent.tools = vouch.protect([submit_claim], parent=grant)
 
 To build a chain explicitly, sign each credential under its parent. The
 `parent_credential` argument appends a delegation link and enforces resource
-narrowing and the depth limit.
+narrowing at build time. The full non-expansion rule (no link may broaden its parent on any of action, target, resource, time, rate, or policy) is checked at verification, and there is no fixed chain-depth limit; verifiers bound cost with their own budgets.
 
 ```python
 from vouch import Signer


### PR DESCRIPTION
This implements v1.7 capability attenuation: the fixed delegation depth limit is replaced by a non-expansion rule. A delegation link may restate or narrow its parent and may never broaden it on any of six dimensions (action, target, resource, time, rate, policy). Chain cost is bounded by verifier-side budgets (depth, verification time, cumulative TTL) rather than a protocol depth ceiling, and a revoked link invalidates the chain below it.

A single validator implements the rule with default-deny semantics and structured rejection reasons (`scope_exceeds_parent` naming the offending dimension, `verifier_budget_exceeded`, `delegation_revoked`, `subject_issuer_mismatch`, `untrusted_principal`, `outside_validity_window`), verifier budgets, and cascade revocation. It ships in the Rust core (exposed through the uniffi and wasm bindings) and in the Python, Go, and TypeScript SDKs, all pinned to a shared interop-vector suite (`test-vectors/delegation-attenuation`) so the four implementations agree verdict-for-verdict. The signers drop the fixed depth cap and enforce non-expansion at verification. The resolved v1.7 delegation spec draft, the umbrella paper, and the delegation surfaces are updated to match.
