### PR TITLE
Switch the JVM SDK Maven coordinate to io.github.vouch-protocol

### DIFF
--- a/.github/workflows/publish-maven.yml
+++ b/.github/workflows/publish-maven.yml
@@ -1,4 +1,4 @@
-# Publish the JVM SDK (com.vouchprotocol:vouch-core) to Maven Central.
+# Publish the JVM SDK (io.github.vouch-protocol:vouch-core) to Maven Central.
 #
 # Trigger: push a tag like `jvm-v0.1.0`, or run manually (workflow_dispatch).
 # Required repo secrets:

--- a/claude-skill/skills/vouch-protocol/reference/language-sdks.md
+++ b/claude-skill/skills/vouch-protocol/reference/language-sdks.md
@@ -21,7 +21,7 @@ the same shared test vectors.
   the Rust core compiled to WASM. Runs in browsers and in Node.
 - **Swift, for iOS and macOS**: the `VouchCore` Swift package. Built as an
   XCFramework over the core via UniFFI. Add it with Swift Package Manager.
-- **JVM, Java and Kotlin** (`com.vouchprotocol:vouch-core`): a Gradle module.
+- **JVM, Java and Kotlin** (`io.github.vouch-protocol:vouch-core`): a Gradle module.
   Java users get a plain class; Kotlin users get the generated UniFFI binding.
 - **.NET** (`VouchProtocol.Core` on NuGet): a C# library over the C ABI.
 - **C and C++**: the C bindings shipped with the core, a header plus a prebuilt

--- a/claude-skill/skills/vouch-protocol/reference/overview.md
+++ b/claude-skill/skills/vouch-protocol/reference/overview.md
@@ -55,7 +55,7 @@ everywhere, byte for byte.
 - TypeScript and Go: the existing reference SDKs
 - Browser and Node.js (WebAssembly): `npm install @vouch-protocol-official/core-wasm`
 - Swift (iOS and macOS): the `VouchCore` Swift package, over the core via UniFFI
-- JVM (Java and Kotlin): the `com.vouchprotocol:vouch-core` Gradle module
+- JVM (Java and Kotlin): the `io.github.vouch-protocol:vouch-core` Gradle module
 - .NET: `VouchProtocol.Core` on NuGet, over the C ABI
 - C and C++: the C bindings shipped with the core (header plus prebuilt library)
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -10,7 +10,7 @@ be run by hand from the Actions tab (workflow_dispatch).
 |---|---|---|
 | `rust-vX.Y.Z` | publish-crates.yml | `vouch-core`, `vouch-core-uniffi` to crates.io |
 | `dotnet-vX.Y.Z` | publish-nuget.yml | `VouchProtocol.Core` to NuGet.org |
-| `jvm-vX.Y.Z` | publish-maven.yml | `com.vouchprotocol:vouch-core` to Maven Central |
+| `jvm-vX.Y.Z` | publish-maven.yml | `io.github.vouch-protocol:vouch-core` to Maven Central |
 | `swift-vX.Y.Z` | swift-xcframework.yml | VouchCore XCFramework to GitHub Releases |
 | `c-vX.Y.Z` | publish-c.yml | native libs + `vouch_core.h` to GitHub Releases |
 | `npm-vX.Y.Z` | publish-npm.yml | `core-wasm`, `sdk`, `api-client` to npm |

--- a/gemini-gem/knowledge/vouch-knowledge.md
+++ b/gemini-gem/knowledge/vouch-knowledge.md
@@ -88,7 +88,7 @@ everywhere, byte for byte.
 - TypeScript and Go: the existing reference SDKs
 - Browser and Node.js (WebAssembly): `npm install @vouch-protocol-official/core-wasm`
 - Swift (iOS and macOS): the `VouchCore` Swift package, over the core via UniFFI
-- JVM (Java and Kotlin): the `com.vouchprotocol:vouch-core` Gradle module
+- JVM (Java and Kotlin): the `io.github.vouch-protocol:vouch-core` Gradle module
 - .NET: `VouchProtocol.Core` on NuGet, over the C ABI
 - C and C++: the C bindings shipped with the core (header plus prebuilt library)
 
@@ -2080,7 +2080,7 @@ the same shared test vectors.
   the Rust core compiled to WASM. Runs in browsers and in Node.
 - **Swift, for iOS and macOS**: the `VouchCore` Swift package. Built as an
   XCFramework over the core via UniFFI. Add it with Swift Package Manager.
-- **JVM, Java and Kotlin** (`com.vouchprotocol:vouch-core`): a Gradle module.
+- **JVM, Java and Kotlin** (`io.github.vouch-protocol:vouch-core`): a Gradle module.
   Java users get a plain class; Kotlin users get the generated UniFFI binding.
 - **.NET** (`VouchProtocol.Core` on NuGet): a C# library over the C ABI.
 - **C and C++**: the C bindings shipped with the core, a header plus a prebuilt

--- a/openai-gpt/knowledge/vouch-knowledge.md
+++ b/openai-gpt/knowledge/vouch-knowledge.md
@@ -88,7 +88,7 @@ everywhere, byte for byte.
 - TypeScript and Go: the existing reference SDKs
 - Browser and Node.js (WebAssembly): `npm install @vouch-protocol-official/core-wasm`
 - Swift (iOS and macOS): the `VouchCore` Swift package, over the core via UniFFI
-- JVM (Java and Kotlin): the `com.vouchprotocol:vouch-core` Gradle module
+- JVM (Java and Kotlin): the `io.github.vouch-protocol:vouch-core` Gradle module
 - .NET: `VouchProtocol.Core` on NuGet, over the C ABI
 - C and C++: the C bindings shipped with the core (header plus prebuilt library)
 
@@ -2080,7 +2080,7 @@ the same shared test vectors.
   the Rust core compiled to WASM. Runs in browsers and in Node.
 - **Swift, for iOS and macOS**: the `VouchCore` Swift package. Built as an
   XCFramework over the core via UniFFI. Add it with Swift Package Manager.
-- **JVM, Java and Kotlin** (`com.vouchprotocol:vouch-core`): a Gradle module.
+- **JVM, Java and Kotlin** (`io.github.vouch-protocol:vouch-core`): a Gradle module.
   Java users get a plain class; Kotlin users get the generated UniFFI binding.
 - **.NET** (`VouchProtocol.Core` on NuGet): a C# library over the C ABI.
 - **C and C++**: the C bindings shipped with the core, a header plus a prebuilt

--- a/sdks/jvm/build.gradle.kts
+++ b/sdks/jvm/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "1.9.24"
 }
 
-group = "com.vouchprotocol"
+group = "io.github.vouch-protocol"
 version = "2.0.0"
 description = "Vouch Protocol JVM SDK (Kotlin + Java) over the canonical Rust core via JNA / UniFFI."
 

--- a/website-agent/backend/knowledge/language-sdks.md
+++ b/website-agent/backend/knowledge/language-sdks.md
@@ -21,7 +21,7 @@ the same shared test vectors.
   the Rust core compiled to WASM. Runs in browsers and in Node.
 - **Swift, for iOS and macOS**: the `VouchCore` Swift package. Built as an
   XCFramework over the core via UniFFI. Add it with Swift Package Manager.
-- **JVM, Java and Kotlin** (`com.vouchprotocol:vouch-core`): a Gradle module.
+- **JVM, Java and Kotlin** (`io.github.vouch-protocol:vouch-core`): a Gradle module.
   Java users get a plain class; Kotlin users get the generated UniFFI binding.
 - **.NET** (`VouchProtocol.Core` on NuGet): a C# library over the C ABI.
 - **C and C++**: the C bindings shipped with the core, a header plus a prebuilt

--- a/website-agent/backend/knowledge/overview.md
+++ b/website-agent/backend/knowledge/overview.md
@@ -55,7 +55,7 @@ everywhere, byte for byte.
 - TypeScript and Go: the existing reference SDKs
 - Browser and Node.js (WebAssembly): `npm install @vouch-protocol-official/core-wasm`
 - Swift (iOS and macOS): the `VouchCore` Swift package, over the core via UniFFI
-- JVM (Java and Kotlin): the `com.vouchprotocol:vouch-core` Gradle module
+- JVM (Java and Kotlin): the `io.github.vouch-protocol:vouch-core` Gradle module
 - .NET: `VouchProtocol.Core` on NuGet, over the C ABI
 - C and C++: the C bindings shipped with the core (header plus prebuilt library)
 

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -17,7 +17,7 @@ install commands and links below. They are current.
 - .NET: `dotnet add package VouchProtocol.Core`
 - Go: `go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest`
 - Swift (iOS and macOS): add the `VouchCore` Swift package
-- JVM (Java and Kotlin): the `com.vouchprotocol:vouch-core` Gradle module
+- JVM (Java and Kotlin): the `io.github.vouch-protocol:vouch-core` Gradle module
 - C and C++: the C bindings shipped with the core (header plus prebuilt library)
 - HTTP API clients: `npm install @vouch-protocol-official/api-client` or `pip install vouch-api-client`
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -373,7 +373,7 @@ let result = try Vouch.verify(signedCredentialJson, publicKey: publicKey, now: "
 
 \`\`\`kotlin
 // build.gradle.kts
-dependencies { implementation("com.vouchprotocol:vouch-core:0.1.0") }
+dependencies { implementation("io.github.vouch-protocol:vouch-core:0.1.0") }
 \`\`\`
 
 The host native library is bundled inside the jar, so it loads with no extra setup.
@@ -1553,7 +1553,7 @@ Currently one: \`packages/sdk-ts/src/integrations/amnesia.ts\` for the Amnesia e
 
 The framework adapters above are conveniences, not requirements. If you are not on one of these frameworks, integrate Vouch directly.
 
-The signing and verification core ships as an installable package in every major language: \`pip install vouch-protocol\`, \`npm i @vouch-protocol-official/sdk\`, plus Rust (\`vouch-core\`), JVM (\`com.vouchprotocol:vouch-core\`), .NET (\`VouchProtocol.Core\`), Swift (\`VouchCore\`), C, and WebAssembly. See the [Tools page](/tools/) for the full list and install commands.
+The signing and verification core ships as an installable package in every major language: \`pip install vouch-protocol\`, \`npm i @vouch-protocol-official/sdk\`, plus Rust (\`vouch-core\`), JVM (\`io.github.vouch-protocol:vouch-core\`), .NET (\`VouchProtocol.Core\`), Swift (\`VouchCore\`), C, and WebAssembly. See the [Tools page](/tools/) for the full list and install commands.
 
 For a language-agnostic drop-in, three standalone services need no framework and no SDK:
 

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -106,7 +106,7 @@ const LANGUAGE_TILES = [
   },
   {
     name: 'JVM (Java / Kotlin)',
-    install: 'com.vouchprotocol:vouch-core',
+    install: 'io.github.vouch-protocol:vouch-core',
     repoPath: 'sdks/jvm/',
     note: 'Gradle module. A plain Java class, plus the generated Kotlin binding.',
   },

--- a/website/src/app/tools/page.tsx
+++ b/website/src/app/tools/page.tsx
@@ -159,7 +159,7 @@ const GROUPS: Group[] = [
             { name: 'TypeScript', blurb: 'For the browser and Node.', start: 'npm i @vouch-protocol-official/sdk' },
             { name: 'Go', blurb: 'A high-throughput signing sidecar.', start: 'go install github.com/vouch-protocol/vouch/go-sidecar/cmd/vouch-sidecar@latest' },
             { name: 'Rust', blurb: 'The shared core that every wrapper is built on.', start: 'cargo add vouch-core' },
-            { name: 'Java and Kotlin', blurb: 'On the JVM.', start: 'com.vouchprotocol:vouch-core' },
+            { name: 'Java and Kotlin', blurb: 'On the JVM.', start: 'io.github.vouch-protocol:vouch-core' },
             { name: '.NET', blurb: 'For C#.', start: 'VouchProtocol.Core', tag: 'Preview' },
             { name: 'Swift', blurb: 'For iOS and macOS.', start: 'github.com/vouch-protocol/vouch-swift', tag: 'Preview' },
             { name: 'C and WebAssembly', blurb: 'For native, embedded, browser, and edge.', tag: 'Preview' },


### PR DESCRIPTION
Changes the JVM SDK groupId from com.vouchprotocol to io.github.vouch-protocol, the GitHub-org namespace Maven Central auto-verifies (no DNS needed), and updates the coordinate references across the release doc, website, and knowledge base. The Java package com.vouchprotocol.core is unchanged; only the Maven coordinate changes, so the dependency is io.github.vouch-protocol:vouch-core while the import stays com.vouchprotocol.core.Vouch.