### PR TITLE
Expose the Halos safety-evidence functions through the WebAssembly core

### DIFF
--- a/core/wasm/src/lib.rs
+++ b/core/wasm/src/lib.rs
@@ -1094,3 +1094,20 @@ pub fn robotics_verify_consent_evidence(
 ) -> Result<String, JsError> {
     rjson::verify_consent_evidence(params_json, &b64d(robot_public_b64)?).map_err(jerr)
 }
+
+#[wasm_bindgen(js_name = roboticsBuildSafetyEvidence)]
+pub fn robotics_build_safety_evidence(
+    signer_seed_b64: &str,
+    params_json: &str,
+) -> Result<String, JsError> {
+    rjson::build_safety_evidence(&b64d(signer_seed_b64)?, params_json).map_err(jerr)
+}
+
+#[wasm_bindgen(js_name = roboticsVerifySafetyEvidence)]
+pub fn robotics_verify_safety_evidence(
+    credential_json: &str,
+    robot_public_b64: &str,
+    entries_json: &str,
+) -> Result<String, JsError> {
+    rjson::verify_safety_evidence(credential_json, &b64d(robot_public_b64)?, entries_json).map_err(jerr)
+}


### PR DESCRIPTION
This exposes the Halos safety-evidence functions through the WebAssembly core, so a browser can build and verify a `HalosSafetyEvidenceCredential` with real in-browser crypto.

The Rust core, C ABI, and language SDKs for the Halos safety-evidence recorder landed already. This adds the two matching WebAssembly bindings, `roboticsBuildSafetyEvidence` and `roboticsVerifySafetyEvidence`, which wrap the existing `robotics_json` functions. Smoke-tested through the built npm package: build produces a `HalosSafetyEvidenceCredential`, verify accepts the robot key, and verify rejects a wrong key.
