### PR TITLE
Bump the published core-wasm to 2.1.0 for the Halos functions

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,7 +28,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build the WASM core
         working-directory: core/wasm
-        run: bash build-npm.sh 2.0.0
+        run: bash build-npm.sh 2.1.0
       - name: Publish core-wasm
         working-directory: core/wasm/pkg
         run: |


### PR DESCRIPTION
Bump the core-wasm npm package to 2.1.0 so the new Halos safety-evidence WebAssembly functions (roboticsBuildSafetyEvidence, roboticsVerifySafetyEvidence) reach published consumers. These landed in the core after 2.0.0 was published. Publishing runs on a npm-v* tag.
