### PR TITLE
feat(conformance): L2 challenges and server-side re-check in the worker

### DIFF
--- a/conformance-worker/README.md
+++ b/conformance-worker/README.md
@@ -14,10 +14,17 @@ be faked by replaying the public test vectors.
 - `GET /conformance/{id}` , the stored result and signed credential, for re-verification.
 - `GET /conformance/{id}/badge.svg` , the badge.
 
-Checks re-checked today (L1): canonicalization and sign/verify are verified
-cryptographically with the core; validity-window and nonce-replay are behavioural
-(the implementation reports, the worker holds the expected answer). L2 and L3
-challenges reuse the same shape and land next.
+Checks re-checked today, L1 and L2.
+
+L1: canonicalization and sign/verify are verified cryptographically with the
+core; validity-window and nonce-replay are behavioural, with the worker holding
+the expected answer.
+
+L2: the submitted status list is decoded with the core and both the revoked and
+the untouched index are checked, the delegated child's signature and its recorded
+parent are verified, the sidecar result must carry a signed allow and a
+structured deny, and every audit-trail entry hash and chain link is recomputed
+from the raw entries. L3 challenges reuse the same shape.
 
 ## Local check
 

--- a/conformance-worker/lib.js
+++ b/conformance-worker/lib.js
@@ -8,11 +8,33 @@
 
 const CANON_COUNT = 3;
 
-// The L1 checks a level requires. Extend with L2 / L3 as those challenges land.
+// The checks each level requires. Extend with L3 as those challenges land.
 export const LEVEL_CHECKS = {
   L1: ["canonicalization", "sign_verify", "validity_window", "nonce_replay"],
+  L2: ["revocation", "delegation_narrowing", "sidecar_allow_deny", "audit_trail"],
 };
-const LEVEL_ORDER = ["L1"];
+const LEVEL_ORDER = ["L1", "L2"];
+
+// Audit trail: SHA-256 over the JCS-canonical bytes of the entry content, with
+// each entry committing to the previous entry's hash. Matches the reference SDK.
+const GENESIS_HASH = "0".repeat(64);
+
+function hex(buffer) {
+  return [...new Uint8Array(buffer)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+async function sha256Hex(text) {
+  return hex(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(text)));
+}
+
+// The hashed content: every field except entry_hash, with null values dropped.
+function auditContent(entry) {
+  const content = {};
+  for (const key of ["seq", "timestamp", "action", "actor", "resource", "decision", "metadata", "prev_hash"]) {
+    if (entry[key] !== null && entry[key] !== undefined) content[key] = entry[key];
+  }
+  return content;
+}
 
 function randInt(max) {
   const a = new Uint32Array(1);
@@ -96,12 +118,94 @@ export function buildSession(core, implementation, nowIso) {
   });
   expected["nonce-0"] = { firstAccepted: true, secondAccepted: false };
 
+  // revocation: the implementation builds a BitstringStatusList credential with
+  // one index revoked and one left active, plus the matching status entries. The
+  // worker decodes the list with the canonical core and checks both readings.
+  const revokedIndex = randInt(4096);
+  let activeIndex = randInt(4096);
+  if (activeIndex === revokedIndex) activeIndex = (activeIndex + 1) % 4096;
+  challenges.push({
+    challengeId: "revocation-0",
+    check: "revocation",
+    level: "L2",
+    input: {
+      statusListId: `https://conformance.vouch-protocol.com/status/${randInt(1_000_000)}`,
+      revokedIndex,
+      activeIndex,
+      statusPurpose: "revocation",
+    },
+  });
+
+  // delegation_narrowing: the implementation issues a child credential chained to
+  // this parent, narrowed to the given intent. The worker verifies the child's
+  // signature and that the chain records the parent's issuer.
+  const pk = JSON.parse(core.generateEd25519());
+  const parent = credentialSkeleton(
+    pk.did_key,
+    { action: "manage", target: "all_records", resource: "https://conformance.vouch-protocol.com/db" },
+    nowIso,
+    "2100-01-01T00:00:00Z"
+  );
+  const parentSigned = JSON.parse(
+    core.sign(JSON.stringify(parent), pk.seed_b64, `${pk.did_key}#key-1`, nowIso)
+  );
+  challenges.push({
+    challengeId: "delegation-0",
+    check: "delegation_narrowing",
+    level: "L2",
+    input: {
+      parentCredential: parentSigned,
+      narrowedIntent: {
+        action: "read",
+        target: "one_record",
+        resource: "https://conformance.vouch-protocol.com/db/records/1",
+      },
+    },
+  });
+  expected["delegation-0"] = { parentIssuer: pk.did_key };
+
+  // sidecar_allow_deny: one intent the policy allows, one it does not. The
+  // allowed intent must be signed, the disallowed one refused with a reason.
+  const allowedAction = "read";
+  challenges.push({
+    challengeId: "sidecar-0",
+    check: "sidecar_allow_deny",
+    level: "L2",
+    input: {
+      policy: { allowedActions: [allowedAction] },
+      allowedIntent: {
+        action: allowedAction,
+        target: `vector:${randInt(1_000_000)}`,
+        resource: "https://conformance.vouch-protocol.com/allowed",
+      },
+      deniedIntent: {
+        action: "delete",
+        target: `vector:${randInt(1_000_000)}`,
+        resource: "https://conformance.vouch-protocol.com/denied",
+      },
+    },
+  });
+
+  // audit_trail: a fixed action sequence the implementation records as a
+  // hash-linked trail. The worker recomputes every entry hash and the linkage.
+  const actions = [
+    { action: "ALLOWED", actor: "did:web:conformance.vouch-protocol.com", resource: "read_file" },
+    { action: "BLOCKED", actor: "did:web:conformance.vouch-protocol.com", resource: "run_command", decision: "untrusted" },
+    { action: "ALLOWED", actor: "did:web:conformance.vouch-protocol.com", resource: "write_file" },
+  ].map((a, i) => ({ ...a, timestamp: `2026-01-0${i + 1}T00:00:00Z` }));
+  challenges.push({
+    challengeId: "audit-0",
+    check: "audit_trail",
+    level: "L2",
+    input: { actions },
+  });
+
   return { implementation, createdAt: nowIso, challenges, expected };
 }
 
 // Re-check every response against the server-held expected answers, using the
 // canonical core for the cryptographic checks.
-export function recheck(core, session, responses) {
+export async function recheck(core, session, responses) {
   const byId = Object.fromEntries((responses || []).map((r) => [r.challengeId, r]));
   const checks = [];
   for (const ch of session.challenges) {
@@ -123,6 +227,60 @@ export function recheck(core, session, responses) {
         const out = resp?.output || {};
         pass = out.firstAccepted === true && out.secondAccepted === false;
         detail = pass ? "replay rejected on the second presentation" : "replay was not detected";
+      } else if (ch.check === "revocation") {
+        // Decode the submitted status list with the canonical core: the revoked
+        // index must read as revoked and the untouched index as active.
+        const out = resp?.output || {};
+        const listCredential = JSON.stringify(out.statusListCredential);
+        const revoked = core.verifyStatus(JSON.stringify(out.revokedEntry), listCredential) === true;
+        const active = core.verifyStatus(JSON.stringify(out.activeEntry), listCredential) === false;
+        pass = revoked && active;
+        detail = pass
+          ? "revoked index reads revoked, untouched index reads active"
+          : `status readings wrong (revoked=${revoked}, active-clear=${active})`;
+      } else if (ch.check === "delegation_narrowing") {
+        // The child must carry a valid signature and record its parent in the chain.
+        const child = resp?.output;
+        const signed =
+          !!child && core.verifyProof(JSON.stringify(child), session.implementation.publicKeyB64) === true;
+        const chain = child?.credentialSubject?.delegationChain || [];
+        const linked = chain.some((link) => link.issuer === session.expected[ch.challengeId]?.parentIssuer);
+        pass = signed && linked;
+        detail = pass
+          ? "child verifies and records its parent in the delegation chain"
+          : `chain incomplete (signature=${signed}, parent recorded=${linked})`;
+      } else if (ch.check === "sidecar_allow_deny") {
+        const out = resp?.output || {};
+        const allowedOk =
+          !!out.allowed &&
+          core.verifyProof(JSON.stringify(out.allowed), session.implementation.publicKeyB64) === true;
+        const deniedOk = out.denied?.rejected === true && !!out.denied?.reason;
+        pass = allowedOk && deniedOk;
+        detail = pass
+          ? "allowed intent signed, disallowed intent refused with a reason"
+          : `policy not enforced (allowed signed=${allowedOk}, denial structured=${deniedOk})`;
+      } else if (ch.check === "audit_trail") {
+        // Recompute every entry hash and the chain linkage from the raw entries.
+        const entries = resp?.output?.entries || [];
+        let previous = GENESIS_HASH;
+        let ok = entries.length === ch.input.actions.length;
+        for (const entry of entries) {
+          if (!ok) break;
+          if (entry.prev_hash !== previous) {
+            ok = false;
+            break;
+          }
+          const canonical = core.canonicalize(JSON.stringify(auditContent(entry)));
+          if ((await sha256Hex(canonical)) !== entry.entry_hash) {
+            ok = false;
+            break;
+          }
+          previous = entry.entry_hash;
+        }
+        pass = ok;
+        detail = pass
+          ? `${entries.length} entries hash-linked and byte-correct`
+          : "entry hashes or chain linkage did not recompute";
       }
     } catch (err) {
       detail = `error: ${err && err.message ? err.message : err}`;

--- a/conformance-worker/package.json
+++ b/conformance-worker/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@vouch-protocol-official/core-wasm": "^0.1.0"
+    "@vouch-protocol-official/core-wasm": "^2.0.0"
   }
 }

--- a/conformance-worker/package.json
+++ b/conformance-worker/package.json
@@ -4,6 +4,6 @@
   "private": true,
   "type": "module",
   "dependencies": {
-    "@vouch-protocol-official/core-wasm": "^2.0.0"
+    "@vouch-protocol-official/core-wasm": "^2.1.0"
   }
 }

--- a/conformance-worker/smoke.mjs
+++ b/conformance-worker/smoke.mjs
@@ -5,6 +5,7 @@
 // implementation is caught. Run: node smoke.mjs
 import init, * as core from "@vouch-protocol-official/core-wasm";
 import { readFileSync } from "fs";
+import { gzipSync } from "zlib";
 import { webcrypto } from "node:crypto";
 if (!globalThis.crypto) globalThis.crypto = webcrypto;
 
@@ -53,31 +54,132 @@ function implCredential(intent) {
   return JSON.parse(core.sign(JSON.stringify(skel), impl.seed_b64, `${impl.did_key}#key-1`, now));
 }
 
-function honestResponses(session) {
-  return session.challenges.map((ch) => {
-    if (ch.check === "canonicalization") {
-      return { challengeId: ch.challengeId, output: core.canonicalize(JSON.stringify(ch.input)) };
-    }
-    if (ch.check === "sign_verify") {
-      return { challengeId: ch.challengeId, output: implCredential(ch.input.intent) };
-    }
-    if (ch.check === "validity_window") {
-      const r = JSON.parse(
-        core.verify(JSON.stringify(ch.input.credential), ch.input.publicKeyB64, now, 30)
-      );
-      return { challengeId: ch.challengeId, output: { valid: r.valid } };
-    }
-    return { challengeId: ch.challengeId, output: { firstAccepted: true, secondAccepted: false } };
+// --- an honest implementation answering the L2 challenges --------------------
+
+const STATUS_LIST_BYTES = 16384; // 131072 bits, the reference default
+
+function buildStatusList(input) {
+  const bits = new Uint8Array(STATUS_LIST_BYTES);
+  const set = (index) => {
+    bits[Math.floor(index / 8)] |= 1 << (7 - (index % 8));
+  };
+  set(input.revokedIndex);
+  const encodedList = "u" + gzipSync(Buffer.from(bits), { level: 9 }).toString("base64url").replace(/=+$/, "");
+  const entry = (index) => ({
+    id: `${input.statusListId}#${index}`,
+    type: "BitstringStatusListEntry",
+    statusPurpose: input.statusPurpose,
+    statusListIndex: String(index),
+    statusListCredential: input.statusListId,
   });
+  return {
+    statusListCredential: {
+      "@context": ["https://www.w3.org/ns/credentials/v2"],
+      id: input.statusListId,
+      type: ["VerifiableCredential", "BitstringStatusListCredential"],
+      issuer: impl.did_key,
+      validFrom: now,
+      validUntil: "2100-01-01T00:00:00Z",
+      credentialSubject: {
+        id: `${input.statusListId}#list`,
+        type: "BitstringStatusList",
+        statusPurpose: input.statusPurpose,
+        encodedList,
+      },
+    },
+    revokedEntry: entry(input.revokedIndex),
+    activeEntry: entry(input.activeIndex),
+  };
+}
+
+function delegatedChild(input) {
+  const parent = input.parentCredential;
+  const skel = {
+    "@context": ["https://www.w3.org/ns/credentials/v2", "https://vouch-protocol.com/contexts/v1"],
+    id: `urn:uuid:${crypto.randomUUID()}`,
+    type: ["VerifiableCredential", "VouchCredential"],
+    issuer: impl.did_key,
+    validFrom: now,
+    validUntil: "2100-01-01T00:00:00Z",
+    credentialSubject: {
+      id: impl.did_key,
+      vouchVersion: "1.0",
+      intent: input.narrowedIntent,
+      delegationChain: [
+        {
+          issuer: parent.issuer,
+          subject: impl.did_key,
+          intent: parent.credentialSubject.intent,
+          validFrom: parent.validFrom,
+          validUntil: parent.validUntil,
+          parentProofValue: (parent.proof?.proofValue || "").slice(0, 64),
+        },
+      ],
+    },
+  };
+  return JSON.parse(core.sign(JSON.stringify(skel), impl.seed_b64, `${impl.did_key}#key-1`, now));
+}
+
+async function auditEntries(actions) {
+  const GENESIS = "0".repeat(64);
+  const entries = [];
+  let prev = GENESIS;
+  for (let i = 0; i < actions.length; i++) {
+    const content = { seq: i, prev_hash: prev, ...actions[i] };
+    const ordered = {};
+    for (const k of ["seq", "timestamp", "action", "actor", "resource", "decision", "metadata", "prev_hash"]) {
+      if (content[k] !== undefined && content[k] !== null) ordered[k] = content[k];
+    }
+    const digest = await crypto.subtle.digest(
+      "SHA-256",
+      new TextEncoder().encode(core.canonicalize(JSON.stringify(ordered)))
+    );
+    const entry_hash = [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+    entries.push({ ...ordered, entry_hash });
+    prev = entry_hash;
+  }
+  return entries;
+}
+
+async function honestResponses(session) {
+  const out = [];
+  for (const ch of session.challenges) {
+    if (ch.check === "canonicalization") {
+      out.push({ challengeId: ch.challengeId, output: core.canonicalize(JSON.stringify(ch.input)) });
+    } else if (ch.check === "sign_verify") {
+      out.push({ challengeId: ch.challengeId, output: implCredential(ch.input.intent) });
+    } else if (ch.check === "validity_window") {
+      const r = JSON.parse(core.verify(JSON.stringify(ch.input.credential), ch.input.publicKeyB64, now, 30));
+      out.push({ challengeId: ch.challengeId, output: { valid: r.valid } });
+    } else if (ch.check === "nonce_replay") {
+      out.push({ challengeId: ch.challengeId, output: { firstAccepted: true, secondAccepted: false } });
+    } else if (ch.check === "revocation") {
+      out.push({ challengeId: ch.challengeId, output: buildStatusList(ch.input) });
+    } else if (ch.check === "delegation_narrowing") {
+      out.push({ challengeId: ch.challengeId, output: delegatedChild(ch.input) });
+    } else if (ch.check === "sidecar_allow_deny") {
+      out.push({
+        challengeId: ch.challengeId,
+        output: {
+          allowed: implCredential(ch.input.allowedIntent),
+          denied: { rejected: true, reason: `policy_denied:${ch.input.deniedIntent.action}` },
+        },
+      });
+    } else if (ch.check === "audit_trail") {
+      out.push({ challengeId: ch.challengeId, output: { entries: await auditEntries(ch.input.actions) } });
+    }
+  }
+  return out;
 }
 
 const session = buildSession(core, implementation, now);
-ok("session issues at least four challenges", session.challenges.length >= 4);
+ok("session issues L1 and L2 challenges", session.challenges.length >= 8);
 
-const honest = honestResponses(session);
-const checks = recheck(core, session, honest);
-ok("all honest checks pass", checks.every((c) => c.pass));
-ok("derives L1", deriveLevel(checks) === "L1");
+const honest = await honestResponses(session);
+const checks = await recheck(core, session, honest);
+const failed = checks.filter((c) => !c.pass).map((c) => `${c.name}: ${c.detail}`);
+ok(`all honest checks pass${failed.length ? " (" + failed.join("; ") + ")" : ""}`, failed.length === 0);
+ok("derives L2", deriveLevel(checks) === "L2");
 
 const th = await transcriptHash(session, honest);
 const credential = buildConformanceCredential({
@@ -94,9 +196,29 @@ ok("minted badge credential verifies", core.verifyProof(JSON.stringify(signed), 
 const cheat = honest.map((r) =>
   r.challengeId.startsWith("canon-") ? { challengeId: r.challengeId, output: r.output + " " } : r
 );
-const cheatChecks = recheck(core, session, cheat);
+const cheatChecks = await recheck(core, session, cheat);
 ok("cheating canonicalization is caught", cheatChecks.some((c) => c.name === "canonicalization" && !c.pass));
 ok("cheating implementation is denied a level", deriveLevel(cheatChecks) === null);
+
+// A forged audit trail (a tampered entry that keeps its old hash) must not pass.
+const forged = honest.map((r) => {
+  if (!r.challengeId.startsWith("audit-")) return r;
+  const entries = JSON.parse(JSON.stringify(r.output.entries));
+  entries[1].resource = "exfiltrate_secrets";
+  return { challengeId: r.challengeId, output: { entries } };
+});
+const forgedChecks = await recheck(core, session, forged);
+ok("tampered audit trail is caught", forgedChecks.some((c) => c.name === "audit_trail" && !c.pass));
+
+// A status list that never set the revoked bit must not pass.
+const unrevoked = honest.map((r) => {
+  if (!r.challengeId.startsWith("revocation-")) return r;
+  const out = JSON.parse(JSON.stringify(r.output));
+  out.revokedEntry = out.activeEntry;
+  return { challengeId: r.challengeId, output: out };
+});
+const unrevokedChecks = await recheck(core, session, unrevoked);
+ok("unset revocation bit is caught", unrevokedChecks.some((c) => c.name === "revocation" && !c.pass));
 
 console.log(`\n${pass} passed, ${fail} failed`);
 process.exit(fail ? 1 : 0);

--- a/conformance-worker/worker.js
+++ b/conformance-worker/worker.js
@@ -81,7 +81,7 @@ async function submit(request, env, sessionId) {
 
   const body = await request.json();
   const responses = body.responses || [];
-  const checks = recheck(c, session, responses);
+  const checks = await recheck(c, session, responses);
   const level = deriveLevel(checks);
   const th = await transcriptHash(session, responses);
 


### PR DESCRIPTION
Adds the L2 challenges and their server-side re-check to the conformance worker, so a run can now certify L2 as well as L1.

The four L2 challenges ask the implementation to do the work, and the worker re-checks the result with the canonical core rather than trusting what was submitted.

- revocation: the implementation builds a BitstringStatusList credential with one index revoked and one left active. The worker decodes the list with the core and confirms the revoked index reads revoked and the untouched index reads active.
- delegation_narrowing: the implementation issues a child credential chained to a parent the worker signed, narrowed to a given intent. The worker verifies the child's signature and that the chain records the parent's issuer.
- sidecar_allow_deny: one intent the policy allows and one it does not. The allowed intent must come back signed and verifying, the disallowed one refused with a structured reason.
- audit_trail: the implementation records a fixed action sequence as a hash-linked trail. The worker recomputes every entry hash over the canonical bytes and walks the chain linkage from the raw entries.

Security boundary: the worker generates fresh inputs per session and holds the expected answers server-side, so a transcript from one session proves nothing about another, and a hand-written pass fails the signature, status-decode, and hash recomputation. The checks confirm behaviour, so an implementation that proxies to a correct core also passes, which is what behavioural conformance certifies.

Also bumps the worker's core-wasm dependency to 2.0.0, which is the version whose API the worker calls.

The smoke test covers the full loop for L1 and L2 and adds negative cases: a tampered audit entry and a status list with the revocation bit never set are both rejected.
