### PR TITLE
Add the Halos safety-evidence recorder to the FAQ, help, and knowledge base

### DIFF
--- a/claude-skill/skills/vouch-protocol/reference/robotics.md
+++ b/claude-skill/skills/vouch-protocol/reference/robotics.md
@@ -1201,6 +1201,14 @@ Credential format, so one verifier and one trust model cover all twenty-one.
   identity, a bystander can sign a `BystanderConsentToken` bound to that one capture
   so it cannot be replayed, and `verify_consent_evidence` confirms the basis (and,
   for explicit consent, the covering tokens) while only hashes are ever stored (21).
+- Can a robot on a certified safety stack such as NVIDIA Halos prove what it actually
+  did? Yes, Halos safety-evidence: `SafetyEventRecorder` records the safety-event stream
+  (the safety monitor, event integrator, decision maker, and sensor pipeline, plus
+  emergency stops and operator actions) into the tamper-evident encrypted black-box, and
+  `build_safety_evidence` signs a `HalosSafetyEvidenceCredential` sealing the black-box
+  head and entry count bound to the robot's identity and the certified stack elements it
+  ran on, so `verify_safety_evidence` confirms the record is unaltered, untruncated,
+  attributable, and tied to the certified configuration without the black-box key (22).
 
 ## Status
 
@@ -1242,6 +1250,7 @@ verifies and integrates with:
 - `verify_wear_attestation` with `attenuate_for_wear` for wear and the narrowed
   capability scope.
 - `verify_consent_evidence` for bystander-consent evidence.
+- `verify_safety_evidence` for Halos safety-evidence.
 - `verify_handoff_chain` for a physical custody chain.
 
 Output is byte-identical to the reference SDKs, so a robot credential produced in

--- a/website-agent/backend/knowledge/robotics.md
+++ b/website-agent/backend/knowledge/robotics.md
@@ -1201,6 +1201,14 @@ Credential format, so one verifier and one trust model cover all twenty-one.
   identity, a bystander can sign a `BystanderConsentToken` bound to that one capture
   so it cannot be replayed, and `verify_consent_evidence` confirms the basis (and,
   for explicit consent, the covering tokens) while only hashes are ever stored (21).
+- Can a robot on a certified safety stack such as NVIDIA Halos prove what it actually
+  did? Yes, Halos safety-evidence: `SafetyEventRecorder` records the safety-event stream
+  (the safety monitor, event integrator, decision maker, and sensor pipeline, plus
+  emergency stops and operator actions) into the tamper-evident encrypted black-box, and
+  `build_safety_evidence` signs a `HalosSafetyEvidenceCredential` sealing the black-box
+  head and entry count bound to the robot's identity and the certified stack elements it
+  ran on, so `verify_safety_evidence` confirms the record is unaltered, untruncated,
+  attributable, and tied to the certified configuration without the black-box key (22).
 
 ## Status
 
@@ -1242,6 +1250,7 @@ verifies and integrates with:
 - `verify_wear_attestation` with `attenuate_for_wear` for wear and the narrowed
   capability scope.
 - `verify_consent_evidence` for bystander-consent evidence.
+- `verify_safety_evidence` for Halos safety-evidence.
 - `verify_handoff_chain` for a physical custody chain.
 
 Output is byte-identical to the reference SDKs, so a robot credential produced in

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -962,6 +962,25 @@ The four CLI commands are \`vouch root init\`, \`vouch root recognize\`, \`vouch
       },
     ],
   },
+  {
+    id: 'robotics-halos',
+    audience: 'Robotics: Halos evidence',
+    title: 'Safety-evidence for a certified stack',
+    domain: 'robotics',
+    items: [
+      {
+        q: 'A robot runs a certified safety stack like NVIDIA Halos. Can it prove what it actually did?',
+        a: `Yes. A safety certification shows a robot's stack is safe by design, it does not record what a specific robot did. \`SafetyEventRecorder\` captures the safety-event stream, the safety monitor, event integrator, decision maker, and sensor pipeline, plus emergency stops and operator actions, into the tamper-evident encrypted black-box. \`build_safety_evidence\` has the robot sign a \`HalosSafetyEvidenceCredential\` that seals the black-box head and entry count and binds them to the robot's identity and the certified stack elements it ran on.`,
+        helpLinks: [{ label: 'Halos safety-evidence guide', href: '/help/#robotics-halos' }],
+        meta: 'Shipped - vouch.robotics.halos',
+      },
+      {
+        q: 'Can someone check that record without being able to read what the robot captured?',
+        a: `Yes. \`verify_safety_evidence\` confirms the record is unaltered, has not been truncated or extended since it was sealed, is attributable to that robot, and is tied to the named certified configuration, all from the encrypted entries and without the black-box key. Only a holder of the key can open the payloads, so a certifier or an insurer verifies the record while its contents stay confidential.`,
+        meta: 'Shipped - vouch.robotics.halos',
+      },
+    ],
+  },
 
   // =====================================================================
   // FOR DEVELOPERS

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -3005,6 +3005,30 @@ ok, subject = verify_consent_evidence(ev, robot_key, capture=frame, consent_toke
 Security boundary: the open layer is the cryptographic binding of a consent basis to a capture and its verification, holding only hashes. On-device biometric detection and redaction, and managed consent-registry orchestration, are commercial.
 `,
       },
+      {
+        id: 'robotics-halos',
+        title: 'Halos safety-evidence',
+        summary: 'A robot running a certified safety stack signs a tamper-evident record of what it did, bound to its identity and the certified configuration, verifiable without reading the payloads.',
+        body: `
+A robot may run a certified functional-safety stack such as NVIDIA Halos. The certification shows the stack is safe by design. This records what a specific robot actually did and binds that record to the robot's identity and the certified configuration it ran on.
+
+The problem it closes: a design-time safety certification produces no signed, verifiable account of a specific robot's events in service, and a plain log can be altered, truncated, or detached from the robot.
+
+How it works: \`SafetyEventRecorder\` writes each safety event, tagged by its source (the safety monitor, the event integrator, the decision maker, and the sensor pipeline, plus emergency stops and operator actions), into the encrypted, hash-linked black-box. \`build_safety_evidence\` has the robot sign a \`HalosSafetyEvidenceCredential\` sealing the black-box head and entry count, bound to its identity and the certified stack elements (the compute module, the safety operating system version, and the safety-application set). \`verify_safety_evidence\` checks the robot's proof and, when given the entries, that the chain is intact, its length matches the sealed count, and its head matches the sealed head, so a tampered, truncated, extended, or reordered record is rejected.
+
+\`\`\`python
+from vouch.robotics import SafetyEventRecorder, build_safety_evidence, verify_safety_evidence
+
+rec = SafetyEventRecorder(blackbox_key)
+rec.record("SAIM", "camera_blockage_cleared", {"cam": 2})
+rec.record("SDM", "slow_stop", {"reason": "out_of_distribution"})
+ev = build_safety_evidence(robot, halos_stack={"igxSom": "...", "halosCore": "...", "blueprint": ["SAIM", "SEI", "SDM"]}, window={"from": t0, "to": t1}, recorder=rec)
+ok, subject = verify_safety_evidence(ev, robot_key, entries=rec.entries())
+\`\`\`
+
+Security boundary: the open layer is the recorder and the signed evidence credential, composing the existing black-box and robot-identity primitives. The entries stay encrypted, so integrity, completeness, attribution, and configuration verify without the black-box key.
+`,
+      },
     ],
   },
   {


### PR DESCRIPTION
This adds the Halos safety-evidence recorder to the user-facing text surfaces, matching how the other robotics capabilities are documented.

- **FAQ** (`faq-data.ts`): a `robotics-halos` entry covering what the recorder proves and that a verifier can check the record without the black-box key.
- **Help** (`help-data.ts`): a `robotics-halos` guide with the problem it closes, how it works, a Python example, and the security boundary.
- **Knowledge base** (`claude-skill/.../reference/robotics.md` and `website-agent/backend/knowledge/robotics.md`, kept byte-identical): the capability description and the wrapper-SDK verify entry.

The interactive demo is deferred behind the core-wasm republish, and the GPT and Gemini knowledge are left for their own update pass.
