### PR TITLE
chore(core): single-source the WASM package version from the crate version

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -28,7 +28,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: Build the WASM core
         working-directory: core/wasm
-        run: bash build-npm.sh 2.1.0
+        run: bash build-npm.sh
       - name: Publish core-wasm
         working-directory: core/wasm/pkg
         run: |

--- a/core/wasm/Cargo.lock
+++ b/core/wasm/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-core-wasm"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "base64",
  "getrandom",

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vouch-core-wasm"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 authors = ["Ramprasad Anandam Gaddam"]
 description = "Vouch Protocol core, WASM build (browser + Node): JCS canonicalization, Ed25519, did:key/multikey, Data Integrity (eddsa-jcs-2022), credentials, delegation, dual-proof ML-DSA-44, and BitstringStatusList revocation. Thin wasm-bindgen wrapper over the canonical vouch-core crate."

--- a/core/wasm/build-npm.sh
+++ b/core/wasm/build-npm.sh
@@ -7,14 +7,19 @@
 # (web target, runs in browser + Node) and re-applies the npm publish metadata +
 # README + LICENSE, so `cd pkg && npm publish` produces a correct package.
 #
-# Usage:  ./build-npm.sh [version]      # default version: 0.1.0
+# Usage:  ./build-npm.sh [version]
+#
+# The version defaults to the crate version in Cargo.toml, which is what the
+# compiled `version()` reports. Keeping one source of truth means the published
+# package and the version baked into the WASM can never disagree.
 #
 set -euo pipefail
 cd "$(dirname "$0")"
 export PATH="$HOME/.cargo/bin:$PATH"
 
 NPM_NAME="@vouch-protocol-official/core-wasm"
-NPM_VERSION="${1:-0.1.0}"
+CRATE_VERSION="$(sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)"
+NPM_VERSION="${1:-$CRATE_VERSION}"
 
 echo "==> wasm-pack build (target=web, release)"
 wasm-pack build --target web --release


### PR DESCRIPTION
The published core-wasm package version and the version compiled into the WASM came from two different places, so `version()` reported 2.0.0 while the package on npm was 2.1.0.

- Bumps the crate to 2.1.0, which is what `version()` reports.
- The build script now takes the npm version from the crate version by default, so there is one source of truth.
- The publish workflow no longer passes a hardcoded version.
