### PR TITLE
Harden the MCP verify tool to resolve issuer keys and fail closed

### DIFF
--- a/packages/vouch-mcp/tests/test_smoke.py
+++ b/packages/vouch-mcp/tests/test_smoke.py
@@ -49,16 +49,22 @@ def test_registered_tool_names():
     } <= names
 
 
-def test_sign_and_verify_roundtrip():
-    kp = generate_identity("agent.example.com")
+def _configure(kp):
     os.environ["VOUCH_PRIVATE_KEY"] = kp.private_key_jwk
     os.environ["VOUCH_DID"] = kp.did
-
     from vouch.autosign import reset_default_signer
 
     reset_default_signer()
-
     from vouch.integrations.mcp import server
+
+    return server
+
+
+def test_sign_and_verify_roundtrip_offline_key():
+    # did:web cannot be resolved offline in a test, so supply the issuer key
+    # directly (the offline verification path).
+    kp = generate_identity("agent.example.com")
+    server = _configure(kp)
 
     out = server.sign("read", "https://api.example.com", "customer:123")
     cred = json.loads(out)
@@ -68,5 +74,45 @@ def test_sign_and_verify_roundtrip():
     ok, _ = Verifier.verify(cred, public_key=pub)
     assert ok is True
 
-    verdict = server.verify(out, public_key=None)
-    assert "VERIFIED" in verdict or "REJECTED" in verdict
+    # The verify tool accepts the genuine credential when given the key...
+    assert "VERIFIED" in server.verify(out, public_key=kp.public_key_jwk)
+    # ...and rejects a tampered one.
+    bad = json.loads(out)
+    bad["proof"]["proofValue"] = "z" + ("2" * (len(bad["proof"]["proofValue"]) - 1))
+    assert "REJECTED" in server.verify(json.dumps(bad), public_key=kp.public_key_jwk)
+
+
+def test_verify_resolves_did_key_and_rejects_forgery():
+    # did:key is self-certifying (the key is in the DID), so the no-key path
+    # resolves it offline. This is the regression guard for the fail-open bug:
+    # a forged or tampered credential must be REJECTED, not VERIFIED.
+    from vouch.root_of_trust import generate_did_key_identity
+
+    kp = generate_did_key_identity()
+    assert kp.did.startswith("did:key:")
+    server = _configure(kp)
+
+    out = server.sign("read", "https://api.example.com", "customer:123")
+
+    # Genuine credential, no key passed -> resolver fetches it from the DID.
+    assert "VERIFIED" in server.verify(out)
+
+    # Corrupted signature, no key passed -> must be rejected.
+    bad_sig = json.loads(out)
+    bad_sig["proof"]["proofValue"] = "z" + ("2" * (len(bad_sig["proof"]["proofValue"]) - 1))
+    assert "REJECTED" in server.verify(json.dumps(bad_sig))
+
+    # Tampered intent, no key passed -> must be rejected.
+    bad_intent = json.loads(out)
+    bad_intent["credentialSubject"]["intent"]["action"] = "delete"
+    assert "REJECTED" in server.verify(json.dumps(bad_intent))
+
+
+def test_verify_fails_closed_when_key_unresolvable():
+    # A did:web that cannot be resolved must yield REJECTED on the no-key path,
+    # never VERIFIED on structural checks alone.
+    kp = generate_identity("unresolvable.example.invalid")
+    server = _configure(kp)
+
+    out = server.sign("read", "https://api.example.com", "customer:123")
+    assert "REJECTED" in server.verify(out)

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -149,13 +149,21 @@ def verify(credential_json: str, public_key: Optional[str] = None) -> str:
     Args:
         credential_json: The credential as a JSON string.
         public_key: Optional Multikey public key of the issuer. If omitted,
-            the issuer's DID is resolved to fetch its key.
+            the issuer's DID is resolved to fetch its key (did:key offline,
+            did:web over the network). If the key cannot be obtained, the
+            credential is rejected rather than accepted.
 
     Returns:
         A human-readable verdict: the issuer DID and authorized intent when
         valid, or a rejection reason.
     """
-    from vouch import Verifier
+    # Use the module-level resolver-enabled verify(). When no public_key is
+    # supplied it resolves the issuer's key from the credential's DID and
+    # checks the signature. Critically, it fails closed: an unresolvable key
+    # yields (False, None), so a forged or tampered credential is rejected
+    # instead of passing on structural checks alone. (The static
+    # Verifier.verify skips the signature check entirely when given no key.)
+    from vouch import verify as verify_credential
 
     try:
         credential = json.loads(credential_json)
@@ -163,7 +171,7 @@ def verify(credential_json: str, public_key: Optional[str] = None) -> str:
         return f"REJECTED: not valid JSON ({e})"
 
     try:
-        is_valid, passport = Verifier.verify(credential, public_key=public_key)
+        is_valid, passport = verify_credential(credential, public_key=public_key)
     except Exception as e:
         return f"REJECTED: verification error ({e})"
 


### PR DESCRIPTION
The MCP `verify` tool now resolves the issuer's key from the credential's DID and confirms the signature before returning a verdict. When no key is supplied it resolves `did:key` offline and `did:web` over the network; if the key cannot be obtained it returns a rejection rather than a verdict based on structural checks alone. Callers that already hold the issuer key can still pass it directly for fully offline verification.

Security boundary: `verify` establishes that a credential was signed by the key the issuer's DID commits to, and that the validity window and intent binding hold. It assumes the DID document (for `did:web`) is served over authenticated HTTPS by the issuer's own domain; `did:key` is self-certifying and needs no network.

Tests cover the resolution path (a genuine credential is accepted, a credential whose signature or intent does not check out is rejected), the offline-key path, and the case where the issuer key cannot be resolved.
