### PR TITLE
Document the MCP verify key-resolution behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ML-DSA proof values use base64url-nopad Multibase (`u`), the encoding the
   Quantum-Resistant Cryptosuites specification defines. The classical
   `eddsa-jcs-2022` proof value stays base58btc (`z`).
+- The MCP server's `verify` tool resolves the issuer's key from the
+  credential's DID (`did:key` offline, `did:web` over the network) and confirms
+  the signature before returning a verdict. Callers that already hold the
+  issuer key can pass it directly for fully offline verification.
 
 ### Deprecated
 

--- a/packages/vouch-mcp/README.md
+++ b/packages/vouch-mcp/README.md
@@ -104,8 +104,17 @@ VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
 
 Signing proves *you* acted. Verifying is how *everyone else* benefits: any
 MCP-capable agent, in any framework, can confirm another agent's credential with
-a single tool call and no SDK. That is what turns Vouch from a per-app library
-into an interoperable trust layer.
+a single tool call and no SDK. That is what turns Vouch Protocol from a per-app
+library into an interoperable trust layer.
+
+### Verifying without a key
+
+`verify` checks the cryptographic signature, so a credential that only looks
+well-formed will not pass. When you do not pass a key, it resolves the issuer's
+key from the credential's DID: `did:key` is
+self-certifying and resolves offline, while `did:web` is fetched over HTTPS from
+the issuer's own domain. If the key cannot be resolved, the credential is
+rejected. To verify fully offline, pass the issuer's key as `public_key`.
 
 ## Registry
 


### PR DESCRIPTION
Documents the MCP `verify` tool key-resolution behavior so adopters know what to expect. The changelog and the vouch-mcp README now state that when no key is supplied, `verify` resolves the issuer key from the credential DID (`did:key` offline, `did:web` over HTTPS) and that you can pass the key directly for fully offline verification.
