### PR TITLE
Release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-02
+
 ### Added
 
 - Authority Freshness treats a change in authority state as a first-class input

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "2.0.2"
+version = "2.1.0"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts the 2.1.0 release. See the CHANGELOG for the full list. Highlights: Authority Freshness as a first-class trust input, W3C-aligned Data Integrity hashing and the `mldsa44-jcs-2024` identifier, the post-quantum profile as a Data Integrity proof set, and MCP `verify` resolving the issuer key from the credential DID. Bumps `vouch-protocol` to 2.1.0 and moves the changelog section. Includes the documentation from #379, which this supersedes.
