### PR TITLE
feat(sdks): port the robotics evidence-pack and VLA accountability examples to TypeScript, Go, and Rust

### DIFF
--- a/core/vouch-core/examples/robotics_evidence_pack.rs
+++ b/core/vouch-core/examples/robotics_evidence_pack.rs
@@ -1,0 +1,301 @@
+//! Regulatory evidence pack for a robot, assembled from Vouch robotics
+//! credentials (Rust). Mirrors examples/robotics_ai_act_evidence_pack.py.
+//!
+//! A robot presents signed credentials -- a hardware-rooted identity, a model
+//! provenance attestation, a physical capability scope, a safety record
+//! anchored to a tamper-evident ledger, a heartbeat carrying a motion digest,
+//! and perception provenance for its sensor frames -- and the conformance
+//! checker maps them onto all five built-in regulatory profiles (EU AI Act
+//! high-risk, ISO 10218, ISO/TS 15066, EU Machinery Regulation 2023/1230,
+//! UL 3300). An assessor then signs one point-in-time conformance attestation
+//! per profile that an auditor or notified body can verify offline.
+//!
+//! Run it:  cargo run --example robotics_evidence_pack   (from core/vouch-core)
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use vouch_core::keys::Ed25519KeyPair;
+use vouch_core::robotics::{
+    build_conformance_attestation, build_perception_attestation, build_physical_scope_credential,
+    build_provenance_attestation, build_robot_heartbeat, build_safety_record, check_conformance,
+    hash_frame, mint_robot_identity, robot_identity_binding, verify_conformance_attestation,
+    BuildConformanceAttestation, BuildPerception, BuildPhysicalScope, BuildProvenance,
+    BuildRobotHeartbeat, BuildSafetyRecord, MintRobotIdentity, MotionCollector, MotionSample,
+    PerceptionLog, SafetyEventLog,
+};
+
+/// The five built-in conformance profiles. The Rust core keeps the profile
+/// registry private, so the ids are listed here.
+const ALL_PROFILE_IDS: [&str; 5] = [
+    "eu-ai-act-high-risk",
+    "iso-10218",
+    "iso-ts-15066",
+    "eu-machinery-2023-1230",
+    "ul-3300",
+];
+
+const NOW: &str = "2026-01-01T00:00:00Z";
+const ROBOT_DID: &str = "did:web:ar7.example.com";
+const ASSESSOR_DID: &str = "did:web:assessor.example.com";
+const ROBOT_SEED: [u8; 32] = [3u8; 32];
+const ROOT_SEED: [u8; 32] = [7u8; 32];
+const ASSESSOR_SEED: [u8; 32] = [11u8; 32];
+
+/// Multibase (base64url) SHA-256, the hash form Vouch credentials carry.
+fn digest(data: &[u8]) -> String {
+    format!("u{}", URL_SAFE_NO_PAD.encode(Sha256::digest(data)))
+}
+
+fn robot_config() -> Value {
+    json!({"temperature": 0.0, "max_torque": 12.5})
+}
+
+/// Build the four base credentials: identity, model provenance, physical
+/// scope, and a safety record over a tamper-evident ledger. These satisfy
+/// eu-ai-act-high-risk, iso-10218, and eu-machinery-2023-1230, but leave gaps
+/// in iso-ts-15066 (no motion monitoring) and ul-3300 (no perception
+/// integrity).
+fn build_base_credentials() -> Vec<Value> {
+    let robot_kp = Ed25519KeyPair::from_seed(&ROBOT_SEED);
+    let root_kp = Ed25519KeyPair::from_seed(&ROOT_SEED);
+
+    // The (software) hardware root signs a binding over the robot DID and key.
+    let binding = robot_identity_binding(ROBOT_DID, &robot_kp.public_multikey());
+    let identity = mint_robot_identity(
+        &ROBOT_SEED,
+        &MintRobotIdentity {
+            robot_did: ROBOT_DID.into(),
+            make: "Acme Robotics".into(),
+            model: "AR-7".into(),
+            serial: "SN-000123".into(),
+            owner: None,
+            root_kind: "TPM".into(), // reference; use a real TPM in deployment
+            root_public_multibase: root_kp.public_multikey(),
+            attestation: root_kp.sign(&binding).to_vec(),
+            lifecycle: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("mint identity");
+
+    let provenance = build_provenance_attestation(
+        &ROBOT_SEED,
+        &BuildProvenance {
+            issuer_did: ROBOT_DID.into(),
+            robot_did: ROBOT_DID.into(),
+            model_name: "Gemini Robotics ER 2".into(),
+            weights_hash: digest(b"gemini-robotics-er-2-weights"),
+            safety_policy: digest(b"factory-floor-safety-policy-v3"),
+            config: Some(robot_config()),
+            version: Some("2.0".into()),
+            supersedes: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build provenance");
+
+    let scope = build_physical_scope_credential(
+        &ROBOT_SEED,
+        &BuildPhysicalScope {
+            issuer_did: ROBOT_DID.into(),
+            subject_did: ROBOT_DID.into(),
+            max_force_n: Some(80.0),
+            max_speed_mps: Some(1.5),
+            max_speed_near_humans_mps: Some(0.5),
+            allowed_zones: Some(vec!["cell-3".into()]),
+            valid_from: NOW.into(),
+            ..Default::default()
+        },
+    )
+    .expect("build scope");
+
+    let mut ledger = SafetyEventLog::new(None);
+    ledger
+        .append(
+            "near_miss",
+            "low",
+            Some(&json!({"note": "pallet edge proximity"})),
+            None,
+            "2026-01-01T00:00:01Z",
+        )
+        .expect("append near_miss");
+    ledger
+        .append(
+            "manual_override",
+            "info",
+            None,
+            Some("did:web:operator.example.com"),
+            "2026-01-01T00:00:02Z",
+        )
+        .expect("append manual_override");
+    let record = build_safety_record(
+        &ASSESSOR_SEED,
+        &BuildSafetyRecord {
+            issuer_did: ASSESSOR_DID.into(),
+            robot_did: ROBOT_DID.into(),
+            summary: ledger.summarize(),
+            period_start: None,
+            period_end: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build safety record");
+
+    vec![identity, provenance, scope, record]
+}
+
+/// Build the two credentials that close the remaining gaps: a heartbeat whose
+/// motion digest proves the last interval stayed inside the physical envelope
+/// (ISO/TS 15066 continuous monitoring), and perception provenance binding a
+/// captured camera frame to the robot's key (UL 3300 sensing integrity).
+fn build_monitoring_credentials(scope_credential: &Value) -> Vec<Value> {
+    let scope = scope_credential["credentialSubject"]["physicalScope"].clone();
+
+    let mut collector = MotionCollector::new(Some(scope));
+    collector
+        .record(&MotionSample {
+            force_n: Some(12.0),
+            speed_mps: Some(0.4),
+            near_humans: true,
+            zone: Some("cell-3".into()),
+            ..Default::default()
+        })
+        .expect("record sample");
+    collector
+        .record(&MotionSample {
+            force_n: Some(25.0),
+            speed_mps: Some(1.1),
+            zone: Some("cell-3".into()),
+            ..Default::default()
+        })
+        .expect("record sample");
+    let heartbeat = build_robot_heartbeat(
+        &ROBOT_SEED,
+        &BuildRobotHeartbeat {
+            robot_did: ROBOT_DID.into(),
+            session_id: "shift-A".into(),
+            interval_index: 0,
+            interval_seconds: 30,
+            motion_digest: collector.digest(),
+            valid_from: NOW.into(),
+        },
+    )
+    .expect("build heartbeat");
+
+    let frame: &[u8] = b"\x89frame-bytes-from-the-front-camera";
+    let mut log = PerceptionLog::new(None);
+    log.record(
+        "cam-front",
+        "camera",
+        Some(frame),
+        None,
+        "2026-01-01T00:00:03Z",
+    )
+    .expect("record frame");
+    let perception = build_perception_attestation(
+        &ROBOT_SEED,
+        &BuildPerception {
+            robot_did: ROBOT_DID.into(),
+            sensor_id: "cam-front".into(),
+            modality: "camera".into(),
+            frame_hash: hash_frame(frame),
+            captured_at: None,
+            log_head: Some(log.head().to_string()),
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build perception");
+
+    vec![heartbeat, perception]
+}
+
+fn print_summary(reports: &[(String, Value)]) {
+    for (pid, report) in reports {
+        let verdict = if report["conforms"].as_bool().unwrap_or(false) {
+            "CONFORMS"
+        } else {
+            "GAPS"
+        };
+        println!(
+            "  {:<24} {:<8} ({}/{})  {}",
+            pid,
+            verdict,
+            report["satisfiedCount"],
+            report["totalCount"],
+            report["regime"].as_str().unwrap_or("")
+        );
+        for req in report["requirements"].as_array().into_iter().flatten() {
+            if !req["satisfied"].as_bool().unwrap_or(false) {
+                println!(
+                    "    gap: {}: {}",
+                    req["clause"].as_str().unwrap_or(""),
+                    req["title"].as_str().unwrap_or("")
+                );
+            }
+        }
+    }
+}
+
+fn check_all_profiles(credentials: &[Value]) -> Vec<(String, Value)> {
+    ALL_PROFILE_IDS
+        .iter()
+        .map(|pid| {
+            let report = check_conformance(credentials, pid).expect("check conformance");
+            (pid.to_string(), report)
+        })
+        .collect()
+}
+
+fn main() {
+    let assessor_kp = Ed25519KeyPair::from_seed(&ASSESSOR_SEED);
+
+    // The base credential set leaves gaps in two of the five profiles.
+    let base = build_base_credentials();
+    println!("base credential set (identity, provenance, scope, safety record):");
+    print_summary(&check_all_profiles(&base));
+
+    // The heartbeat and perception credentials close them.
+    let mut credentials = base.clone();
+    credentials.extend(build_monitoring_credentials(&base[2]));
+    println!("\nfull evidence pack ({} credentials):", credentials.len());
+    let reports = check_all_profiles(&credentials);
+    print_summary(&reports);
+
+    // One signed, offline-verifiable conformance attestation per profile.
+    println!(
+        "\nsigned attestations ({} profiles):",
+        ALL_PROFILE_IDS.len()
+    );
+    for (pid, report) in &reports {
+        let attestation = build_conformance_attestation(
+            &ASSESSOR_SEED,
+            &BuildConformanceAttestation {
+                issuer_did: ASSESSOR_DID.into(),
+                robot_did: ROBOT_DID.into(),
+                report: report.clone(),
+                valid_from: NOW.into(),
+                valid_until: None,
+            },
+        )
+        .expect("build attestation");
+        let subject = verify_conformance_attestation(&attestation, &assessor_kp.public_key())
+            .expect("verify attestation");
+        let report_digest = subject
+            .as_ref()
+            .and_then(|s| s["reportDigest"].as_str())
+            .unwrap_or("");
+        println!(
+            "  {:<24} verifies={}  reportDigest={}...",
+            pid,
+            subject.is_some(),
+            &report_digest[..16.min(report_digest.len())]
+        );
+    }
+}

--- a/core/vouch-core/examples/robotics_vla_accountability_loop.rs
+++ b/core/vouch-core/examples/robotics_vla_accountability_loop.rs
@@ -1,0 +1,196 @@
+//! VLA accountability loop: provenance on load, a pre-actuation scope gate,
+//! and a tamper-evident black box (Rust). Mirrors
+//! examples/robotics_vla_accountability_loop.py.
+//!
+//! A robot driven by a vision-language-action model (here Gemini Robotics ER 2)
+//! composes three Vouch robotics primitives into one accountable control loop:
+//!
+//!   1. Provenance on load: before autonomy is enabled, the robot verifies the
+//!      signed ModelProvenanceAttestation for the exact weights and config it
+//!      is about to run.
+//!   2. Pre-actuation scope gate: every action the planner proposes is checked
+//!      against the robot's signed PhysicalCapabilityScope before actuating;
+//!      an over-speed or out-of-zone action is denied, not attempted.
+//!   3. Tamper-evident black box: every decision, allowed or denied, is
+//!      appended to an encrypted, hash-linked black-box log. Anyone can verify
+//!      the chain; only a holder of the key can read the payloads.
+//!
+//! Run it:  cargo run --example robotics_vla_accountability_loop   (from core/vouch-core)
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use vouch_core::keys::Ed25519KeyPair;
+use vouch_core::robotics::{
+    build_physical_scope_credential, build_provenance_attestation, check_physical_action,
+    verify_blackbox_chain, verify_provenance_attestation, BlackBoxLog, BuildPhysicalScope,
+    BuildProvenance, PhysicalAction,
+};
+
+const VLA_MODEL_NAME: &str = "Gemini Robotics ER 2";
+const NOW: &str = "2026-01-01T00:00:00Z";
+const ROBOT_DID: &str = "did:web:ar7.example.com";
+const ROBOT_SEED: [u8; 32] = [3u8; 32];
+const BLACKBOX_KEY: [u8; 32] = [9u8; 32];
+
+/// Multibase (base64url) SHA-256, the hash form Vouch credentials carry.
+fn digest(data: &[u8]) -> String {
+    format!("u{}", URL_SAFE_NO_PAD.encode(Sha256::digest(data)))
+}
+
+fn vla_config() -> Value {
+    json!({"planner": "er-2", "temperature": 0.0, "max_plan_steps": 8})
+}
+
+/// What the planner proposes during one task episode. The first two stay
+/// inside the envelope; the sprint exceeds the near-human speed cap and the
+/// loading-bay fetch leaves the allowed zone, so the gate must deny both.
+fn planned_actions() -> Vec<(&'static str, PhysicalAction)> {
+    vec![
+        (
+            "pick up the cup",
+            PhysicalAction {
+                force_n: Some(20.0),
+                speed_mps: Some(0.3),
+                near_humans: true,
+                zone: Some("cell-3".into()),
+                ..Default::default()
+            },
+        ),
+        (
+            "hand cup to operator",
+            PhysicalAction {
+                force_n: Some(10.0),
+                speed_mps: Some(0.2),
+                near_humans: true,
+                zone: Some("cell-3".into()),
+                ..Default::default()
+            },
+        ),
+        (
+            "sprint to the dock",
+            PhysicalAction {
+                speed_mps: Some(2.5),
+                near_humans: true,
+                zone: Some("cell-3".into()),
+                ..Default::default()
+            },
+        ),
+        (
+            "fetch from loading bay",
+            PhysicalAction {
+                force_n: Some(15.0),
+                speed_mps: Some(0.5),
+                zone: Some("loading-bay".into()),
+                ..Default::default()
+            },
+        ),
+    ]
+}
+
+fn main() {
+    let robot_kp = Ed25519KeyPair::from_seed(&ROBOT_SEED);
+
+    // 1. provenance on load: no verified provenance, no autonomy.
+    let attestation = build_provenance_attestation(
+        &ROBOT_SEED,
+        &BuildProvenance {
+            issuer_did: ROBOT_DID.into(),
+            robot_did: ROBOT_DID.into(),
+            model_name: VLA_MODEL_NAME.into(),
+            weights_hash: digest(b"gemini-robotics-er-2-weights"),
+            safety_policy: digest(b"factory-floor-safety-policy-v3"),
+            config: Some(vla_config()),
+            version: Some("2.0".into()),
+            supersedes: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build provenance");
+    let subject =
+        verify_provenance_attestation(&attestation, &robot_kp.public_key(), Some(&vla_config()))
+            .expect("verify provenance");
+    let ok = subject.is_some();
+    let model = subject
+        .as_ref()
+        .and_then(|s| s["vla"]["modelName"].as_str())
+        .unwrap_or("");
+    println!("provenance verifies: {ok}  model={model}");
+    assert!(
+        ok,
+        "refusing to enable autonomy without verified provenance"
+    );
+
+    // 2. pre-actuation scope gate, with every decision black-boxed.
+    let scope_cred = build_physical_scope_credential(
+        &ROBOT_SEED,
+        &BuildPhysicalScope {
+            issuer_did: ROBOT_DID.into(),
+            subject_did: ROBOT_DID.into(),
+            max_force_n: Some(80.0),
+            max_speed_mps: Some(1.5),
+            max_speed_near_humans_mps: Some(0.5),
+            allowed_zones: Some(vec!["cell-3".into()]),
+            valid_from: NOW.into(),
+            ..Default::default()
+        },
+    )
+    .expect("build scope");
+    let scope = scope_cred["credentialSubject"]["physicalScope"].clone();
+
+    let mut blackbox = BlackBoxLog::new(&BLACKBOX_KEY, None).expect("black box");
+    for (i, (task, action)) in planned_actions().iter().enumerate() {
+        let result = check_physical_action(&scope, action);
+        let event = if result.ok {
+            "actuation_allowed"
+        } else {
+            "actuation_denied"
+        };
+        blackbox
+            .append(
+                event,
+                &json!({
+                    "task": task,
+                    "zone": action.zone,
+                    "speedMps": action.speed_mps,
+                    "nearHumans": action.near_humans,
+                    "reasons": result.reasons,
+                }),
+                &format!("2026-01-01T00:00:{:02}Z", i + 1),
+            )
+            .expect("append decision");
+        let verdict = if result.ok { "ALLOW" } else { "DENY " };
+        let why = if result.reasons.is_empty() {
+            String::new()
+        } else {
+            format!("  ({})", result.reasons.join("; "))
+        };
+        println!("  [{verdict}] {task}{why}");
+    }
+
+    // 3. the black box is tamper-evident without the key.
+    let entries: Vec<Value> = entries_of(&blackbox);
+    let chain = verify_blackbox_chain(&entries, None);
+    println!(
+        "black-box chain verifies: {}  entries={}",
+        chain.ok,
+        entries.len()
+    );
+
+    // Rewriting history (the denied sprint becomes "allowed") breaks the chain.
+    let mut tampered = entries.clone();
+    tampered[2]["event"] = json!("actuation_allowed");
+    let detected = verify_blackbox_chain(&tampered, None);
+    println!(
+        "tampered chain detected: {}  ({})",
+        !detected.ok,
+        detected.reason.unwrap_or_default()
+    );
+}
+
+fn entries_of(log: &BlackBoxLog) -> Vec<Value> {
+    log.entries().to_vec()
+}

--- a/core/vouch-core/tests/robotics_examples_flow.rs
+++ b/core/vouch-core/tests/robotics_examples_flow.rs
@@ -1,0 +1,325 @@
+//! Integration tests mirroring the runnable robotics examples
+//! (examples/robotics_evidence_pack.rs and
+//! examples/robotics_vla_accountability_loop.rs), and the Python
+//! tests/test_examples_robotics.py: the full evidence pack conforms to all
+//! five built-in profiles, each signed conformance attestation verifies, the
+//! VLA gate allows the safe actions and denies the over-speed and out-of-zone
+//! ones, and the black-box chain verifies and detects tampering.
+
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use serde_json::{json, Value};
+use sha2::{Digest, Sha256};
+
+use vouch_core::keys::Ed25519KeyPair;
+use vouch_core::robotics::{
+    build_conformance_attestation, build_perception_attestation, build_physical_scope_credential,
+    build_provenance_attestation, build_robot_heartbeat, build_safety_record, check_conformance,
+    check_physical_action, hash_frame, mint_robot_identity, robot_identity_binding,
+    verify_blackbox_chain, verify_conformance_attestation, BlackBoxLog,
+    BuildConformanceAttestation, BuildPerception, BuildPhysicalScope, BuildProvenance,
+    BuildRobotHeartbeat, BuildSafetyRecord, MintRobotIdentity, MotionCollector, MotionSample,
+    PerceptionLog, PhysicalAction, SafetyEventLog,
+};
+
+const ALL_PROFILE_IDS: [&str; 5] = [
+    "eu-ai-act-high-risk",
+    "iso-10218",
+    "iso-ts-15066",
+    "eu-machinery-2023-1230",
+    "ul-3300",
+];
+
+const NOW: &str = "2026-01-01T00:00:00Z";
+const ROBOT_DID: &str = "did:web:ar7.example.com";
+const ASSESSOR_DID: &str = "did:web:assessor.example.com";
+const ROBOT_SEED: [u8; 32] = [3u8; 32];
+const ROOT_SEED: [u8; 32] = [7u8; 32];
+const ASSESSOR_SEED: [u8; 32] = [11u8; 32];
+
+fn digest(data: &[u8]) -> String {
+    format!("u{}", URL_SAFE_NO_PAD.encode(Sha256::digest(data)))
+}
+
+fn scope_credential() -> Value {
+    build_physical_scope_credential(
+        &ROBOT_SEED,
+        &BuildPhysicalScope {
+            issuer_did: ROBOT_DID.into(),
+            subject_did: ROBOT_DID.into(),
+            max_force_n: Some(80.0),
+            max_speed_mps: Some(1.5),
+            max_speed_near_humans_mps: Some(0.5),
+            allowed_zones: Some(vec!["cell-3".into()]),
+            valid_from: NOW.into(),
+            ..Default::default()
+        },
+    )
+    .expect("build scope")
+}
+
+/// The six-credential evidence pack the example assembles: identity,
+/// provenance, scope, safety record, heartbeat, and perception provenance.
+fn evidence_pack() -> Vec<Value> {
+    let robot_kp = Ed25519KeyPair::from_seed(&ROBOT_SEED);
+    let root_kp = Ed25519KeyPair::from_seed(&ROOT_SEED);
+
+    let binding = robot_identity_binding(ROBOT_DID, &robot_kp.public_multikey());
+    let identity = mint_robot_identity(
+        &ROBOT_SEED,
+        &MintRobotIdentity {
+            robot_did: ROBOT_DID.into(),
+            make: "Acme Robotics".into(),
+            model: "AR-7".into(),
+            serial: "SN-000123".into(),
+            owner: None,
+            root_kind: "TPM".into(),
+            root_public_multibase: root_kp.public_multikey(),
+            attestation: root_kp.sign(&binding).to_vec(),
+            lifecycle: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("mint identity");
+
+    let provenance = build_provenance_attestation(
+        &ROBOT_SEED,
+        &BuildProvenance {
+            issuer_did: ROBOT_DID.into(),
+            robot_did: ROBOT_DID.into(),
+            model_name: "Gemini Robotics ER 2".into(),
+            weights_hash: digest(b"gemini-robotics-er-2-weights"),
+            safety_policy: digest(b"factory-floor-safety-policy-v3"),
+            config: Some(json!({"temperature": 0.0, "max_torque": 12.5})),
+            version: Some("2.0".into()),
+            supersedes: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build provenance");
+
+    let scope = scope_credential();
+
+    let mut ledger = SafetyEventLog::new(None);
+    ledger
+        .append("near_miss", "low", None, None, "2026-01-01T00:00:01Z")
+        .expect("append");
+    let record = build_safety_record(
+        &ASSESSOR_SEED,
+        &BuildSafetyRecord {
+            issuer_did: ASSESSOR_DID.into(),
+            robot_did: ROBOT_DID.into(),
+            summary: ledger.summarize(),
+            period_start: None,
+            period_end: None,
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build safety record");
+
+    let mut collector =
+        MotionCollector::new(Some(scope["credentialSubject"]["physicalScope"].clone()));
+    collector
+        .record(&MotionSample {
+            force_n: Some(12.0),
+            speed_mps: Some(0.4),
+            near_humans: true,
+            zone: Some("cell-3".into()),
+            ..Default::default()
+        })
+        .expect("record");
+    let heartbeat = build_robot_heartbeat(
+        &ROBOT_SEED,
+        &BuildRobotHeartbeat {
+            robot_did: ROBOT_DID.into(),
+            session_id: "shift-A".into(),
+            interval_index: 0,
+            interval_seconds: 30,
+            motion_digest: collector.digest(),
+            valid_from: NOW.into(),
+        },
+    )
+    .expect("build heartbeat");
+
+    let frame: &[u8] = b"\x89frame-bytes-from-the-front-camera";
+    let mut log = PerceptionLog::new(None);
+    log.record(
+        "cam-front",
+        "camera",
+        Some(frame),
+        None,
+        "2026-01-01T00:00:03Z",
+    )
+    .expect("record frame");
+    let perception = build_perception_attestation(
+        &ROBOT_SEED,
+        &BuildPerception {
+            robot_did: ROBOT_DID.into(),
+            sensor_id: "cam-front".into(),
+            modality: "camera".into(),
+            frame_hash: hash_frame(frame),
+            captured_at: None,
+            log_head: Some(log.head().to_string()),
+            valid_from: NOW.into(),
+            valid_until: None,
+        },
+    )
+    .expect("build perception");
+
+    vec![identity, provenance, scope, record, heartbeat, perception]
+}
+
+#[test]
+fn evidence_pack_conforms_to_all_five_profiles() {
+    let credentials = evidence_pack();
+    for pid in ALL_PROFILE_IDS {
+        let report = check_conformance(&credentials, pid).expect("check conformance");
+        assert_eq!(
+            report["conforms"],
+            json!(true),
+            "profile {pid} does not conform: {report}"
+        );
+        assert_eq!(report["satisfiedCount"], report["totalCount"]);
+    }
+}
+
+#[test]
+fn base_credentials_leave_the_expected_gaps() {
+    let credentials = evidence_pack();
+    let base = &credentials[..4];
+    for (pid, want) in [
+        ("iso-ts-15066", false),
+        ("ul-3300", false),
+        ("eu-ai-act-high-risk", true),
+    ] {
+        let report = check_conformance(base, pid).expect("check conformance");
+        assert_eq!(report["conforms"], json!(want), "profile {pid}");
+    }
+}
+
+#[test]
+fn every_signed_attestation_verifies() {
+    let credentials = evidence_pack();
+    let assessor_kp = Ed25519KeyPair::from_seed(&ASSESSOR_SEED);
+    let robot_kp = Ed25519KeyPair::from_seed(&ROBOT_SEED);
+
+    for pid in ALL_PROFILE_IDS {
+        let report = check_conformance(&credentials, pid).expect("check conformance");
+        let attestation = build_conformance_attestation(
+            &ASSESSOR_SEED,
+            &BuildConformanceAttestation {
+                issuer_did: ASSESSOR_DID.into(),
+                robot_did: ROBOT_DID.into(),
+                report,
+                valid_from: NOW.into(),
+                valid_until: None,
+            },
+        )
+        .expect("build attestation");
+
+        let subject = verify_conformance_attestation(&attestation, &assessor_kp.public_key())
+            .expect("verify attestation")
+            .unwrap_or_else(|| panic!("attestation for {pid} does not verify"));
+        assert_eq!(subject["profileId"], json!(pid));
+        assert_eq!(subject["conforms"], json!(true));
+
+        let wrong = verify_conformance_attestation(&attestation, &robot_kp.public_key())
+            .expect("verify under wrong key");
+        assert!(
+            wrong.is_none(),
+            "attestation for {pid} verified under the wrong key"
+        );
+    }
+}
+
+#[test]
+fn vla_gate_allows_safe_and_denies_unsafe_actions() {
+    let scope = scope_credential()["credentialSubject"]["physicalScope"].clone();
+
+    let cases: Vec<(&str, PhysicalAction, bool, &str)> = vec![
+        (
+            "pick up the cup",
+            PhysicalAction {
+                force_n: Some(20.0),
+                speed_mps: Some(0.3),
+                near_humans: true,
+                zone: Some("cell-3".into()),
+                ..Default::default()
+            },
+            true,
+            "",
+        ),
+        (
+            "hand cup to operator",
+            PhysicalAction {
+                force_n: Some(10.0),
+                speed_mps: Some(0.2),
+                near_humans: true,
+                zone: Some("cell-3".into()),
+                ..Default::default()
+            },
+            true,
+            "",
+        ),
+        (
+            "sprint to the dock",
+            PhysicalAction {
+                speed_mps: Some(2.5),
+                near_humans: true,
+                zone: Some("cell-3".into()),
+                ..Default::default()
+            },
+            false,
+            "speed_exceeded",
+        ),
+        (
+            "fetch from loading bay",
+            PhysicalAction {
+                force_n: Some(15.0),
+                speed_mps: Some(0.5),
+                zone: Some("loading-bay".into()),
+                ..Default::default()
+            },
+            false,
+            "zone_not_allowed",
+        ),
+    ];
+
+    let mut blackbox = BlackBoxLog::new(&[9u8; 32], None).expect("black box");
+    for (i, (task, action, want_ok, want_reason)) in cases.iter().enumerate() {
+        let result = check_physical_action(&scope, action);
+        assert_eq!(result.ok, *want_ok, "{task}: reasons {:?}", result.reasons);
+        if !want_reason.is_empty() {
+            assert!(
+                result.reasons.iter().any(|r| r.contains(want_reason)),
+                "{task}: reasons {:?} missing {want_reason}",
+                result.reasons
+            );
+        }
+        blackbox
+            .append(
+                if result.ok {
+                    "actuation_allowed"
+                } else {
+                    "actuation_denied"
+                },
+                &json!({"task": task, "reasons": result.reasons}),
+                &format!("2026-01-01T00:00:{:02}Z", i + 1),
+            )
+            .expect("append decision");
+    }
+
+    let entries: Vec<Value> = blackbox.entries().to_vec();
+    assert_eq!(entries.len(), cases.len());
+    let chain = verify_blackbox_chain(&entries, None);
+    assert!(chain.ok, "chain does not verify: {:?}", chain.reason);
+
+    let mut tampered = entries.clone();
+    tampered[2]["event"] = json!("actuation_allowed");
+    let detected = verify_blackbox_chain(&tampered, None);
+    assert!(!detected.ok, "tampered chain still verifies");
+    assert!(detected.reason.unwrap_or_default().contains("tampered"));
+}

--- a/go-sidecar/examples/robotics-evidence-pack/main.go
+++ b/go-sidecar/examples/robotics-evidence-pack/main.go
@@ -1,0 +1,266 @@
+// Command robotics-evidence-pack assembles a regulatory evidence pack for a
+// robot from Vouch robotics credentials (Go). Mirrors
+// examples/robotics_ai_act_evidence_pack.py.
+//
+// A robot presents signed credentials -- a hardware-rooted identity, a model
+// provenance attestation, a physical capability scope, a safety record
+// anchored to a tamper-evident ledger, a heartbeat carrying a motion digest,
+// and perception provenance for its sensor frames -- and the conformance
+// checker maps them onto all five built-in regulatory profiles (EU AI Act
+// high-risk, ISO 10218, ISO/TS 15066, EU Machinery Regulation 2023/1230,
+// UL 3300). An assessor then signs one point-in-time conformance attestation
+// per profile that an auditor or notified body can verify offline.
+//
+// Run it:  go run ./examples/robotics-evidence-pack   (from go-sidecar/)
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"log"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/robotics"
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+// The five built-in conformance profiles. The Go package keeps the profile
+// registry private, so the ids are listed here.
+var allProfileIDs = []string{
+	"eu-ai-act-high-risk",
+	"iso-10218",
+	"iso-ts-15066",
+	"eu-machinery-2023-1230",
+	"ul-3300",
+}
+
+var robotConfig = map[string]any{"temperature": 0.0, "max_torque": 12.5}
+
+type party struct {
+	signer *signer.Signer
+	pub    ed25519.PublicKey
+	did    string
+}
+
+// makeParty generates an identity for one party and wraps it in a Signer.
+func makeParty(did string) (party, error) {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		return party{}, err
+	}
+	s, err := signer.New(signer.Config{DID: did, Ed25519Seed: seed})
+	if err != nil {
+		return party{}, err
+	}
+	return party{signer: s, pub: s.PublicKeyEd25519(), did: did}, nil
+}
+
+// digest is the multibase (base64url) SHA-256, the hash form Vouch credentials carry.
+func digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "u" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func f(v float64) *float64 { return &v }
+
+// buildBaseCredentials builds the four base credentials: identity, model
+// provenance, physical scope, and a safety record over a tamper-evident
+// ledger. These satisfy eu-ai-act-high-risk, iso-10218, and
+// eu-machinery-2023-1230, but leave gaps in iso-ts-15066 (no motion
+// monitoring) and ul-3300 (no perception integrity).
+func buildBaseCredentials(robot, authority party) ([]map[string]any, error) {
+	rootSeed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(rootSeed); err != nil {
+		return nil, err
+	}
+	root, err := robotics.NewSoftwareRoot(rootSeed, "TPM") // reference; use a real TPM in deployment
+	if err != nil {
+		return nil, err
+	}
+	identity, err := robotics.MintRobotIdentity(robot.signer, root, robotics.MintOptions{
+		Make: "Acme Robotics", Model: "AR-7", Serial: "SN-000123",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	provenance, err := robotics.BuildProvenanceAttestation(robot.signer, robotics.BuildProvenanceOptions{
+		RobotDID:     robot.did,
+		ModelName:    "Gemini Robotics ER 2",
+		WeightsHash:  digest([]byte("gemini-robotics-er-2-weights")),
+		SafetyPolicy: digest([]byte("factory-floor-safety-policy-v3")),
+		Config:       robotConfig,
+		Version:      "2.0",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	scope, err := robotics.BuildPhysicalScopeCredential(robot.signer, robotics.BuildPhysicalScopeOptions{
+		SubjectDID:            robot.did,
+		MaxForceN:             f(80.0),
+		MaxSpeedMps:           f(1.5),
+		MaxSpeedNearHumansMps: f(0.5),
+		AllowedZones:          []string{"cell-3"},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	ledger := robotics.NewSafetyEventLog("")
+	if _, err := ledger.Append("near_miss", robotics.AppendSafetyOptions{
+		Severity: "low", Details: map[string]any{"note": "pallet edge proximity"},
+	}); err != nil {
+		return nil, err
+	}
+	if _, err := ledger.Append("manual_override", robotics.AppendSafetyOptions{
+		Actor: "did:web:operator.example.com",
+	}); err != nil {
+		return nil, err
+	}
+	record, err := robotics.BuildSafetyRecord(authority.signer, robotics.BuildSafetyRecordOptions{
+		RobotDID: robot.did, Summary: ledger.Summarize(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return []map[string]any{identity, provenance, scope, record}, nil
+}
+
+// buildMonitoringCredentials builds the two credentials that close the
+// remaining gaps: a heartbeat whose motion digest proves the last interval
+// stayed inside the physical envelope (ISO/TS 15066 continuous monitoring),
+// and perception provenance binding a captured camera frame to the robot's
+// key (UL 3300 sensing integrity).
+func buildMonitoringCredentials(robot party, scopeCred map[string]any) ([]map[string]any, error) {
+	subject := scopeCred["credentialSubject"].(map[string]any)
+	scope := subject["physicalScope"].(map[string]any)
+
+	collector := robotics.NewMotionCollector(scope)
+	if err := collector.Record(robotics.MotionRecord{
+		ForceN: f(12.0), SpeedMps: f(0.4), NearHumans: true, Zone: "cell-3",
+	}); err != nil {
+		return nil, err
+	}
+	if err := collector.Record(robotics.MotionRecord{
+		ForceN: f(25.0), SpeedMps: f(1.1), Zone: "cell-3",
+	}); err != nil {
+		return nil, err
+	}
+	heartbeat, err := robotics.BuildRobotHeartbeat(robot.signer, robotics.BuildHeartbeatOptions{
+		SessionID:       "shift-A",
+		IntervalIndex:   0,
+		MotionDigest:    collector.Digest(),
+		IntervalSeconds: 30,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	frame := []byte("\x89frame-bytes-from-the-front-camera")
+	plog := robotics.NewPerceptionLog("")
+	if _, err := plog.Record(robotics.RecordOptions{
+		SensorID: "cam-front", Modality: "camera", Frame: frame,
+	}); err != nil {
+		return nil, err
+	}
+	perception, err := robotics.BuildPerceptionAttestation(robot.signer, robotics.BuildPerceptionOptions{
+		RobotDID:  robot.did,
+		SensorID:  "cam-front",
+		Modality:  "camera",
+		FrameHash: robotics.HashFrame(frame),
+		LogHead:   plog.Head(),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return []map[string]any{heartbeat, perception}, nil
+}
+
+// checkAllProfiles runs the conformance checker over every built-in profile.
+func checkAllProfiles(credentials []map[string]any) (map[string]map[string]any, error) {
+	reports := make(map[string]map[string]any, len(allProfileIDs))
+	for _, pid := range allProfileIDs {
+		report, err := robotics.CheckConformance(credentials, pid)
+		if err != nil {
+			return nil, err
+		}
+		reports[pid] = report
+	}
+	return reports, nil
+}
+
+func printSummary(reports map[string]map[string]any) {
+	for _, pid := range allProfileIDs {
+		report := reports[pid]
+		verdict := "GAPS"
+		if report["conforms"].(bool) {
+			verdict = "CONFORMS"
+		}
+		fmt.Printf("  %-24s %-8s (%v/%v)  %v\n",
+			pid, verdict, report["satisfiedCount"], report["totalCount"], report["regime"])
+		for _, raw := range report["requirements"].([]any) {
+			r := raw.(map[string]any)
+			if !r["satisfied"].(bool) {
+				fmt.Printf("    gap: %v: %v\n", r["clause"], r["title"])
+			}
+		}
+	}
+}
+
+func main() {
+	robot, err := makeParty("did:web:ar7.example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+	assessor, err := makeParty("did:web:assessor.example.com")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// The base credential set leaves gaps in two of the five profiles.
+	base, err := buildBaseCredentials(robot, assessor)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Println("base credential set (identity, provenance, scope, safety record):")
+	reports, err := checkAllProfiles(base)
+	if err != nil {
+		log.Fatal(err)
+	}
+	printSummary(reports)
+
+	// The heartbeat and perception credentials close them.
+	monitoring, err := buildMonitoringCredentials(robot, base[2])
+	if err != nil {
+		log.Fatal(err)
+	}
+	credentials := append(base, monitoring...)
+	fmt.Printf("\nfull evidence pack (%d credentials):\n", len(credentials))
+	reports, err = checkAllProfiles(credentials)
+	if err != nil {
+		log.Fatal(err)
+	}
+	printSummary(reports)
+
+	// One signed, offline-verifiable conformance attestation per profile.
+	fmt.Printf("\nsigned attestations (%d profiles):\n", len(allProfileIDs))
+	for _, pid := range allProfileIDs {
+		attestation, err := robotics.BuildConformanceAttestation(assessor.signer, robotics.BuildConformanceAttestationOptions{
+			RobotDID: robot.did, Report: reports[pid],
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+		ok, subject := robotics.VerifyConformanceAttestation(attestation, assessor.pub)
+		reportDigest, _ := subject["reportDigest"].(string)
+		if len(reportDigest) > 16 {
+			reportDigest = reportDigest[:16]
+		}
+		fmt.Printf("  %-24s verifies=%v  reportDigest=%s...\n", pid, ok, reportDigest)
+	}
+}

--- a/go-sidecar/examples/robotics-vla-accountability-loop/main.go
+++ b/go-sidecar/examples/robotics-vla-accountability-loop/main.go
@@ -1,0 +1,154 @@
+// Command robotics-vla-accountability-loop runs a VLA control loop with
+// provenance on load, a pre-actuation scope gate, and a tamper-evident black
+// box (Go). Mirrors examples/robotics_vla_accountability_loop.py.
+//
+// A robot driven by a vision-language-action model (here Gemini Robotics ER 2)
+// composes three Vouch robotics primitives into one accountable control loop:
+//
+//  1. Provenance on load: before autonomy is enabled, the robot verifies the
+//     signed ModelProvenanceAttestation for the exact weights and config it is
+//     about to run.
+//  2. Pre-actuation scope gate: every action the planner proposes is checked
+//     against the robot's signed PhysicalCapabilityScope before actuating; an
+//     over-speed or out-of-zone action is denied, not attempted.
+//  3. Tamper-evident black box: every decision, allowed or denied, is appended
+//     to an encrypted, hash-linked black-box log. Anyone can verify the chain;
+//     only a holder of the key can read the payloads.
+//
+// Run it:  go run ./examples/robotics-vla-accountability-loop   (from go-sidecar/)
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/robotics"
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+const vlaModelName = "Gemini Robotics ER 2"
+
+var vlaConfig = map[string]any{"planner": "er-2", "temperature": 0.0, "max_plan_steps": 8}
+
+type plannedAction struct {
+	task   string
+	action robotics.PhysicalAction
+}
+
+// What the planner proposes during one task episode. The first two stay inside
+// the envelope; the sprint exceeds the near-human speed cap and the loading-bay
+// fetch leaves the allowed zone, so the gate must deny both.
+var plannedActions = []plannedAction{
+	{"pick up the cup", robotics.PhysicalAction{ForceN: f(20.0), SpeedMps: f(0.3), NearHumans: true, Zone: "cell-3"}},
+	{"hand cup to operator", robotics.PhysicalAction{ForceN: f(10.0), SpeedMps: f(0.2), NearHumans: true, Zone: "cell-3"}},
+	{"sprint to the dock", robotics.PhysicalAction{SpeedMps: f(2.5), NearHumans: true, Zone: "cell-3"}},
+	{"fetch from loading bay", robotics.PhysicalAction{ForceN: f(15.0), SpeedMps: f(0.5), Zone: "loading-bay"}},
+}
+
+func f(v float64) *float64 { return &v }
+
+// digest is the multibase (base64url) SHA-256, the hash form Vouch credentials carry.
+func digest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "u" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+func main() {
+	seed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(seed); err != nil {
+		log.Fatal(err)
+	}
+	robotDID := "did:web:ar7.example.com"
+	robot, err := signer.New(signer.Config{DID: robotDID, Ed25519Seed: seed})
+	if err != nil {
+		log.Fatal(err)
+	}
+	robotPub := robot.PublicKeyEd25519()
+
+	// 1. provenance on load: no verified provenance, no autonomy.
+	attestation, err := robotics.BuildProvenanceAttestation(robot, robotics.BuildProvenanceOptions{
+		RobotDID:     robotDID,
+		ModelName:    vlaModelName,
+		WeightsHash:  digest([]byte("gemini-robotics-er-2-weights")),
+		SafetyPolicy: digest([]byte("factory-floor-safety-policy-v3")),
+		Config:       vlaConfig,
+		Version:      "2.0",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	ok, subject := robotics.VerifyProvenanceAttestation(attestation, robotPub, vlaConfig)
+	vla, _ := subject["vla"].(map[string]any)
+	fmt.Printf("provenance verifies: %v  model=%v\n", ok, vla["modelName"])
+	if !ok {
+		log.Fatal("refusing to enable autonomy without verified provenance")
+	}
+
+	// 2. pre-actuation scope gate, with every decision black-boxed.
+	scopeCred, err := robotics.BuildPhysicalScopeCredential(robot, robotics.BuildPhysicalScopeOptions{
+		SubjectDID:            robotDID,
+		MaxForceN:             f(80.0),
+		MaxSpeedMps:           f(1.5),
+		MaxSpeedNearHumansMps: f(0.5),
+		AllowedZones:          []string{"cell-3"},
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	scope := scopeCred["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		log.Fatal(err)
+	}
+	blackbox, err := robotics.NewBlackBoxLog(key, "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	for _, p := range plannedActions {
+		result := robotics.CheckPhysicalAction(scope, p.action)
+		event := "actuation_denied"
+		verdict := "DENY "
+		if result.OK {
+			event = "actuation_allowed"
+			verdict = "ALLOW"
+		}
+		if _, err := blackbox.Append(event, map[string]any{
+			"task":       p.task,
+			"zone":       p.action.Zone,
+			"speedMps":   p.action.SpeedMps,
+			"nearHumans": p.action.NearHumans,
+			"reasons":    result.Reasons,
+		}, ""); err != nil {
+			log.Fatal(err)
+		}
+		why := ""
+		if len(result.Reasons) > 0 {
+			why = "  (" + strings.Join(result.Reasons, "; ") + ")"
+		}
+		fmt.Printf("  [%s] %s%s\n", verdict, p.task, why)
+	}
+
+	// 3. the black box is tamper-evident without the key.
+	entries := blackbox.Entries()
+	chain := robotics.VerifyBlackboxChain(entries, "")
+	fmt.Printf("black-box chain verifies: %v  entries=%d\n", chain.OK, len(entries))
+
+	// Rewriting history (the denied sprint becomes "allowed") breaks the chain.
+	tampered := make([]map[string]any, len(entries))
+	for i, e := range entries {
+		copied := make(map[string]any, len(e))
+		for k, v := range e {
+			copied[k] = v
+		}
+		tampered[i] = copied
+	}
+	tampered[2]["event"] = "actuation_allowed"
+	detected := robotics.VerifyBlackboxChain(tampered, "")
+	fmt.Printf("tampered chain detected: %v  (%s)\n", !detected.OK, detected.Reason)
+}

--- a/go-sidecar/robotics/examples_flow_test.go
+++ b/go-sidecar/robotics/examples_flow_test.go
@@ -1,0 +1,256 @@
+package robotics
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/vouch-protocol/vouch/go-sidecar/signer"
+)
+
+// These tests mirror the runnable example commands under
+// examples/robotics-evidence-pack and examples/robotics-vla-accountability-loop
+// (and the Python tests/test_examples_robotics.py): the full evidence pack
+// conforms to all five built-in profiles, each signed attestation verifies,
+// the VLA gate allows the safe actions and denies the over-speed and
+// out-of-zone ones, and the black-box chain verifies and detects tampering.
+
+var exampleProfileIDs = []string{
+	"eu-ai-act-high-risk",
+	"iso-10218",
+	"iso-ts-15066",
+	"eu-machinery-2023-1230",
+	"ul-3300",
+}
+
+func exampleDigest(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "u" + base64.RawURLEncoding.EncodeToString(sum[:])
+}
+
+// exampleEvidencePack builds the six-credential evidence pack the example
+// command assembles: identity, provenance, scope, safety record, heartbeat,
+// and perception provenance.
+func exampleEvidencePack(t *testing.T, robot, authority *signer.Signer, robotDID string) []map[string]any {
+	t.Helper()
+
+	rootSeed := make([]byte, ed25519.SeedSize)
+	if _, err := rand.Read(rootSeed); err != nil {
+		t.Fatal(err)
+	}
+	root, err := NewSoftwareRoot(rootSeed, "TPM")
+	if err != nil {
+		t.Fatal(err)
+	}
+	identity, err := MintRobotIdentity(robot, root, MintOptions{
+		Make: "Acme Robotics", Model: "AR-7", Serial: "SN-000123",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prov, err := BuildProvenanceAttestation(robot, BuildProvenanceOptions{
+		RobotDID:     robotDID,
+		ModelName:    "Gemini Robotics ER 2",
+		WeightsHash:  exampleDigest([]byte("gemini-robotics-er-2-weights")),
+		SafetyPolicy: exampleDigest([]byte("factory-floor-safety-policy-v3")),
+		Config:       map[string]any{"temperature": 0.0, "max_torque": 12.5},
+		Version:      "2.0",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scope, err := BuildPhysicalScopeCredential(robot, BuildPhysicalScopeOptions{
+		SubjectDID:            robotDID,
+		MaxForceN:             fptr(80.0),
+		MaxSpeedMps:           fptr(1.5),
+		MaxSpeedNearHumansMps: fptr(0.5),
+		AllowedZones:          []string{"cell-3"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ledger := NewSafetyEventLog("")
+	if _, err := ledger.Append("near_miss", AppendSafetyOptions{Severity: "low"}); err != nil {
+		t.Fatal(err)
+	}
+	record, err := BuildSafetyRecord(authority, BuildSafetyRecordOptions{
+		RobotDID: robotDID, Summary: ledger.Summarize(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scopeObj := scope["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+	collector := NewMotionCollector(scopeObj)
+	if err := collector.Record(MotionRecord{
+		ForceN: fptr(12.0), SpeedMps: fptr(0.4), NearHumans: true, Zone: "cell-3",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	heartbeat, err := BuildRobotHeartbeat(robot, BuildHeartbeatOptions{
+		SessionID: "shift-A", IntervalIndex: 0, MotionDigest: collector.Digest(), IntervalSeconds: 30,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	frame := []byte("\x89frame-bytes-from-the-front-camera")
+	plog := NewPerceptionLog("")
+	if _, err := plog.Record(RecordOptions{SensorID: "cam-front", Modality: "camera", Frame: frame}); err != nil {
+		t.Fatal(err)
+	}
+	perception, err := BuildPerceptionAttestation(robot, BuildPerceptionOptions{
+		RobotDID: robotDID, SensorID: "cam-front", Modality: "camera",
+		FrameHash: HashFrame(frame), LogHead: plog.Head(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return []map[string]any{identity, prov, scope, record, heartbeat, perception}
+}
+
+func TestEvidencePackConformsToAllProfiles(t *testing.T) {
+	robotDID := "did:web:ar7.example.com"
+	robot := newRobot(t, robotDID)
+	authority := newRobot(t, "did:web:assessor.example.com")
+	creds := exampleEvidencePack(t, robot, authority, robotDID)
+
+	for _, pid := range exampleProfileIDs {
+		report, err := CheckConformance(creds, pid)
+		if err != nil {
+			t.Fatalf("CheckConformance(%s): %v", pid, err)
+		}
+		if !report["conforms"].(bool) {
+			t.Errorf("profile %s does not conform: %v", pid, report)
+		}
+	}
+
+	// Without the heartbeat and perception credentials, iso-ts-15066 and
+	// ul-3300 must report gaps while eu-ai-act-high-risk still conforms.
+	base := creds[:4]
+	for pid, wantConforms := range map[string]bool{
+		"iso-ts-15066": false, "ul-3300": false, "eu-ai-act-high-risk": true,
+	} {
+		report, err := CheckConformance(base, pid)
+		if err != nil {
+			t.Fatalf("CheckConformance(%s): %v", pid, err)
+		}
+		if report["conforms"].(bool) != wantConforms {
+			t.Errorf("base set: profile %s conforms=%v, want %v", pid, report["conforms"], wantConforms)
+		}
+	}
+}
+
+func TestEvidencePackAttestationsVerify(t *testing.T) {
+	robotDID := "did:web:ar7.example.com"
+	robot := newRobot(t, robotDID)
+	assessor := newRobot(t, "did:web:assessor.example.com")
+	creds := exampleEvidencePack(t, robot, assessor, robotDID)
+
+	for _, pid := range exampleProfileIDs {
+		report, err := CheckConformance(creds, pid)
+		if err != nil {
+			t.Fatalf("CheckConformance(%s): %v", pid, err)
+		}
+		att, err := BuildConformanceAttestation(assessor, BuildConformanceAttestationOptions{
+			RobotDID: robotDID, Report: report,
+		})
+		if err != nil {
+			t.Fatalf("BuildConformanceAttestation(%s): %v", pid, err)
+		}
+		ok, subject := VerifyConformanceAttestation(att, assessor.PublicKeyEd25519())
+		if !ok {
+			t.Fatalf("attestation for %s does not verify", pid)
+		}
+		if subject["profileId"] != pid || subject["conforms"] != true {
+			t.Errorf("attestation subject for %s wrong: %v", pid, subject)
+		}
+		if wrongOK, _ := VerifyConformanceAttestation(att, robot.PublicKeyEd25519()); wrongOK {
+			t.Errorf("attestation for %s verified under the wrong key", pid)
+		}
+	}
+}
+
+func TestVlaLoopGateAndBlackbox(t *testing.T) {
+	robotDID := "did:web:ar7.example.com"
+	robot := newRobot(t, robotDID)
+
+	scopeCred, err := BuildPhysicalScopeCredential(robot, BuildPhysicalScopeOptions{
+		SubjectDID:            robotDID,
+		MaxForceN:             fptr(80.0),
+		MaxSpeedMps:           fptr(1.5),
+		MaxSpeedNearHumansMps: fptr(0.5),
+		AllowedZones:          []string{"cell-3"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	scope := scopeCred["credentialSubject"].(map[string]any)["physicalScope"].(map[string]any)
+
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	blackbox, err := NewBlackBoxLog(key, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		task       string
+		action     PhysicalAction
+		wantOK     bool
+		wantReason string
+	}{
+		{"pick up the cup", PhysicalAction{ForceN: fptr(20.0), SpeedMps: fptr(0.3), NearHumans: true, Zone: "cell-3"}, true, ""},
+		{"hand cup to operator", PhysicalAction{ForceN: fptr(10.0), SpeedMps: fptr(0.2), NearHumans: true, Zone: "cell-3"}, true, ""},
+		{"sprint to the dock", PhysicalAction{SpeedMps: fptr(2.5), NearHumans: true, Zone: "cell-3"}, false, "speed_exceeded"},
+		{"fetch from loading bay", PhysicalAction{ForceN: fptr(15.0), SpeedMps: fptr(0.5), Zone: "loading-bay"}, false, "zone_not_allowed"},
+	}
+	for _, c := range cases {
+		result := CheckPhysicalAction(scope, c.action)
+		if result.OK != c.wantOK {
+			t.Errorf("%s: ok=%v, want %v (reasons %v)", c.task, result.OK, c.wantOK, result.Reasons)
+		}
+		if c.wantReason != "" && !strings.Contains(strings.Join(result.Reasons, ";"), c.wantReason) {
+			t.Errorf("%s: reasons %v missing %q", c.task, result.Reasons, c.wantReason)
+		}
+		event := "actuation_denied"
+		if result.OK {
+			event = "actuation_allowed"
+		}
+		if _, err := blackbox.Append(event, map[string]any{"task": c.task, "reasons": result.Reasons}, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	entries := blackbox.Entries()
+	if len(entries) != len(cases) {
+		t.Fatalf("expected %d entries, got %d", len(cases), len(entries))
+	}
+	if chain := VerifyBlackboxChain(entries, ""); !chain.OK {
+		t.Fatalf("chain does not verify: %s", chain.Reason)
+	}
+
+	tampered := make([]map[string]any, len(entries))
+	for i, e := range entries {
+		copied := make(map[string]any, len(e))
+		for k, v := range e {
+			copied[k] = v
+		}
+		tampered[i] = copied
+	}
+	tampered[2]["event"] = "actuation_allowed"
+	if chain := VerifyBlackboxChain(tampered, ""); chain.OK {
+		t.Fatal("tampered chain still verifies")
+	} else if !strings.Contains(chain.Reason, "tampered") {
+		t.Errorf("unexpected tamper reason: %s", chain.Reason)
+	}
+}

--- a/packages/sdk-ts/examples/robotics-evidence-pack.ts
+++ b/packages/sdk-ts/examples/robotics-evidence-pack.ts
@@ -1,0 +1,233 @@
+/**
+ * Regulatory evidence pack for a robot, assembled from Vouch robotics
+ * credentials (TypeScript). Mirrors examples/robotics_ai_act_evidence_pack.py.
+ *
+ * A robot presents signed credentials -- a hardware-rooted identity, a model
+ * provenance attestation, a physical capability scope, a safety record
+ * anchored to a tamper-evident ledger, a heartbeat carrying a motion digest,
+ * and perception provenance for its sensor frames -- and the conformance
+ * checker maps them onto all five built-in regulatory profiles (EU AI Act
+ * high-risk, ISO 10218, ISO/TS 15066, EU Machinery Regulation 2023/1230,
+ * UL 3300). An assessor then signs one point-in-time conformance attestation
+ * per profile that an auditor or notified body can verify offline.
+ *
+ * Run it:  npx tsx examples/robotics-evidence-pack.ts   (from packages/sdk-ts)
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  MotionCollector,
+  PerceptionLog,
+  SafetyEventLog,
+  Signer,
+  SoftwareRootOfTrust,
+  buildConformanceAttestation,
+  buildPerceptionAttestation,
+  buildPhysicalScopeCredential,
+  buildProvenanceAttestation,
+  buildRobotHeartbeat,
+  buildSafetyRecord,
+  checkConformance,
+  generateIdentity,
+  hashFrame,
+  mintRobotIdentity,
+  verifyConformanceAttestation,
+  type ConformanceReport,
+} from '../src';
+
+export const ALL_PROFILE_IDS = [
+  'eu-ai-act-high-risk',
+  'iso-10218',
+  'iso-ts-15066',
+  'eu-machinery-2023-1230',
+  'ul-3300',
+];
+
+export const ROBOT_CONFIG = { temperature: 0.0, max_torque: 12.5 };
+
+export interface Party {
+  signer: Signer;
+  did: string;
+  pub: crypto.KeyObject;
+}
+
+/** Generate an identity for one party and wrap it in a Signer. */
+export async function makeParty(domain: string): Promise<Party> {
+  const keys = await generateIdentity(domain);
+  const did = keys.did as string;
+  const signer = new Signer({ privateKey: keys.privateKeyJwk, did });
+  const pub = crypto.createPublicKey({
+    key: JSON.parse(keys.publicKeyJwk) as crypto.JsonWebKey,
+    format: 'jwk',
+  });
+  return { signer, did, pub };
+}
+
+/** Multibase (base64url) SHA-256, the hash form Vouch credentials carry. */
+export function digest(data: Buffer | string): string {
+  return 'u' + crypto.createHash('sha256').update(data).digest('base64url');
+}
+
+/**
+ * Build the four base credentials: identity, model provenance, physical
+ * scope, and a safety record over a tamper-evident ledger. These satisfy
+ * eu-ai-act-high-risk, iso-10218, and eu-machinery-2023-1230, but leave gaps
+ * in iso-ts-15066 (no motion monitoring) and ul-3300 (no perception
+ * integrity).
+ */
+export async function buildBaseCredentials(
+  robot: Party,
+  authority: Party
+): Promise<Array<Record<string, unknown>>> {
+  const root = new SoftwareRootOfTrust(undefined, 'TPM'); // reference; use a real TPM in deployment
+  const identity = await mintRobotIdentity(robot.signer, root, {
+    make: 'Acme Robotics',
+    model: 'AR-7',
+    serial: 'SN-000123',
+  });
+
+  const provenance = await buildProvenanceAttestation(robot.signer, {
+    robotDid: robot.did,
+    modelName: 'Gemini Robotics ER 2',
+    weightsHash: digest('gemini-robotics-er-2-weights'),
+    safetyPolicy: digest('factory-floor-safety-policy-v3'),
+    config: ROBOT_CONFIG,
+    version: '2.0',
+  });
+
+  const scope = await buildPhysicalScopeCredential(robot.signer, {
+    subjectDid: robot.did,
+    maxForceN: 80.0,
+    maxSpeedMps: 1.5,
+    maxSpeedNearHumansMps: 0.5,
+    allowedZones: ['cell-3'],
+  });
+
+  const ledger = new SafetyEventLog();
+  ledger.append('near_miss', { severity: 'low', details: { note: 'pallet edge proximity' } });
+  ledger.append('manual_override', { severity: 'info', actor: 'did:web:operator.example.com' });
+  const record = await buildSafetyRecord(authority.signer, {
+    robotDid: robot.did,
+    summary: ledger.summarize(),
+  });
+
+  return [identity, provenance, scope, record];
+}
+
+/**
+ * Build the two credentials that close the remaining gaps: a heartbeat whose
+ * motion digest proves the last interval stayed inside the physical envelope
+ * (ISO/TS 15066 continuous monitoring), and perception provenance binding a
+ * captured camera frame to the robot's key (UL 3300 sensing integrity).
+ */
+export async function buildMonitoringCredentials(
+  robot: Party,
+  scopeCredential: Record<string, unknown>
+): Promise<Array<Record<string, unknown>>> {
+  const subject = scopeCredential.credentialSubject as Record<string, unknown>;
+  const collector = new MotionCollector(subject.physicalScope as Record<string, unknown>);
+  collector.record({ forceN: 12.0, speedMps: 0.4, nearHumans: true, zone: 'cell-3' });
+  collector.record({ forceN: 25.0, speedMps: 1.1, nearHumans: false, zone: 'cell-3' });
+  const heartbeat = await buildRobotHeartbeat(robot.signer, {
+    sessionId: 'shift-A',
+    intervalIndex: 0,
+    motionDigest: collector.digest(),
+    intervalSeconds: 30,
+  });
+
+  const frame = Buffer.from('\x89frame-bytes-from-the-front-camera', 'binary');
+  const log = new PerceptionLog();
+  log.record({ sensorId: 'cam-front', modality: 'camera', frame });
+  const perception = await buildPerceptionAttestation(robot.signer, {
+    robotDid: robot.did,
+    sensorId: 'cam-front',
+    modality: 'camera',
+    frameHash: hashFrame(frame),
+    logHead: log.head(),
+  });
+
+  return [heartbeat, perception];
+}
+
+/** Build the full six-credential evidence pack covering all five profiles. */
+export async function buildEvidencePack(
+  robot: Party,
+  authority: Party
+): Promise<Array<Record<string, unknown>>> {
+  const base = await buildBaseCredentials(robot, authority);
+  const monitoring = await buildMonitoringCredentials(robot, base[2]);
+  return [...base, ...monitoring];
+}
+
+/** Run the conformance checker over every built-in profile. */
+export function checkAllProfiles(
+  credentials: Array<Record<string, unknown>>
+): Record<string, ConformanceReport> {
+  const reports: Record<string, ConformanceReport> = {};
+  for (const pid of ALL_PROFILE_IDS) {
+    reports[pid] = checkConformance(credentials, pid);
+  }
+  return reports;
+}
+
+/** Sign one point-in-time conformance attestation per profile report. */
+export async function signAttestations(
+  assessor: Party,
+  robotDid: string,
+  reports: Record<string, ConformanceReport>
+): Promise<Record<string, Record<string, unknown>>> {
+  const attestations: Record<string, Record<string, unknown>> = {};
+  for (const [pid, report] of Object.entries(reports)) {
+    attestations[pid] = await buildConformanceAttestation(assessor.signer, {
+      robotDid,
+      report,
+    });
+  }
+  return attestations;
+}
+
+function printSummary(reports: Record<string, ConformanceReport>): void {
+  for (const [pid, report] of Object.entries(reports)) {
+    const verdict = report.conforms ? 'CONFORMS' : 'GAPS';
+    console.log(
+      `  ${pid.padEnd(24)} ${verdict.padEnd(8)} ` +
+        `(${report.satisfiedCount}/${report.totalCount})  ${report.regime}`
+    );
+    for (const req of report.requirements) {
+      if (!req.satisfied) console.log(`    gap: ${req.clause}: ${req.title}`);
+    }
+  }
+}
+
+export async function main(): Promise<void> {
+  const robot = await makeParty('ar7.example.com');
+  const assessor = await makeParty('assessor.example.com');
+
+  // The base credential set leaves gaps in two of the five profiles.
+  const base = await buildBaseCredentials(robot, assessor);
+  console.log('base credential set (identity, provenance, scope, safety record):');
+  printSummary(checkAllProfiles(base));
+
+  // The heartbeat and perception credentials close them.
+  const credentials = [...base, ...(await buildMonitoringCredentials(robot, base[2]))];
+  console.log(`\nfull evidence pack (${credentials.length} credentials):`);
+  const reports = checkAllProfiles(credentials);
+  printSummary(reports);
+
+  // One signed, offline-verifiable conformance attestation per profile.
+  console.log(`\nsigned attestations (${ALL_PROFILE_IDS.length} profiles):`);
+  const attestations = await signAttestations(assessor, robot.did, reports);
+  for (const [pid, attestation] of Object.entries(attestations)) {
+    const res = verifyConformanceAttestation(attestation, assessor.pub);
+    const reportDigest = (res.subject?.reportDigest as string) ?? '';
+    console.log(`  ${pid.padEnd(24)} verifies=${res.ok}  reportDigest=${reportDigest.slice(0, 16)}...`);
+  }
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/sdk-ts/examples/robotics-vla-accountability-loop.ts
+++ b/packages/sdk-ts/examples/robotics-vla-accountability-loop.ts
@@ -1,0 +1,160 @@
+/**
+ * VLA accountability loop: provenance on load, a pre-actuation scope gate, and
+ * a tamper-evident black box (TypeScript). Mirrors
+ * examples/robotics_vla_accountability_loop.py.
+ *
+ * A robot driven by a vision-language-action model (here Gemini Robotics ER 2)
+ * composes three Vouch robotics primitives into one accountable control loop:
+ *
+ *   1. Provenance on load: before autonomy is enabled, the robot verifies the
+ *      signed ModelProvenanceAttestation for the exact weights and config it
+ *      is about to run.
+ *   2. Pre-actuation scope gate: every action the planner proposes is checked
+ *      against the robot's signed PhysicalCapabilityScope before actuating;
+ *      an over-speed or out-of-zone action is denied, not attempted.
+ *   3. Tamper-evident black box: every decision, allowed or denied, is
+ *      appended to an encrypted, hash-linked black-box log. Anyone can verify
+ *      the chain; only a holder of the key can read the payloads.
+ *
+ * Run it:  npx tsx examples/robotics-vla-accountability-loop.ts   (from packages/sdk-ts)
+ */
+
+import * as crypto from 'crypto';
+
+import {
+  BlackBoxLog,
+  Signer,
+  buildPhysicalScopeCredential,
+  buildProvenanceAttestation,
+  checkPhysicalAction,
+  generateIdentity,
+  verifyBlackboxChain,
+  verifyProvenanceAttestation,
+  type CheckResult,
+  type PhysicalAction,
+} from '../src';
+
+export const VLA_MODEL_NAME = 'Gemini Robotics ER 2';
+export const VLA_CONFIG = { planner: 'er-2', temperature: 0.0, max_plan_steps: 8 };
+
+// What the planner proposes during one task episode. The first two stay inside
+// the envelope; the sprint exceeds the near-human speed cap and the loading-bay
+// fetch leaves the allowed zone, so the gate must deny both.
+export const PLANNED_ACTIONS: Array<[string, PhysicalAction]> = [
+  ['pick up the cup', { forceN: 20.0, speedMps: 0.3, nearHumans: true, zone: 'cell-3' }],
+  ['hand cup to operator', { forceN: 10.0, speedMps: 0.2, nearHumans: true, zone: 'cell-3' }],
+  ['sprint to the dock', { speedMps: 2.5, nearHumans: true, zone: 'cell-3' }],
+  ['fetch from loading bay', { forceN: 15.0, speedMps: 0.5, zone: 'loading-bay' }],
+];
+
+export interface Party {
+  signer: Signer;
+  did: string;
+  pub: crypto.KeyObject;
+}
+
+/** Generate an identity for one party and wrap it in a Signer. */
+export async function makeParty(domain: string): Promise<Party> {
+  const keys = await generateIdentity(domain);
+  const did = keys.did as string;
+  const signer = new Signer({ privateKey: keys.privateKeyJwk, did });
+  const pub = crypto.createPublicKey({
+    key: JSON.parse(keys.publicKeyJwk) as crypto.JsonWebKey,
+    format: 'jwk',
+  });
+  return { signer, did, pub };
+}
+
+/** Multibase (base64url) SHA-256, the hash form Vouch credentials carry. */
+export function digest(data: Buffer | string): string {
+  return 'u' + crypto.createHash('sha256').update(data).digest('base64url');
+}
+
+/** Sign the model's provenance and verify it before enabling autonomy. */
+export async function loadModelWithProvenance(robot: Party): Promise<{
+  ok: boolean;
+  attestation: Record<string, unknown>;
+  subject?: Record<string, unknown>;
+}> {
+  const attestation = await buildProvenanceAttestation(robot.signer, {
+    robotDid: robot.did,
+    modelName: VLA_MODEL_NAME,
+    weightsHash: digest('gemini-robotics-er-2-weights'),
+    safetyPolicy: digest('factory-floor-safety-policy-v3'),
+    config: VLA_CONFIG,
+    version: '2.0',
+  });
+  const res = verifyProvenanceAttestation(attestation, robot.pub, VLA_CONFIG);
+  return { ok: res.ok, attestation, subject: res.subject };
+}
+
+/**
+ * Gate each proposed action against the physical scope, record every decision
+ * in the black box, and return the per-action decisions.
+ */
+export function runAccountabilityLoop(
+  scope: Record<string, unknown>,
+  blackbox: BlackBoxLog,
+  actions: Array<[string, PhysicalAction]> = PLANNED_ACTIONS
+): Array<[string, CheckResult]> {
+  const decisions: Array<[string, CheckResult]> = [];
+  for (const [task, action] of actions) {
+    const result = checkPhysicalAction(scope, action);
+    blackbox.append(result.ok ? 'actuation_allowed' : 'actuation_denied', {
+      task,
+      zone: action.zone ?? null,
+      speedMps: action.speedMps ?? null,
+      nearHumans: action.nearHumans ?? false,
+      reasons: result.reasons,
+    });
+    decisions.push([task, result]);
+  }
+  return decisions;
+}
+
+export async function main(): Promise<void> {
+  const robot = await makeParty('ar7.example.com');
+
+  // 1. provenance on load: no verified provenance, no autonomy.
+  const loaded = await loadModelWithProvenance(robot);
+  const vla = loaded.subject?.vla as Record<string, unknown> | undefined;
+  console.log(`provenance verifies: ${loaded.ok}  model=${vla?.modelName}`);
+  if (!loaded.ok) {
+    throw new Error('refusing to enable autonomy without verified provenance');
+  }
+
+  // 2. pre-actuation scope gate, with every decision black-boxed.
+  const scopeCred = await buildPhysicalScopeCredential(robot.signer, {
+    subjectDid: robot.did,
+    maxForceN: 80.0,
+    maxSpeedMps: 1.5,
+    maxSpeedNearHumansMps: 0.5,
+    allowedZones: ['cell-3'],
+  });
+  const subject = scopeCred.credentialSubject as Record<string, unknown>;
+  const scope = subject.physicalScope as Record<string, unknown>;
+  const blackbox = new BlackBoxLog(crypto.randomBytes(32));
+  for (const [task, result] of runAccountabilityLoop(scope, blackbox)) {
+    const verdict = result.ok ? 'ALLOW' : 'DENY ';
+    const why = result.reasons.length ? `  (${result.reasons.join('; ')})` : '';
+    console.log(`  [${verdict}] ${task}${why}`);
+  }
+
+  // 3. the black box is tamper-evident without the key.
+  const entries = blackbox.entries();
+  const chain = verifyBlackboxChain(entries);
+  console.log(`black-box chain verifies: ${chain.ok}  entries=${entries.length}`);
+
+  // Rewriting history (the denied sprint becomes "allowed") breaks the chain.
+  const tampered = entries.map((e) => ({ ...e }));
+  tampered[2].event = 'actuation_allowed';
+  const detected = verifyBlackboxChain(tampered);
+  console.log(`tampered chain detected: ${!detected.ok}  (${detected.reason})`);
+}
+
+if (typeof require !== 'undefined' && require.main === module) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/packages/sdk-ts/tests/robotics-examples.test.ts
+++ b/packages/sdk-ts/tests/robotics-examples.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Tests for the runnable robotics examples (examples/robotics-evidence-pack.ts
+ * and examples/robotics-vla-accountability-loop.ts). Mirrors the Python
+ * tests/test_examples_robotics.py: every profile conforms on the full evidence
+ * pack, each signed attestation verifies, the VLA gate allows the safe actions
+ * and denies the over-speed and out-of-zone ones, and the black-box chain
+ * verifies and detects tampering.
+ */
+
+import * as crypto from 'crypto';
+
+import { BlackBoxLog, verifyBlackboxChain, verifyConformanceAttestation } from '../src';
+
+import {
+  ALL_PROFILE_IDS,
+  buildBaseCredentials,
+  buildEvidencePack,
+  buildMonitoringCredentials,
+  checkAllProfiles,
+  makeParty,
+  signAttestations,
+} from '../examples/robotics-evidence-pack';
+
+import {
+  VLA_MODEL_NAME,
+  loadModelWithProvenance,
+  runAccountabilityLoop,
+} from '../examples/robotics-vla-accountability-loop';
+
+import { buildPhysicalScopeCredential } from '../src';
+
+describe('evidence pack example', () => {
+  it('covers all five profiles and every profile conforms', async () => {
+    const robot = await makeParty('ar7.example.com');
+    const assessor = await makeParty('assessor.example.com');
+    const credentials = await buildEvidencePack(robot, assessor);
+    const reports = checkAllProfiles(credentials);
+
+    expect(Object.keys(reports).sort()).toEqual([...ALL_PROFILE_IDS].sort());
+    for (const [pid, report] of Object.entries(reports)) {
+      expect(report.conforms, `${pid} does not conform`).toBe(true);
+      expect(report.satisfiedCount).toBe(report.totalCount);
+    }
+  });
+
+  it('leaves the expected gaps on the base credential set', async () => {
+    const robot = await makeParty('ar7.example.com');
+    const assessor = await makeParty('assessor.example.com');
+    const base = await buildBaseCredentials(robot, assessor);
+    const reports = checkAllProfiles(base);
+
+    expect(reports['iso-ts-15066'].conforms).toBe(false);
+    expect(reports['ul-3300'].conforms).toBe(false);
+    expect(reports['eu-ai-act-high-risk'].conforms).toBe(true);
+  });
+
+  it('signs one attestation per profile and each verifies', async () => {
+    const robot = await makeParty('ar7.example.com');
+    const assessor = await makeParty('assessor.example.com');
+    const base = await buildBaseCredentials(robot, assessor);
+    const credentials = [...base, ...(await buildMonitoringCredentials(robot, base[2]))];
+    const reports = checkAllProfiles(credentials);
+    const attestations = await signAttestations(assessor, robot.did, reports);
+
+    expect(Object.keys(attestations)).toHaveLength(5);
+    for (const [pid, attestation] of Object.entries(attestations)) {
+      const res = verifyConformanceAttestation(attestation, assessor.pub);
+      expect(res.ok, `${pid} attestation does not verify`).toBe(true);
+      expect(res.subject?.conforms).toBe(true);
+      expect(res.subject?.profileId).toBe(pid);
+    }
+  });
+
+  it('rejects an attestation under the wrong key', async () => {
+    const robot = await makeParty('ar7.example.com');
+    const assessor = await makeParty('assessor.example.com');
+    const credentials = await buildEvidencePack(robot, assessor);
+    const reports = checkAllProfiles(credentials);
+    const attestations = await signAttestations(assessor, robot.did, reports);
+    const res = verifyConformanceAttestation(attestations['eu-ai-act-high-risk'], robot.pub);
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe('VLA accountability loop example', () => {
+  async function runLoop() {
+    const robot = await makeParty('ar7.example.com');
+    const scopeCred = await buildPhysicalScopeCredential(robot.signer, {
+      subjectDid: robot.did,
+      maxForceN: 80.0,
+      maxSpeedMps: 1.5,
+      maxSpeedNearHumansMps: 0.5,
+      allowedZones: ['cell-3'],
+    });
+    const subject = scopeCred.credentialSubject as Record<string, unknown>;
+    const scope = subject.physicalScope as Record<string, unknown>;
+    const blackbox = new BlackBoxLog(crypto.randomBytes(32));
+    const decisions = runAccountabilityLoop(scope, blackbox);
+    return { decisions, blackbox };
+  }
+
+  it('verifies model provenance on load', async () => {
+    const robot = await makeParty('ar7.example.com');
+    const loaded = await loadModelWithProvenance(robot);
+    expect(loaded.ok).toBe(true);
+    const vla = loaded.subject?.vla as Record<string, unknown>;
+    expect(vla.modelName).toBe(VLA_MODEL_NAME);
+    expect(loaded.attestation.proof).toBeDefined();
+  });
+
+  it('allows the safe actions and denies the over-speed and out-of-zone ones', async () => {
+    const { decisions } = await runLoop();
+    const byTask = new Map(decisions);
+    expect(byTask.get('pick up the cup')?.ok).toBe(true);
+    expect(byTask.get('hand cup to operator')?.ok).toBe(true);
+    expect(byTask.get('sprint to the dock')?.ok).toBe(false);
+    expect(
+      byTask.get('sprint to the dock')?.reasons.some((r) => r.includes('speed_exceeded'))
+    ).toBe(true);
+    expect(byTask.get('fetch from loading bay')?.ok).toBe(false);
+    expect(
+      byTask.get('fetch from loading bay')?.reasons.some((r) => r.startsWith('zone_not_allowed'))
+    ).toBe(true);
+  });
+
+  it('black-box chain verifies and detects tampering', async () => {
+    const { decisions, blackbox } = await runLoop();
+    const entries = blackbox.entries();
+    expect(entries).toHaveLength(decisions.length);
+
+    expect(verifyBlackboxChain(entries).ok).toBe(true);
+
+    const tampered = entries.map((e) => ({ ...e }));
+    tampered[2].event = 'actuation_allowed';
+    const res = verifyBlackboxChain(tampered);
+    expect(res.ok).toBe(false);
+    expect(res.reason).toContain('tampered');
+  });
+});


### PR DESCRIPTION
## Description

Ports the two robotics accountability examples to the three reference SDKs that carry the producer-side surface, so the same flows are runnable in every reference language and produce the same report digests.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

None.

## Changes Made

- **TypeScript** (`packages/sdk-ts/examples/`) — `robotics-evidence-pack.ts` and `robotics-vla-accountability-loop.ts`, written to the SDK's options-object and `{ ok, subject }` conventions, plus `tests/robotics-examples.test.ts` (Vitest) driving the exported helpers.
- **Go** (`go-sidecar/examples/`) — `robotics-evidence-pack/` and `robotics-vla-accountability-loop/` commands using the package's `Options` structs and `*float64` optional numerics, plus `robotics/examples_flow_test.go`.
- **Rust** (`core/vouch-core/examples/`) — `robotics_evidence_pack.rs` and `robotics_vla_accountability_loop.rs` using the crate's params-struct and seed-based signing API, plus `tests/robotics_examples_flow.rs`.

The profile registry is private in Go and Rust, so those ports list the five profile ids explicitly and read `regime`/`version` off the report.

## Testing

- [x] Existing tests pass — TypeScript 404 passed (37 files); Go `go build ./... && go test ./...` all packages ok; Rust `cargo test` green
- [x] New tests added for new functionality — one example-flow test module per language, asserting all five profiles conform, each attestation verifies, the gate allows/denies the expected actions, and the black-box chain verifies and detects tampering
- [x] Manual testing performed — all six example programs run and print identical per-profile summaries and report digests across the four languages

## Checklist

- [x] My code follows the project's code style (`gofmt`/`go vet` clean, `tsc --noEmit` clean)
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Se9bMrksZcQDect8FBRDd)_