### PR TITLE
test(sdks): verify-side robotics examples for the Swift, JVM, .NET, and C++ wrappers

### DIFF
--- a/sdks/cpp/examples/Makefile
+++ b/sdks/cpp/examples/Makefile
@@ -1,7 +1,9 @@
 # Build and run the Vouch C bindings example against the prebuilt core library.
-CC      ?= cc
-CFLAGS  ?= -O2 -Wall -Wextra -std=c11 -I../include
-LDFLAGS ?= -L../lib -lvouch_core_uniffi
+CC       ?= cc
+CXX      ?= c++
+CFLAGS   ?= -O2 -Wall -Wextra -std=c11 -I../include
+CXXFLAGS ?= -O2 -Wall -Wextra -std=c++17 -I../include
+LDFLAGS  ?= -L../lib -lvouch_core_uniffi
 
 example: example.c
 	$(CC) $(CFLAGS) example.c -o example $(LDFLAGS)
@@ -9,7 +11,13 @@ example: example.c
 run: example
 	LD_LIBRARY_PATH=../lib ./example
 
-clean:
-	rm -f example
+robotics_verify_example: robotics_verify_example.cpp
+	$(CXX) $(CXXFLAGS) robotics_verify_example.cpp -o robotics_verify_example $(LDFLAGS)
 
-.PHONY: run clean
+run-robotics: robotics_verify_example
+	LD_LIBRARY_PATH=../lib ./robotics_verify_example
+
+clean:
+	rm -f example robotics_verify_example
+
+.PHONY: run run-robotics clean

--- a/sdks/cpp/examples/robotics_verify_example.cpp
+++ b/sdks/cpp/examples/robotics_verify_example.cpp
@@ -1,0 +1,209 @@
+// Verify-side example for the two robotics accountability flows, using only
+// the curated vouch::robotics surface (vouch.hpp). Mirrors the producer-side
+// Python/TypeScript/Go/Rust examples (examples/robotics_ai_act_evidence_pack.py
+// and examples/robotics_vla_accountability_loop.py) from the consuming side:
+//
+//   1. Regulatory evidence pack: check_conformance maps the shared interop
+//      vector's Python-signed credential set onto all five built-in profiles,
+//      reporting CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery
+//      Regulation and the exact open clause for the two profiles the set
+//      leaves gaps in; build_conformance_attestation then signs a
+//      point-in-time attestation per profile and
+//      verify_conformance_attestation checks it offline.
+//   2. VLA accountability loop: verify_identity / verify_robot_credential
+//      authenticate the robot before trusting it (the wrapper-side analogue
+//      of provenance-on-load), and check_action reproduces the pre-actuation
+//      scope gate, denying the over-speed and out-of-zone actions and
+//      allowing the safe ones.
+//
+// Build and run (after building the core library):
+//   make -C sdks/cpp/examples robotics_verify_example run-robotics
+// or directly:
+//   g++ -O2 -std=c++17 -I../include robotics_verify_example.cpp
+//     -o robotics_verify_example -L../lib -lvouch_core_uniffi
+//   LD_LIBRARY_PATH=../lib ./robotics_verify_example
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+
+#include "vouch.hpp"
+
+// The five built-in conformance profiles. The curated surface keeps the
+// profile registry inside the core, so the ids are listed here.
+static const char* kAllProfileIds[] = {
+    "eu-ai-act-high-risk",
+    "iso-10218",
+    "iso-ts-15066",
+    "eu-machinery-2023-1230",
+    "ul-3300",
+};
+
+// A fixed assessor signing seed (0x03 x 32) and its Ed25519 public key, both
+// standard base64, so the attestation round-trip is deterministic.
+static const char* kAssessorSeedB64 = "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=";
+static const char* kAssessorPubB64 = "7UkoxijRwsbq6QM4kFmVYSlZJzpcY/k2NsFGFKyHN9E=";
+
+// ---- interop-vector helpers (the same controlled-JSON extraction the C++
+// robotics tests use; the vector is well-formed by construction) -------------
+
+static std::string load_vector(const char* path) {
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    std::fprintf(stderr, "cannot open interop vector at %s\n", path);
+    std::exit(2);
+  }
+  std::ostringstream ss;
+  ss << in.rdbuf();
+  return ss.str();
+}
+
+// Return the raw JSON text of the value for a top-level key. Handles nested
+// braces and brackets and skips over string contents (including escapes).
+static std::string field(const std::string& doc, const std::string& key) {
+  std::string pat = "\"" + key + "\"";
+  size_t k = doc.find(pat);
+  if (k == std::string::npos) {
+    std::fprintf(stderr, "interop vector missing field %s\n", key.c_str());
+    std::exit(2);
+  }
+  size_t colon = doc.find(':', k + pat.size());
+  size_t i = colon + 1;
+  while (i < doc.size() && (doc[i] == ' ' || doc[i] == '\n' || doc[i] == '\r' ||
+                            doc[i] == '\t')) {
+    i++;
+  }
+  size_t start = i;
+  char open = doc[i];
+  if (open == '{' || open == '[') {
+    char close = (open == '{') ? '}' : ']';
+    int depth = 0;
+    bool in_str = false;
+    for (; i < doc.size(); i++) {
+      char c = doc[i];
+      if (in_str) {
+        if (c == '\\') {
+          i++;
+        } else if (c == '"') {
+          in_str = false;
+        }
+        continue;
+      }
+      if (c == '"') {
+        in_str = true;
+      } else if (c == open) {
+        depth++;
+      } else if (c == close) {
+        depth--;
+        if (depth == 0) return doc.substr(start, i - start + 1);
+      }
+    }
+  } else if (open == '"') {
+    for (i++; i < doc.size(); i++) {
+      if (doc[i] == '\\') {
+        i++;
+      } else if (doc[i] == '"') {
+        return doc.substr(start, i - start + 1);
+      }
+    }
+  }
+  std::fprintf(stderr, "interop vector field %s is malformed\n", key.c_str());
+  std::exit(2);
+}
+
+// Convert a base64url-no-pad string (a JWK "x") to standard base64.
+static std::string b64url_to_std(const std::string& b64url) {
+  std::string s = b64url;
+  for (char& c : s) {
+    if (c == '-') {
+      c = '+';
+    } else if (c == '_') {
+      c = '/';
+    }
+  }
+  while (s.size() % 4 != 0) s.push_back('=');
+  return s;
+}
+
+static std::string pub_b64_from_jwk(const std::string& jwk) {
+  return b64url_to_std(vouch::detail::json_string(jwk, "x"));
+}
+
+static bool contains(const std::string& s, const std::string& needle) {
+  return s.find(needle) != std::string::npos;
+}
+
+int main(int argc, char** argv) {
+  const char* vector_path =
+      (argc > 1) ? argv[1] : "../../../test-vectors/robotics/vector.json";
+  const std::string vec = load_vector(vector_path);
+  const std::string robot_pub = pub_b64_from_jwk(field(vec, "robot_public_key_jwk"));
+  const std::string identity = field(vec, "robot_identity_credential");
+  const std::string credentials = field(vec, "conformance_credentials");
+
+  // 1. Authenticate the robot before trusting anything it presents.
+  const std::string subject = vouch::robotics::verify_identity(identity, robot_pub);
+  const bool identity_ok = subject != "null" && contains(subject, "Acme Robotics");
+  const bool proof_ok = vouch::robotics::verify_robot_credential(identity, robot_pub);
+  std::printf("robot identity verifies: %s (%s)\n", identity_ok ? "true" : "false",
+              proof_ok ? "proof ok" : "proof FAILED");
+
+  // 2. The evidence pack from the verify side: CONFORMS or the open clause,
+  //    per profile, then one signed attestation per profile.
+  std::printf("\nconformance across the five profiles:\n");
+  int attested = 0;
+  for (const char* pid : kAllProfileIds) {
+    const std::string report = vouch::robotics::check_conformance(credentials, pid);
+    const bool conforms = contains(report, "\"conforms\":true");
+    std::printf("  %-24s %s\n", pid, conforms ? "CONFORMS" : "GAPS");
+
+    const std::string params =
+        std::string("{\"issuerDid\":\"did:web:assessor.example.com\",") +
+        "\"robotDid\":\"did:web:robot.example.com\"," + "\"report\":" + report +
+        "," + "\"validFrom\":\"2026-01-01T00:00:00Z\"}";
+    const std::string attestation =
+        vouch::robotics::build_conformance_attestation(kAssessorSeedB64, params);
+    const std::string att_subject =
+        vouch::robotics::verify_conformance_attestation(attestation, kAssessorPubB64);
+    if (att_subject != "null" && contains(att_subject, pid)) attested++;
+  }
+  std::printf("signed attestations verified: %d/5\n", attested);
+
+  // 3. The VLA pre-actuation scope gate: allow the safe actions, deny the
+  //    over-speed and out-of-zone ones.
+  const std::string scope =
+      "{\"maxForceN\":80.0,\"maxSpeedMps\":1.5,"
+      "\"maxSpeedNearHumansMps\":0.5,\"allowedZones\":[\"cell-3\"]}";
+  struct Case {
+    const char* task;
+    const char* action;
+    bool want_ok;
+  } cases[] = {
+      {"pick up the cup",
+       "{\"forceN\":20.0,\"speedMps\":0.3,\"nearHumans\":true,\"zone\":\"cell-3\"}",
+       true},
+      {"hand cup to operator",
+       "{\"forceN\":10.0,\"speedMps\":0.2,\"nearHumans\":true,\"zone\":\"cell-3\"}",
+       true},
+      {"sprint to the dock",
+       "{\"speedMps\":2.5,\"nearHumans\":true,\"zone\":\"cell-3\"}", false},
+      {"fetch from loading bay",
+       "{\"forceN\":15.0,\"speedMps\":0.5,\"zone\":\"loading-bay\"}", false},
+  };
+
+  std::printf("\nVLA pre-actuation gate:\n");
+  bool gate_ok = true;
+  for (const Case& c : cases) {
+    const std::string result = vouch::robotics::check_action(scope, c.action);
+    const bool ok = contains(result, "\"ok\":true");
+    if (ok != c.want_ok) gate_ok = false;
+    std::printf("  [%s] %s\n", ok ? "ALLOW" : "DENY ", c.task);
+  }
+
+  const bool all_ok = identity_ok && proof_ok && attested == 5 && gate_ok;
+  std::printf("\n%s\n", all_ok ? "ALL ROBOTICS VERIFY EXAMPLE CHECKS PASSED"
+                               : "SOME CHECKS FAILED");
+  return all_ok ? 0 : 1;
+}

--- a/sdks/dotnet/VouchCore.Tests/RoboticsVerifyExampleTests.cs
+++ b/sdks/dotnet/VouchCore.Tests/RoboticsVerifyExampleTests.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using VouchProtocol.Core;
+using Xunit;
+
+namespace VouchProtocol.Core.Tests;
+
+/// <summary>
+/// Verify-side example for the two robotics accountability flows, using only
+/// the curated wrapper surface. Mirrors the producer-side
+/// Python/TypeScript/Go/Rust examples (examples/robotics_ai_act_evidence_pack.py
+/// and examples/robotics_vla_accountability_loop.py) from the consuming side:
+///
+/// Regulatory evidence pack: CheckConformance maps the shared interop vector's
+/// Python-signed credential set onto all five built-in profiles, reporting
+/// CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery Regulation and
+/// the exact open clause for the two profiles the set leaves gaps in;
+/// BuildConformanceAttestation then signs a point-in-time attestation per
+/// profile and VerifyConformanceAttestation checks it offline.
+///
+/// VLA accountability loop: VerifyIdentity / VerifyRobotCredential
+/// authenticate the robot before trusting it (the wrapper-side analogue of
+/// provenance-on-load), and CheckAction reproduces the pre-actuation scope
+/// gate, denying the over-speed and out-of-zone actions and allowing the safe
+/// ones.
+/// </summary>
+public class RoboticsVerifyExampleTests
+{
+    private static readonly string[] AllProfileIds =
+    {
+        "eu-ai-act-high-risk",
+        "iso-10218",
+        "iso-ts-15066",
+        "eu-machinery-2023-1230",
+        "ul-3300",
+    };
+
+    // A fixed assessor signing seed (0x03 x 32) and its Ed25519 public key, so
+    // the attestation round-trip is deterministic like the Rust core tests.
+    private const string AssessorSeedB64 = "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=";
+    private const string AssessorPubB64 = "7UkoxijRwsbq6QM4kFmVYSlZJzpcY/k2NsFGFKyHN9E=";
+
+    private const string Scope =
+        "{\"maxForceN\":80.0,\"maxSpeedMps\":1.5,\"maxSpeedNearHumansMps\":0.5,\"allowedZones\":[\"cell-3\"]}";
+
+    private static readonly JsonElement Vector = LoadVector();
+
+    private static JsonElement LoadVector()
+        => JsonDocument.Parse(File.ReadAllText("robotics-vector.json")).RootElement;
+
+    private static string KeyB64(JsonElement jwk)
+    {
+        string x = jwk.GetProperty("x").GetString()!;
+        return Convert.ToBase64String(FromBase64Url(x));
+    }
+
+    private static byte[] FromBase64Url(string s)
+    {
+        string b = s.Replace('-', '+').Replace('_', '/');
+        switch (b.Length % 4)
+        {
+            case 2: b += "=="; break;
+            case 3: b += "="; break;
+        }
+        return Convert.FromBase64String(b);
+    }
+
+    private static string RobotPublicB64()
+        => KeyB64(Vector.GetProperty("robot_public_key_jwk"));
+
+    private static string CredentialsJson()
+        => Vector.GetProperty("conformance_credentials").GetRawText();
+
+    [Fact]
+    public void VerifiesTheRobotBeforeTrustingIt()
+    {
+        string credential = Vector.GetProperty("robot_identity_credential").GetRawText();
+
+        string subject = VouchRobotics.VerifyIdentity(credential, RobotPublicB64());
+        Assert.NotEqual("null", subject);
+        using var doc = JsonDocument.Parse(subject);
+        Assert.Equal("Acme Robotics", doc.RootElement.GetProperty("make").GetString());
+
+        Assert.True(VouchRobotics.VerifyRobotCredential(credential, RobotPublicB64()));
+    }
+
+    [Fact]
+    public void ReportsConformanceAndGapsAcrossAllFiveProfiles()
+    {
+        foreach (string pid in AllProfileIds)
+        {
+            using var report = JsonDocument.Parse(
+                VouchRobotics.CheckConformance(CredentialsJson(), pid));
+            Assert.Equal(pid, report.RootElement.GetProperty("profileId").GetString());
+
+            bool conforms = report.RootElement.GetProperty("conforms").GetBoolean();
+            if (pid == "iso-ts-15066" || pid == "ul-3300")
+            {
+                // The vector's four-credential set carries no heartbeat motion
+                // digest and no perception provenance, so exactly these two
+                // profiles must report the open clause.
+                Assert.False(conforms);
+            }
+            else
+            {
+                Assert.True(conforms);
+            }
+        }
+    }
+
+    [Fact]
+    public void SignsAndVerifiesOneAttestationPerProfile()
+    {
+        foreach (string pid in AllProfileIds)
+        {
+            string report = VouchRobotics.CheckConformance(CredentialsJson(), pid);
+            string paramsJson =
+                "{\"issuerDid\":\"did:web:assessor.example.com\"," +
+                "\"robotDid\":\"did:web:robot.example.com\"," +
+                "\"report\":" + report + "," +
+                "\"validFrom\":\"2026-01-01T00:00:00Z\"}";
+            string attestation = VouchRobotics.BuildConformanceAttestation(AssessorSeedB64, paramsJson);
+
+            string subject = VouchRobotics.VerifyConformanceAttestation(attestation, AssessorPubB64);
+            Assert.NotEqual("null", subject);
+            using var doc = JsonDocument.Parse(subject);
+            Assert.Equal(pid, doc.RootElement.GetProperty("profileId").GetString());
+
+            // A wrong key must not verify the attestation.
+            Assert.Equal("null",
+                VouchRobotics.VerifyConformanceAttestation(attestation, RobotPublicB64()));
+        }
+    }
+
+    [Theory]
+    [InlineData("{\"forceN\":20.0,\"speedMps\":0.3,\"nearHumans\":true,\"zone\":\"cell-3\"}", true, null)]
+    [InlineData("{\"forceN\":10.0,\"speedMps\":0.2,\"nearHumans\":true,\"zone\":\"cell-3\"}", true, null)]
+    [InlineData("{\"speedMps\":2.5,\"nearHumans\":true,\"zone\":\"cell-3\"}", false, "speed_exceeded")]
+    [InlineData("{\"forceN\":15.0,\"speedMps\":0.5,\"zone\":\"loading-bay\"}", false, "zone_not_allowed")]
+    public void VlaGateAllowsSafeAndDeniesUnsafeActions(string action, bool wantOk, string? wantReason)
+    {
+        string result = VouchRobotics.CheckAction(Scope, action);
+        using var doc = JsonDocument.Parse(result);
+        Assert.Equal(wantOk, doc.RootElement.GetProperty("ok").GetBoolean());
+        if (wantReason != null)
+        {
+            Assert.Contains(wantReason, result);
+        }
+    }
+}

--- a/sdks/jvm/src/test/java/com/vouchprotocol/core/RoboticsVerifyExampleTest.java
+++ b/sdks/jvm/src/test/java/com/vouchprotocol/core/RoboticsVerifyExampleTest.java
@@ -1,0 +1,153 @@
+package com.vouchprotocol.core;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verify-side example for the two robotics accountability flows, using only the
+ * curated wrapper surface. Mirrors the producer-side Python/TypeScript/Go/Rust
+ * examples (examples/robotics_ai_act_evidence_pack.py and
+ * examples/robotics_vla_accountability_loop.py) from the consuming side:
+ *
+ * <ul>
+ *   <li>Regulatory evidence pack: {@code checkConformance} maps the shared
+ *       interop vector's Python-signed credential set onto all five built-in
+ *       profiles, reporting CONFORMS for the EU AI Act, ISO 10218, and the EU
+ *       Machinery Regulation and the exact open clause for the two profiles the
+ *       set leaves gaps in; {@code buildConformanceAttestation} then signs a
+ *       point-in-time attestation per profile and
+ *       {@code verifyConformanceAttestation} checks it offline.</li>
+ *   <li>VLA accountability loop: {@code verifyIdentity} /
+ *       {@code verifyRobotCredential} authenticate the robot before trusting
+ *       it (the wrapper-side analogue of provenance-on-load), and
+ *       {@code checkAction} reproduces the pre-actuation scope gate, denying
+ *       the over-speed and out-of-zone actions and allowing the safe ones.</li>
+ * </ul>
+ *
+ * Keys in the vector are JWKs whose {@code x} is base64url-no-pad raw Ed25519
+ * material; the wrapper's {@code *B64} arguments take standard base64.
+ */
+class RoboticsVerifyExampleTest {
+
+    private static final List<String> ALL_PROFILE_IDS = List.of(
+            "eu-ai-act-high-risk",
+            "iso-10218",
+            "iso-ts-15066",
+            "eu-machinery-2023-1230",
+            "ul-3300");
+
+    // A fixed assessor signing seed (0x03 x 32) and its Ed25519 public key, so
+    // the attestation round-trip is deterministic like the Rust core tests.
+    private static final String ASSESSOR_SEED_B64 = "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=";
+    private static final String ASSESSOR_PUB_B64 = "7UkoxijRwsbq6QM4kFmVYSlZJzpcY/k2NsFGFKyHN9E=";
+
+    private static final String SCOPE =
+            "{\"maxForceN\":80.0,\"maxSpeedMps\":1.5,"
+            + "\"maxSpeedNearHumansMps\":0.5,\"allowedZones\":[\"cell-3\"]}";
+
+    private static final Map<String, Object> VECTOR = loadVector();
+
+    private static Map<String, Object> loadVector() {
+        Path module = Paths.get("").toAbsolutePath();
+        Path vector = module.resolve(Paths.get("..", "..", "test-vectors", "robotics", "vector.json")).normalize();
+        try {
+            return Json.parseObject(new String(Files.readAllBytes(vector), StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new RuntimeException("read interop vector at " + vector, e);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static String robotPublicB64() {
+        Map<String, Object> jwk = (Map<String, Object>) VECTOR.get("robot_public_key_jwk");
+        byte[] raw = Base64.getUrlDecoder().decode((String) jwk.get("x"));
+        return Base64.getEncoder().encodeToString(raw);
+    }
+
+    private static String credentialsJson() {
+        return Json.write(VECTOR.get("conformance_credentials"));
+    }
+
+    @Test
+    void verifiesTheRobotBeforeTrustingIt() {
+        String credential = Json.write(VECTOR.get("robot_identity_credential"));
+
+        String subject = VouchRobotics.verifyIdentity(credential, robotPublicB64());
+        assertNotEquals("null", subject, "the Python-minted identity must verify");
+        assertTrue(subject.contains("\"make\":\"Acme Robotics\""), subject);
+
+        assertTrue(VouchRobotics.verifyRobotCredential(credential, robotPublicB64()),
+                "the identity credential proof must verify under the robot key");
+    }
+
+    @Test
+    void reportsConformanceAndGapsAcrossAllFiveProfiles() {
+        for (String pid : ALL_PROFILE_IDS) {
+            Map<String, Object> report = Json.parseObject(
+                    VouchRobotics.checkConformance(credentialsJson(), pid));
+            assertEquals(pid, report.get("profileId"));
+
+            boolean conforms = Boolean.TRUE.equals(report.get("conforms"));
+            if (pid.equals("iso-ts-15066") || pid.equals("ul-3300")) {
+                // The vector's four-credential set carries no heartbeat motion
+                // digest and no perception provenance, so exactly these two
+                // profiles must report the open clause.
+                assertFalse(conforms, pid + " should report gaps: " + report);
+            } else {
+                assertTrue(conforms, pid + " should conform: " + report);
+            }
+        }
+    }
+
+    @Test
+    void signsAndVerifiesOneAttestationPerProfile() {
+        for (String pid : ALL_PROFILE_IDS) {
+            String report = VouchRobotics.checkConformance(credentialsJson(), pid);
+            String params = "{\"issuerDid\":\"did:web:assessor.example.com\","
+                    + "\"robotDid\":\"did:web:robot.example.com\","
+                    + "\"report\":" + report + ","
+                    + "\"validFrom\":\"2026-01-01T00:00:00Z\"}";
+            String attestation = VouchRobotics.buildConformanceAttestation(ASSESSOR_SEED_B64, params);
+
+            String subject = VouchRobotics.verifyConformanceAttestation(attestation, ASSESSOR_PUB_B64);
+            assertNotEquals("null", subject, pid + " attestation must verify");
+            assertTrue(subject.contains("\"profileId\":\"" + pid + "\""), subject);
+
+            // A wrong key must not verify the attestation.
+            assertEquals("null",
+                    VouchRobotics.verifyConformanceAttestation(attestation, robotPublicB64()));
+        }
+    }
+
+    @Test
+    void vlaGateAllowsSafeAndDeniesUnsafeActions() {
+        String pick = VouchRobotics.checkAction(SCOPE,
+                "{\"forceN\":20.0,\"speedMps\":0.3,\"nearHumans\":true,\"zone\":\"cell-3\"}");
+        assertTrue(pick.contains("\"ok\":true"), "safe pick should pass: " + pick);
+
+        String hand = VouchRobotics.checkAction(SCOPE,
+                "{\"forceN\":10.0,\"speedMps\":0.2,\"nearHumans\":true,\"zone\":\"cell-3\"}");
+        assertTrue(hand.contains("\"ok\":true"), "safe handover should pass: " + hand);
+
+        String sprint = VouchRobotics.checkAction(SCOPE,
+                "{\"speedMps\":2.5,\"nearHumans\":true,\"zone\":\"cell-3\"}");
+        assertTrue(sprint.contains("\"ok\":false"), "over-speed sprint should fail: " + sprint);
+        assertTrue(sprint.contains("speed_exceeded"), sprint);
+
+        String fetch = VouchRobotics.checkAction(SCOPE,
+                "{\"forceN\":15.0,\"speedMps\":0.5,\"zone\":\"loading-bay\"}");
+        assertTrue(fetch.contains("\"ok\":false"), "out-of-zone fetch should fail: " + fetch);
+        assertTrue(fetch.contains("zone_not_allowed"), fetch);
+    }
+}

--- a/sdks/swift/Tests/VouchCoreTests/RoboticsVerifyExampleTests.swift
+++ b/sdks/swift/Tests/VouchCoreTests/RoboticsVerifyExampleTests.swift
@@ -1,0 +1,167 @@
+import XCTest
+
+@testable import VouchCore
+
+/// Verify-side example for the two robotics accountability flows, using only
+/// the curated wrapper surface. Mirrors the producer-side
+/// Python/TypeScript/Go/Rust examples (examples/robotics_ai_act_evidence_pack.py
+/// and examples/robotics_vla_accountability_loop.py) from the consuming side:
+///
+/// - Regulatory evidence pack: `checkConformance` maps the shared interop
+///   vector's Python-signed credential set onto all five built-in profiles,
+///   reporting CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery
+///   Regulation and the exact open clause for the two profiles the set leaves
+///   gaps in; `buildConformanceAttestation` then signs a point-in-time
+///   attestation per profile and `verifyConformanceAttestation` checks it
+///   offline.
+/// - VLA accountability loop: `verifyIdentity` / `verifyRobotCredential`
+///   authenticate the robot before trusting it (the wrapper-side analogue of
+///   provenance-on-load), and `checkAction` reproduces the pre-actuation scope
+///   gate, denying the over-speed and out-of-zone actions and allowing the
+///   safe ones.
+final class RoboticsVerifyExampleTests: XCTestCase {
+    private let allProfileIds = [
+        "eu-ai-act-high-risk",
+        "iso-10218",
+        "iso-ts-15066",
+        "eu-machinery-2023-1230",
+        "ul-3300",
+    ]
+
+    // A fixed assessor signing seed (0x03 x 32), so the attestation
+    // round-trip is deterministic like the Rust core tests.
+    private let assessorSeed = Data(repeating: 3, count: 32)
+    // The Ed25519 public key that seed derives (base64url-no-pad).
+    private let assessorPub = "7UkoxijRwsbq6QM4kFmVYSlZJzpcY_k2NsFGFKyHN9E"
+
+    private let scope = """
+        {"maxForceN":80.0,"maxSpeedMps":1.5,"maxSpeedNearHumansMps":0.5,"allowedZones":["cell-3"]}
+        """
+
+    func testVerifiesTheRobotBeforeTrustingIt() throws {
+        let v = try vector()
+        let credential = try jsonString(v["robot_identity_credential"]!)
+        let robotKey = try jwkPublicKey(v["robot_public_key_jwk"]!)
+
+        let subject = try VouchRobotics.verifyIdentity(credential, robotPublicKey: robotKey)
+        XCTAssertNotEqual(subject, "null", "the Python-minted identity must verify")
+        XCTAssertTrue(subject.contains("\"make\":\"Acme Robotics\""))
+
+        XCTAssertTrue(
+            try VouchRobotics.verifyRobotCredential(credential, ed25519Public: robotKey),
+            "the identity credential proof must verify under the robot key"
+        )
+    }
+
+    func testReportsConformanceAndGapsAcrossAllFiveProfiles() throws {
+        let v = try vector()
+        let credentials = try jsonString(v["conformance_credentials"]!)
+
+        for pid in allProfileIds {
+            let report = try VouchRobotics.checkConformance(
+                credentialsJson: credentials,
+                profileId: pid
+            )
+            XCTAssertTrue(report.contains("\"profileId\":\"\(pid)\""))
+            if pid == "iso-ts-15066" || pid == "ul-3300" {
+                // The vector's four-credential set carries no heartbeat motion
+                // digest and no perception provenance, so exactly these two
+                // profiles must report the open clause.
+                XCTAssertTrue(report.contains("\"conforms\":false"), "\(pid): \(report)")
+            } else {
+                XCTAssertTrue(report.contains("\"conforms\":true"), "\(pid): \(report)")
+            }
+        }
+    }
+
+    func testSignsAndVerifiesOneAttestationPerProfile() throws {
+        let v = try vector()
+        let credentials = try jsonString(v["conformance_credentials"]!)
+        let assessorKey = base64urlDecode(assessorPub)
+        let robotKey = try jwkPublicKey(v["robot_public_key_jwk"]!)
+
+        for pid in allProfileIds {
+            let report = try VouchRobotics.checkConformance(
+                credentialsJson: credentials,
+                profileId: pid
+            )
+            let params = """
+                {"issuerDid":"did:web:assessor.example.com",\
+                "robotDid":"did:web:robot.example.com",\
+                "report":\(report),\
+                "validFrom":"2026-01-01T00:00:00Z"}
+                """
+            let attestation = try VouchRobotics.buildConformanceAttestation(
+                signerSeed: assessorSeed,
+                paramsJson: params
+            )
+
+            let subject = try VouchRobotics.verifyConformanceAttestation(
+                attestation,
+                publicKey: assessorKey
+            )
+            XCTAssertNotEqual(subject, "null", "\(pid) attestation must verify")
+            XCTAssertTrue(subject.contains("\"profileId\":\"\(pid)\""))
+
+            // A wrong key must not verify the attestation.
+            XCTAssertEqual(
+                try VouchRobotics.verifyConformanceAttestation(attestation, publicKey: robotKey),
+                "null"
+            )
+        }
+    }
+
+    func testVlaGateAllowsSafeAndDeniesUnsafeActions() throws {
+        let pick = try VouchRobotics.checkAction(
+            scopeJson: scope,
+            actionJson: "{\"forceN\":20.0,\"speedMps\":0.3,\"nearHumans\":true,\"zone\":\"cell-3\"}"
+        )
+        XCTAssertTrue(pick.contains("\"ok\":true"), "safe pick should pass: \(pick)")
+
+        let hand = try VouchRobotics.checkAction(
+            scopeJson: scope,
+            actionJson: "{\"forceN\":10.0,\"speedMps\":0.2,\"nearHumans\":true,\"zone\":\"cell-3\"}"
+        )
+        XCTAssertTrue(hand.contains("\"ok\":true"), "safe handover should pass: \(hand)")
+
+        let sprint = try VouchRobotics.checkAction(
+            scopeJson: scope,
+            actionJson: "{\"speedMps\":2.5,\"nearHumans\":true,\"zone\":\"cell-3\"}"
+        )
+        XCTAssertTrue(sprint.contains("\"ok\":false"), "over-speed sprint should fail: \(sprint)")
+        XCTAssertTrue(sprint.contains("speed_exceeded"))
+
+        let fetch = try VouchRobotics.checkAction(
+            scopeJson: scope,
+            actionJson: "{\"forceN\":15.0,\"speedMps\":0.5,\"zone\":\"loading-bay\"}"
+        )
+        XCTAssertTrue(fetch.contains("\"ok\":false"), "out-of-zone fetch should fail: \(fetch)")
+        XCTAssertTrue(fetch.contains("zone_not_allowed"))
+    }
+
+    // MARK: Fixture + JSON + key helpers
+
+    private func vector() throws -> [String: Any] {
+        let url = Bundle.module.url(forResource: "vector", withExtension: "json")!
+        return try JSONSerialization.jsonObject(with: Data(contentsOf: url)) as! [String: Any]
+    }
+
+    /// Decode a JWK OKP Ed25519 public key (its base64url-no-pad `x` member)
+    /// into the raw 32-byte key `Data` the curated wrapper expects.
+    private func jwkPublicKey(_ jwk: Any) throws -> Data {
+        let x = (jwk as! [String: Any])["x"] as! String
+        return base64urlDecode(x)
+    }
+
+    /// Standard base64 decoding of a base64url-no-pad string.
+    private func base64urlDecode(_ s: String) -> Data {
+        var b64 = s.replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        while b64.count % 4 != 0 { b64.append("=") }
+        return Data(base64Encoded: b64)!
+    }
+
+    private func jsonString(_ value: Any) throws -> String {
+        String(data: try JSONSerialization.data(withJSONObject: value), encoding: .utf8)!
+    }
+}


### PR DESCRIPTION
## Description

Reproduces the two robotics accountability flows from the consuming side in each wrapper SDK, using only the curated robotics surface those wrappers expose.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

None.

## Changes Made

The wrappers carry the verify-side surface only (no heartbeat, perception, provenance, safety-record, or black-box verbs), and none of them had an examples directory, so each example follows that wrapper's existing test-as-example convention:

- **JVM** — `RoboticsVerifyExampleTest.java` (JUnit 5)
- **.NET** — `RoboticsVerifyExampleTests.cs` (xUnit)
- **Swift** — `RoboticsVerifyExampleTests.swift` (XCTest)
- **C++** — `examples/robotics_verify_example.cpp`, a runnable program wired into the existing examples `Makefile` (`robotics_verify_example` / `run-robotics` targets)

Each verifies the Python-minted robot identity from `test-vectors/robotics/vector.json` before trusting it, maps that credential set onto all five conformance profiles (CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery Regulation; the exact open clause for ISO/TS 15066 and UL 3300, which need a heartbeat motion digest and perception provenance the four-credential set does not carry), signs and verifies one conformance attestation per profile from a fixed assessor seed while rejecting a wrong key, and reproduces the VLA pre-actuation gate.

## Testing

- [x] Existing tests pass — JVM suite green under `./gradlew test` against a locally built native core (the new test class: 4 tests, 0 failures); C++ example builds warning-free and passes against the same library
- [x] New tests added for new functionality
- [x] Manual testing performed

> **Note for reviewers:** there is no Swift or .NET toolchain in the environment these were written in, so those two files are unexecuted here. They follow their sibling tests line-for-line over the identical C ABI, and their CI jobs (`sdk-tests.yml`) exercise them. Worth a close look on first CI run.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [ ] All tests pass locally — JVM and C++ verified locally; Swift and .NET rely on CI (see note above)
- [x] My commits are signed off (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Se9bMrksZcQDect8FBRDd)_