### PR TITLE
feat(sdks): add C and WASM robotics accountability examples

### DIFF
--- a/core/wasm/robotics-examples.mjs
+++ b/core/wasm/robotics-examples.mjs
@@ -1,0 +1,252 @@
+// Robotics accountability examples for core-wasm: ports both flows the Python
+// reference runs (examples/robotics_ai_act_evidence_pack.py and
+// examples/robotics_vla_accountability_loop.py) onto the WASM producer surface.
+//
+//   1. Regulatory evidence pack: assemble the six credentials (identity, model
+//      provenance, physical scope, safety record, heartbeat with a motion
+//      digest, perception provenance), check them against all five built-in
+//      conformance profiles, and sign plus verify one point-in-time
+//      conformance attestation per profile.
+//   2. VLA accountability loop: provenance verified on load, the pre-actuation
+//      scope gate denying the over-speed and out-of-zone actions, and the
+//      encrypted hash-linked black box, including the tamper-detection case.
+//
+// Follows smoke.mjs: the ok(name, cond) PASS/FAIL harness, the Node ESM crypto
+// polyfill, and fixed seeds so the run is deterministic and needs no RNG.
+//
+// Run:  node robotics-examples.mjs   (after ./build-npm.sh)
+import init, * as core from './pkg/vouch_core_wasm.js';
+import { readFileSync } from 'fs';
+import { webcrypto } from 'node:crypto';
+// Node ESM RNG polyfill for getrandom (browsers expose this natively).
+if (!globalThis.crypto) globalThis.crypto = webcrypto;
+
+await init({ module_or_path: readFileSync(new URL('./pkg/vouch_core_wasm_bg.wasm', import.meta.url)) });
+
+let pass = 0, fail = 0;
+const ok = (name, cond) => { console.log(`  ${cond ? 'PASS' : 'FAIL'}  ${name}`); cond ? pass++ : fail++; };
+
+// Fixed Ed25519 seeds (0x01/0x07/0x03 repeated) and their public keys, so the
+// whole run is reproducible. The assessor pair is the same one the C++
+// robotics example pins.
+const ROBOT_SEED = 'AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQE=';
+const ROBOT_PUB = 'iojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w=';
+const ROOT_SEED = 'BwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwcHBwc=';
+const ROOT_PUB = '6kpsY+KcUgq+9VB7Ey7F+ZVHdq6+vnuSQh7qaRRG0iw=';
+const ASSESSOR_SEED = 'AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=';
+const ASSESSOR_PUB = '7UkoxijRwsbq6QM4kFmVYSlZJzpcY/k2NsFGFKyHN9E=';
+const OTHER_PUB = 'T7LUicUOAmZaTdRW8bYFPLoLNRUeDVaJRq1cyfw8jSU=';
+const BLACKBOX_KEY = 'CQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQkJCQk=';
+
+const ROBOT_DID = 'did:web:ar7.example.com';
+const ASSESSOR_DID = 'did:web:assessor.example.com';
+const NOW = '2026-01-01T00:00:00Z';
+
+const ALL_PROFILE_IDS = [
+  'eu-ai-act-high-risk',
+  'iso-10218',
+  'iso-ts-15066',
+  'eu-machinery-2023-1230',
+  'ul-3300',
+];
+
+// Multibase (base64url, 'u' prefix) of raw bytes, the hash/signature form Vouch
+// credentials carry.
+const mb64 = (buf) => 'u' + Buffer.from(buf).toString('base64url');
+const digest = async (text) =>
+  mb64(new Uint8Array(await webcrypto.subtle.digest('SHA-256', Buffer.from(text))));
+
+console.log('vouch core-wasm', core.version(), '- robotics accountability examples\n');
+console.log('evidence pack:');
+
+// ---- identity -------------------------------------------------------------
+// The hardware root signs the binding of the robot DID to the robot key. WASM
+// exposes ed25519Sign, so the attestation here is genuine, not a placeholder.
+const robotMultikey = core.didKeyFromEd25519(ROBOT_PUB).replace('did:key:', '');
+const binding = core.canonicalize(JSON.stringify({ key: robotMultikey, robotDid: ROBOT_DID }));
+const attestation = mb64(
+  Buffer.from(core.ed25519Sign(ROOT_SEED, Buffer.from(binding).toString('base64')), 'base64')
+);
+const rootMultikey = core.didKeyFromEd25519(ROOT_PUB).replace('did:key:', '');
+
+const identity = core.roboticsMintIdentity(ROBOT_SEED, JSON.stringify({
+  robotDid: ROBOT_DID,
+  make: 'Acme Robotics',
+  model: 'AR-7',
+  serial: 'SN-000123',
+  rootKind: 'TPM',
+  rootPublicMultibase: rootMultikey,
+  attestation,
+  validFrom: NOW,
+}));
+const identitySubject = core.roboticsVerifyIdentity(identity, ROBOT_PUB);
+ok('identity mints and verifies (real hardware-root attestation)',
+  JSON.parse(identitySubject).make === 'Acme Robotics');
+
+// ---- model provenance -----------------------------------------------------
+const CONFIG = { temperature: 0.0, max_torque: 12.5 };
+const provenance = core.roboticsBuildProvenance(ROBOT_SEED, JSON.stringify({
+  issuerDid: ROBOT_DID,
+  robotDid: ROBOT_DID,
+  modelName: 'Gemini Robotics ER 2',
+  weightsHash: await digest('gemini-robotics-er-2-weights'),
+  safetyPolicy: await digest('factory-floor-safety-policy-v3'),
+  config: CONFIG,
+  version: '2.0',
+  validFrom: NOW,
+}));
+
+// ---- physical capability scope --------------------------------------------
+const scopeCred = core.roboticsBuildScope(ROBOT_SEED, JSON.stringify({
+  issuerDid: ROBOT_DID,
+  subjectDid: ROBOT_DID,
+  maxForceN: 80.0,
+  maxSpeedMps: 1.5,
+  maxSpeedNearHumansMps: 0.5,
+  allowedZones: ['cell-3'],
+  validFrom: NOW,
+}));
+const scope = JSON.parse(scopeCred).credentialSubject.physicalScope;
+
+// ---- safety record over a tamper-evident ledger ---------------------------
+let safetyHead = core.roboticsGenesisPrevHash();
+const safetyEntries = [];
+for (const [eventType, severity, ts] of [
+  ['near_miss', 'low', '2026-01-01T00:00:01Z'],
+  ['manual_override', 'info', '2026-01-01T00:00:02Z'],
+]) {
+  const appended = JSON.parse(core.roboticsSafetyAppend(JSON.stringify({
+    prevHash: safetyHead, eventType, severity, timestamp: ts,
+  })));
+  safetyEntries.push(appended.entry);
+  safetyHead = appended.head;
+}
+const summary = core.roboticsSummarizeSafety(JSON.stringify(safetyEntries), safetyHead);
+const safetyRecord = core.roboticsBuildSafetyRecord(ASSESSOR_SEED, JSON.stringify({
+  issuerDid: ASSESSOR_DID,
+  robotDid: ROBOT_DID,
+  summary: JSON.parse(summary),
+  validFrom: NOW,
+}));
+
+// ---- heartbeat carrying a motion digest (ISO/TS 15066 monitoring) ----------
+const motionDigest = core.roboticsMotionDigest(JSON.stringify({
+  scope,
+  samples: [
+    { forceN: 12.0, speedMps: 0.4, nearHumans: true, zone: 'cell-3' },
+    { forceN: 25.0, speedMps: 1.1, nearHumans: false, zone: 'cell-3' },
+  ],
+}));
+const heartbeat = core.roboticsBuildHeartbeat(ROBOT_SEED, JSON.stringify({
+  robotDid: ROBOT_DID,
+  sessionId: 'shift-A',
+  intervalIndex: 0,
+  intervalSeconds: 30,
+  motionDigest: JSON.parse(motionDigest),
+  validFrom: NOW,
+}));
+
+// ---- perception provenance (UL 3300 sensing integrity) --------------------
+const frameMb = mb64(Buffer.from('\x89frame-bytes-from-the-front-camera', 'binary'));
+const frameHash = core.roboticsHashFrame(Buffer.from(frameMb.slice(1), 'base64url').toString('base64'));
+const perceptionRecord = JSON.parse(core.roboticsPerceptionRecord(JSON.stringify({
+  prevHash: core.roboticsGenesisPrevHash(),
+  frameMb,
+  sensorId: 'cam-front',
+  modality: 'camera',
+  timestamp: '2026-01-01T00:00:03Z',
+})));
+const perception = core.roboticsBuildPerception(ROBOT_SEED, JSON.stringify({
+  robotDid: ROBOT_DID,
+  sensorId: 'cam-front',
+  modality: 'camera',
+  frameHash,
+  logHead: perceptionRecord.head,
+  validFrom: NOW,
+}));
+
+// ---- check every profile, and sign an attestation per profile -------------
+const base = [identity, provenance, scopeCred, safetyRecord].map(JSON.parse);
+const full = [...base, JSON.parse(heartbeat), JSON.parse(perception)];
+
+ok('full evidence pack carries six credentials', full.length === 6);
+
+let allConform = true;
+for (const pid of ALL_PROFILE_IDS) {
+  const report = JSON.parse(core.roboticsCheckConformance(JSON.stringify(full), pid));
+  if (!report.conforms) allConform = false;
+  console.log(`    ${pid.padEnd(24)} ${report.conforms ? 'CONFORMS' : 'GAPS'} ` +
+    `(${report.satisfiedCount}/${report.totalCount})  ${report.regime}`);
+}
+ok('all five profiles conform on the full pack', allConform);
+
+// The base four credentials leave exactly the two documented gaps.
+const baseGaps = ALL_PROFILE_IDS.filter((pid) =>
+  !JSON.parse(core.roboticsCheckConformance(JSON.stringify(base), pid)).conforms);
+ok('base set leaves exactly the iso-ts-15066 and ul-3300 gaps',
+  baseGaps.length === 2 && baseGaps.includes('iso-ts-15066') && baseGaps.includes('ul-3300'));
+
+let attestationsOk = true, wrongKeyRejected = true;
+for (const pid of ALL_PROFILE_IDS) {
+  const report = core.roboticsCheckConformance(JSON.stringify(full), pid);
+  const att = core.roboticsBuildConformanceAttestation(ASSESSOR_SEED, JSON.stringify({
+    issuerDid: ASSESSOR_DID, robotDid: ROBOT_DID, report: JSON.parse(report), validFrom: NOW,
+  }));
+  const subject = JSON.parse(core.roboticsVerifyConformanceAttestation(att, ASSESSOR_PUB));
+  if (subject.profileId !== pid || subject.conforms !== true) attestationsOk = false;
+  try {
+    const bad = core.roboticsVerifyConformanceAttestation(att, OTHER_PUB);
+    if (bad && bad !== 'null') wrongKeyRejected = false;
+  } catch { /* throwing is also a rejection */ }
+}
+ok('every signed conformance attestation verifies', attestationsOk);
+ok('a wrong key is rejected', wrongKeyRejected);
+
+// ---- 2. VLA accountability loop -------------------------------------------
+console.log('\nVLA accountability loop:');
+
+const provSubject = core.roboticsVerifyProvenance(provenance, ROBOT_PUB, JSON.stringify(CONFIG));
+ok('provenance verifies on load (no provenance, no autonomy)',
+  JSON.parse(provSubject).vla.modelName === 'Gemini Robotics ER 2');
+
+// The planner's proposed episode: two safe actions, one over-speed near a
+// human, one outside the allowed zone.
+const PLANNED = [
+  ['pick up the cup', { forceN: 20.0, speedMps: 0.3, nearHumans: true, zone: 'cell-3' }, true],
+  ['hand cup to operator', { forceN: 10.0, speedMps: 0.2, nearHumans: true, zone: 'cell-3' }, true],
+  ['sprint to the dock', { speedMps: 2.5, nearHumans: true, zone: 'cell-3' }, false],
+  ['fetch from loading bay', { forceN: 15.0, speedMps: 0.5, zone: 'loading-bay' }, false],
+];
+
+let gateCorrect = true;
+let prevHash = core.roboticsGenesisPrevHash();
+const entries = [];
+PLANNED.forEach(([task, action, wantAllowed], i) => {
+  const result = JSON.parse(core.roboticsCheckAction(JSON.stringify(scope), JSON.stringify(action)));
+  if (result.ok !== wantAllowed) gateCorrect = false;
+  // seq is a u64 on the Rust side, which wasm-bindgen maps to BigInt.
+  const entry = JSON.parse(core.roboticsBlackboxAppend(
+    BLACKBOX_KEY, BigInt(i),
+    result.ok ? 'actuation_allowed' : 'actuation_denied',
+    JSON.stringify({ task, reasons: result.reasons }),
+    `2026-01-01T00:00:0${i + 1}Z`,
+    prevHash,
+  ));
+  entries.push(entry);
+  prevHash = entry.entryHash;
+  const why = result.reasons.length ? `  (${result.reasons.join('; ')})` : '';
+  console.log(`    [${result.ok ? 'ALLOW' : 'DENY '}] ${task}${why}`);
+});
+ok('gate allows the safe actions and denies over-speed and out-of-zone', gateCorrect);
+
+const chain = JSON.parse(core.roboticsVerifyChain(JSON.stringify(entries), undefined));
+ok('black-box chain verifies', chain.ok === true);
+
+// Rewriting history (the denied sprint becomes "allowed") breaks the chain.
+const tampered = entries.map((e) => ({ ...e }));
+tampered[2].event = 'actuation_allowed';
+const detected = JSON.parse(core.roboticsVerifyChain(JSON.stringify(tampered), undefined));
+ok('tampering is detected', detected.ok === false && String(detected.reason).includes('tampered'));
+
+console.log(`\n${pass} passed, ${fail} failed`);
+process.exit(fail === 0 ? 0 : 1);

--- a/sdks/cpp/.gitignore
+++ b/sdks/cpp/.gitignore
@@ -1,3 +1,5 @@
 lib/*.a
 examples/example
+examples/robotics_verify_example
+examples/robotics_example
 build/

--- a/sdks/cpp/examples/Makefile
+++ b/sdks/cpp/examples/Makefile
@@ -17,7 +17,13 @@ robotics_verify_example: robotics_verify_example.cpp
 run-robotics: robotics_verify_example
 	LD_LIBRARY_PATH=../lib ./robotics_verify_example
 
-clean:
-	rm -f example robotics_verify_example
+robotics_example: robotics_example.c
+	$(CC) $(CFLAGS) robotics_example.c -o robotics_example $(LDFLAGS)
 
-.PHONY: run run-robotics clean
+run-robotics-c: robotics_example
+	LD_LIBRARY_PATH=../lib ./robotics_example
+
+clean:
+	rm -f example robotics_verify_example robotics_example
+
+.PHONY: run run-robotics run-robotics-c clean

--- a/sdks/cpp/examples/robotics_example.c
+++ b/sdks/cpp/examples/robotics_example.c
@@ -1,0 +1,325 @@
+/*
+ * Vouch Protocol robotics C example.
+ *
+ * The C ABI (vouch_core.h) exposes a narrower robotics surface than the
+ * reference SDKs: 18 vouch_robotics_* entry points, verify-side plus identity
+ * minting and conformance attestation. This example exercises that surface as
+ * a trimmed version of the two accountability flows the Python, TypeScript, Go
+ * and Rust examples run in full (examples/robotics_ai_act_evidence_pack.py and
+ * examples/robotics_vla_accountability_loop.py):
+ *
+ *   1. Identity: verify the Python-minted RobotIdentityCredential from the
+ *      shared interop vector (cross-language proof), then mint one from C.
+ *   2. Action gate: check a safe and two unsafe actions against a physical
+ *      capability scope, the pre-actuation gate of the VLA loop.
+ *   3. Evidence pack: run check_conformance over the vector's credential set,
+ *      then sign a point-in-time conformance attestation and verify it, and
+ *      confirm a wrong key is rejected.
+ *
+ * A note on minting, and a real limit of the C ABI: a RobotIdentityCredential
+ * embeds a hardware-root attestation, the secure element's signature over the
+ * binding of the robot DID to the robot key. The C ABI deliberately exposes no
+ * raw-signature primitive (vouch_sign signs a credential, not arbitrary bytes),
+ * so that signature must come from the TPM or secure element itself, or from a
+ * reference SDK. Step 1b below mints with a placeholder attestation to show the
+ * mint path and the credential shape, and then shows verify_identity REJECTING
+ * it: the hardware root is enforced, not decorative.
+ *
+ * Every returned string is freed with vouch_string_free (see example.c).
+ *
+ * Build + run:  make robotics_example run-robotics   (see ../Makefile)
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "vouch_core.h"
+
+/* A fixed assessor signing seed (0x03 x 32) and its Ed25519 public key, both
+ * standard base64, so the attestation round-trip is deterministic. Shared with
+ * robotics_verify_example.cpp. */
+static const char *kAssessorSeedB64 = "AwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwM=";
+static const char *kAssessorPubB64 = "7UkoxijRwsbq6QM4kFmVYSlZJzpcY/k2NsFGFKyHN9E=";
+
+/* A different key (0x04 x 32) used only to prove a wrong key is rejected. */
+static const char *kOtherPubB64 = "T7LUicUOAmZaTdRW8bYFPLoLNRUeDVaJRq1cyfw8jSU=";
+
+static const char *kScopeJson =
+    "{\"maxForceN\":80.0,\"maxSpeedMps\":1.5,"
+    "\"maxSpeedNearHumansMps\":0.5,\"allowedZones\":[\"cell-3\"]}";
+
+/* ---- small helpers -------------------------------------------------------- */
+
+/* The verify entry points signal "invalid" by returning the JSON literal
+ * "null" rather than a NULL pointer (a NULL pointer means a hard error, with a
+ * message in err_out). Both count as a rejection. */
+static int rejected(const char *out) {
+    return out == NULL || strcmp(out, "null") == 0;
+}
+
+/* Take ownership of a C ABI return value, aborting with the error it set. */
+static char *take(char *out, char *err, const char *what) {
+    if (!out) {
+        fprintf(stderr, "%s failed: %s\n", what, err ? err : "(no message)");
+        if (err) vouch_string_free(err);
+        exit(2);
+    }
+    return out;
+}
+
+static char *read_file(const char *path) {
+    FILE *f = fopen(path, "rb");
+    if (!f) return NULL;
+    fseek(f, 0, SEEK_END);
+    long n = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    char *buf = malloc((size_t)n + 1);
+    if (!buf || fread(buf, 1, (size_t)n, f) != (size_t)n) {
+        free(buf);
+        fclose(f);
+        return NULL;
+    }
+    buf[n] = 0;
+    fclose(f);
+    return buf;
+}
+
+/* Return the raw JSON text of the value for a key (caller frees). Handles
+ * nested braces/brackets and skips string contents, the same controlled
+ * extraction the C++ robotics example uses; the vector is well-formed by
+ * construction, so this is not a general-purpose JSON parser. */
+static char *json_value(const char *doc, const char *key) {
+    char pat[128];
+    snprintf(pat, sizeof pat, "\"%s\"", key);
+    const char *k = strstr(doc, pat);
+    if (!k) {
+        fprintf(stderr, "interop vector missing field %s\n", key);
+        exit(2);
+    }
+    const char *p = strchr(k + strlen(pat), ':');
+    if (!p) exit(2);
+    p++;
+    while (*p == ' ' || *p == '\n' || *p == '\r' || *p == '\t') p++;
+    const char *start = p;
+    char open = *p;
+    if (open == '{' || open == '[') {
+        char close = (open == '{') ? '}' : ']';
+        int depth = 0;
+        int in_str = 0;
+        for (; *p; p++) {
+            if (in_str) {
+                if (*p == '\\') {
+                    p++;
+                } else if (*p == '"') {
+                    in_str = 0;
+                }
+                continue;
+            }
+            if (*p == '"') {
+                in_str = 1;
+            } else if (*p == open) {
+                depth++;
+            } else if (*p == close) {
+                if (--depth == 0) {
+                    p++;
+                    break;
+                }
+            }
+        }
+    } else if (open == '"') {
+        p++;
+        for (; *p; p++) {
+            if (*p == '\\') {
+                p++;
+            } else if (*p == '"') {
+                p++;
+                break;
+            }
+        }
+    } else {
+        while (*p && *p != ',' && *p != '}' && *p != '\n') p++;
+    }
+    size_t len = (size_t)(p - start);
+    char *out = malloc(len + 1);
+    memcpy(out, start, len);
+    out[len] = 0;
+    return out;
+}
+
+/* Strip surrounding quotes from a JSON string value, in place. */
+static char *unquote(char *s) {
+    size_t n = strlen(s);
+    if (n >= 2 && s[0] == '"' && s[n - 1] == '"') {
+        memmove(s, s + 1, n - 2);
+        s[n - 2] = 0;
+    }
+    return s;
+}
+
+/* base64url (no padding) -> standard base64, which the C ABI expects for keys. */
+static char *b64url_to_b64(const char *in) {
+    size_t n = strlen(in);
+    size_t pad = (4 - (n % 4)) % 4;
+    char *out = malloc(n + pad + 1);
+    for (size_t i = 0; i < n; i++) {
+        out[i] = in[i] == '-' ? '+' : (in[i] == '_' ? '/' : in[i]);
+    }
+    for (size_t i = 0; i < pad; i++) out[n + i] = '=';
+    out[n + pad] = 0;
+    return out;
+}
+
+/* Report a check_action verdict: the result JSON is {"ok":bool,"reasons":[..]}. */
+static void report_action(const char *label, const char *scope, const char *action) {
+    char *err = NULL;
+    char *res = take(vouch_robotics_check_action(scope, action, &err), err, "check_action");
+    int allowed = strstr(res, "\"ok\":true") != NULL;
+    char *reasons = json_value(res, "reasons");
+    if (allowed) {
+        printf("  [ALLOW] %s\n", label);
+    } else {
+        printf("  [DENY ] %-24s %s\n", label, reasons);
+    }
+    free(reasons);
+    vouch_string_free(res);
+}
+
+int main(int argc, char **argv) {
+    const char *vector_path =
+        argc > 1 ? argv[1] : "../../../test-vectors/robotics/vector.json";
+    char *doc = read_file(vector_path);
+    if (!doc) {
+        fprintf(stderr, "cannot open interop vector at %s\n", vector_path);
+        return 2;
+    }
+
+    char *err = NULL;
+    char *version = vouch_version();
+    printf("vouch core %s, robotics over the C ABI\n\n", version ? version : "?");
+    if (version) vouch_string_free(version);
+
+    /* ---- 1a. verify the Python-minted identity (cross-language interop) ---- */
+    char *jwk = json_value(doc, "robot_public_key_jwk");
+    char *x_q = json_value(jwk, "x");
+    char *robot_pub = b64url_to_b64(unquote(x_q));
+    char *identity = json_value(doc, "robot_identity_credential");
+
+    err = NULL;
+    char *subject =
+        take(vouch_robotics_verify_identity(identity, robot_pub, &err), err, "verify_identity");
+    char *make = json_value(subject, "make");
+    char *model = json_value(subject, "model");
+    printf("identity verifies (minted in Python): %s %s\n", unquote(make), unquote(model));
+    free(make);
+    free(model);
+    vouch_string_free(subject);
+
+    /* ---- 1b. mint from C, and show the hardware root is enforced ---------- */
+    err = NULL;
+    char *keys = take(vouch_generate_ed25519(&err), err, "generate_ed25519");
+    char *seed_q = json_value(keys, "seed_b64");
+    char *pub_q = json_value(keys, "public_b64");
+    char *mk_q = json_value(keys, "multikey");
+    char *seed = unquote(seed_q);
+    char *fresh_pub = unquote(pub_q);
+    char *root_mk = unquote(mk_q);
+
+    /* A syntactically valid but cryptographically fabricated attestation: the
+     * C ABI cannot produce the real one (no raw-signature primitive). */
+    char params[1024];
+    snprintf(params, sizeof params,
+             "{\"robotDid\":\"did:web:ar7.example.com\",\"make\":\"Acme Robotics\","
+             "\"model\":\"AR-7\",\"serial\":\"SN-000123\",\"rootKind\":\"TPM\","
+             "\"rootPublicMultibase\":\"%s\","
+             "\"attestation\":\"uAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\","
+             "\"validFrom\":\"2026-01-01T00:00:00Z\"}",
+             root_mk);
+
+    err = NULL;
+    char *minted = take(vouch_robotics_mint_identity(seed, params, &err), err, "mint_identity");
+    char *minted_type = json_value(minted, "type");
+    printf("minted from C: type=%s\n", minted_type);
+    free(minted_type);
+
+    err = NULL;
+    char *minted_subject = vouch_robotics_verify_identity(minted, fresh_pub, &err);
+    printf("  hardware root enforced: locally minted credential %s\n",
+           rejected(minted_subject) ? "REJECTED (expected: fabricated attestation)"
+                                    : "ACCEPTED (unexpected)");
+    if (minted_subject) vouch_string_free(minted_subject);
+    if (err) vouch_string_free(err);
+    vouch_string_free(minted);
+    free(seed_q);
+    free(pub_q);
+    free(mk_q);
+    vouch_string_free(keys);
+
+    /* ---- 2. the pre-actuation scope gate --------------------------------- */
+    printf("\npre-actuation scope gate:\n");
+    report_action("pick up the cup", kScopeJson,
+                  "{\"forceN\":20.0,\"speedMps\":0.3,\"nearHumans\":true,\"zone\":\"cell-3\"}");
+    report_action("sprint to the dock", kScopeJson,
+                  "{\"speedMps\":2.5,\"nearHumans\":true,\"zone\":\"cell-3\"}");
+    report_action("fetch from loading bay", kScopeJson,
+                  "{\"forceN\":15.0,\"speedMps\":0.5,\"zone\":\"loading-bay\"}");
+
+    /* ---- 3. the evidence pack: conformance + signed attestation ----------- */
+    char *creds = json_value(doc, "conformance_credentials");
+    char *profile_q = json_value(doc, "conformance_profile_id");
+    char *profile = unquote(profile_q);
+
+    err = NULL;
+    char *report =
+        take(vouch_robotics_check_conformance(creds, profile, &err), err, "check_conformance");
+    int conforms = strstr(report, "\"conforms\":true") != NULL;
+    char *satisfied = json_value(report, "satisfiedCount");
+    char *total = json_value(report, "totalCount");
+    printf("\nconformance (%s): %s %s/%s\n", profile, conforms ? "CONFORMS" : "GAPS", satisfied,
+           total);
+    free(satisfied);
+    free(total);
+
+    /* Sign a point-in-time attestation over that report, then verify it. */
+    size_t att_len = strlen(report) + 512;
+    char *att_params = malloc(att_len);
+    snprintf(att_params, att_len,
+             "{\"issuerDid\":\"did:web:assessor.example.com\","
+             "\"robotDid\":\"did:web:ar7.example.com\",\"report\":%s,"
+             "\"validFrom\":\"2026-01-01T00:00:00Z\"}",
+             report);
+
+    err = NULL;
+    char *attestation =
+        take(vouch_robotics_build_conformance_attestation(kAssessorSeedB64, att_params, &err), err,
+             "build_conformance_attestation");
+
+    err = NULL;
+    char *att_subject =
+        take(vouch_robotics_verify_conformance_attestation(attestation, kAssessorPubB64, &err), err,
+             "verify_conformance_attestation");
+    char *digest = json_value(att_subject, "reportDigest");
+    printf("attestation verifies: true  reportDigest=%.18s...\n", unquote(digest));
+    free(digest);
+    vouch_string_free(att_subject);
+
+    err = NULL;
+    char *wrong = vouch_robotics_verify_conformance_attestation(attestation, kOtherPubB64, &err);
+    printf("wrong key rejected: %s\n", rejected(wrong) ? "yes" : "no (unexpected)");
+    if (wrong) vouch_string_free(wrong);
+    if (err) vouch_string_free(err);
+
+    free(att_params);
+    vouch_string_free(attestation);
+    vouch_string_free(report);
+    free(profile_q);
+    free(creds);
+    free(identity);
+    free(robot_pub);
+    free(x_q);
+    free(jwk);
+    free(doc);
+
+    printf("\nall robotics C ABI checks completed\n");
+    return 0;
+}


### PR DESCRIPTION
## Description

Adds robotics examples for the C ABI and the WASM core, the two SDK surfaces the earlier ports (#383, #384) did not cover. Both already export robotics symbols; this exercises them.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

None.

## Changes Made

**C** — `sdks/cpp/examples/robotics_example.c`, with `robotics_example` and `run-robotics-c` targets added to the existing Makefile. The C ABI exposes 18 `vouch_robotics_*` entry points, narrower than the reference SDKs, so this is the trimmed flow: verify the Python-minted identity from the shared interop vector, mint one from C, run the pre-actuation gate over a safe and two unsafe actions, check conformance, then sign and verify a conformance attestation and confirm a wrong key is rejected. Every returned string is released with `vouch_string_free`.

**WASM** — `core/wasm/robotics-examples.mjs`. The WASM core exports the full producer surface, so both flows port in full: the six-credential evidence pack across all five profiles with one signed attestation each, and the VLA accountability loop with provenance-on-load, the scope gate, the black-box chain and the tamper case. Follows the `smoke.mjs` conventions — the `ok(name, cond)` harness, the Node crypto polyfill, and fixed seeds so runs are deterministic.

Also adds both example binaries to `sdks/cpp/.gitignore`, which previously listed only `examples/example`.

### Two ABI characteristics worth knowing

The C example documents these because they affect anyone writing against the surface:

1. The verify entry points signal "invalid" by returning the JSON literal `"null"`, not a NULL pointer — NULL indicates a hard error with a message in `err_out`. Both count as a rejection.
2. There is no raw-signature primitive (`vouch_sign` signs a credential, not arbitrary bytes), so a genuine hardware-root attestation cannot be produced from C; it must come from the secure element or a reference SDK. The example mints with a placeholder and shows `verify_identity` rejecting it, demonstrating that the hardware root is enforced rather than decorative. WASM does expose `ed25519Sign`, so its attestation is genuine.

## Testing

- [x] Existing tests pass
- [x] New tests added for new functionality — the WASM example is a 10-assertion harness
- [x] Manual testing performed

Both build and run the way CI does. The C example compiles warning-free under `-Wall -Wextra`; the WASM example reports `10 passed, 0 failed` and independently reproduces the Python `reportDigest` values byte for byte.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)