### PR TITLE
feat(integrations): vouch_ros2, the accountability loop as a ROS 2 node

### DIFF
--- a/integrations/ros2/README.md
+++ b/integrations/ros2/README.md
@@ -1,0 +1,238 @@
+# vouch_ros2 — the Vouch accountability loop as a ROS 2 node
+
+`vouch_ros2` puts the Vouch accountability loop between a planner and a robot's
+actuators. It is the ROS 2 packaging of
+[`examples/robotics_vla_accountability_loop.py`](../../examples/robotics_vla_accountability_loop.py):
+
+1. **Provenance on load.** On startup the node signs a
+   `ModelProvenanceAttestation` recording the planner/model, weights hash,
+   safety policy and config in use, and publishes it latched on
+   `vouch/provenance`.
+2. **Pre-actuation scope gate.** Every action the planner proposes is checked
+   with `check_physical_action` against a signed `PhysicalCapabilityScope`
+   *before* it can reach the actuators. Only allowed actions are republished on
+   the actuator topic; deny reasons go out on a separate topic and nothing
+   actuates.
+3. **Tamper-evident black box.** Every decision, allowed or denied, is appended
+   to an encrypted, hash-linked `BlackBoxLog`. Anyone can verify the chain;
+   only a key holder can read the payloads.
+
+```
+  planner ──▶ /planner/proposed_action ──▶ ┌──────────────────┐ ──▶ /actuator/action ──▶ actuators
+                                           │ vouch_action_gate│ ──▶ /vouch/denials
+                                           │  scope gate      │ ──▶ /vouch/provenance   (latched)
+                                           └──────────────────┘ ──▶ /vouch/blackbox_head (latched)
+                                                    │
+                                                    ▼
+                                            black box (JSONL)
+```
+
+## Why ROS 2 Jazzy
+
+This package targets **ROS 2 Jazzy Jalisco**. Jazzy's Tier 1 platform is Ubuntu
+24.04 Noble, which is what this repository's container runs. Humble Hawksbill —
+the previous LTS — targets Ubuntu 22.04 Jammy and is not installable on Noble
+without building from source, so Jazzy is the right target here. The package is
+pure `ament_python` with no C++ or `rosidl` code generation and depends only on
+`rclpy` and `std_msgs`, so it should also build unchanged on Humble (22.04) and
+Kilted if you need those.
+
+## Message format
+
+Every topic carries `std_msgs/msg/String` whose `data` is a JSON object. This
+keeps the package a pure `ament_python` build with no interface generation, and
+lets you bridge to whatever action type your stack already uses with a small
+adapter node rather than adopting a new `.msg`.
+
+A proposed action (`proposed_action_topic`) — every field optional; `snake_case`
+or `camelCase` both accepted:
+
+```json
+{
+  "action_id": "a-17",
+  "task": "pick up the cup",
+  "force_n": 20.0,
+  "speed_mps": 0.3,
+  "near_humans": true,
+  "zone": "cell-3",
+  "time_hm": "09:30"
+}
+```
+
+An **allowed** action is republished verbatim on `allowed_action_topic` with one
+field added, linking it to its black-box entry:
+
+```json
+{ "...": "the planner's own payload", "vouchEntryHash": "u3Qy..." }
+```
+
+A **denied** action publishes on `denial_topic` and reaches no actuator:
+
+```json
+{
+  "actionId": "a-19",
+  "task": "sprint to the dock",
+  "zone": "cell-3",
+  "speedMps": 2.5,
+  "nearHumans": true,
+  "reasons": ["near_humans speed_exceeded: 2.5 m/s > 0.5 m/s"],
+  "vouchEntryHash": "uJk2..."
+}
+```
+
+An unparsable payload is denied too: the node never actuates a message it could
+not understand.
+
+## Parameters
+
+| Parameter | Default | Meaning |
+| --- | --- | --- |
+| `proposed_action_topic` | `planner/proposed_action` | Planner output the gate subscribes to. |
+| `allowed_action_topic` | `actuator/action` | Where allowed actions are republished. |
+| `denial_topic` | `vouch/denials` | Where deny reasons are published. |
+| `provenance_topic` | `vouch/provenance` | Latched startup attestation. |
+| `blackbox_head_topic` | `vouch/blackbox_head` | Latched chain head + allow/deny counts. |
+| `queue_depth` | `10` | Pub/sub queue depth. |
+| `scope.max_force_n` | `80.0` | Force cap, newtons. Negative = unbounded. |
+| `scope.max_speed_mps` | `1.5` | Speed cap, m/s. Negative = unbounded. |
+| `scope.max_speed_near_humans_mps` | `0.5` | Slower cap applied when `near_humans`. |
+| `scope.allowed_zones` | `['cell-3']` | Zone ids the robot may act in. Empty = unrestricted. |
+| `scope.shift_windows_json` | `""` | JSON `[{"start":"HH:MM","end":"HH:MM"}]`. |
+| `identity.did` | `""` | Robot DID. |
+| `identity.private_key_jwk` | `""` | Ed25519 private key JWK that signs the attestation. |
+| `blackbox.key_hex` | `""` | 32-byte AES-256 key, 64 hex chars. |
+| `blackbox.key_file` | `""` | File holding that hex key instead. |
+| `blackbox.log_path` | `""` | Append each entry as JSONL here. |
+| `model.name` | `unnamed-planner` | The planner/model being gated. |
+| `model.version` | `""` | Model version. |
+| `model.weights_hash` | `""` | Multibase SHA-256 of the weights. |
+| `model.weights_file` | `""` | Hash this artifact instead of supplying the digest. |
+| `model.safety_policy` | `""` | Active safety-policy id or hash. |
+| `model.config_json` | `{}` | Runtime config; its JCS SHA-256 goes in the attestation. |
+| `stamp_time_from_clock` | `false` | Stamp untimed actions from the ROS clock, so shift windows bite. |
+
+The scope must bound **at least one** dimension. A gate with an entirely empty
+scope would allow everything, so the node refuses to start rather than pretend
+to enforce.
+
+Leaving `identity.*`, `blackbox.*` or `model.weights_*` empty is allowed for a
+bench run — the node generates ephemeral key material and logs a warning for
+each — but nothing signed with an ephemeral key is verifiable once the process
+exits. Configure them for anything real.
+
+## Build
+
+`vouch_ros2` needs the `vouch-protocol` Python distribution in the same
+interpreter ROS uses. It is on PyPI, not in the ROS index:
+
+```bash
+# ROS 2 Jazzy on Ubuntu 24.04 Noble
+source /opt/ros/jazzy/setup.bash
+python3 -m pip install --break-system-packages vouch-protocol
+```
+
+Then build it like any ament_python package. The package root is this
+directory, so symlink or copy it into a colcon workspace's `src/`:
+
+```bash
+mkdir -p ~/robot_ws/src
+ln -s "$(pwd)/integrations/ros2" ~/robot_ws/src/vouch_ros2
+
+cd ~/robot_ws
+colcon build --packages-select vouch_ros2 --symlink-install
+source install/setup.bash
+```
+
+## Run
+
+```bash
+ros2 launch vouch_ros2 vouch_action_gate.launch.py \
+    proposed_action_topic:=/planner/proposed_action \
+    allowed_action_topic:=/actuator/action \
+    max_speed_near_humans_mps:=0.5 \
+    allowed_zones:="['cell-3']" \
+    model_name:="Gemini Robotics ER 2" \
+    blackbox_log_path:=/var/log/robot/blackbox.jsonl
+```
+
+or without launch:
+
+```bash
+ros2 run vouch_ros2 vouch_action_gate --ros-args \
+    --params-file src/vouch_ros2/config/gate_params.yaml
+```
+
+Poke it by hand:
+
+```bash
+# allowed: inside the envelope
+ros2 topic pub --once /planner/proposed_action std_msgs/msg/String \
+  '{data: "{\"task\": \"pick up the cup\", \"force_n\": 20.0, \"speed_mps\": 0.3, \"near_humans\": true, \"zone\": \"cell-3\"}"}'
+
+# denied: over the near-human speed cap
+ros2 topic pub --once /planner/proposed_action std_msgs/msg/String \
+  '{data: "{\"task\": \"sprint to the dock\", \"speed_mps\": 2.5, \"near_humans\": true, \"zone\": \"cell-3\"}"}'
+
+ros2 topic echo /actuator/action      # only the allowed one appears
+ros2 topic echo /vouch/denials        # the deny reason appears here
+ros2 topic echo /vouch/provenance     # the signed startup attestation
+```
+
+## Verifying a black box afterwards
+
+`blackbox.log_path` is JSONL, one entry per line, and the chain is verifiable
+without the encryption key:
+
+```python
+import json
+from vouch.robotics import open_entry, verify_blackbox_chain
+
+entries = [json.loads(line) for line in open("blackbox.jsonl")]
+print(verify_blackbox_chain(entries))          # (True, None) unless tampered
+
+key = bytes.fromhex(open("blackbox.key").read().strip())
+for entry in entries:
+    print(entry["event"], open_entry(entry, key))
+```
+
+## Tests
+
+The gating, provenance, black-box and parameter logic lives in
+`vouch_ros2/core.py` and `vouch_ros2/params.py`, both plain Python with no ROS
+imports — `vouch_ros2/node.py` is a thin rclpy shell over them and imports
+rclpy guarded. So the loop is testable with pytest alone, with no ROS install
+and no physical robot:
+
+```bash
+# from the repository root
+python -m pytest tests/test_ros2_action_gate.py -v
+```
+
+The tests live in the repository's top-level `tests/` directory, matching the
+rest of this repo (`pyproject.toml` sets `testpaths = ["tests"]`). They cover
+the allow/deny decisions, the signed attestation, the hash chain and its
+tamper-detection, the parameter surface, and — statically — the manifest,
+entry point and launch file that only a real `colcon build` could exercise.
+
+## Using the core without ROS
+
+Nothing in `vouch_ros2.core` needs ROS, so the same gate can front any control
+stack:
+
+```python
+from vouch_ros2 import core_from_params, defaults
+
+params = defaults()
+params["model.name"] = "Gemini Robotics ER 2"
+gate, info = core_from_params(params)
+
+decision = gate.evaluate({"task": "sprint", "speed_mps": 2.5, "near_humans": True})
+if decision.allowed:
+    actuate(decision.actuator_payload())
+else:
+    print(decision.denial_payload()["reasons"])
+```
+
+## License
+
+Apache-2.0, same as the rest of the Vouch Protocol repository.

--- a/integrations/ros2/config/gate_params.yaml
+++ b/integrations/ros2/config/gate_params.yaml
@@ -1,0 +1,60 @@
+# Example parameters for the vouch_action_gate node.
+#
+#   ros2 launch vouch_ros2 vouch_action_gate.launch.py params_file:=gate_params.yaml
+#   ros2 run vouch_ros2 vouch_action_gate --ros-args --params-file gate_params.yaml
+#
+# "/**" applies to the node under any name or namespace.
+/**:
+  ros__parameters:
+    # --- topics -------------------------------------------------------------
+    proposed_action_topic: "planner/proposed_action"
+    allowed_action_topic: "actuator/action"
+    denial_topic: "vouch/denials"
+    provenance_topic: "vouch/provenance"
+    blackbox_head_topic: "vouch/blackbox_head"
+    queue_depth: 10
+
+    # --- physical capability scope -----------------------------------------
+    # The envelope every proposed action is checked against. A negative number
+    # means "leave this dimension unbounded"; an empty allowed_zones list means
+    # "do not restrict zones". At least one dimension must be bounded.
+    scope:
+      max_force_n: 80.0
+      max_speed_mps: 1.5
+      max_speed_near_humans_mps: 0.5
+      allowed_zones: ["cell-3"]
+      # JSON, because ROS 2 parameters have no list-of-dict type. Checked only
+      # when an action carries a time (or stamp_time_from_clock is true).
+      shift_windows_json: '[{"start": "06:00", "end": "18:00"}]'
+
+    # --- robot key material -------------------------------------------------
+    # The Ed25519 key that signs the provenance attestation. Leave both empty
+    # for a bench run and the node generates an ephemeral identity, logging a
+    # warning: nothing signed with it is verifiable after the process exits.
+    identity:
+      did: ""
+      private_key_jwk: ""
+
+    # --- black box ----------------------------------------------------------
+    # 32-byte AES-256 key as 64 hex chars, inline or in a file. Anyone can
+    # verify the hash chain without it; only a key holder can read payloads.
+    blackbox:
+      key_hex: ""
+      key_file: ""
+      log_path: ""
+
+    # --- planner / model provenance ----------------------------------------
+    model:
+      name: "Gemini Robotics ER 2"
+      version: "2.0"
+      # Set weights_hash directly, or point weights_file at the artifact and
+      # the node hashes the bytes actually on disk.
+      weights_hash: ""
+      weights_file: ""
+      safety_policy: "factory-floor-safety-policy-v3"
+      config_json: '{"planner": "er-2", "temperature": 0.0, "max_plan_steps": 8}'
+
+    # --- behaviour ----------------------------------------------------------
+    # Stamp actions that carry no time with the ROS clock, so shift windows are
+    # enforced even when the planner does not send one.
+    stamp_time_from_clock: false

--- a/integrations/ros2/launch/vouch_action_gate.launch.py
+++ b/integrations/ros2/launch/vouch_action_gate.launch.py
@@ -1,0 +1,101 @@
+"""
+Launch the Vouch action gate between a planner and a robot's actuators.
+
+    ros2 launch vouch_ros2 vouch_action_gate.launch.py \
+        proposed_action_topic:=/planner/proposed_action \
+        allowed_action_topic:=/actuator/action \
+        blackbox_log_path:=/var/log/robot/blackbox.jsonl
+
+Every launch argument maps to the identically named node parameter, with the
+dotted scope/identity/blackbox/model prefixes flattened to underscores (launch
+argument names cannot contain dots). Each override is wrapped in a
+``ParameterValue`` with an explicit type, because launch substitutions are
+strings and the node declares typed parameters.
+
+For anything richer -- shift windows, a full model config -- pass a YAML file:
+
+    ros2 launch vouch_ros2 vouch_action_gate.launch.py params_file:=my_gate.yaml
+
+See config/gate_params.yaml for the shape.
+"""
+
+import os
+from typing import List
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+PACKAGE = "vouch_ros2"
+
+# (launch argument, node parameter, default, type)
+ARGUMENTS = [
+    ("proposed_action_topic", "proposed_action_topic", "planner/proposed_action", str),
+    ("allowed_action_topic", "allowed_action_topic", "actuator/action", str),
+    ("denial_topic", "denial_topic", "vouch/denials", str),
+    ("provenance_topic", "provenance_topic", "vouch/provenance", str),
+    ("blackbox_head_topic", "blackbox_head_topic", "vouch/blackbox_head", str),
+    ("max_force_n", "scope.max_force_n", "80.0", float),
+    ("max_speed_mps", "scope.max_speed_mps", "1.5", float),
+    ("max_speed_near_humans_mps", "scope.max_speed_near_humans_mps", "0.5", float),
+    ("allowed_zones", "scope.allowed_zones", "['cell-3']", List[str]),
+    ("shift_windows_json", "scope.shift_windows_json", "", str),
+    ("robot_did", "identity.did", "", str),
+    ("robot_private_key_jwk", "identity.private_key_jwk", "", str),
+    ("blackbox_key_hex", "blackbox.key_hex", "", str),
+    ("blackbox_key_file", "blackbox.key_file", "", str),
+    ("blackbox_log_path", "blackbox.log_path", "", str),
+    ("model_name", "model.name", "unnamed-planner", str),
+    ("model_version", "model.version", "", str),
+    ("model_weights_hash", "model.weights_hash", "", str),
+    ("model_weights_file", "model.weights_file", "", str),
+    ("model_safety_policy", "model.safety_policy", "", str),
+    ("model_config_json", "model.config_json", "{}", str),
+]
+
+DESCRIPTIONS = {
+    "proposed_action_topic": "Topic the planner publishes proposed actions on (JSON String).",
+    "allowed_action_topic": "Topic allowed actions are republished on, for the actuators.",
+    "denial_topic": "Topic deny reasons are published on.",
+    "allowed_zones": "YAML list of zone ids the robot may operate in.",
+    "blackbox_log_path": "Append each black-box entry to this JSONL file.",
+    "model_weights_file": "Weights artifact to hash into the provenance attestation.",
+}
+
+
+def generate_launch_description():
+    """Build the launch description for a single gate node."""
+    default_params = os.path.join(
+        get_package_share_directory(PACKAGE), "config", "gate_params.yaml"
+    )
+
+    declarations = [
+        DeclareLaunchArgument(arg, default_value=default, description=DESCRIPTIONS.get(arg, ""))
+        for arg, _, default, _ in ARGUMENTS
+    ]
+    declarations.append(
+        DeclareLaunchArgument(
+            "params_file",
+            default_value=default_params,
+            description="YAML parameter file applied before the launch-argument overrides.",
+        )
+    )
+
+    overrides = {
+        param: ParameterValue(LaunchConfiguration(arg), value_type=value_type)
+        for arg, param, _, value_type in ARGUMENTS
+    }
+
+    gate = Node(
+        package=PACKAGE,
+        executable="vouch_action_gate",
+        name="vouch_action_gate",
+        output="screen",
+        emulate_tty=True,
+        parameters=[LaunchConfiguration("params_file"), overrides],
+    )
+
+    return LaunchDescription(declarations + [gate])

--- a/integrations/ros2/package.xml
+++ b/integrations/ros2/package.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>vouch_ros2</name>
+  <version>2.1.0</version>
+  <description>
+    Vouch accountability gate for ROS 2: signs a model-provenance attestation on
+    startup, checks every planner-proposed action against a signed
+    PhysicalCapabilityScope before it can reach the actuators, and records every
+    allow/deny decision in a tamper-evident black box.
+  </description>
+  <maintainer email="hello@vouch-protocol.com">Vouch Protocol Contributors</maintainer>
+  <license>Apache-2.0</license>
+
+  <url type="website">https://vouch-protocol.com</url>
+  <url type="repository">https://github.com/vouch-protocol/vouch</url>
+  <url type="bugtracker">https://github.com/vouch-protocol/vouch/issues</url>
+
+  <buildtool_depend>ament_python</buildtool_depend>
+
+  <exec_depend>rclpy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>launch</exec_depend>
+  <exec_depend>launch_ros</exec_depend>
+  <!-- vouch-protocol is a PyPI distribution, not a ROS package: install it with
+       pip (or rosdep via a rosdep rule) into the same interpreter ROS uses. -->
+  <exec_depend>python3-cryptography</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/integrations/ros2/setup.cfg
+++ b/integrations/ros2/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/vouch_ros2
+[install]
+install_scripts=$base/lib/vouch_ros2

--- a/integrations/ros2/setup.py
+++ b/integrations/ros2/setup.py
@@ -1,0 +1,36 @@
+"""ament_python build for the vouch_ros2 package."""
+
+import os
+from glob import glob
+
+from setuptools import find_packages, setup
+
+package_name = "vouch_ros2"
+
+setup(
+    name=package_name,
+    version="2.1.0",
+    packages=find_packages(exclude=["test", "test.*"]),
+    data_files=[
+        # ament resource index marker: how ROS 2 discovers the package.
+        ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
+        (os.path.join("share", package_name), ["package.xml", "README.md"]),
+        (os.path.join("share", package_name, "launch"), glob("launch/*.launch.py")),
+        (os.path.join("share", package_name, "config"), glob("config/*.yaml")),
+    ],
+    install_requires=["setuptools", "vouch-protocol>=2.1.0"],
+    zip_safe=True,
+    maintainer="Vouch Protocol Contributors",
+    maintainer_email="hello@vouch-protocol.com",
+    description=(
+        "Vouch accountability gate for ROS 2: model provenance on startup, a "
+        "pre-actuation physical capability scope gate, and a tamper-evident black box."
+    ),
+    license="Apache-2.0",
+    tests_require=["pytest"],
+    entry_points={
+        "console_scripts": [
+            "vouch_action_gate = vouch_ros2.node:main",
+        ],
+    },
+)

--- a/integrations/ros2/vouch_ros2/__init__.py
+++ b/integrations/ros2/vouch_ros2/__init__.py
@@ -1,0 +1,55 @@
+"""
+Vouch accountability gate for ROS 2.
+
+``vouch_ros2.node`` puts the Vouch loop between a planner and a robot's
+actuators: a signed model-provenance attestation on startup, a pre-actuation
+PhysicalCapabilityScope gate on every proposed action, and a tamper-evident
+black box over every allow/deny decision.
+
+Importing this package pulls in **no** ROS dependency: everything here is plain
+Python, so the gating logic can be exercised with pytest on a machine without
+ROS. ``vouch_ros2.node`` is the only module that imports rclpy, and it does so
+lazily.
+"""
+
+from .core import (
+    ALLOWED_EVENT,
+    DENIED_EVENT,
+    PROVENANCE_EVENT,
+    ActionGateCore,
+    ActionGateError,
+    Decision,
+    ProposedAction,
+    build_scope,
+    build_scope_credential,
+    load_blackbox_key,
+    load_signer,
+    multibase_sha256,
+    parse_action,
+    scope_from_credential,
+)
+from .params import PARAMETERS, core_from_params, defaults, scope_from_params, warnings_for
+
+__version__ = "2.1.0"
+
+__all__ = [
+    "ALLOWED_EVENT",
+    "DENIED_EVENT",
+    "PARAMETERS",
+    "PROVENANCE_EVENT",
+    "ActionGateCore",
+    "ActionGateError",
+    "Decision",
+    "ProposedAction",
+    "__version__",
+    "build_scope",
+    "build_scope_credential",
+    "core_from_params",
+    "defaults",
+    "load_blackbox_key",
+    "load_signer",
+    "multibase_sha256",
+    "parse_action",
+    "scope_from_credential",
+    "scope_from_params",
+]

--- a/integrations/ros2/vouch_ros2/core.py
+++ b/integrations/ros2/vouch_ros2/core.py
@@ -1,0 +1,425 @@
+"""
+The Vouch accountability core for a ROS 2 action gate -- plain Python, no ROS.
+
+This module holds every decision the gate makes, so the logic can be unit
+tested with pytest alone: no rclpy, no DDS, no physical robot. The ROS node in
+``vouch_ros2.node`` is a thin shell that moves messages in and out of this
+class and owns nothing else.
+
+The loop mirrors ``examples/robotics_vla_accountability_loop.py``:
+
+  1. Provenance on load: :class:`ActionGateCore` signs a
+     ModelProvenanceAttestation for the planner/model in use before it will
+     gate anything, and re-verifies it against its own public key.
+  2. Pre-actuation scope gate: every proposed action is checked with
+     ``check_physical_action`` against a signed PhysicalCapabilityScope. Only
+     allowed actions are handed back for republication to the actuators.
+  3. Tamper-evident black box: every decision, allowed or denied, is appended
+     to a hash-linked, encrypted :class:`BlackBoxLog`.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from vouch import Signer, generate_identity
+from vouch.robotics import (
+    BlackBoxLog,
+    PhysicalAction,
+    build_physical_scope_credential,
+    build_provenance_attestation,
+    check_physical_action,
+    verify_blackbox_chain,
+    verify_provenance_attestation,
+)
+
+ALLOWED_EVENT = "actuation_allowed"
+DENIED_EVENT = "actuation_denied"
+PROVENANCE_EVENT = "provenance_recorded"
+
+#: Fields a proposed-action payload may carry. Anything else is ignored.
+ACTION_FIELDS = ("action_id", "task", "force_n", "speed_mps", "near_humans", "zone", "time_hm")
+
+
+class ActionGateError(Exception):
+    """Raised on malformed gate configuration or an unparsable action payload."""
+
+
+def multibase_sha256(data: bytes) -> str:
+    """Multibase (base64url) SHA-256, the hash form Vouch credentials carry."""
+    digest = hashlib.sha256(data).digest()
+    return "u" + base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+
+
+@dataclass
+class ProposedAction:
+    """One action a planner proposes, before the gate has ruled on it."""
+
+    action_id: str = ""
+    task: str = ""
+    force_n: Optional[float] = None
+    speed_mps: Optional[float] = None
+    near_humans: bool = False
+    zone: Optional[str] = None
+    time_hm: Optional[str] = None
+    #: The verbatim payload, republished unchanged when the action is allowed.
+    raw: Dict[str, Any] = field(default_factory=dict)
+
+    def to_physical_action(self) -> PhysicalAction:
+        """The ``PhysicalAction`` the scope gate checks."""
+        return PhysicalAction(
+            force_n=self.force_n,
+            speed_mps=self.speed_mps,
+            near_humans=self.near_humans,
+            zone=self.zone,
+            time_hm=self.time_hm,
+        )
+
+
+@dataclass
+class Decision:
+    """The gate's ruling on one proposed action, plus its black-box entry."""
+
+    action: ProposedAction
+    allowed: bool
+    reasons: List[str]
+    entry: Dict[str, Any]
+
+    @property
+    def event(self) -> str:
+        return ALLOWED_EVENT if self.allowed else DENIED_EVENT
+
+    def actuator_payload(self) -> Dict[str, Any]:
+        """What to republish on the actuator topic. Allowed actions only."""
+        if not self.allowed:
+            raise ActionGateError("denied actions are never republished to actuators")
+        payload = dict(self.action.raw)
+        payload["vouchEntryHash"] = self.entry["entryHash"]
+        return payload
+
+    def denial_payload(self) -> Dict[str, Any]:
+        """What to publish on the denial topic. Denied actions only."""
+        if self.allowed:
+            raise ActionGateError("allowed actions carry no denial payload")
+        return {
+            "actionId": self.action.action_id,
+            "task": self.action.task,
+            "zone": self.action.zone,
+            "speedMps": self.action.speed_mps,
+            "forceN": self.action.force_n,
+            "nearHumans": self.action.near_humans,
+            "reasons": list(self.reasons),
+            "vouchEntryHash": self.entry["entryHash"],
+        }
+
+
+def parse_action(payload: Any) -> ProposedAction:
+    """
+    Parse a proposed-action payload into a :class:`ProposedAction`.
+
+    Accepts a JSON string (what the node receives on a ``std_msgs/String``
+    topic) or an already-decoded mapping. Unknown keys are preserved in ``raw``
+    so the actuator republication is byte-for-byte the planner's own message
+    plus the black-box entry hash.
+    """
+    if isinstance(payload, (bytes, bytearray)):
+        payload = payload.decode("utf-8")
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise ActionGateError(f"proposed action is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ActionGateError(
+            f"proposed action must be a JSON object, got {type(payload).__name__}"
+        )
+
+    def _num(key: str) -> Optional[float]:
+        value = payload.get(key, payload.get(_camel(key)))
+        if value is None or value == "":
+            return None
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise ActionGateError(f"field {key!r} is not a number: {value!r}") from exc
+
+    def _str(key: str) -> Optional[str]:
+        value = payload.get(key, payload.get(_camel(key)))
+        return None if value is None else str(value)
+
+    return ProposedAction(
+        action_id=_str("action_id") or "",
+        task=_str("task") or "",
+        force_n=_num("force_n"),
+        speed_mps=_num("speed_mps"),
+        near_humans=bool(payload.get("near_humans", payload.get("nearHumans", False))),
+        zone=_str("zone"),
+        time_hm=_str("time_hm"),
+        raw=dict(payload),
+    )
+
+
+def _camel(snake: str) -> str:
+    head, *rest = snake.split("_")
+    return head + "".join(part.title() for part in rest)
+
+
+def build_scope(
+    *,
+    max_force_n: Optional[float] = None,
+    max_speed_mps: Optional[float] = None,
+    max_speed_near_humans_mps: Optional[float] = None,
+    allowed_zones: Optional[Sequence[str]] = None,
+    shift_windows: Optional[Sequence[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """
+    Build a bare physicalScope object from flat parameters.
+
+    A negative cap means "unset": ROS 2 parameters have no null, so a launch
+    file signals "do not bound this dimension" with a negative number.
+    """
+    scope: Dict[str, Any] = {}
+    if max_force_n is not None and max_force_n >= 0:
+        scope["maxForceN"] = float(max_force_n)
+    if max_speed_mps is not None and max_speed_mps >= 0:
+        scope["maxSpeedMps"] = float(max_speed_mps)
+    if max_speed_near_humans_mps is not None and max_speed_near_humans_mps >= 0:
+        scope["maxSpeedNearHumansMps"] = float(max_speed_near_humans_mps)
+    if allowed_zones:
+        scope["allowedZones"] = [str(zone) for zone in allowed_zones]
+    if shift_windows:
+        scope["shiftWindows"] = [dict(window) for window in shift_windows]
+    if not scope:
+        raise ActionGateError(
+            "physical scope is empty: an unbounded gate would allow every action; "
+            "set at least one of max_force_n / max_speed_mps / "
+            "max_speed_near_humans_mps / allowed_zones / shift_windows"
+        )
+    return scope
+
+
+def load_signer(private_key_jwk: str = "", did: str = "") -> Tuple[Signer, str, str]:
+    """
+    Build the robot's signer. Returns ``(signer, did, public_key_jwk)``.
+
+    With no key material an ephemeral identity is generated so a bench run
+    works out of the box; the caller is expected to say so loudly, since an
+    ephemeral key makes the attestation unverifiable after the process exits.
+    """
+    if private_key_jwk and did:
+        signer = Signer(private_key=private_key_jwk, did=did)
+        try:
+            public_key_jwk = signer.get_public_key_jwk()
+        except Exception:  # noqa: BLE001 - a backend may not expose the public JWK
+            public_key_jwk = ""
+        if not isinstance(public_key_jwk, str):
+            public_key_jwk = json.dumps(public_key_jwk)
+        return signer, did, public_key_jwk
+    if private_key_jwk or did:
+        raise ActionGateError("identity.private_key_jwk and identity.did must be set together")
+    keypair = generate_identity(domain="robot.local")
+    return (
+        Signer(private_key=keypair.private_key_jwk, did=keypair.did),
+        keypair.did,
+        keypair.public_key_jwk,
+    )
+
+
+def load_blackbox_key(key_hex: str = "", key_file: str = "") -> bytes:
+    """
+    Resolve the 32-byte AES-256 black-box key from a hex parameter or a file.
+
+    With neither set an ephemeral key is generated: the chain is still
+    tamper-evident to anyone, but nobody can decrypt the payloads afterwards.
+    """
+    if key_hex and key_file:
+        raise ActionGateError("set blackbox.key_hex or blackbox.key_file, not both")
+    if key_file:
+        with open(key_file, "rb") as handle:
+            raw = handle.read().strip()
+        key_hex = raw.decode("ascii")
+    if not key_hex:
+        return os.urandom(32)
+    try:
+        key = binascii.unhexlify(key_hex)
+    except (binascii.Error, ValueError) as exc:
+        raise ActionGateError(f"black-box key is not valid hex: {exc}") from exc
+    if len(key) != 32:
+        raise ActionGateError(f"black-box key must be 32 bytes (64 hex chars), got {len(key)}")
+    return key
+
+
+class ActionGateCore:
+    """
+    The accountability loop, with no ROS in it.
+
+    On construction it signs (and re-verifies) a ModelProvenanceAttestation for
+    the planner in use and opens a black box. :meth:`evaluate` then gates one
+    proposed action, records the decision, and reports whether the action may
+    reach the actuators.
+    """
+
+    def __init__(
+        self,
+        *,
+        signer: Signer,
+        robot_did: str,
+        scope: Dict[str, Any],
+        model_name: str,
+        weights_hash: str,
+        safety_policy: str,
+        model_config: Optional[Dict[str, Any]] = None,
+        model_version: Optional[str] = None,
+        public_key_jwk: Any = None,
+        blackbox_key: Optional[bytes] = None,
+        blackbox_path: str = "",
+        clock: Optional[Callable[[], str]] = None,
+    ) -> None:
+        if not scope:
+            raise ActionGateError("refusing to gate against an empty physical scope")
+        self.signer = signer
+        self.robot_did = robot_did
+        self.scope = dict(scope)
+        self.model_config = dict(model_config) if model_config is not None else None
+        self._clock = clock
+        self._blackbox_path = blackbox_path
+
+        self.provenance = build_provenance_attestation(
+            signer,
+            robot_did=robot_did,
+            model_name=model_name,
+            weights_hash=weights_hash,
+            safety_policy=safety_policy,
+            config=self.model_config,
+            version=model_version,
+        )
+        self.provenance_verified = False
+        if public_key_jwk:
+            self.provenance_verified, _subject = verify_provenance_attestation(
+                self.provenance, public_key_jwk, config=self.model_config
+            )
+
+        self.blackbox = BlackBoxLog(key=blackbox_key or os.urandom(32))
+        self._decisions: List[Decision] = []
+        self._append(
+            PROVENANCE_EVENT,
+            {
+                "robotDid": robot_did,
+                "modelName": model_name,
+                "weightsHash": weights_hash,
+                "safetyPolicy": safety_policy,
+                "provenanceVerified": self.provenance_verified,
+                "scope": self.scope,
+            },
+        )
+
+    # -- gating ------------------------------------------------------------
+
+    def evaluate(self, payload: Any) -> Decision:
+        """
+        Gate one proposed action and record the decision in the black box.
+
+        ``payload`` is a JSON string, a mapping, or a :class:`ProposedAction`.
+        """
+        action = payload if isinstance(payload, ProposedAction) else parse_action(payload)
+        if action.time_hm is None and self._clock is not None:
+            action.time_hm = self._clock()
+
+        result = check_physical_action(self.scope, action.to_physical_action())
+        entry = self._append(
+            ALLOWED_EVENT if result.ok else DENIED_EVENT,
+            {
+                "actionId": action.action_id,
+                "task": action.task,
+                "zone": action.zone,
+                "forceN": action.force_n,
+                "speedMps": action.speed_mps,
+                "nearHumans": action.near_humans,
+                "timeHm": action.time_hm,
+                "reasons": list(result.reasons),
+            },
+        )
+        decision = Decision(
+            action=action, allowed=result.ok, reasons=list(result.reasons), entry=entry
+        )
+        self._decisions.append(decision)
+        return decision
+
+    # -- black box ---------------------------------------------------------
+
+    def _append(self, event: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        entry = self.blackbox.append(event, payload)
+        if self._blackbox_path:
+            with open(self._blackbox_path, "a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry, sort_keys=True) + "\n")
+        return entry
+
+    def entries(self) -> List[Dict[str, Any]]:
+        return self.blackbox.entries()
+
+    def head(self) -> str:
+        return self.blackbox.head()
+
+    def verify_chain(self) -> Tuple[bool, Optional[str]]:
+        """Verify the black-box hash chain. Needs no key: tamper-evidence is public."""
+        return verify_blackbox_chain(self.blackbox.entries())
+
+    def decisions(self) -> List[Decision]:
+        return list(self._decisions)
+
+    def counts(self) -> Dict[str, int]:
+        allowed = sum(1 for d in self._decisions if d.allowed)
+        return {"allowed": allowed, "denied": len(self._decisions) - allowed}
+
+
+def build_scope_credential(
+    signer: Signer, *, subject_did: str, scope: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Self-issue a signed PhysicalCapabilityScope credential from a scope object.
+
+    A fleet deployment loads a scope credential issued by the fleet authority
+    instead; this exists so a bench or launch-file run still has a signed,
+    publishable scope rather than a bare dict.
+    """
+    return build_physical_scope_credential(
+        signer,
+        subject_did=subject_did,
+        max_force_n=scope.get("maxForceN"),
+        max_speed_mps=scope.get("maxSpeedMps"),
+        max_speed_near_humans_mps=scope.get("maxSpeedNearHumansMps"),
+        allowed_zones=scope.get("allowedZones"),
+        shift_windows=scope.get("shiftWindows"),
+    )
+
+
+def scope_from_credential(credential: Dict[str, Any]) -> Dict[str, Any]:
+    """Pull the physicalScope object out of a PhysicalCapabilityScope credential."""
+    try:
+        return dict(credential["credentialSubject"]["physicalScope"])
+    except (KeyError, TypeError) as exc:
+        raise ActionGateError("credential has no credentialSubject.physicalScope") from exc
+
+
+__all__ = [
+    "ALLOWED_EVENT",
+    "DENIED_EVENT",
+    "PROVENANCE_EVENT",
+    "ActionGateCore",
+    "ActionGateError",
+    "Decision",
+    "ProposedAction",
+    "build_scope",
+    "build_scope_credential",
+    "load_blackbox_key",
+    "load_signer",
+    "multibase_sha256",
+    "parse_action",
+    "scope_from_credential",
+]

--- a/integrations/ros2/vouch_ros2/node.py
+++ b/integrations/ros2/vouch_ros2/node.py
@@ -1,0 +1,192 @@
+"""
+``vouch_action_gate``: the ROS 2 node that sits between planner and actuators.
+
+Every message this node handles is a ``std_msgs/String`` carrying JSON, so the
+package stays a pure ``ament_python`` build with no ``rosidl`` message
+generation and no ``ament_cmake`` dependency. Point it at whatever your planner
+already publishes by remapping topics; the payload shape is documented in the
+package README.
+
+The node owns no policy. It reads parameters, hands them to
+:func:`vouch_ros2.params.core_from_params`, and for each incoming message asks
+:class:`vouch_ros2.core.ActionGateCore` for a decision:
+
+  * allowed -> republished on ``allowed_action_topic`` (the actuator side)
+  * denied  -> the reasons go out on ``denial_topic``; nothing reaches actuators
+
+rclpy is imported guarded so ``import vouch_ros2`` works on a machine with no
+ROS installed and the core stays unit testable.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional
+
+from .core import Decision
+from .params import PARAMETERS, core_from_params
+
+try:  # pragma: no cover - exercised only where ROS 2 is installed
+    import rclpy
+    from rclpy.node import Node as _RclpyNode
+    from rclpy.qos import DurabilityPolicy, HistoryPolicy, QoSProfile, ReliabilityPolicy
+    from std_msgs.msg import String
+
+    ROS_AVAILABLE = True
+    ROS_IMPORT_ERROR: Optional[BaseException] = None
+except ImportError as exc:  # pragma: no cover - the no-ROS path taken by tests
+    rclpy = None  # type: ignore[assignment]
+    String = None  # type: ignore[assignment]
+    DurabilityPolicy = HistoryPolicy = QoSProfile = ReliabilityPolicy = None  # type: ignore
+    _RclpyNode = object  # type: ignore[assignment,misc]
+    ROS_AVAILABLE = False
+    ROS_IMPORT_ERROR = exc
+
+NODE_NAME = "vouch_action_gate"
+
+_NO_ROS_HELP = (
+    "rclpy is not importable, so the Vouch action gate cannot run as a ROS 2 node. "
+    "Source a ROS 2 Jazzy install first (`source /opt/ros/jazzy/setup.bash`). "
+    "The gating, provenance and black-box logic in vouch_ros2.core needs no ROS "
+    "and can be used directly from plain Python."
+)
+
+
+def require_ros() -> None:
+    """Raise a helpful error when rclpy is missing."""
+    if not ROS_AVAILABLE:
+        raise ImportError(_NO_ROS_HELP) from ROS_IMPORT_ERROR
+
+
+def _latched_qos(depth: int = 1) -> Any:
+    """Transient-local QoS so a late subscriber still receives the attestation."""
+    return QoSProfile(
+        depth=depth,
+        history=HistoryPolicy.KEEP_LAST,
+        reliability=ReliabilityPolicy.RELIABLE,
+        durability=DurabilityPolicy.TRANSIENT_LOCAL,
+    )
+
+
+class VouchActionGate(_RclpyNode):
+    """Gates planner-proposed actions against a signed PhysicalCapabilityScope."""
+
+    def __init__(self) -> None:
+        require_ros()
+        super().__init__(NODE_NAME)
+
+        for name, default in PARAMETERS:
+            self.declare_parameter(name, default)
+        params = {name: self.get_parameter(name).value for name, _ in PARAMETERS}
+
+        self.core, info = core_from_params(params, clock=self._clock_hm)
+        for warning in info["warnings"]:
+            self.get_logger().warn(warning)
+        self.get_logger().info(
+            f"vouch action gate armed: did={info['did']} scope={json.dumps(info['scope'])} "
+            f"provenance_verified={self.core.provenance_verified}"
+        )
+
+        depth = int(params["queue_depth"])
+        self._allowed_pub = self.create_publisher(String, params["allowed_action_topic"], depth)
+        self._denial_pub = self.create_publisher(String, params["denial_topic"], depth)
+        self._provenance_pub = self.create_publisher(
+            String, params["provenance_topic"], _latched_qos()
+        )
+        self._head_pub = self.create_publisher(
+            String, params["blackbox_head_topic"], _latched_qos()
+        )
+        self._subscription = self.create_subscription(
+            String, params["proposed_action_topic"], self.on_proposed_action, depth
+        )
+
+        # Publish the startup attestation once, latched, so anything that joins
+        # the graph later can still see what model this robot is running.
+        self._provenance_pub.publish(String(data=json.dumps(self.core.provenance)))
+        self._publish_head()
+
+        self.get_logger().info(
+            f"gating {params['proposed_action_topic']} -> {params['allowed_action_topic']} "
+            f"(denials on {params['denial_topic']})"
+        )
+
+    # -- callbacks ---------------------------------------------------------
+
+    def on_proposed_action(self, msg: Any) -> None:
+        """Gate one proposed action. Only allowed actions reach the actuators."""
+        try:
+            decision = self.core.evaluate(msg.data)
+        except Exception as exc:  # noqa: BLE001 - a bad payload must never actuate
+            self.get_logger().error(f"rejecting unparsable proposed action: {exc}")
+            self._denial_pub.publish(
+                String(data=json.dumps({"reasons": [f"unparsable_action: {exc}"]}))
+            )
+            return
+        self._publish_decision(decision)
+
+    def _publish_decision(self, decision: Decision) -> None:
+        if decision.allowed:
+            self._allowed_pub.publish(String(data=json.dumps(decision.actuator_payload())))
+            self.get_logger().info(f"ALLOW {decision.action.task or decision.action.action_id}")
+        else:
+            self._denial_pub.publish(String(data=json.dumps(decision.denial_payload())))
+            self.get_logger().warn(
+                f"DENY {decision.action.task or decision.action.action_id}: "
+                f"{'; '.join(decision.reasons)}"
+            )
+        self._publish_head()
+
+    def _publish_head(self) -> None:
+        counts = self.core.counts()
+        self._head_pub.publish(
+            String(
+                data=json.dumps(
+                    {
+                        "head": self.core.head(),
+                        "entries": len(self.core.entries()),
+                        "allowed": counts["allowed"],
+                        "denied": counts["denied"],
+                    }
+                )
+            )
+        )
+
+    def _clock_hm(self) -> str:
+        """ "HH:MM" UTC from the ROS clock, for shift-window checks."""
+        import datetime
+
+        seconds = self.get_clock().now().nanoseconds / 1e9
+        return datetime.datetime.fromtimestamp(seconds, tz=datetime.timezone.utc).strftime("%H:%M")
+
+    def report_on_shutdown(self) -> None:
+        """Log the final black-box state so an operator sees the chain verdict."""
+        chain_ok, error = self.core.verify_chain()
+        counts = self.core.counts()
+        self.get_logger().info(
+            f"black box: entries={len(self.core.entries())} allowed={counts['allowed']} "
+            f"denied={counts['denied']} chain_verifies={chain_ok}"
+            + (f" ({error})" if error else "")
+        )
+
+
+def main(args: Optional[list] = None) -> None:
+    """Console entry point (``ros2 run vouch_ros2 vouch_action_gate``)."""
+    require_ros()
+    rclpy.init(args=args)
+    node = VouchActionGate()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.report_on_shutdown()
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+__all__ = ["NODE_NAME", "ROS_AVAILABLE", "VouchActionGate", "main", "require_ros"]
+
+
+if __name__ == "__main__":
+    main()

--- a/integrations/ros2/vouch_ros2/params.py
+++ b/integrations/ros2/vouch_ros2/params.py
@@ -1,0 +1,213 @@
+"""
+The node's ROS parameter table, and the parameters-to-core factory.
+
+Kept free of rclpy so the whole configuration path -- scope, key material,
+topic names -- is unit testable without ROS installed. ``PARAMETERS`` is the
+single source of truth: the node declares exactly these, and
+:func:`core_from_params` consumes exactly these.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional, Tuple
+
+from .core import (
+    ActionGateCore,
+    ActionGateError,
+    build_scope,
+    load_blackbox_key,
+    load_signer,
+    multibase_sha256,
+)
+
+#: (name, default) for every parameter the node declares. Order is declaration
+#: order. A negative numeric default means "this dimension is unbounded".
+PARAMETERS: Tuple[Tuple[str, Any], ...] = (
+    # Topics
+    ("proposed_action_topic", "planner/proposed_action"),
+    ("allowed_action_topic", "actuator/action"),
+    ("denial_topic", "vouch/denials"),
+    ("provenance_topic", "vouch/provenance"),
+    ("blackbox_head_topic", "vouch/blackbox_head"),
+    ("queue_depth", 10),
+    # Physical capability scope
+    ("scope.max_force_n", 80.0),
+    ("scope.max_speed_mps", 1.5),
+    ("scope.max_speed_near_humans_mps", 0.5),
+    ("scope.allowed_zones", ["cell-3"]),
+    ("scope.shift_windows_json", ""),
+    # Robot key material
+    ("identity.did", ""),
+    ("identity.private_key_jwk", ""),
+    # Black box
+    ("blackbox.key_hex", ""),
+    ("blackbox.key_file", ""),
+    ("blackbox.log_path", ""),
+    # Planner / model provenance
+    ("model.name", "unnamed-planner"),
+    ("model.version", ""),
+    ("model.weights_hash", ""),
+    ("model.weights_file", ""),
+    ("model.safety_policy", ""),
+    ("model.config_json", "{}"),
+    # Behaviour
+    ("stamp_time_from_clock", False),
+)
+
+PARAMETER_DEFAULTS: Dict[str, Any] = dict(PARAMETERS)
+
+
+def defaults() -> Dict[str, Any]:
+    """A fresh copy of the default parameter set."""
+    return {name: (list(value) if isinstance(value, list) else value) for name, value in PARAMETERS}
+
+
+def _json_param(params: Dict[str, Any], name: str, fallback: Any) -> Any:
+    raw = params.get(name, PARAMETER_DEFAULTS.get(name, ""))
+    if raw in ("", None):
+        return fallback
+    try:
+        return json.loads(raw) if isinstance(raw, str) else raw
+    except json.JSONDecodeError as exc:
+        raise ActionGateError(f"parameter {name!r} is not valid JSON: {exc}") from exc
+
+
+def _shift_windows(params: Dict[str, Any]) -> Optional[List[Dict[str, str]]]:
+    windows = _json_param(params, "scope.shift_windows_json", None)
+    if windows is None:
+        return None
+    if not isinstance(windows, list) or not all(isinstance(w, dict) for w in windows):
+        raise ActionGateError(
+            "scope.shift_windows_json must be a JSON list of "
+            '{"start": "HH:MM", "end": "HH:MM"} objects'
+        )
+    return [{str(k): str(v) for k, v in w.items()} for w in windows]
+
+
+def scope_from_params(params: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the physicalScope object the gate checks against."""
+    return build_scope(
+        max_force_n=params.get("scope.max_force_n"),
+        max_speed_mps=params.get("scope.max_speed_mps"),
+        max_speed_near_humans_mps=params.get("scope.max_speed_near_humans_mps"),
+        allowed_zones=params.get("scope.allowed_zones"),
+        shift_windows=_shift_windows(params),
+    )
+
+
+def weights_hash_from_params(params: Dict[str, Any]) -> str:
+    """
+    Resolve the model weights hash.
+
+    ``model.weights_hash`` wins when set. Otherwise ``model.weights_file`` is
+    hashed here, so the attestation covers the bytes actually on disk. With
+    neither, the model name is hashed as a placeholder -- enough to make the
+    attestation well formed, not enough to prove which weights ran, so the node
+    warns.
+    """
+    recorded = params.get("model.weights_hash") or ""
+    if recorded:
+        return str(recorded)
+    weights_file = params.get("model.weights_file") or ""
+    if weights_file:
+        import hashlib
+
+        digest = hashlib.sha256()
+        with open(weights_file, "rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        import base64
+
+        return "u" + base64.urlsafe_b64encode(digest.digest()).rstrip(b"=").decode("ascii")
+    return multibase_sha256(f"unverified-weights:{params.get('model.name', '')}".encode("utf-8"))
+
+
+def warnings_for(params: Dict[str, Any]) -> List[str]:
+    """Operational warnings the node should log at startup. Never fatal."""
+    notes: List[str] = []
+    if not params.get("identity.private_key_jwk") or not params.get("identity.did"):
+        notes.append(
+            "no identity.did / identity.private_key_jwk set: signing the provenance "
+            "attestation with an ephemeral key, which nobody can verify after this "
+            "process exits"
+        )
+    if not params.get("blackbox.key_hex") and not params.get("blackbox.key_file"):
+        notes.append(
+            "no blackbox.key_hex / blackbox.key_file set: the black box is sealed with "
+            "an ephemeral key, so the chain stays verifiable but the payloads become "
+            "unreadable after this process exits"
+        )
+    if not params.get("model.weights_hash") and not params.get("model.weights_file"):
+        notes.append(
+            "no model.weights_hash / model.weights_file set: the provenance attestation "
+            "records a placeholder digest and does not bind the weights actually loaded"
+        )
+    if not params.get("model.safety_policy"):
+        notes.append("no model.safety_policy set: recording a placeholder policy identifier")
+    if not params.get("blackbox.log_path"):
+        notes.append("no blackbox.log_path set: black-box entries are held in memory only")
+    return notes
+
+
+def core_from_params(
+    params: Dict[str, Any], *, clock: Any = None
+) -> Tuple[ActionGateCore, Dict[str, Any]]:
+    """
+    Build an :class:`ActionGateCore` from a flat parameter mapping.
+
+    Returns ``(core, info)`` where ``info`` carries the resolved DID, scope,
+    and startup warnings the node logs.
+    """
+    merged = defaults()
+    merged.update({k: v for k, v in params.items() if v is not None})
+
+    scope = scope_from_params(merged)
+    signer, did, public_key_jwk = load_signer(
+        str(merged.get("identity.private_key_jwk") or ""),
+        str(merged.get("identity.did") or ""),
+    )
+    blackbox_key = load_blackbox_key(
+        str(merged.get("blackbox.key_hex") or ""),
+        str(merged.get("blackbox.key_file") or ""),
+    )
+    model_config = _json_param(merged, "model.config_json", {})
+    if not isinstance(model_config, dict):
+        raise ActionGateError("model.config_json must be a JSON object")
+
+    safety_policy = str(merged.get("model.safety_policy") or "") or multibase_sha256(
+        b"unspecified-safety-policy"
+    )
+
+    core = ActionGateCore(
+        signer=signer,
+        robot_did=did,
+        scope=scope,
+        model_name=str(merged.get("model.name") or "unnamed-planner"),
+        weights_hash=weights_hash_from_params(merged),
+        safety_policy=safety_policy,
+        model_config=model_config,
+        model_version=str(merged.get("model.version") or "") or None,
+        public_key_jwk=public_key_jwk,
+        blackbox_key=blackbox_key,
+        blackbox_path=str(merged.get("blackbox.log_path") or ""),
+        clock=clock if merged.get("stamp_time_from_clock") else None,
+    )
+    info = {
+        "did": did,
+        "scope": scope,
+        "warnings": warnings_for(merged),
+        "params": merged,
+    }
+    return core, info
+
+
+__all__ = [
+    "PARAMETERS",
+    "PARAMETER_DEFAULTS",
+    "core_from_params",
+    "defaults",
+    "scope_from_params",
+    "warnings_for",
+    "weights_hash_from_params",
+]

--- a/tests/test_ros2_action_gate.py
+++ b/tests/test_ros2_action_gate.py
@@ -1,0 +1,467 @@
+"""
+Tests for the ROS 2 action-gate package (integrations/ros2).
+
+These run with pytest alone: no ROS 2 install, no DDS, no physical robot. The
+package deliberately keeps every decision in `vouch_ros2.core` /
+`vouch_ros2.params`, both plain Python, so the gating, provenance and
+black-box logic is testable off-robot; `vouch_ros2.node` is a thin rclpy shell
+over it and imports rclpy guarded, which is asserted here too.
+
+Mirrors the path-loading convention used by test_examples_robotics.py: the
+package lives outside the importable `vouch` tree, so its directory is placed
+on sys.path for the duration of the test module.
+"""
+
+import ast
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree
+
+ROS2_PKG_DIR = Path(__file__).resolve().parent.parent / "integrations" / "ros2"
+if str(ROS2_PKG_DIR) not in sys.path:
+    sys.path.insert(0, str(ROS2_PKG_DIR))
+
+import vouch_ros2  # noqa: E402
+from vouch_ros2 import node as gate_node  # noqa: E402
+from vouch_ros2.core import (  # noqa: E402
+    ActionGateCore,
+    ActionGateError,
+    build_scope,
+    build_scope_credential,
+    load_blackbox_key,
+    load_signer,
+    multibase_sha256,
+    parse_action,
+    scope_from_credential,
+)
+from vouch_ros2.params import core_from_params, defaults, scope_from_params  # noqa: E402
+from vouch.robotics import (
+    open_entry,
+    verify_blackbox_chain,
+    verify_provenance_attestation,
+)  # noqa: E402
+
+SCOPE = {
+    "maxForceN": 80.0,
+    "maxSpeedMps": 1.5,
+    "maxSpeedNearHumansMps": 0.5,
+    "allowedZones": ["cell-3"],
+}
+
+# The same episode the VLA accountability-loop example plans: two actions
+# inside the envelope, an over-speed sprint, and an out-of-zone fetch.
+EPISODE = [
+    {
+        "task": "pick up the cup",
+        "force_n": 20.0,
+        "speed_mps": 0.3,
+        "near_humans": True,
+        "zone": "cell-3",
+    },
+    {
+        "task": "hand cup to operator",
+        "force_n": 10.0,
+        "speed_mps": 0.2,
+        "near_humans": True,
+        "zone": "cell-3",
+    },
+    {"task": "sprint to the dock", "speed_mps": 2.5, "near_humans": True, "zone": "cell-3"},
+    {"task": "fetch from loading bay", "force_n": 15.0, "speed_mps": 0.5, "zone": "loading-bay"},
+]
+
+ROS_MODULES = {"rclpy", "std_msgs", "rosidl_runtime_py", "launch", "launch_ros", "rclcpp"}
+
+
+def _imported_names(path):
+    """Every module name a source file imports, from its AST."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    names = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.module and node.level == 0:
+            names.append(node.module)
+    return names
+
+
+def make_core(**overrides):
+    """An ActionGateCore with a fresh ephemeral identity and black-box key."""
+    signer, did, public_key = load_signer()
+    kwargs = dict(
+        signer=signer,
+        robot_did=did,
+        scope=dict(SCOPE),
+        model_name="Gemini Robotics ER 2",
+        weights_hash=multibase_sha256(b"gemini-robotics-er-2-weights"),
+        safety_policy=multibase_sha256(b"factory-floor-safety-policy-v3"),
+        model_config={"planner": "er-2", "temperature": 0.0},
+        model_version="2.0",
+        public_key_jwk=public_key,
+        blackbox_key=b"\x11" * 32,
+    )
+    kwargs.update(overrides)
+    return ActionGateCore(**kwargs)
+
+
+class TestPackageImportsWithoutRos(unittest.TestCase):
+    """The point of the split: the core imports and runs with no ROS present."""
+
+    def test_core_never_imports_a_ros_module(self):
+        # Static check over the import graph, so this holds on a machine that
+        # does have ROS installed too.
+        for module in (vouch_ros2, vouch_ros2.core, vouch_ros2.params):
+            for name in _imported_names(Path(module.__file__)):
+                self.assertNotIn(
+                    name.split(".")[0],
+                    ROS_MODULES,
+                    f"{module.__name__} imports {name}; the core must stay ROS-free",
+                )
+        self.assertTrue(hasattr(vouch_ros2, "ActionGateCore"))
+
+    def test_node_module_imports_whether_or_not_ros_is_present(self):
+        # The node module must import even without ROS, so tooling (and this
+        # test) can introspect it; without rclpy it simply refuses to run.
+        self.assertTrue(hasattr(gate_node, "VouchActionGate"))
+        if gate_node.ROS_AVAILABLE:
+            self.assertIsNone(gate_node.require_ros())
+        else:
+            with self.assertRaises(ImportError):
+                gate_node.require_ros()
+
+    def test_node_advertises_its_entry_point_name(self):
+        self.assertEqual(gate_node.NODE_NAME, "vouch_action_gate")
+
+
+class TestActionParsing(unittest.TestCase):
+    def test_parses_json_string_from_a_string_message(self):
+        action = parse_action('{"task": "pick", "speed_mps": 0.3, "zone": "cell-3"}')
+        self.assertEqual(action.task, "pick")
+        self.assertEqual(action.speed_mps, 0.3)
+        self.assertEqual(action.zone, "cell-3")
+
+    def test_accepts_camel_case_from_a_javascript_planner(self):
+        action = parse_action({"speedMps": 2.0, "nearHumans": True, "forceN": 5, "task": "x"})
+        self.assertEqual(action.speed_mps, 2.0)
+        self.assertEqual(action.force_n, 5.0)
+        self.assertTrue(action.near_humans)
+
+    def test_rejects_unparsable_payloads(self):
+        with self.assertRaises(ActionGateError):
+            parse_action("not json")
+        with self.assertRaises(ActionGateError):
+            parse_action("[1, 2, 3]")
+        with self.assertRaises(ActionGateError):
+            parse_action('{"speed_mps": "fast"}')
+
+
+class TestGating(unittest.TestCase):
+    def setUp(self):
+        self.core = make_core()
+
+    def test_in_envelope_action_is_allowed(self):
+        decision = self.core.evaluate(EPISODE[0])
+        self.assertTrue(decision.allowed)
+        self.assertEqual(decision.reasons, [])
+
+    def test_over_speed_near_humans_is_denied(self):
+        decision = self.core.evaluate(EPISODE[2])
+        self.assertFalse(decision.allowed)
+        self.assertTrue(any("speed_exceeded" in r for r in decision.reasons))
+
+    def test_out_of_zone_action_is_denied(self):
+        decision = self.core.evaluate(EPISODE[3])
+        self.assertFalse(decision.allowed)
+        self.assertIn("zone_not_allowed: loading-bay", decision.reasons)
+
+    def test_over_force_action_is_denied(self):
+        decision = self.core.evaluate({"task": "crush", "force_n": 500.0, "zone": "cell-3"})
+        self.assertFalse(decision.allowed)
+        self.assertTrue(any("force_exceeded" in r for r in decision.reasons))
+
+    def test_only_allowed_actions_reach_the_actuators(self):
+        decisions = [self.core.evaluate(a) for a in EPISODE]
+        allowed = [d for d in decisions if d.allowed]
+        denied = [d for d in decisions if not d.allowed]
+        self.assertEqual(len(allowed), 2)
+        self.assertEqual(len(denied), 2)
+        for decision in allowed:
+            payload = decision.actuator_payload()
+            self.assertEqual(payload["task"], decision.action.task)
+            self.assertIn("vouchEntryHash", payload)
+        for decision in denied:
+            with self.assertRaises(ActionGateError):
+                decision.actuator_payload()
+            self.assertTrue(decision.denial_payload()["reasons"])
+        self.assertEqual(self.core.counts(), {"allowed": 2, "denied": 2})
+
+    def test_denial_payload_carries_reasons_and_black_box_link(self):
+        decision = self.core.evaluate(EPISODE[3])
+        payload = decision.denial_payload()
+        self.assertEqual(payload["zone"], "loading-bay")
+        self.assertEqual(payload["reasons"], decision.reasons)
+        self.assertEqual(payload["vouchEntryHash"], decision.entry["entryHash"])
+
+    def test_shift_window_denies_an_out_of_hours_action(self):
+        core = make_core(
+            scope=dict(SCOPE, shiftWindows=[{"start": "06:00", "end": "18:00"}]),
+            clock=lambda: "23:30",
+        )
+        decision = core.evaluate(EPISODE[0])
+        self.assertFalse(decision.allowed)
+        self.assertIn("outside_shift_window: 23:30", decision.reasons)
+
+    def test_refuses_an_empty_scope(self):
+        signer, did, _ = load_signer()
+        with self.assertRaises(ActionGateError):
+            ActionGateCore(
+                signer=signer,
+                robot_did=did,
+                scope={},
+                model_name="m",
+                weights_hash="u0",
+                safety_policy="p",
+            )
+        with self.assertRaises(ActionGateError):
+            build_scope(max_force_n=-1.0, max_speed_mps=-1.0)
+
+
+class TestProvenance(unittest.TestCase):
+    def test_startup_attestation_is_signed_and_verifies(self):
+        signer, did, public_key = load_signer()
+        config = {"planner": "er-2", "temperature": 0.0}
+        core = ActionGateCore(
+            signer=signer,
+            robot_did=did,
+            scope=dict(SCOPE),
+            model_name="Gemini Robotics ER 2",
+            weights_hash=multibase_sha256(b"weights"),
+            safety_policy=multibase_sha256(b"policy"),
+            model_config=config,
+            model_version="2.0",
+            public_key_jwk=public_key,
+        )
+        self.assertTrue(core.provenance_verified)
+        ok, subject = verify_provenance_attestation(core.provenance, public_key, config=config)
+        self.assertTrue(ok)
+        self.assertEqual(subject["vla"]["modelName"], "Gemini Robotics ER 2")
+        self.assertEqual(subject["id"], did)
+        self.assertIn("ModelProvenanceAttestation", core.provenance["type"])
+
+    def test_attestation_does_not_verify_under_a_different_config(self):
+        core = make_core()
+        ok, _ = verify_provenance_attestation(
+            core.provenance, load_signer()[2], config={"planner": "someone-else"}
+        )
+        self.assertFalse(ok)
+
+    def test_scope_credential_round_trips(self):
+        signer, did, _ = load_signer()
+        credential = build_scope_credential(signer, subject_did=did, scope=dict(SCOPE))
+        self.assertEqual(scope_from_credential(credential), SCOPE)
+        with self.assertRaises(ActionGateError):
+            scope_from_credential({"credentialSubject": {}})
+
+
+class TestBlackBox(unittest.TestCase):
+    def test_every_decision_is_recorded_and_the_chain_verifies(self):
+        core = make_core()
+        for action in EPISODE:
+            core.evaluate(action)
+        entries = core.entries()
+        # one provenance entry plus one entry per decision
+        self.assertEqual(len(entries), len(EPISODE) + 1)
+        self.assertEqual(entries[0]["event"], "provenance_recorded")
+        self.assertEqual(
+            [e["event"] for e in entries[1:]],
+            [
+                "actuation_allowed",
+                "actuation_allowed",
+                "actuation_denied",
+                "actuation_denied",
+            ],
+        )
+        chain_ok, error = core.verify_chain()
+        self.assertTrue(chain_ok, error)
+        self.assertEqual(core.head(), entries[-1]["entryHash"])
+
+    def test_rewriting_a_denial_breaks_the_chain(self):
+        core = make_core()
+        for action in EPISODE:
+            core.evaluate(action)
+        tampered = core.entries()
+        tampered[3]["event"] = "actuation_allowed"
+        chain_ok, error = verify_blackbox_chain(tampered)
+        self.assertFalse(chain_ok)
+        self.assertIsNotNone(error)
+
+    def test_payloads_are_readable_only_with_the_key(self):
+        key = b"\x22" * 32
+        core = make_core(blackbox_key=key)
+        core.evaluate(EPISODE[2])
+        entry = core.entries()[-1]
+        payload = open_entry(entry, key)
+        self.assertEqual(payload["task"], "sprint to the dock")
+        self.assertTrue(payload["reasons"])
+        self.assertNotIn("sprint", entry["ciphertext"])
+
+    def test_entries_are_appended_to_the_log_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "blackbox.jsonl")
+            core = make_core(blackbox_path=path)
+            core.evaluate(EPISODE[0])
+            core.evaluate(EPISODE[3])
+            with open(path, encoding="utf-8") as handle:
+                lines = [json.loads(line) for line in handle if line.strip()]
+        self.assertEqual(len(lines), 3)
+        chain_ok, error = verify_blackbox_chain(lines)
+        self.assertTrue(chain_ok, error)
+
+    def test_key_material_is_validated(self):
+        self.assertEqual(len(load_blackbox_key()), 32)
+        self.assertEqual(load_blackbox_key("aa" * 32), b"\xaa" * 32)
+        with self.assertRaises(ActionGateError):
+            load_blackbox_key("aa" * 16)
+        with self.assertRaises(ActionGateError):
+            load_blackbox_key("zz" * 32)
+        with self.assertRaises(ActionGateError):
+            load_blackbox_key("aa" * 32, "/nonexistent/key")
+
+
+class TestParameters(unittest.TestCase):
+    def test_defaults_declare_every_topic_the_node_uses(self):
+        params = defaults()
+        for name in (
+            "proposed_action_topic",
+            "allowed_action_topic",
+            "denial_topic",
+            "provenance_topic",
+            "blackbox_head_topic",
+        ):
+            self.assertTrue(params[name], f"{name} has no default")
+        self.assertEqual(len(params), len(vouch_ros2.PARAMETERS))
+
+    def test_scope_is_built_from_parameters(self):
+        params = defaults()
+        params["scope.shift_windows_json"] = '[{"start": "06:00", "end": "18:00"}]'
+        scope = scope_from_params(params)
+        self.assertEqual(scope["maxSpeedNearHumansMps"], 0.5)
+        self.assertEqual(scope["allowedZones"], ["cell-3"])
+        self.assertEqual(scope["shiftWindows"], [{"start": "06:00", "end": "18:00"}])
+
+    def test_negative_parameter_means_unbounded(self):
+        params = defaults()
+        params["scope.max_force_n"] = -1.0
+        self.assertNotIn("maxForceN", scope_from_params(params))
+
+    def test_malformed_json_parameters_are_rejected(self):
+        params = defaults()
+        params["scope.shift_windows_json"] = "{not json"
+        with self.assertRaises(ActionGateError):
+            scope_from_params(params)
+        params = defaults()
+        params["model.config_json"] = "[1, 2]"
+        with self.assertRaises(ActionGateError):
+            core_from_params(params)
+
+    def test_core_from_params_gates_end_to_end(self):
+        params = defaults()
+        params["model.name"] = "Gemini Robotics ER 2"
+        params["model.safety_policy"] = "factory-floor-safety-policy-v3"
+        core, info = core_from_params(params)
+        self.assertTrue(info["did"].startswith("did:"))
+        self.assertTrue(info["warnings"], "an unconfigured gate must warn loudly")
+        self.assertTrue(core.provenance_verified)
+        self.assertTrue(core.evaluate(json.dumps(EPISODE[0])).allowed)
+        self.assertFalse(core.evaluate(json.dumps(EPISODE[3])).allowed)
+        chain_ok, error = core.verify_chain()
+        self.assertTrue(chain_ok, error)
+
+    def test_partial_identity_is_a_configuration_error(self):
+        with self.assertRaises(ActionGateError):
+            load_signer("", "did:web:robot.example.com")
+
+    def test_supplied_identity_signs_the_attestation(self):
+        from vouch import generate_identity
+
+        keypair = generate_identity(domain="ar7.example.com")
+        params = defaults()
+        params["identity.did"] = keypair.did
+        params["identity.private_key_jwk"] = keypair.private_key_jwk
+        core, info = core_from_params(params)
+        self.assertEqual(info["did"], keypair.did)
+        ok, subject = verify_provenance_attestation(
+            core.provenance, keypair.public_key_jwk, config=core.model_config
+        )
+        self.assertTrue(ok)
+        self.assertEqual(subject["id"], keypair.did)
+
+
+class TestAmentPackageMetadata(unittest.TestCase):
+    """
+    Static checks on the parts that need colcon to exercise for real.
+
+    A colcon build cannot run here, so these assert what can be asserted
+    offline: the manifest parses and declares an ament_python build, the
+    resource marker exists, the console entry point names something that
+    actually exists, and the launch file is valid Python that declares an
+    argument for every override it passes.
+    """
+
+    def test_manifest_declares_an_ament_python_build(self):
+        manifest = ElementTree.parse(ROS2_PKG_DIR / "package.xml").getroot()
+        self.assertEqual(manifest.get("format"), "3")
+        self.assertEqual(manifest.findtext("name"), "vouch_ros2")
+        self.assertEqual(manifest.findtext("buildtool_depend"), "ament_python")
+        self.assertEqual(manifest.findtext("export/build_type"), "ament_python")
+        exec_depends = {el.text for el in manifest.findall("exec_depend")}
+        self.assertIn("rclpy", exec_depends)
+        self.assertIn("std_msgs", exec_depends)
+
+    def test_ament_resource_marker_exists(self):
+        self.assertTrue((ROS2_PKG_DIR / "resource" / "vouch_ros2").is_file())
+        self.assertTrue((ROS2_PKG_DIR / "setup.cfg").is_file())
+        self.assertTrue((ROS2_PKG_DIR / "README.md").is_file())
+
+    def test_console_entry_point_resolves(self):
+        setup_py = (ROS2_PKG_DIR / "setup.py").read_text(encoding="utf-8")
+        self.assertIn("vouch_action_gate = vouch_ros2.node:main", setup_py)
+        self.assertTrue(callable(gate_node.main))
+
+    def test_launch_file_parses_and_declares_every_argument_it_uses(self):
+        launch_file = ROS2_PKG_DIR / "launch" / "vouch_action_gate.launch.py"
+        tree = ast.parse(launch_file.read_text(encoding="utf-8"))
+        self.assertTrue(
+            any(
+                isinstance(n, ast.FunctionDef) and n.name == "generate_launch_description"
+                for n in tree.body
+            )
+        )
+        source = launch_file.read_text(encoding="utf-8")
+        declared = dict(vouch_ros2.PARAMETERS)
+        for _, param, _, _ in _launch_arguments(tree):
+            self.assertIn(param, declared, f"launch sets undeclared parameter {param}")
+        self.assertIn("params_file", source)
+
+
+def _launch_arguments(tree):
+    """The ARGUMENTS table from the launch module, read statically."""
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and getattr(node.targets[0], "id", "") == "ARGUMENTS":
+            return [
+                (
+                    element.elts[0].value,
+                    element.elts[1].value,
+                    element.elts[2].value,
+                    None,
+                )
+                for element in node.value.elts
+            ]
+    raise AssertionError("launch file has no ARGUMENTS table")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

Adds `vouch_ros2`, a ROS 2 package that places the accountability loop between a planner and a robot's actuators, so adding Vouch to a robot is a dependency rather than a demo.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

None.

## Changes Made

New package at `integrations/ros2/`. `vouch/integrations/` holds importable `vouch.integrations.*` modules and `pyproject.toml` packages only `vouch*`, so an ament package with its own `package.xml` cannot live there; self-contained buildable sub-projects sit at repo top level (`go-sidecar/`, `cloudflare-worker/`, `vscode-vouch/`), which this follows.

**Target: ROS 2 Jazzy** — its Tier 1 platform is Ubuntu 24.04 Noble. Humble targets 22.04 Jammy.

The node:
1. Subscribes to a proposed-action topic.
2. Gates each action with `check_physical_action` against a `PhysicalCapabilityScope`.
3. Republishes only allowed actions; publishes deny reasons on a separate topic.
4. Signs a `ModelProvenanceAttestation` on startup recording the planner/model in use.
5. Appends every allow/deny decision to a `BlackBoxLog`.
6. Exposes scope, key material and topic names as ROS parameters.

Ships `package.xml`, `setup.py`, `setup.cfg`, the resource marker, `vouch_ros2/{__init__,core,params,node}.py`, a launch file, `config/gate_params.yaml`, a README with colcon build and run instructions, and `tests/test_ros2_action_gate.py`.

All gating, provenance and black-box logic lives in a pure-Python `core.py` that the rclpy node is a thin shim over, with `rclpy`/`std_msgs` imported behind `try/except ImportError`. The entire decision path is therefore unit-testable without ROS, a robot, or hardware.

## Testing

- [x] Existing tests pass — full suite 1342 passed, 16 skipped, no regressions
- [x] New tests added for new functionality — 33 tests, none requiring ROS or a robot
- [x] Manual testing performed

Also verified: `black`/`ruff` clean, `py_compile` on `setup.py`, the launch file and all four modules, XML parse of `package.xml`, YAML parse of `gate_params.yaml`. The tests assert statically that the manifest parses with `build_type == ament_python`, the resource marker and `setup.cfg` exist, the console-script entry point resolves to a real callable, and the launch file's arguments only name parameters the node declares.

## Limitations

**The ROS build path is not exercised by CI or locally.** `colcon build`, `ros2 launch` and `ros2 run` have not been run against this package — the static checks above catch wiring errors, not runtime behaviour. A first real build should confirm dotted parameter names (`scope.max_force_n`) declaring and reading back under rclpy, the `ParameterValue(..., value_type=...)` coercion in the launch file, the nested-YAML to dotted-parameter mapping, and transient-local QoS delivering the startup attestation to late joiners. The ament linters are declared as test deps but no in-package linter test is included, so `colcon test` currently finds no tests.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [ ] All tests pass locally — the Python core does; see Limitations
- [x] My commits are signed off (DCO)