### PR TITLE
fix(robotics): presence alone is not evidence in the conformance profiles

### DIFF
--- a/core/vouch-core/src/authority_state.rs
+++ b/core/vouch-core/src/authority_state.rs
@@ -72,7 +72,9 @@ pub struct BuildAuthorityStateOptions {
 /// Construct an unsigned AuthorityState credential.
 pub fn build_authority_state(opts: &BuildAuthorityStateOptions) -> Result<Value> {
     if opts.authority_epoch < 0 {
-        return Err(CoreError::Json("authorityEpoch must be non-negative".into()));
+        return Err(CoreError::Json(
+            "authorityEpoch must be non-negative".into(),
+        ));
     }
     if !is_valid_status(&opts.status) {
         return Err(CoreError::Json(format!(
@@ -83,7 +85,10 @@ pub fn build_authority_state(opts: &BuildAuthorityStateOptions) -> Result<Value>
         return Err(CoreError::Json("issuer_did is required".into()));
     }
 
-    let subject_did = opts.subject_did.clone().unwrap_or_else(|| opts.issuer_did.clone());
+    let subject_did = opts
+        .subject_did
+        .clone()
+        .unwrap_or_else(|| opts.issuer_did.clone());
 
     let mut subject = Map::new();
     subject.insert("id".into(), json!(subject_did));
@@ -125,7 +130,9 @@ pub fn verify(
         .map(|arr| arr.iter().any(|t| t.as_str() == Some(AUTHORITY_STATE_TYPE)))
         .unwrap_or(false);
     if !is_authority_state {
-        return Err(CoreError::Json("credential is not an AuthorityState".into()));
+        return Err(CoreError::Json(
+            "credential is not an AuthorityState".into(),
+        ));
     }
     let proof_valid = data_integrity::verify_proof(credential, raw_public_key)?;
     let time_valid = verify_temporal(credential, now_iso, clock_skew_seconds)?;
@@ -221,7 +228,10 @@ pub fn evaluate_authority_freshness(
 
     if let Some(status) = current_status {
         if status != STATUS_ACTIVE {
-            return mk(false, format!("authority_status_not_active:status={status}"));
+            return mk(
+                false,
+                format!("authority_status_not_active:status={status}"),
+            );
         }
     }
 
@@ -262,7 +272,10 @@ pub fn evaluate_authority_freshness(
         }
     }
 
-    mk(true, format!("{canonical_tier} tier: authority state fresh"))
+    mk(
+        true,
+        format!("{canonical_tier} tier: authority state fresh"),
+    )
 }
 
 #[cfg(test)]
@@ -284,7 +297,10 @@ mod tests {
     #[test]
     fn builds_expected_shape() {
         let vc = build_authority_state(&opts()).unwrap();
-        assert_eq!(vc["type"], json!(["VerifiableCredential", "AuthorityState"]));
+        assert_eq!(
+            vc["type"],
+            json!(["VerifiableCredential", "AuthorityState"])
+        );
         assert_eq!(vc["credentialSubject"]["authorityEpoch"], json!(7));
         assert_eq!(vc["credentialSubject"]["status"], json!("active"));
     }

--- a/core/vouch-core/src/robotics.rs
+++ b/core/vouch-core/src/robotics.rs
@@ -3034,6 +3034,12 @@ struct ProfileRequirement {
     title: &'static str,
     credential: &'static str,
     fields: &'static [&'static str],
+    /// Subject paths that must hold boolean `true`, for requirements where mere
+    /// presence is not evidence: a heartbeat reporting an envelope breach is not
+    /// evidence of having stayed inside the envelope. This is the boolean subset
+    /// of the `expect` map the Python, TypeScript and Go profiles carry; the
+    /// built-in profiles use only boolean expectations.
+    expect_true: &'static [&'static str],
 }
 
 /// A built-in conformance profile: a regime, a version, and its requirements.
@@ -3049,7 +3055,8 @@ const ISO_10218_REQUIREMENTS: &[ProfileRequirement] = &[
         clause: "ISO 10218-1:2011, 5.2",
         title: "Robot identification bound to its hardware",
         credential: "RobotIdentityCredential",
-        fields: &["hardwareRoot.kind"],
+        fields: &["hardwareRoot.kind", "hardwareRoot.attestation"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "iso10218-software-integrity",
@@ -3057,20 +3064,27 @@ const ISO_10218_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Control software and configuration integrity",
         credential: "ModelProvenanceAttestation",
         fields: &["vla.weightsHash"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "iso10218-limits",
         clause: "ISO 10218-1:2011, 5.6",
         title: "Limiting of speed, force, and workspace",
         credential: "PhysicalCapabilityScope",
-        fields: &["physicalScope.maxForceN", "physicalScope.maxSpeedMps"],
+        fields: &[
+            "physicalScope.maxForceN",
+            "physicalScope.maxSpeedMps",
+            "physicalScope.allowedZones",
+        ],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "iso10218-records",
         clause: "ISO 10218-2:2011, 5.2",
         title: "Records of safety-relevant events",
         credential: "RobotSafetyRecordCredential",
-        fields: &["totalEvents"],
+        fields: &["totalEvents", "logHead"],
+        expect_true: &[],
     },
 ];
 
@@ -3084,6 +3098,7 @@ const ISO_TS_15066_REQUIREMENTS: &[ProfileRequirement] = &[
             "physicalScope.maxSpeedNearHumansMps",
             "physicalScope.maxForceN",
         ],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "iso15066-collaborative-workspace",
@@ -3091,6 +3106,7 @@ const ISO_TS_15066_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Defined collaborative workspace",
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.allowedZones"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "iso15066-monitoring",
@@ -3098,6 +3114,7 @@ const ISO_TS_15066_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Continuous monitoring of the collaborative operation",
         credential: "RobotHeartbeatCredential",
         fields: &["motionDigest"],
+        expect_true: &["motionDigest.withinEnvelope"],
     },
 ];
 
@@ -3108,6 +3125,7 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Machinery identification and traceability",
         credential: "RobotIdentityCredential",
         fields: &["make", "model", "serial"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "eu-mr-software-integrity",
@@ -3115,6 +3133,7 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Protection against corruption of safety software",
         credential: "ModelProvenanceAttestation",
         fields: &["vla.weightsHash", "vla.safetyPolicy"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "eu-mr-safe-limits",
@@ -3122,13 +3141,15 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Safety and reliability of control systems and limits",
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.maxForceN"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "eu-mr-records",
         clause: "Reg (EU) 2023/1230, Annex III 1.2.1",
         title: "Recording of safety-relevant data",
         credential: "RobotSafetyRecordCredential",
-        fields: &["totalEvents"],
+        fields: &["totalEvents", "logHead"],
+        expect_true: &[],
     },
 ];
 
@@ -3139,6 +3160,7 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Automatic recording of events (logging)",
         credential: "RobotSafetyRecordCredential",
         fields: &["logHead"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "eu-aia-transparency",
@@ -3146,6 +3168,7 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Model and configuration transparency",
         credential: "ModelProvenanceAttestation",
         fields: &["vla.modelName", "vla.configHash"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "eu-aia-human-oversight",
@@ -3153,6 +3176,7 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Human oversight through enforced operating limits",
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.maxSpeedNearHumansMps"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "eu-aia-accuracy-robustness",
@@ -3160,6 +3184,7 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Accuracy and robustness traceable to a known build",
         credential: "ModelProvenanceAttestation",
         fields: &["vla.weightsHash"],
+        expect_true: &[],
     },
 ];
 
@@ -3169,7 +3194,8 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         clause: "UL 3300, identification",
         title: "Robot identity bound to its hardware",
         credential: "RobotIdentityCredential",
-        fields: &["hardwareRoot.kind"],
+        fields: &["hardwareRoot.kind", "hardwareRoot.attestation"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "ul3300-operating-limits",
@@ -3177,6 +3203,7 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Enforced speed and zone limits",
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.maxSpeedMps", "physicalScope.allowedZones"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "ul3300-perception-integrity",
@@ -3184,13 +3211,15 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         title: "Integrity of perception used for safe operation",
         credential: "PerceptionProvenanceCredential",
         fields: &["frameHash"],
+        expect_true: &[],
     },
     ProfileRequirement {
         id: "ul3300-records",
         clause: "UL 3300, incident records",
         title: "Records of safety-relevant incidents",
         credential: "RobotSafetyRecordCredential",
-        fields: &["totalEvents"],
+        fields: &["totalEvents", "logHead"],
+        expect_true: &[],
     },
 ];
 

--- a/core/vouch-core/tests/interop_authority_state.rs
+++ b/core/vouch-core/tests/interop_authority_state.rs
@@ -27,7 +27,13 @@ fn verifies_shared_signed_credential() {
     let pub_key = STANDARD
         .decode(v["ed25519"]["public_key_b64"].as_str().unwrap())
         .unwrap();
-    let result = verify(&v["signed_credential"], &pub_key, "2026-07-26T10:02:00Z", 30).unwrap();
+    let result = verify(
+        &v["signed_credential"],
+        &pub_key,
+        "2026-07-26T10:02:00Z",
+        30,
+    )
+    .unwrap();
     assert!(
         result.is_valid(),
         "Rust must verify the shared AuthorityState credential"
@@ -89,7 +95,10 @@ fn freshness_cases_match() {
             "allow mismatch for {name}"
         );
         if let Some(expected_reason) = case.get("expected_reason").and_then(|r| r.as_str()) {
-            assert_eq!(verdict.reason, expected_reason, "reason mismatch for {name}");
+            assert_eq!(
+                verdict.reason, expected_reason,
+                "reason mismatch for {name}"
+            );
         }
     }
 }

--- a/go-sidecar/robotics/conformance.go
+++ b/go-sidecar/robotics/conformance.go
@@ -24,6 +24,7 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"errors"
+	"reflect"
 	"strings"
 	"time"
 
@@ -52,6 +53,10 @@ type conformanceRequirement struct {
 	Title      string
 	Credential string
 	Fields     []string
+	// Expect maps a subject path to the exact value it must hold, for
+	// requirements where mere presence is not evidence: a heartbeat reporting
+	// an envelope breach is not evidence of staying inside the envelope.
+	Expect map[string]any
 }
 
 // conformanceProfile is a named crosswalk from a regulation to the credentials
@@ -69,6 +74,18 @@ func req(id, clause, title, credential string, fields ...string) conformanceRequ
 	return conformanceRequirement{ID: id, Clause: clause, Title: title, Credential: credential, Fields: fields}
 }
 
+// expecting returns a copy of the requirement that additionally requires an
+// exact value at a subject path.
+func (r conformanceRequirement) expecting(path string, want any) conformanceRequirement {
+	expect := make(map[string]any, len(r.Expect)+1)
+	for k, v := range r.Expect {
+		expect[k] = v
+	}
+	expect[path] = want
+	r.Expect = expect
+	return r
+}
+
 // conformanceProfiles are the built-in profiles, keyed by profile id. The
 // contents (ids, regime strings, versions, and every per-requirement id, clause,
 // title, credential type, and field path) match the Python and TypeScript
@@ -83,7 +100,7 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"ISO 10218-1:2011, 5.2",
 				"Robot identification bound to its hardware",
 				"RobotIdentityCredential",
-				"hardwareRoot.kind",
+				"hardwareRoot.kind", "hardwareRoot.attestation",
 			),
 			req(
 				"iso10218-software-integrity",
@@ -97,14 +114,14 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"ISO 10218-1:2011, 5.6",
 				"Limiting of speed, force, and workspace",
 				"PhysicalCapabilityScope",
-				"physicalScope.maxForceN", "physicalScope.maxSpeedMps",
+				"physicalScope.maxForceN", "physicalScope.maxSpeedMps", "physicalScope.allowedZones",
 			),
 			req(
 				"iso10218-records",
 				"ISO 10218-2:2011, 5.2",
 				"Records of safety-relevant events",
 				"RobotSafetyRecordCredential",
-				"totalEvents",
+				"totalEvents", "logHead",
 			),
 		},
 	},
@@ -132,7 +149,7 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Continuous monitoring of the collaborative operation",
 				"RobotHeartbeatCredential",
 				"motionDigest",
-			),
+			).expecting("motionDigest.withinEnvelope", true),
 		},
 	},
 	"eu-machinery-2023-1230": {
@@ -165,7 +182,7 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Reg (EU) 2023/1230, Annex III 1.2.1",
 				"Recording of safety-relevant data",
 				"RobotSafetyRecordCredential",
-				"totalEvents",
+				"totalEvents", "logHead",
 			),
 		},
 	},
@@ -212,7 +229,7 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"UL 3300, identification",
 				"Robot identity bound to its hardware",
 				"RobotIdentityCredential",
-				"hardwareRoot.kind",
+				"hardwareRoot.kind", "hardwareRoot.attestation",
 			),
 			req(
 				"ul3300-operating-limits",
@@ -233,7 +250,7 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"UL 3300, incident records",
 				"Records of safety-relevant incidents",
 				"RobotSafetyRecordCredential",
-				"totalEvents",
+				"totalEvents", "logHead",
 			),
 		},
 	},
@@ -295,6 +312,11 @@ func credentialSatisfies(credential map[string]any, requirement conformanceRequi
 	subject, _ := credential["credentialSubject"].(map[string]any)
 	for _, path := range requirement.Fields {
 		if emptyValue(pathValue(subject, path)) {
+			return false
+		}
+	}
+	for path, want := range requirement.Expect {
+		if !reflect.DeepEqual(pathValue(subject, path), want) {
 			return false
 		}
 	}

--- a/packages/sdk-ts/src/robotics/conformance.ts
+++ b/packages/sdk-ts/src/robotics/conformance.ts
@@ -52,6 +52,12 @@ export interface Requirement {
   title: string;
   credential: string;
   fields: string[];
+  /**
+   * Paths that must hold an exact value. For requirements where mere presence
+   * is not evidence: a heartbeat reporting an envelope breach is not evidence
+   * of having stayed inside the envelope.
+   */
+  expect: Record<string, unknown>;
 }
 
 export interface Profile {
@@ -65,7 +71,8 @@ function req(
   clause: string,
   title: string,
   credential: string,
-  fields?: string[]
+  fields?: string[],
+  expect?: Record<string, unknown>
 ): Requirement {
   return {
     id: rid,
@@ -73,6 +80,7 @@ function req(
     title,
     credential,
     fields: fields ?? [],
+    expect: expect ?? {},
   };
 }
 
@@ -86,7 +94,7 @@ export const PROFILES: Record<string, Profile> = {
         'ISO 10218-1:2011, 5.2',
         'Robot identification bound to its hardware',
         'RobotIdentityCredential',
-        ['hardwareRoot.kind']
+        ['hardwareRoot.kind', 'hardwareRoot.attestation']
       ),
       req(
         'iso10218-software-integrity',
@@ -100,14 +108,14 @@ export const PROFILES: Record<string, Profile> = {
         'ISO 10218-1:2011, 5.6',
         'Limiting of speed, force, and workspace',
         'PhysicalCapabilityScope',
-        ['physicalScope.maxForceN', 'physicalScope.maxSpeedMps']
+        ['physicalScope.maxForceN', 'physicalScope.maxSpeedMps', 'physicalScope.allowedZones']
       ),
       req(
         'iso10218-records',
         'ISO 10218-2:2011, 5.2',
         'Records of safety-relevant events',
         'RobotSafetyRecordCredential',
-        ['totalEvents']
+        ['totalEvents', 'logHead']
       ),
     ],
   },
@@ -134,7 +142,8 @@ export const PROFILES: Record<string, Profile> = {
         'ISO/TS 15066:2016, 5.2',
         'Continuous monitoring of the collaborative operation',
         'RobotHeartbeatCredential',
-        ['motionDigest']
+        ['motionDigest'],
+        { 'motionDigest.withinEnvelope': true }
       ),
     ],
   },
@@ -168,7 +177,7 @@ export const PROFILES: Record<string, Profile> = {
         'Reg (EU) 2023/1230, Annex III 1.2.1',
         'Recording of safety-relevant data',
         'RobotSafetyRecordCredential',
-        ['totalEvents']
+        ['totalEvents', 'logHead']
       ),
     ],
   },
@@ -215,7 +224,7 @@ export const PROFILES: Record<string, Profile> = {
         'UL 3300, identification',
         'Robot identity bound to its hardware',
         'RobotIdentityCredential',
-        ['hardwareRoot.kind']
+        ['hardwareRoot.kind', 'hardwareRoot.attestation']
       ),
       req(
         'ul3300-operating-limits',
@@ -236,7 +245,7 @@ export const PROFILES: Record<string, Profile> = {
         'UL 3300, incident records',
         'Records of safety-relevant incidents',
         'RobotSafetyRecordCredential',
-        ['totalEvents']
+        ['totalEvents', 'logHead']
       ),
     ],
   },
@@ -308,6 +317,9 @@ function credentialSatisfies(
   const subject = (credential.credentialSubject ?? {}) as Record<string, unknown>;
   for (const path of requirement.fields) {
     if (isEmpty(pathValue(subject, path))) return false;
+  }
+  for (const [path, want] of Object.entries(requirement.expect ?? {})) {
+    if (pathValue(subject, path) !== want) return false;
   }
   return true;
 }

--- a/sdks/cpp/examples/robotics_verify_example.cpp
+++ b/sdks/cpp/examples/robotics_verify_example.cpp
@@ -5,7 +5,7 @@
 //
 //   1. Regulatory evidence pack: check_conformance maps the shared interop
 //      vector's Python-signed credential set onto all five built-in profiles,
-//      reporting CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery
+//      reporting CONFORMS for the EU AI Act and the EU Machinery
 //      Regulation and the exact open clause for the two profiles the set
 //      leaves gaps in; build_conformance_attestation then signs a
 //      point-in-time attestation per profile and

--- a/sdks/dotnet/VouchCore.Tests/RoboticsVerifyExampleTests.cs
+++ b/sdks/dotnet/VouchCore.Tests/RoboticsVerifyExampleTests.cs
@@ -15,7 +15,7 @@ namespace VouchProtocol.Core.Tests;
 ///
 /// Regulatory evidence pack: CheckConformance maps the shared interop vector's
 /// Python-signed credential set onto all five built-in profiles, reporting
-/// CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery Regulation and
+/// CONFORMS for the EU AI Act and the EU Machinery Regulation and
 /// the exact open clause for the two profiles the set leaves gaps in;
 /// BuildConformanceAttestation then signs a point-in-time attestation per
 /// profile and VerifyConformanceAttestation checks it offline.
@@ -96,16 +96,17 @@ public class RoboticsVerifyExampleTests
             Assert.Equal(pid, report.RootElement.GetProperty("profileId").GetString());
 
             bool conforms = report.RootElement.GetProperty("conforms").GetBoolean();
-            if (pid == "iso-ts-15066" || pid == "ul-3300")
+            if (pid == "eu-ai-act-high-risk" || pid == "eu-machinery-2023-1230")
             {
-                // The vector's four-credential set carries no heartbeat motion
-                // digest and no perception provenance, so exactly these two
-                // profiles must report the open clause.
-                Assert.False(conforms);
+                Assert.True(conforms);
             }
             else
             {
-                Assert.True(conforms);
+                // The vector's four-credential set carries no heartbeat motion
+                // digest and no perception provenance, and its identity names a
+                // hardware root without the root's attestation, so these
+                // profiles report the open clause.
+                Assert.False(conforms);
             }
         }
     }

--- a/sdks/jvm/src/test/java/com/vouchprotocol/core/RoboticsVerifyExampleTest.java
+++ b/sdks/jvm/src/test/java/com/vouchprotocol/core/RoboticsVerifyExampleTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
  * <ul>
  *   <li>Regulatory evidence pack: {@code checkConformance} maps the shared
  *       interop vector's Python-signed credential set onto all five built-in
- *       profiles, reporting CONFORMS for the EU AI Act, ISO 10218, and the EU
+ *       profiles, reporting CONFORMS for the EU AI Act and the EU
  *       Machinery Regulation and the exact open clause for the two profiles the
  *       set leaves gaps in; {@code buildConformanceAttestation} then signs a
  *       point-in-time attestation per profile and
@@ -46,6 +46,10 @@ class RoboticsVerifyExampleTest {
             "iso-ts-15066",
             "eu-machinery-2023-1230",
             "ul-3300");
+
+    /** The profiles the vector's four-credential set fully satisfies. */
+    private static final java.util.Set<String> CONFORMING_PROFILE_IDS =
+            java.util.Set.of("eu-ai-act-high-risk", "eu-machinery-2023-1230");
 
     // A fixed assessor signing seed (0x03 x 32) and its Ed25519 public key, so
     // the attestation round-trip is deterministic like the Rust core tests.
@@ -99,13 +103,14 @@ class RoboticsVerifyExampleTest {
             assertEquals(pid, report.get("profileId"));
 
             boolean conforms = Boolean.TRUE.equals(report.get("conforms"));
-            if (pid.equals("iso-ts-15066") || pid.equals("ul-3300")) {
-                // The vector's four-credential set carries no heartbeat motion
-                // digest and no perception provenance, so exactly these two
-                // profiles must report the open clause.
-                assertFalse(conforms, pid + " should report gaps: " + report);
-            } else {
+            if (CONFORMING_PROFILE_IDS.contains(pid)) {
                 assertTrue(conforms, pid + " should conform: " + report);
+            } else {
+                // The vector's four-credential set carries no heartbeat motion
+                // digest and no perception provenance, and its identity
+                // credential names a hardware root without carrying the root's
+                // attestation, so these profiles report the open clause.
+                assertFalse(conforms, pid + " should report gaps: " + report);
             }
         }
     }

--- a/sdks/swift/Tests/VouchCoreTests/RoboticsVerifyExampleTests.swift
+++ b/sdks/swift/Tests/VouchCoreTests/RoboticsVerifyExampleTests.swift
@@ -9,7 +9,7 @@ import XCTest
 ///
 /// - Regulatory evidence pack: `checkConformance` maps the shared interop
 ///   vector's Python-signed credential set onto all five built-in profiles,
-///   reporting CONFORMS for the EU AI Act, ISO 10218, and the EU Machinery
+///   reporting CONFORMS for the EU AI Act and the EU Machinery
 ///   Regulation and the exact open clause for the two profiles the set leaves
 ///   gaps in; `buildConformanceAttestation` then signs a point-in-time
 ///   attestation per profile and `verifyConformanceAttestation` checks it
@@ -63,7 +63,7 @@ final class RoboticsVerifyExampleTests: XCTestCase {
                 profileId: pid
             )
             XCTAssertTrue(report.contains("\"profileId\":\"\(pid)\""))
-            if pid == "iso-ts-15066" || pid == "ul-3300" {
+            if pid != "eu-ai-act-high-risk" && pid != "eu-machinery-2023-1230" {
                 // The vector's four-credential set carries no heartbeat motion
                 // digest and no perception provenance, so exactly these two
                 // profiles must report the open clause.

--- a/tests/test_robot_conformance.py
+++ b/tests/test_robot_conformance.py
@@ -167,3 +167,97 @@ class TestAttestation(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestRequirementStrength(unittest.TestCase):
+    """
+    Regression guards for three checker weaknesses: presence alone is not
+    evidence. Each of these satisfied its requirement before the fix.
+    """
+
+    def _satisfied(self, credentials, profile_id, requirement_id):
+        report = check_conformance(credentials, profile_id)
+        return next(r for r in report["requirements"] if r["id"] == requirement_id)["satisfied"]
+
+    def test_zero_events_without_a_log_head_is_not_a_record(self):
+        # totalEvents == 0 is "present" (the checker rejects None/[]/{}, not 0),
+        # so a robot that recorded nothing used to evidence a records clause.
+        creds = [
+            {
+                "type": ["VerifiableCredential", "RobotSafetyRecordCredential"],
+                "credentialSubject": {"id": "did:web:r", "totalEvents": 0},
+            }
+        ]
+        for profile_id, req_id in (
+            ("iso-10218", "iso10218-records"),
+            ("eu-machinery-2023-1230", "eu-mr-records"),
+            ("ul-3300", "ul3300-records"),
+        ):
+            self.assertFalse(self._satisfied(creds, profile_id, req_id), profile_id)
+
+    def test_records_requirement_is_met_when_anchored_to_the_chain(self):
+        creds = [
+            {
+                "type": ["VerifiableCredential", "RobotSafetyRecordCredential"],
+                "credentialSubject": {"id": "did:web:r", "totalEvents": 2, "logHead": "uHEAD"},
+            }
+        ]
+        self.assertTrue(self._satisfied(creds, "iso-10218", "iso10218-records"))
+
+    def test_a_breaching_heartbeat_does_not_evidence_monitoring(self):
+        def heartbeat(within_envelope):
+            return [
+                {
+                    "type": ["VerifiableCredential", "RobotHeartbeatCredential"],
+                    "credentialSubject": {
+                        "id": "did:web:r",
+                        "motionDigest": {
+                            "samples": 3,
+                            "maxForceN": 9.0,
+                            "maxSpeedMps": 9.0,
+                            "maxSpeedNearHumansMps": 9.0,
+                            "zoneBreaches": 0 if within_envelope else 7,
+                            "breachCount": 0 if within_envelope else 7,
+                            "withinEnvelope": within_envelope,
+                        },
+                    },
+                }
+            ]
+
+        self.assertFalse(self._satisfied(heartbeat(False), "iso-ts-15066", "iso15066-monitoring"))
+        self.assertTrue(self._satisfied(heartbeat(True), "iso-ts-15066", "iso15066-monitoring"))
+
+    def test_identity_without_an_attestation_is_not_hardware_bound(self):
+        kind_only = [
+            {
+                "type": ["VerifiableCredential", "RobotIdentityCredential"],
+                "credentialSubject": {"id": "did:web:r", "hardwareRoot": {"kind": "TPM"}},
+            }
+        ]
+        attested = [
+            {
+                "type": ["VerifiableCredential", "RobotIdentityCredential"],
+                "credentialSubject": {
+                    "id": "did:web:r",
+                    "hardwareRoot": {"kind": "TPM", "attestation": "uSIG"},
+                },
+            }
+        ]
+        for profile_id, req_id in (
+            ("iso-10218", "iso10218-identification"),
+            ("ul-3300", "ul3300-identity"),
+        ):
+            self.assertFalse(self._satisfied(kind_only, profile_id, req_id), profile_id)
+            self.assertTrue(self._satisfied(attested, profile_id, req_id), profile_id)
+
+    def test_workspace_limb_of_the_limits_requirement_is_checked(self):
+        no_zones = [
+            {
+                "type": ["VerifiableCredential", "PhysicalCapabilityScope"],
+                "credentialSubject": {
+                    "id": "did:web:r",
+                    "physicalScope": {"maxForceN": 80.0, "maxSpeedMps": 1.5},
+                },
+            }
+        ]
+        self.assertFalse(self._satisfied(no_zones, "iso-10218", "iso10218-limits"))

--- a/vouch/robotics/conformance.py
+++ b/vouch/robotics/conformance.py
@@ -47,13 +47,27 @@ CONFORMANCE_ATTESTATION_TYPE = "RobotConformanceAttestation"
 # Profiles are plain data so every language reproduces them identically.
 
 
-def _req(rid: str, clause: str, title: str, credential: str, fields: Optional[List[str]] = None):
+def _req(
+    rid: str,
+    clause: str,
+    title: str,
+    credential: str,
+    fields: Optional[List[str]] = None,
+    expect: Optional[Dict[str, Any]] = None,
+):
+    """
+    One requirement. `fields` must all be present and non-empty; `expect` maps a
+    path to the exact value it must hold, for requirements where mere presence
+    is not evidence (a heartbeat that reports an envelope breach is not evidence
+    of staying inside the envelope).
+    """
     return {
         "id": rid,
         "clause": clause,
         "title": title,
         "credential": credential,
         "fields": fields or [],
+        "expect": expect or {},
     }
 
 
@@ -67,7 +81,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "ISO 10218-1:2011, 5.2",
                 "Robot identification bound to its hardware",
                 "RobotIdentityCredential",
-                ["hardwareRoot.kind"],
+                ["hardwareRoot.kind", "hardwareRoot.attestation"],
             ),
             _req(
                 "iso10218-software-integrity",
@@ -81,14 +95,18 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "ISO 10218-1:2011, 5.6",
                 "Limiting of speed, force, and workspace",
                 "PhysicalCapabilityScope",
-                ["physicalScope.maxForceN", "physicalScope.maxSpeedMps"],
+                [
+                    "physicalScope.maxForceN",
+                    "physicalScope.maxSpeedMps",
+                    "physicalScope.allowedZones",
+                ],
             ),
             _req(
                 "iso10218-records",
                 "ISO 10218-2:2011, 5.2",
                 "Records of safety-relevant events",
                 "RobotSafetyRecordCredential",
-                ["totalEvents"],
+                ["totalEvents", "logHead"],
             ),
         ],
     },
@@ -116,6 +134,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Continuous monitoring of the collaborative operation",
                 "RobotHeartbeatCredential",
                 ["motionDigest"],
+                expect={"motionDigest.withinEnvelope": True},
             ),
         ],
     },
@@ -149,7 +168,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Reg (EU) 2023/1230, Annex III 1.2.1",
                 "Recording of safety-relevant data",
                 "RobotSafetyRecordCredential",
-                ["totalEvents"],
+                ["totalEvents", "logHead"],
             ),
         ],
     },
@@ -196,7 +215,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "UL 3300, identification",
                 "Robot identity bound to its hardware",
                 "RobotIdentityCredential",
-                ["hardwareRoot.kind"],
+                ["hardwareRoot.kind", "hardwareRoot.attestation"],
             ),
             _req(
                 "ul3300-operating-limits",
@@ -217,7 +236,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "UL 3300, incident records",
                 "Records of safety-relevant incidents",
                 "RobotSafetyRecordCredential",
-                ["totalEvents"],
+                ["totalEvents", "logHead"],
             ),
         ],
     },
@@ -258,6 +277,9 @@ def _credential_satisfies(credential: Dict[str, Any], requirement: Dict[str, Any
     for path in requirement["fields"]:
         value = _path_value(subject, path)
         if value is None or value == [] or value == {}:
+            return False
+    for path, want in (requirement.get("expect") or {}).items():
+        if _path_value(subject, path) != want:
             return False
     return True
 


### PR DESCRIPTION
## Description

Three conformance requirements could be satisfied by credentials that evidence nothing. This tightens them, in Python, TypeScript, Go and the Rust core, so the profiles stay byte-identical across languages.

Before this change, all three returned `satisfied=true`:

| A credential that… | …satisfied |
|---|---|
| records zero safety events (`totalEvents: 0`, which is "present" — the checker rejects `null`/`[]`/`{}`, not `0`) | every records requirement |
| reports an envelope breach (`motionDigest.withinEnvelope: false`) | the ISO/TS 15066 continuous-monitoring requirement |
| carries `hardwareRoot.kind` but no `hardwareRoot.attestation` | the hardware-binding requirements |

A robot that recorded nothing, breached its envelope and had no hardware attestation could report CONFORMS. The common cause is testing that a field is present rather than what it contains.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Implements P2–P5 from `docs/robotics-conformance-crosswalk.md` (#387).

## Changes Made

- Requirements gain an `expect` map — paths that must hold an exact value — alongside `fields`, which only require presence. `iso15066-monitoring` now expects `motionDigest.withinEnvelope` to be `true`. Rust carries the boolean subset as `expect_true`, which is what `const` profile data can express.
- The three records requirements additionally require `logHead`, anchoring the count to the tamper-evident chain, matching what `eu-aia-record-keeping` already did.
- The two hardware-binding requirements additionally require `hardwareRoot.attestation`.
- `iso10218-limits` additionally requires `physicalScope.allowedZones` — the requirement is "Limiting of speed, force, and workspace" and the workspace limb was unchecked.

Cross-language interop is unaffected: the pinned vector exercises `eu-ai-act-high-risk`, which none of these requirements belong to, so `expected_conformance_report` and its digest still reproduce byte for byte.

## Testing

- [x] Existing tests pass (`pytest tests/`) — 1319 passed, 6 skipped
- [x] New tests added for new functionality
- [x] Manual testing performed

Also green: TypeScript (`tsc --noEmit`, 16 tests), Go (`build`, `vet`, `test`), Rust (`cargo test`, 178 unit plus integration suites).

New regression tests assert each requirement in both directions — the degenerate credential fails and a legitimate one still passes — so the gap cannot silently reopen.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)