### PR TITLE
docs(robotics): point the crosswalk at the merged fix rather than its branch

### DIFF
--- a/docs/robotics-conformance-crosswalk.md
+++ b/docs/robotics-conformance-crosswalk.md
@@ -232,8 +232,8 @@ See "Why nothing was changed in code" below.
 
 ## Status of the proposals
 
-**P2, P3, P4 and P5 have since been implemented** (branch
-`claude/robotics-conformance-checker-fixes-x7eng6`). Requirements gained an
+**P2, P3, P4 and P5 have since been implemented** (commit `30cc6344`).
+Requirements gained an
 `expect` map so a requirement can assert a *value* and not merely presence; the
 continuous-monitoring requirement now requires `motionDigest.withinEnvelope` to
 be true; the three records requirements require `logHead`; the two


### PR DESCRIPTION
## Description

`docs/robotics-conformance-crosswalk.md` referenced the working branch that carried the P2–P5 implementation. That branch is merged (#390) and deleted, so the reference is unresolvable for anyone reading the document on `main`. Points at commit `30cc6344` instead.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Follow-up to #387 and #390.

## Changes Made

One-line reference change in the "Status of the proposals" section.

## Testing

- [x] Existing tests pass — documentation-only change
- [ ] New tests added for new functionality — n/a
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [ ] I have added tests for new functionality — n/a, documentation only
- [x] All tests pass locally
- [x] My commits are signed off (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Se9bMrksZcQDect8FBRDd)_