### PR TITLE
chore: close the process gaps that let unverified work look verified

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -128,6 +128,27 @@ jobs:
         working-directory: sdks/dotnet
         run: dotnet test --nologo
 
+  swift:
+    name: Swift SDK
+    # Swift previously had no PR-triggered job, so Swift changes could merge
+    # having been compiled nowhere: `swift test` ran only from
+    # swift-xcframework.yml on workflow_dispatch or a swift-v* tag. This builds
+    # on Linux in the official Swift container. The package resolves VouchCore
+    # from a prebuilt XCFramework binaryTarget, which is Apple-platform only, so
+    # this job builds the sources it can and is allowed to fail while that is
+    # the case -- it exists to surface syntax and API breakage early rather than
+    # to gate the merge.
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    container: swift:6.0
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve and build
+        working-directory: sdks/swift
+        run: |
+          swift --version
+          swift build 2>&1 | tail -40
+
   jvm:
     name: JVM SDK
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,6 +182,32 @@ Types:
 - `refactor`: Code change that neither fixes a bug nor adds a feature
 - `chore`: Maintenance tasks
 
+## Changing cross-language behaviour
+
+Some behaviour is implemented separately in Python, TypeScript, Go and the Rust
+core, and then *asserted* again in the Swift, JVM, .NET and C++ wrapper test
+suites. The robotics conformance profiles
+(`vouch/robotics/conformance.py` and its three siblings) are the clearest case.
+
+Two things routinely catch people out:
+
+- **The shared interop vector pins the report FORMAT, not the BEHAVIOUR.**
+  Reproducing `expected_conformance_report` and its digest proves the languages
+  agree on serialisation. It does not prove a profile change is safe: the
+  vector exercises one profile, and behavioural assertions for the others live
+  in each wrapper's own tests.
+- **A change can pass the entire Python suite and still break JVM or .NET**,
+  because those suites encode expected conformance outcomes for the shared
+  vector's credential set.
+
+Before changing anything the profiles depend on:
+
+1. Grep the requirement id and every field path across all SDK test
+   directories to enumerate the consumers, e.g.
+   `grep -rn "iso10218-identification\|hardwareRoot.attestation" sdks/ packages/ go-sidecar/ core/`.
+2. Apply the change identically in all four implementations.
+3. Run `make test-all-sdks`, which runs every suite rather than Python alone.
+
 ## Coding Standards
 
 - **Python**: Follow [PEP 8](https://pep8.org/)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 
 .DEFAULT_GOAL := help
 
-.PHONY: help install-all build-all build-ts clean run-bridge test lint dev-setup publish-all
+.PHONY: help install-all build-all build-ts clean run-bridge test test-all-sdks lint dev-setup publish-all
 
 # Default target
 help: ## Show this help message
@@ -61,6 +61,23 @@ test: ## Run all tests
 	cd packages/bridge && pytest tests/ -v 2>/dev/null || echo "No bridge tests yet"
 	cd packages/sdk-py && pytest tests/ -v 2>/dev/null || echo "No SDK tests yet"
 	@echo "✅ Tests complete!"
+
+# Run every SDK's test suite.
+#
+# `make test` covers Python only. Conformance behaviour is asserted separately
+# in each wrapper SDK's suite -- the shared interop vector pins the report
+# FORMAT, not the BEHAVIOUR -- so a change to vouch/robotics/conformance.py can
+# pass every Python test and still break JVM, .NET or C++. Run this before
+# changing anything the profiles depend on.
+test-all-sdks: ## Run the test suite of every SDK (needs each toolchain)
+	@echo "🧪 Python..."      && pytest tests/ -q
+	@echo "🧪 TypeScript..."  && cd packages/sdk-ts && npm test
+	@echo "🧪 Go..."          && cd go-sidecar && go test ./...
+	@echo "🧪 Rust core..."   && cargo test --manifest-path core/vouch-core/Cargo.toml -q
+	@echo "🧪 JVM..."         && cd sdks/jvm && bash build-native.sh && ./gradlew test --no-daemon
+	@echo "🧪 .NET..."        && cd sdks/dotnet && bash build-native.sh && dotnet test --nologo
+	@echo "🧪 C/C++..."       && $(MAKE) -C sdks/cpp/examples run-robotics run-robotics-c
+	@echo "✅ All SDK suites complete!"
 
 # Run linters
 lint: ## Run linters on all packages

--- a/examples/robotics_openvla_gated_loop.py
+++ b/examples/robotics_openvla_gated_loop.py
@@ -46,6 +46,15 @@ get them and exits 0, so CI can run it unattended:
     pip install 'vouch-protocol[openvla]'
     huggingface-cli download openvla/openvla-7b
 
+Status: the OpenVLA code path is UNVERIFIED. It has never been executed
+against a real checkpoint. Before relying on it, confirm against real weights,
+in this order: `predict_action`'s return shape (a batched (1,7) array rather
+than 7 floats trips the arity guard), the processor `.to(device, dtype=...)`
+convention, the gripper convention for `bridge_orig` (see
+`action_vector_to_physical_action` -- the default is fail-safe until pinned),
+and CONTROL_PERIOD_S as the dataset's real control rate. Everything that does
+not need weights is covered by tests.
+
 Run it:  python examples/robotics_openvla_gated_loop.py
 """
 

--- a/integrations/ros2/README.md
+++ b/integrations/ros2/README.md
@@ -1,5 +1,15 @@
 # vouch_ros2 — the Vouch accountability loop as a ROS 2 node
 
+> **Status: unbuilt — not yet verified against a ROS runtime.** The package is
+> complete and its decision logic is covered by tests that need neither ROS nor
+> a robot, but `colcon build`, `ros2 launch` and `ros2 run` have not been
+> executed against it. A first real build should confirm: dotted parameter
+> names (`scope.max_force_n`) declaring and reading back under rclpy, the
+> `ParameterValue(..., value_type=...)` coercion in the launch file, the
+> nested-YAML to dotted-parameter mapping, and transient-local QoS delivering
+> the startup attestation to late joiners. Treat it as reviewed source, not as
+> a running node, until that has happened.
+
 `vouch_ros2` puts the Vouch accountability loop between a planner and a robot's
 actuators. It is the ROS 2 packaging of
 [`examples/robotics_vla_accountability_loop.py`](../../examples/robotics_vla_accountability_loop.py):

--- a/sdks/cpp/examples/Makefile
+++ b/sdks/cpp/examples/Makefile
@@ -1,29 +1,50 @@
-# Build and run the Vouch C bindings example against the prebuilt core library.
+# Build and run the Vouch C bindings examples against the prebuilt core library.
+#
+# Every example links ../lib/libvouch_core_uniffi.so. That library is built
+# separately from core/, so it can silently go stale relative to the Rust
+# sources -- an example then "passes" while exercising the old core. The
+# examples therefore depend on the library, and `make check-lib` warns when it
+# is older than core/.
 CC       ?= cc
 CXX      ?= c++
 CFLAGS   ?= -O2 -Wall -Wextra -std=c11 -I../include
 CXXFLAGS ?= -O2 -Wall -Wextra -std=c++17 -I../include
 LDFLAGS  ?= -L../lib -lvouch_core_uniffi
+CORE_LIB ?= ../lib/libvouch_core_uniffi.so
+CORE_SRC ?= ../../../core
 
-example: example.c
+$(CORE_LIB):
+	@echo "error: $(CORE_LIB) is missing. Build it first:" >&2
+	@echo "  cargo build --release --manifest-path ../../../core/uniffi/Cargo.toml" >&2
+	@echo "  cp ../../../core/uniffi/target/release/libvouch_core_uniffi.so ../lib/" >&2
+	@false
+
+# Warn (do not fail) when the prebuilt library predates the Rust sources.
+check-lib: $(CORE_LIB)
+	@if [ -n "$$(find $(CORE_SRC) -name '*.rs' -newer $(CORE_LIB) -print -quit 2>/dev/null)" ]; then \
+		echo "warning: $(CORE_LIB) is older than sources in $(CORE_SRC)." >&2; \
+		echo "         Examples may exercise a stale core. Rebuild before trusting a pass." >&2; \
+	fi
+
+example: example.c $(CORE_LIB)
 	$(CC) $(CFLAGS) example.c -o example $(LDFLAGS)
 
-run: example
+run: check-lib example
 	LD_LIBRARY_PATH=../lib ./example
 
-robotics_verify_example: robotics_verify_example.cpp
+robotics_verify_example: robotics_verify_example.cpp $(CORE_LIB)
 	$(CXX) $(CXXFLAGS) robotics_verify_example.cpp -o robotics_verify_example $(LDFLAGS)
 
-run-robotics: robotics_verify_example
+run-robotics: check-lib robotics_verify_example
 	LD_LIBRARY_PATH=../lib ./robotics_verify_example
 
-robotics_example: robotics_example.c
+robotics_example: robotics_example.c $(CORE_LIB)
 	$(CC) $(CFLAGS) robotics_example.c -o robotics_example $(LDFLAGS)
 
-run-robotics-c: robotics_example
+run-robotics-c: check-lib robotics_example
 	LD_LIBRARY_PATH=../lib ./robotics_example
 
 clean:
 	rm -f example robotics_verify_example robotics_example
 
-.PHONY: run run-robotics run-robotics-c clean
+.PHONY: check-lib run run-robotics run-robotics-c clean

--- a/sdks/jvm/.gitignore
+++ b/sdks/jvm/.gitignore
@@ -1,0 +1,4 @@
+build/
+.gradle/
+lib/
+src/main/resources/*/


### PR DESCRIPTION
## Description

Six small fixes, each addressing a way the repo currently lets a change look checked when it is not. All of them were found by things that actually went wrong while landing the robotics work (#385–#390).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

## Related Issues

Follow-up to #385–#390.

## Changes Made

**Swift had no PR-triggered CI at all.** `swift test` ran only from `swift-xcframework.yml` on `workflow_dispatch` or a `swift-v*` tag, so Swift changes could merge having been compiled nowhere — as `RoboticsVerifyExampleTests.swift` did in #384. Adds a Linux `swift build` job to `sdk-tests.yml`. It is `continue-on-error` because the package resolves `VouchCore` from an Apple-only XCFramework `binaryTarget`; it surfaces syntax and API breakage early rather than gating the merge, and should become blocking once a macOS runner or a Linux-resolvable target exists.

**`make test` runs Python only**, but conformance behaviour is asserted separately in every wrapper SDK suite. Adds `make test-all-sdks` covering all seven, and documents the trap in `CONTRIBUTING.md`: *the shared interop vector pins the report **format**, not the **behaviour***. Reproducing its digest does not prove a profile change is safe — the vector exercises one profile, and the other assertions live in the wrappers. A change can pass the entire Python suite and still break JVM and .NET, which is exactly what happened in #390.

**The C/C++ examples could pass against a stale core.** Every target depended only on its own source, never on `../lib/libvouch_core_uniffi.so`, so a library built before a Rust change produced a green run against the old core — a false pass I hit while verifying #390. The library is now a prerequisite, a missing one fails with the exact build command, and `check-lib` warns when it predates `core/`:

```
warning: ../lib/libvouch_core_uniffi.so is older than sources in ../../../core.
         Examples may exercise a stale core. Rebuild before trusting a pass.
```

**Unverified work is now marked as such in-tree**, not only in PR descriptions: the ROS 2 README carries a "Status: unbuilt — not yet verified against a ROS runtime" banner, and the OpenVLA example's docstring states the model path has never run against a checkpoint. Both list what a first real run must confirm.

**The JVM build no longer dirties the tree**: gitignores `build/`, `.gradle/`, `lib/` and the generated resources subdirectories, and records `gradlew`'s executable bit so `chmod +x` stops showing as a change. `vouch_core.kt` is deliberately tracked and left alone.

## Testing

- [x] Existing tests pass (`pytest tests/`) — 1372 passed, 6 skipped
- [ ] New tests added for new functionality — n/a, tooling and docs
- [x] Manual testing performed

`make -n test-all-sdks` expands correctly, the workflow YAML parses with the new job present, and the staleness warning was confirmed to fire against a deliberately stale library. `NATIVE_LIBS.txt` remains tracked — only the generated platform subdirectories are ignored.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [ ] I have added tests for new functionality — n/a, tooling and docs
- [x] All tests pass locally
- [x] My commits are signed off (DCO)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Se9bMrksZcQDect8FBRDd)_