### PR TITLE
feat(robotics): carry clause-citation provenance in every conformance report

### DIFF
--- a/core/vouch-core/examples/robotics_evidence_pack.rs
+++ b/core/vouch-core/examples/robotics_evidence_pack.rs
@@ -216,6 +216,24 @@ fn build_monitoring_credentials(scope_credential: &Value) -> Vec<Value> {
     vec![heartbeat, perception]
 }
 
+/// Render the report's clause-citation provenance, worst first.
+///
+/// CONFORMS answers "does the evidence cover the clauses this profile maps?",
+/// which is a different and weaker claim than "does the robot comply with the
+/// regulation". Printing the provenance beside the verdict keeps the two apart:
+/// a profile whose clause numbers came from secondary sources, or which only
+/// names topics, says so on the same line as the result.
+fn citation_summary(report: &Value) -> String {
+    ["descriptive", "unverified-secondary", "verified-primary"]
+        .iter()
+        .filter_map(|status| match report["citations"][status].as_i64() {
+            Some(n) if n > 0 => Some(format!("{n} {status}")),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn print_summary(reports: &[(String, Value)]) {
     for (pid, report) in reports {
         let verdict = if report["conforms"].as_bool().unwrap_or(false) {
@@ -231,6 +249,7 @@ fn print_summary(reports: &[(String, Value)]) {
             report["totalCount"],
             report["regime"].as_str().unwrap_or("")
         );
+        println!("    citations: {}", citation_summary(report));
         for req in report["requirements"].as_array().into_iter().flatten() {
             if !req["satisfied"].as_bool().unwrap_or(false) {
                 println!(

--- a/core/vouch-core/src/robotics.rs
+++ b/core/vouch-core/src/robotics.rs
@@ -3026,6 +3026,65 @@ pub fn verify_decommission(
 
 pub const CONFORMANCE_ATTESTATION_TYPE: &str = "RobotConformanceAttestation";
 
+/// How well-sourced a requirement's clause citation is. A profile can be a
+/// useful crosswalk while its citations are only as good as the sources that
+/// were available, and a reader is entitled to know which. Every report and
+/// every signed attestation carries these, so a conformance result never
+/// implies more authority over the regulation than it has.
+///
+/// The clause text was read from the official published source.
+pub const CITATION_VERIFIED_PRIMARY: &str = "verified-primary";
+/// The mapping is believed sound, but the clause number comes from secondary
+/// sources rather than the standard or official journal itself. The default,
+/// because it is the honest default.
+pub const CITATION_UNVERIFIED_SECONDARY: &str = "unverified-secondary";
+/// Not a clause reference at all, only a description of the topic. An assessor
+/// cannot look it up.
+pub const CITATION_DESCRIPTIVE: &str = "descriptive";
+
+/// Every citation provenance value, in report order.
+pub const CITATION_STATUSES: &[&str] = &[
+    CITATION_VERIFIED_PRIMARY,
+    CITATION_UNVERIFIED_SECONDARY,
+    CITATION_DESCRIPTIVE,
+];
+
+// Citation notes shared by several requirements. Macros rather than consts so
+// they can be `concat!`-ed into the longer per-requirement notes, byte-for-byte
+// identical with the Python, TypeScript and Go profiles.
+macro_rules! iso_paywall_note {
+    () => {
+        "Clause number taken from secondary sources; the standard is paywalled \
+         and the text has not been read."
+    };
+}
+
+macro_rules! iso_10218_note {
+    () => {
+        concat!(
+            iso_paywall_note!(),
+            " ISO 10218-1/-2:2011 were superseded by the 2025 editions (in \
+             force 1 April 2025); this mapping still cites the 2011 clause \
+             numbering and has not been migrated."
+        )
+    };
+}
+
+macro_rules! oj_note {
+    () => {
+        "Article number taken from a third-party reproduction of the Official \
+         Journal text, not from EUR-Lex itself."
+    };
+}
+
+macro_rules! ul_note {
+    () => {
+        "UL 3300 (now ANSI/CAN/UL 3300:2024) is paywalled and no clause \
+         numbering was available; this names the topic only and cannot be \
+         looked up."
+    };
+}
+
 /// One requirement in a profile: a clause of a regulation mapped to the
 /// credential type and field paths that satisfy it.
 struct ProfileRequirement {
@@ -3040,6 +3099,11 @@ struct ProfileRequirement {
     /// of the `expect` map the Python, TypeScript and Go profiles carry; the
     /// built-in profiles use only boolean expectations.
     expect_true: &'static [&'static str],
+    /// Provenance of the `clause` reference above, one of [`CITATION_STATUSES`].
+    citation: &'static str,
+    /// Anything a reader should know about the citation, such as a known
+    /// conflict between sources.
+    citation_note: Option<&'static str>,
 }
 
 /// A built-in conformance profile: a regime, a version, and its requirements.
@@ -3057,6 +3121,8 @@ const ISO_10218_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotIdentityCredential",
         fields: &["hardwareRoot.kind", "hardwareRoot.attestation"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(iso_10218_note!()),
     },
     ProfileRequirement {
         id: "iso10218-software-integrity",
@@ -3065,6 +3131,8 @@ const ISO_10218_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "ModelProvenanceAttestation",
         fields: &["vla.weightsHash"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(iso_10218_note!()),
     },
     ProfileRequirement {
         id: "iso10218-limits",
@@ -3077,6 +3145,8 @@ const ISO_10218_REQUIREMENTS: &[ProfileRequirement] = &[
             "physicalScope.allowedZones",
         ],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(iso_10218_note!()),
     },
     ProfileRequirement {
         id: "iso10218-records",
@@ -3085,6 +3155,8 @@ const ISO_10218_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotSafetyRecordCredential",
         fields: &["totalEvents", "logHead"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(iso_10218_note!()),
     },
 ];
 
@@ -3099,6 +3171,13 @@ const ISO_TS_15066_REQUIREMENTS: &[ProfileRequirement] = &[
             "physicalScope.maxForceN",
         ],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(concat!(
+            iso_paywall_note!(),
+            " Secondary sources disagree on whether power and force limiting \
+             is 5.5.4 or 5.5.2; confirm against the published table of \
+             contents before relying on the number."
+        )),
     },
     ProfileRequirement {
         id: "iso15066-collaborative-workspace",
@@ -3107,6 +3186,12 @@ const ISO_TS_15066_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.allowedZones"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(concat!(
+            iso_paywall_note!(),
+            " Shares the unresolved 5.5.2/5.5.4 numbering conflict with \
+             iso15066-power-force-limiting."
+        )),
     },
     ProfileRequirement {
         id: "iso15066-monitoring",
@@ -3115,6 +3200,8 @@ const ISO_TS_15066_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotHeartbeatCredential",
         fields: &["motionDigest"],
         expect_true: &["motionDigest.withinEnvelope"],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(iso_paywall_note!()),
     },
 ];
 
@@ -3126,6 +3213,8 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotIdentityCredential",
         fields: &["make", "model", "serial"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(oj_note!()),
     },
     ProfileRequirement {
         id: "eu-mr-software-integrity",
@@ -3134,6 +3223,12 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "ModelProvenanceAttestation",
         fields: &["vla.weightsHash", "vla.safetyPolicy"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(concat!(
+            oj_note!(),
+            " The Annex III subclause for protection against corruption has \
+             not been confirmed and may need to be re-pointed."
+        )),
     },
     ProfileRequirement {
         id: "eu-mr-safe-limits",
@@ -3142,6 +3237,8 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.maxForceN"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(oj_note!()),
     },
     ProfileRequirement {
         id: "eu-mr-records",
@@ -3150,6 +3247,8 @@ const EU_MACHINERY_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotSafetyRecordCredential",
         fields: &["totalEvents", "logHead"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(oj_note!()),
     },
 ];
 
@@ -3161,6 +3260,8 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotSafetyRecordCredential",
         fields: &["logHead"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(oj_note!()),
     },
     ProfileRequirement {
         id: "eu-aia-transparency",
@@ -3169,6 +3270,8 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "ModelProvenanceAttestation",
         fields: &["vla.modelName", "vla.configHash"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(oj_note!()),
     },
     ProfileRequirement {
         id: "eu-aia-human-oversight",
@@ -3177,6 +3280,13 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.maxSpeedNearHumansMps"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(concat!(
+            oj_note!(),
+            " Art. 14 also requires a means for the overseer to intervene or \
+             stop the system, which an operating-limit scope alone does not \
+             evidence."
+        )),
     },
     ProfileRequirement {
         id: "eu-aia-accuracy-robustness",
@@ -3185,6 +3295,8 @@ const EU_AI_ACT_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "ModelProvenanceAttestation",
         fields: &["vla.weightsHash"],
         expect_true: &[],
+        citation: CITATION_UNVERIFIED_SECONDARY,
+        citation_note: Some(oj_note!()),
     },
 ];
 
@@ -3196,6 +3308,8 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotIdentityCredential",
         fields: &["hardwareRoot.kind", "hardwareRoot.attestation"],
         expect_true: &[],
+        citation: CITATION_DESCRIPTIVE,
+        citation_note: Some(ul_note!()),
     },
     ProfileRequirement {
         id: "ul3300-operating-limits",
@@ -3204,6 +3318,8 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "PhysicalCapabilityScope",
         fields: &["physicalScope.maxSpeedMps", "physicalScope.allowedZones"],
         expect_true: &[],
+        citation: CITATION_DESCRIPTIVE,
+        citation_note: Some(ul_note!()),
     },
     ProfileRequirement {
         id: "ul3300-perception-integrity",
@@ -3212,6 +3328,8 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "PerceptionProvenanceCredential",
         fields: &["frameHash"],
         expect_true: &[],
+        citation: CITATION_DESCRIPTIVE,
+        citation_note: Some(ul_note!()),
     },
     ProfileRequirement {
         id: "ul3300-records",
@@ -3220,6 +3338,8 @@ const UL_3300_REQUIREMENTS: &[ProfileRequirement] = &[
         credential: "RobotSafetyRecordCredential",
         fields: &["totalEvents", "logHead"],
         expect_true: &[],
+        citation: CITATION_DESCRIPTIVE,
+        citation_note: Some(ul_note!()),
     },
 ];
 
@@ -3231,7 +3351,7 @@ fn conformance_profile(profile_id: &str) -> Option<ConformanceProfile> {
     match profile_id {
         "iso-10218" => Some(ConformanceProfile {
             regime: "ISO 10218-1/-2 industrial robots",
-            version: "2011",
+            version: "2011 (superseded by the 2025 editions; mapping not yet migrated)",
             requirements: ISO_10218_REQUIREMENTS,
         }),
         "iso-ts-15066" => Some(ConformanceProfile {
@@ -3251,7 +3371,7 @@ fn conformance_profile(profile_id: &str) -> Option<ConformanceProfile> {
         }),
         "ul-3300" => Some(ConformanceProfile {
             regime: "UL 3300 service, communication, and mobile robots",
-            version: "2022",
+            version: "2022 (see ANSI/CAN/UL 3300:2024)",
             requirements: UL_3300_REQUIREMENTS,
         }),
         _ => None,
@@ -3295,8 +3415,10 @@ fn value_present(value: &Value) -> bool {
 }
 
 /// True when `credential` satisfies `requirement`: its type array includes the
-/// requirement's credential type and its credentialSubject has a non-null,
-/// non-empty value at every field path.
+/// requirement's credential type, its credentialSubject has a non-null,
+/// non-empty value at every field path, and every `expect_true` path holds
+/// boolean `true`. Presence alone is not evidence: a heartbeat that reports an
+/// envelope breach does not evidence having stayed inside the envelope.
 fn credential_satisfies(credential: &Value, requirement: &ProfileRequirement) -> bool {
     if !credential_types(credential).contains(&requirement.credential) {
         return false;
@@ -3309,6 +3431,11 @@ fn credential_satisfies(credential: &Value, requirement: &ProfileRequirement) ->
             _ => return false,
         }
     }
+    for path in requirement.expect_true {
+        if path_value(subject, path) != Some(&Value::Bool(true)) {
+            return false;
+        }
+    }
     true
 }
 
@@ -3318,14 +3445,23 @@ fn credential_satisfies(credential: &Value, requirement: &ProfileRequirement) ->
 /// expected to have verified the credentials' signatures first; this checks
 /// structure and coverage, not proofs.
 ///
+/// Every requirement carries the provenance of its clause citation, and the
+/// report totals them, so a result never reads as more authoritative about the
+/// regulation than its sources are.
+///
 /// The report has exactly `{profileId, regime, version, conforms,
-/// satisfiedCount, totalCount, requirements:[{id, clause, title, satisfied}]}`.
+/// satisfiedCount, totalCount, citations:{...},
+/// requirements:[{id, clause, title, satisfied, citation, citationNote?}]}`.
 pub fn check_conformance(credentials: &[Value], profile_id: &str) -> Result<Value> {
     let prof = conformance_profile(profile_id)
         .ok_or_else(|| CoreError::Json(format!("unknown conformance profile: {profile_id}")))?;
 
     let mut results: Vec<Value> = Vec::with_capacity(prof.requirements.len());
     let mut satisfied = 0i64;
+    let mut citations = Map::new();
+    for status in CITATION_STATUSES {
+        citations.insert((*status).into(), json!(0i64));
+    }
     for requirement in prof.requirements {
         let ok = credentials
             .iter()
@@ -3333,12 +3469,21 @@ pub fn check_conformance(credentials: &[Value], profile_id: &str) -> Result<Valu
         if ok {
             satisfied += 1;
         }
-        results.push(json!({
-            "id": requirement.id,
-            "clause": requirement.clause,
-            "title": requirement.title,
-            "satisfied": ok,
-        }));
+        let seen = citations
+            .get(requirement.citation)
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0);
+        citations.insert(requirement.citation.into(), json!(seen + 1));
+        let mut result = Map::new();
+        result.insert("id".into(), json!(requirement.id));
+        result.insert("clause".into(), json!(requirement.clause));
+        result.insert("title".into(), json!(requirement.title));
+        result.insert("satisfied".into(), json!(ok));
+        result.insert("citation".into(), json!(requirement.citation));
+        if let Some(note) = requirement.citation_note {
+            result.insert("citationNote".into(), json!(note));
+        }
+        results.push(Value::Object(result));
     }
     let total = prof.requirements.len() as i64;
 
@@ -3349,6 +3494,7 @@ pub fn check_conformance(credentials: &[Value], profile_id: &str) -> Result<Valu
     report.insert("conforms".into(), json!(satisfied == total));
     report.insert("satisfiedCount".into(), json!(satisfied));
     report.insert("totalCount".into(), json!(total));
+    report.insert("citations".into(), Value::Object(citations));
     report.insert("requirements".into(), Value::Array(results));
     Ok(Value::Object(report))
 }
@@ -3414,6 +3560,13 @@ pub fn build_conformance_attestation(
     subject.insert(
         "totalCount".into(),
         report.get("totalCount").cloned().unwrap_or(Value::Null),
+    );
+    subject.insert(
+        "citations".into(),
+        report
+            .get("citations")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(Map::new())),
     );
     subject.insert("reportDigest".into(), json!(report_digest(&params.report)));
     subject.insert("report".into(), params.report.clone());
@@ -6741,6 +6894,69 @@ mod tests {
                 .as_str()
                 .unwrap()
         );
+    }
+
+    // Presence alone is not evidence. A heartbeat that reports an envelope
+    // breach must not satisfy the continuous-monitoring requirement just by
+    // carrying a motionDigest.
+    #[test]
+    fn a_breaching_heartbeat_does_not_evidence_monitoring() {
+        let breaching = json!({
+            "type": ["VerifiableCredential", "RobotHeartbeatCredential"],
+            "credentialSubject": {
+                "motionDigest": {"withinEnvelope": false, "samples": 120}
+            }
+        });
+        let report = check_conformance(&[breaching.clone()], "iso-ts-15066").unwrap();
+        let monitoring = report["requirements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["id"] == json!("iso15066-monitoring"))
+            .expect("monitoring requirement present");
+        assert_eq!(monitoring["satisfied"], json!(false));
+
+        // The same heartbeat reporting no breach does satisfy it.
+        let mut clean = breaching;
+        clean["credentialSubject"]["motionDigest"]["withinEnvelope"] = json!(true);
+        let report = check_conformance(&[clean], "iso-ts-15066").unwrap();
+        let monitoring = report["requirements"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|r| r["id"] == json!("iso15066-monitoring"))
+            .unwrap();
+        assert_eq!(monitoring["satisfied"], json!(true));
+    }
+
+    // Every requirement declares where its clause number came from, and the
+    // report totals them, so CONFORMS never reads as more authoritative about
+    // the regulation than its sources are.
+    #[test]
+    fn conformance_report_carries_citation_provenance() {
+        for profile_id in [
+            "iso-10218",
+            "iso-ts-15066",
+            "eu-machinery-2023-1230",
+            "eu-ai-act-high-risk",
+            "ul-3300",
+        ] {
+            let report = check_conformance(&[], profile_id).unwrap();
+            let citations = report["citations"].as_object().unwrap();
+            assert_eq!(citations.len(), CITATION_STATUSES.len());
+            let counted: i64 = citations.values().map(|v| v.as_i64().unwrap()).sum();
+            assert_eq!(counted, report["totalCount"].as_i64().unwrap());
+            for result in report["requirements"].as_array().unwrap() {
+                let citation = result["citation"].as_str().unwrap();
+                assert!(CITATION_STATUSES.contains(&citation));
+            }
+        }
+
+        // UL 3300 is paywalled with no clause numbering available, so none of
+        // its "clauses" are citable.
+        let ul = check_conformance(&[], "ul-3300").unwrap();
+        assert_eq!(ul["citations"][CITATION_DESCRIPTIVE], ul["totalCount"]);
+        assert_eq!(ul["citations"][CITATION_VERIFIED_PRIMARY], json!(0));
     }
 
     #[test]

--- a/core/wasm/robotics-examples.mjs
+++ b/core/wasm/robotics-examples.mjs
@@ -171,14 +171,36 @@ const full = [...base, JSON.parse(heartbeat), JSON.parse(perception)];
 
 ok('full evidence pack carries six credentials', full.length === 6);
 
-let allConform = true;
+// CONFORMS answers "does the evidence cover the clauses this profile maps?",
+// which is a different and weaker claim than "does the robot comply with the
+// regulation". The citation summary prints beside the verdict so a profile
+// whose clause numbers came from secondary sources, or which only names
+// topics, says so on the same line as the result.
+const citationSummary = (report) =>
+  ['descriptive', 'unverified-secondary', 'verified-primary']
+    .filter((status) => report.citations?.[status])
+    .map((status) => `${report.citations[status]} ${status}`)
+    .join(', ');
+
+let allConform = true, citationsCarried = true;
 for (const pid of ALL_PROFILE_IDS) {
   const report = JSON.parse(core.roboticsCheckConformance(JSON.stringify(full), pid));
   if (!report.conforms) allConform = false;
+  const counted = Object.values(report.citations ?? {}).reduce((a, b) => a + b, 0);
+  if (counted !== report.totalCount) citationsCarried = false;
   console.log(`    ${pid.padEnd(24)} ${report.conforms ? 'CONFORMS' : 'GAPS'} ` +
     `(${report.satisfiedCount}/${report.totalCount})  ${report.regime}`);
+  console.log(`      citations: ${citationSummary(report)}`);
 }
 ok('all five profiles conform on the full pack', allConform);
+ok('every report totals its clause-citation provenance', citationsCarried);
+
+// UL 3300 is paywalled with no clause numbering available, so a conforming
+// UL 3300 report must still say none of its "clauses" can be looked up.
+const ul = JSON.parse(core.roboticsCheckConformance(JSON.stringify(full), 'ul-3300'));
+ok('a conforming ul-3300 report still reports descriptive-only citations',
+  ul.conforms === true && ul.citations.descriptive === ul.totalCount &&
+  ul.citations['verified-primary'] === 0);
 
 // The base four credentials leave exactly the two documented gaps.
 const baseGaps = ALL_PROFILE_IDS.filter((pid) =>

--- a/docs/robotics-conformance-crosswalk.md
+++ b/docs/robotics-conformance-crosswalk.md
@@ -233,14 +233,20 @@ See "Why nothing was changed in code" below.
 ## Status of the proposals
 
 **P2, P3, P4 and P5 have since been implemented** (commit `30cc6344`).
-Requirements gained an
-`expect` map so a requirement can assert a *value* and not merely presence; the
+Requirements gained an `expect` map so a requirement can assert a *value* and not merely presence; the
 continuous-monitoring requirement now requires `motionDigest.withinEnvelope` to
 be true; the three records requirements require `logHead`; the two
 hardware-binding requirements require `hardwareRoot.attestation`; and the
 ISO 10218 limits requirement requires `allowedZones`. All three
-`[demonstrated]` weaknesses above are closed, in Python, TypeScript, Go and the
-Rust core alike, with the pinned interop digest unchanged.
+`[demonstrated]` weaknesses above are closed, with the pinned interop digest
+unchanged.
+
+P5 shipped incomplete and has since been finished. The Rust core carried the
+`expect_true` data but its checker never read it, so the value assertion held
+in Python, TypeScript and Go while Rust — and therefore the C ABI, WASM, Swift,
+JVM, .NET and C++ surfaces built on it — still accepted a heartbeat reporting
+an envelope breach as evidence of continuous monitoring. The Rust checker now
+enforces it, with a regression test that fails without the fix.
 
 **The tables above describe the profiles as they stood when audited**, not as
 they stand now.
@@ -268,13 +274,52 @@ Each was left alone on the same reasoning:
 - The **UL 3300 citations** need real clause numbers, which require the standard.
 
 Where a change would have to rest on text that could not be read, flagging beats
-editing. Each is written up above so it can be fixed in one pass by someone with
-the documents in hand.
+editing.
+
+## Citation provenance is now machine-readable
+
+The three doubts above were, until recently, recorded only here — in a document
+a consumer of a conformance report never sees. A report that read
+`ul-3300 CONFORMS (4/4)` looked exactly as authoritative as one grounded in
+clause text that had actually been read, and the signed attestation carried
+that appearance offline with it.
+
+Every requirement now declares the provenance of its clause reference, and it
+travels in the report and inside the signed attestation:
+
+| Status | Meaning |
+|---|---|
+| `verified-primary` | The clause text was read from the official published source. |
+| `unverified-secondary` | The mapping is believed sound, but the clause number comes from secondary sources rather than the standard or Official Journal itself. |
+| `descriptive` | Not a clause reference at all, only a description of the topic. An assessor cannot look it up. |
+
+Each report carries a `citations` summary counting its requirements by status,
+and each requirement carries an optional `citationNote` recording what a reader
+should know — the unresolved 5.5.2/5.5.4 conflict, the superseded ISO 10218
+editions, the unconfirmed Machinery Annex III subclause, and the fact that
+Art. 14 also requires a means to intervene that an operating-limit scope alone
+does not evidence.
+
+As of this document, **no built-in requirement is `verified-primary`.** The
+fifteen ISO, Machinery and AI Act requirements are `unverified-secondary`; the
+four UL 3300 requirements are `descriptive`. Reaching `verified-primary`
+requires the purchased standards and the EUR-Lex texts — the same blockers P6,
+P7 and P8 name. The difference is that a reader of the report now learns this
+from the report, not from a document they may never open.
+
+The two `version` strings that were misleading on their own are now explicit:
+`iso-10218` reads `"2011 (superseded by the 2025 editions; mapping not yet
+migrated)"` and `ul-3300` reads `"2022 (see ANSI/CAN/UL 3300:2024)"`. Neither
+asserts a mapping that was not checked; both stop the profile from silently
+looking current.
 
 ## Recommended next steps
 
 1. Buy ISO 10218-1/-2:2025, ISO/TS 15066:2016 and UL 3300, and settle P7, P8 and
-   the 15066 clause numbering against the real text.
+   the 15066 clause numbering against the real text. Each requirement settled
+   against the published clause moves from `unverified-secondary` (or
+   `descriptive`) to `verified-primary`, which is visible in every report from
+   that point on.
 2. Apply P2, P3 and P4 — these need no paywalled text; they are internal
    consistency fixes, each currently lets an empty or degenerate credential
    satisfy a requirement, and each is a small, testable change.

--- a/docs/robotics-evidence-pack-for-assessors.md
+++ b/docs/robotics-evidence-pack-for-assessors.md
@@ -67,33 +67,53 @@ rather than only successes:
 ```
 base credential set (identity, provenance, scope, safety record):
   eu-ai-act-high-risk      CONFORMS (4/4)  EU AI Act high-risk systems
+    citations: 4 unverified-secondary
   iso-10218                CONFORMS (4/4)  ISO 10218-1/-2 industrial robots
+    citations: 4 unverified-secondary
   iso-ts-15066             GAPS     (2/3)  ISO/TS 15066 collaborative robots
+    citations: 3 unverified-secondary
     gap: ISO/TS 15066:2016, 5.2: Continuous monitoring of the collaborative operation
   eu-machinery-2023-1230   CONFORMS (4/4)  EU Machinery Regulation 2023/1230
+    citations: 4 unverified-secondary
   ul-3300                  GAPS     (3/4)  UL 3300 service, communication, and mobile robots
+    citations: 4 descriptive
     gap: UL 3300, sensing integrity: Integrity of perception used for safe operation
 
 full evidence pack (6 credentials):
   eu-ai-act-high-risk      CONFORMS (4/4)  EU AI Act high-risk systems
+    citations: 4 unverified-secondary
   iso-10218                CONFORMS (4/4)  ISO 10218-1/-2 industrial robots
+    citations: 4 unverified-secondary
   iso-ts-15066             CONFORMS (3/3)  ISO/TS 15066 collaborative robots
+    citations: 3 unverified-secondary
   eu-machinery-2023-1230   CONFORMS (4/4)  EU Machinery Regulation 2023/1230
+    citations: 4 unverified-secondary
   ul-3300                  CONFORMS (4/4)  UL 3300 service, communication, and mobile robots
+    citations: 4 descriptive
 
 signed attestations (5 profiles):
-  eu-ai-act-high-risk      verifies=True  reportDigest=uMuWAsxwdw8uZVkW...
-  iso-10218                verifies=True  reportDigest=uVAP1stf9MCglXYl...
-  iso-ts-15066             verifies=True  reportDigest=uoSx4OGx6X-CuC8O...
-  eu-machinery-2023-1230   verifies=True  reportDigest=u-Niyinnn4ZQ_9AA...
-  ul-3300                  verifies=True  reportDigest=u7tslKJ4LRSBotZZ...
+  eu-ai-act-high-risk      verifies=True  reportDigest=u3UyS_2gIlWA89dQ...
+  iso-10218                verifies=True  reportDigest=uUFYccEpaDKzBw-G...
+  iso-ts-15066             verifies=True  reportDigest=uTYVY2iZHmUGszKP...
+  eu-machinery-2023-1230   verifies=True  reportDigest=uZnybk05gi8lUBCE...
+  ul-3300                  verifies=True  reportDigest=u2g1UzA3DItc_6bk...
 ```
 
-Two things worth noticing. The tool **names the specific open clause** rather
+Three things worth noticing. The tool **names the specific open clause** rather
 than failing silently — a missing motion digest is reported as the ISO/TS 15066
 continuous-monitoring clause, and missing perception provenance as the UL 3300
-sensing-integrity clause. And `reportDigest` binds each attestation to one exact
+sensing-integrity clause. `reportDigest` binds each attestation to one exact
 report; a later edit to the report invalidates it.
+
+And every result states **how well-sourced its clause references are**, on the
+line directly beneath the verdict. `unverified-secondary` means the mapping is
+believed sound but the clause number came from secondary sources rather than
+the standard or Official Journal itself; `descriptive` means the entry names a
+topic and cannot be looked up at all, which is why every UL 3300 line reads
+that way. A UL 3300 result that says CONFORMS (4/4) and, immediately below,
+`4 descriptive`, is telling an assessor exactly how far to trust it. The
+provenance travels inside the signed attestation too, so it cannot be dropped
+in transit.
 
 ## What this does not prove
 
@@ -118,10 +138,15 @@ Stated plainly, because an overstated claim here would be worse than no claim.
   non-repudiable and traceable to a key, not that it is true.
 - **Absence of evidence is not covered.** The ledger proves recorded entries
   were not tampered with. It cannot prove nothing was omitted before recording.
-- **Standards coverage is uneven.** The EU AI Act and Machinery Regulation texts
-  are public and the mapping is against them directly. ISO 10218, ISO/TS 15066
-  and UL 3300 are paywalled; those mappings are built from clause structure and
-  publicly available summaries, and are flagged accordingly in the crosswalk.
+- **Standards coverage is uneven, and every report says so.** ISO 10218,
+  ISO/TS 15066 and UL 3300 are paywalled, and the EU texts were read from a
+  third-party reproduction rather than EUR-Lex, so no clause in any built-in
+  profile is currently marked `verified-primary`. The per-requirement
+  `citation` field and the report's `citations` summary carry this into every
+  result and every signed attestation; the crosswalk records the specific
+  doubts, including an unresolved conflict over the ISO/TS 15066
+  power-and-force-limiting clause number and the fact that ISO 10218-1/-2:2011
+  were superseded by the 2025 editions.
 
 ## Maturity, honestly
 

--- a/examples/robotics_ai_act_evidence_pack.py
+++ b/examples/robotics_ai_act_evidence_pack.py
@@ -165,6 +165,25 @@ def sign_attestations(assessor, robot_did, reports):
     }
 
 
+def citation_summary(report):
+    """
+    Render the report's clause-citation provenance, worst first.
+
+    CONFORMS answers "does the evidence cover the clauses this profile maps?",
+    which is a different and weaker claim than "does the robot comply with the
+    regulation". Printing the provenance beside the verdict keeps the two
+    apart: a profile whose clause numbers came from secondary sources, or which
+    only names topics, says so on the same line as the result.
+    """
+    counts = report.get("citations") or {}
+    parts = [
+        f"{counts[status]} {status}"
+        for status in ("descriptive", "unverified-secondary", "verified-primary")
+        if counts.get(status)
+    ]
+    return ", ".join(parts)
+
+
 def print_summary(reports):
     for pid, report in reports.items():
         verdict = "CONFORMS" if report["conforms"] else "GAPS"
@@ -172,6 +191,7 @@ def print_summary(reports):
             f"  {pid:24s} {verdict:8s} "
             f"({report['satisfiedCount']}/{report['totalCount']})  {report['regime']}"
         )
+        print(f"    citations: {citation_summary(report)}")
         for req in report["requirements"]:
             if not req["satisfied"]:
                 print(f"    gap: {req['clause']}: {req['title']}")

--- a/go-sidecar/examples/robotics-evidence-pack/main.go
+++ b/go-sidecar/examples/robotics-evidence-pack/main.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/vouch-protocol/vouch/go-sidecar/robotics"
 	"github.com/vouch-protocol/vouch/go-sidecar/signer"
@@ -194,6 +195,24 @@ func checkAllProfiles(credentials []map[string]any) (map[string]map[string]any, 
 	return reports, nil
 }
 
+// citationSummary renders the report's clause-citation provenance, worst first.
+//
+// CONFORMS answers "does the evidence cover the clauses this profile maps?",
+// which is a different and weaker claim than "does the robot comply with the
+// regulation". Printing the provenance beside the verdict keeps the two apart:
+// a profile whose clause numbers came from secondary sources, or which only
+// names topics, says so on the same line as the result.
+func citationSummary(report map[string]any) string {
+	counts, _ := report["citations"].(map[string]any)
+	parts := make([]string, 0, 3)
+	for _, status := range []string{"descriptive", "unverified-secondary", "verified-primary"} {
+		if n, ok := counts[status].(int); ok && n > 0 {
+			parts = append(parts, fmt.Sprintf("%d %s", n, status))
+		}
+	}
+	return strings.Join(parts, ", ")
+}
+
 func printSummary(reports map[string]map[string]any) {
 	for _, pid := range allProfileIDs {
 		report := reports[pid]
@@ -203,6 +222,7 @@ func printSummary(reports map[string]map[string]any) {
 		}
 		fmt.Printf("  %-24s %-8s (%v/%v)  %v\n",
 			pid, verdict, report["satisfiedCount"], report["totalCount"], report["regime"])
+		fmt.Printf("    citations: %s\n", citationSummary(report))
 		for _, raw := range report["requirements"].([]any) {
 			r := raw.(map[string]any)
 			if !r["satisfied"].(bool) {

--- a/go-sidecar/robotics/conformance.go
+++ b/go-sidecar/robotics/conformance.go
@@ -45,6 +45,34 @@ const ConformanceAttestationType = "RobotConformanceAttestation"
 // at the subject). Profiles are plain data so every language reproduces them
 // identically.
 
+// How well-sourced a requirement's clause citation is. A profile can be a
+// useful crosswalk while its citations are only as good as the sources that
+// were available, and a reader is entitled to know which. Every report and
+// every signed attestation carries these, so a conformance result never implies
+// more authority over the regulation than it has.
+//
+//	CitationVerifiedPrimary      the clause text was read from the official
+//	                             published source.
+//	CitationUnverifiedSecondary  the mapping is believed sound, but the clause
+//	                             number comes from secondary sources rather than
+//	                             the standard or official journal itself. The
+//	                             default, because it is the honest default.
+//	CitationDescriptive          not a clause reference at all, only a
+//	                             description of the topic. An assessor cannot
+//	                             look it up.
+const (
+	CitationVerifiedPrimary     = "verified-primary"
+	CitationUnverifiedSecondary = "unverified-secondary"
+	CitationDescriptive         = "descriptive"
+)
+
+// CitationStatuses is every citation provenance value, in report order.
+var CitationStatuses = []string{
+	CitationVerifiedPrimary,
+	CitationUnverifiedSecondary,
+	CitationDescriptive,
+}
+
 // conformanceRequirement is one clause of a regulation mapped to a credential
 // type and the subject fields that satisfy it.
 type conformanceRequirement struct {
@@ -57,6 +85,11 @@ type conformanceRequirement struct {
 	// requirements where mere presence is not evidence: a heartbeat reporting
 	// an envelope breach is not evidence of staying inside the envelope.
 	Expect map[string]any
+	// Citation is the provenance of the Clause reference, and CitationNote
+	// anything a reader should know about it, such as a conflict between
+	// sources.
+	Citation     string
+	CitationNote string
 }
 
 // conformanceProfile is a named crosswalk from a regulation to the credentials
@@ -71,7 +104,14 @@ func req(id, clause, title, credential string, fields ...string) conformanceRequ
 	if fields == nil {
 		fields = []string{}
 	}
-	return conformanceRequirement{ID: id, Clause: clause, Title: title, Credential: credential, Fields: fields}
+	return conformanceRequirement{
+		ID:         id,
+		Clause:     clause,
+		Title:      title,
+		Credential: credential,
+		Fields:     fields,
+		Citation:   CitationUnverifiedSecondary,
+	}
 }
 
 // expecting returns a copy of the requirement that additionally requires an
@@ -86,6 +126,37 @@ func (r conformanceRequirement) expecting(path string, want any) conformanceRequ
 	return r
 }
 
+// citing returns a copy of the requirement with the given citation provenance
+// and note.
+func (r conformanceRequirement) citing(citation, note string) conformanceRequirement {
+	r.Citation = citation
+	r.CitationNote = note
+	return r
+}
+
+// noting returns a copy of the requirement with a citation note, keeping the
+// default unverified-secondary provenance.
+func (r conformanceRequirement) noting(note string) conformanceRequirement {
+	return r.citing(CitationUnverifiedSecondary, note)
+}
+
+const (
+	iso10218EditionNote = "ISO 10218-1/-2:2011 were superseded by the 2025 editions (in force " +
+		"1 April 2025); this mapping still cites the 2011 clause numbering and has " +
+		"not been migrated."
+
+	isoPaywallNote = "Clause number taken from secondary sources; the standard is paywalled and " +
+		"the text has not been read."
+
+	ojNote = "Article number taken from a third-party reproduction of the Official " +
+		"Journal text, not from EUR-Lex itself."
+
+	ulNote = "UL 3300 (now ANSI/CAN/UL 3300:2024) is paywalled and no clause numbering " +
+		"was available; this names the topic only and cannot be looked up."
+
+	iso10218Note = isoPaywallNote + " " + iso10218EditionNote
+)
+
 // conformanceProfiles are the built-in profiles, keyed by profile id. The
 // contents (ids, regime strings, versions, and every per-requirement id, clause,
 // title, credential type, and field path) match the Python and TypeScript
@@ -93,7 +164,7 @@ func (r conformanceRequirement) expecting(path string, want any) conformanceRequ
 var conformanceProfiles = map[string]conformanceProfile{
 	"iso-10218": {
 		Regime:  "ISO 10218-1/-2 industrial robots",
-		Version: "2011",
+		Version: "2011 (superseded by the 2025 editions; mapping not yet migrated)",
 		Requirements: []conformanceRequirement{
 			req(
 				"iso10218-identification",
@@ -101,28 +172,28 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Robot identification bound to its hardware",
 				"RobotIdentityCredential",
 				"hardwareRoot.kind", "hardwareRoot.attestation",
-			),
+			).noting(iso10218Note),
 			req(
 				"iso10218-software-integrity",
 				"ISO 10218-1:2011, 5.3",
 				"Control software and configuration integrity",
 				"ModelProvenanceAttestation",
 				"vla.weightsHash",
-			),
+			).noting(iso10218Note),
 			req(
 				"iso10218-limits",
 				"ISO 10218-1:2011, 5.6",
 				"Limiting of speed, force, and workspace",
 				"PhysicalCapabilityScope",
 				"physicalScope.maxForceN", "physicalScope.maxSpeedMps", "physicalScope.allowedZones",
-			),
+			).noting(iso10218Note),
 			req(
 				"iso10218-records",
 				"ISO 10218-2:2011, 5.2",
 				"Records of safety-relevant events",
 				"RobotSafetyRecordCredential",
 				"totalEvents", "logHead",
-			),
+			).noting(iso10218Note),
 		},
 	},
 	"iso-ts-15066": {
@@ -135,21 +206,24 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Power and force limiting near humans",
 				"PhysicalCapabilityScope",
 				"physicalScope.maxSpeedNearHumansMps", "physicalScope.maxForceN",
-			),
+			).noting(isoPaywallNote + " Secondary sources disagree on whether power and " +
+				"force limiting is 5.5.4 or 5.5.2; confirm against the published " +
+				"table of contents before relying on the number."),
 			req(
 				"iso15066-collaborative-workspace",
 				"ISO/TS 15066:2016, 5.5.2",
 				"Defined collaborative workspace",
 				"PhysicalCapabilityScope",
 				"physicalScope.allowedZones",
-			),
+			).noting(isoPaywallNote + " Shares the unresolved 5.5.2/5.5.4 numbering " +
+				"conflict with iso15066-power-force-limiting."),
 			req(
 				"iso15066-monitoring",
 				"ISO/TS 15066:2016, 5.2",
 				"Continuous monitoring of the collaborative operation",
 				"RobotHeartbeatCredential",
 				"motionDigest",
-			).expecting("motionDigest.withinEnvelope", true),
+			).expecting("motionDigest.withinEnvelope", true).noting(isoPaywallNote),
 		},
 	},
 	"eu-machinery-2023-1230": {
@@ -162,28 +236,29 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Machinery identification and traceability",
 				"RobotIdentityCredential",
 				"make", "model", "serial",
-			),
+			).noting(ojNote),
 			req(
 				"eu-mr-software-integrity",
 				"Reg (EU) 2023/1230, Annex III 1.1.9",
 				"Protection against corruption of safety software",
 				"ModelProvenanceAttestation",
 				"vla.weightsHash", "vla.safetyPolicy",
-			),
+			).noting(ojNote + " The Annex III subclause for protection against corruption " +
+				"has not been confirmed and may need to be re-pointed."),
 			req(
 				"eu-mr-safe-limits",
 				"Reg (EU) 2023/1230, Annex III 1.2.1",
 				"Safety and reliability of control systems and limits",
 				"PhysicalCapabilityScope",
 				"physicalScope.maxForceN",
-			),
+			).noting(ojNote),
 			req(
 				"eu-mr-records",
 				"Reg (EU) 2023/1230, Annex III 1.2.1",
 				"Recording of safety-relevant data",
 				"RobotSafetyRecordCredential",
 				"totalEvents", "logHead",
-			),
+			).noting(ojNote),
 		},
 	},
 	"eu-ai-act-high-risk": {
@@ -196,33 +271,35 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Automatic recording of events (logging)",
 				"RobotSafetyRecordCredential",
 				"logHead",
-			),
+			).noting(ojNote),
 			req(
 				"eu-aia-transparency",
 				"Reg (EU) 2024/1689, Art. 13",
 				"Model and configuration transparency",
 				"ModelProvenanceAttestation",
 				"vla.modelName", "vla.configHash",
-			),
+			).noting(ojNote),
 			req(
 				"eu-aia-human-oversight",
 				"Reg (EU) 2024/1689, Art. 14",
 				"Human oversight through enforced operating limits",
 				"PhysicalCapabilityScope",
 				"physicalScope.maxSpeedNearHumansMps",
-			),
+			).noting(ojNote + " Art. 14 also requires a means for the overseer to " +
+				"intervene or stop the system, which an operating-limit scope alone " +
+				"does not evidence."),
 			req(
 				"eu-aia-accuracy-robustness",
 				"Reg (EU) 2024/1689, Art. 15",
 				"Accuracy and robustness traceable to a known build",
 				"ModelProvenanceAttestation",
 				"vla.weightsHash",
-			),
+			).noting(ojNote),
 		},
 	},
 	"ul-3300": {
 		Regime:  "UL 3300 service, communication, and mobile robots",
-		Version: "2022",
+		Version: "2022 (see ANSI/CAN/UL 3300:2024)",
 		Requirements: []conformanceRequirement{
 			req(
 				"ul3300-identity",
@@ -230,28 +307,28 @@ var conformanceProfiles = map[string]conformanceProfile{
 				"Robot identity bound to its hardware",
 				"RobotIdentityCredential",
 				"hardwareRoot.kind", "hardwareRoot.attestation",
-			),
+			).citing(CitationDescriptive, ulNote),
 			req(
 				"ul3300-operating-limits",
 				"UL 3300, operating limits",
 				"Enforced speed and zone limits",
 				"PhysicalCapabilityScope",
 				"physicalScope.maxSpeedMps", "physicalScope.allowedZones",
-			),
+			).citing(CitationDescriptive, ulNote),
 			req(
 				"ul3300-perception-integrity",
 				"UL 3300, sensing integrity",
 				"Integrity of perception used for safe operation",
 				"PerceptionProvenanceCredential",
 				"frameHash",
-			),
+			).citing(CitationDescriptive, ulNote),
 			req(
 				"ul3300-records",
 				"UL 3300, incident records",
 				"Records of safety-relevant incidents",
 				"RobotSafetyRecordCredential",
 				"totalEvents", "logHead",
-			),
+			).citing(CitationDescriptive, ulNote),
 		},
 	},
 }
@@ -329,12 +406,19 @@ func credentialSatisfies(credential map[string]any, requirement conformanceRequi
 // is expected to have verified the credentials' signatures first; this checks
 // structure and coverage, not proofs.
 //
+// Every requirement carries the provenance of its clause citation, and the
+// report totals them, so a result never reads as more authoritative about the
+// regulation than its sources are.
+//
 // The report marshals to:
 //
 //	{
 //	  "profileId", "regime", "version",
 //	  "conforms": bool, "satisfiedCount", "totalCount",
-//	  "requirements": [{"id", "clause", "title", "satisfied"}],
+//	  "citations": {"verified-primary", "unverified-secondary", "descriptive"},
+//	  "requirements": [
+//	    {"id", "clause", "title", "satisfied", "citation", "citationNote"?}
+//	  ],
 //	}
 func CheckConformance(credentials []map[string]any, profileID string) (map[string]any, error) {
 	prof, err := Profile(profileID)
@@ -343,6 +427,10 @@ func CheckConformance(credentials []map[string]any, profileID string) (map[strin
 	}
 	results := make([]any, 0, len(prof.Requirements))
 	satisfied := 0
+	citations := make(map[string]any, len(CitationStatuses))
+	for _, status := range CitationStatuses {
+		citations[status] = 0
+	}
 	for _, requirement := range prof.Requirements {
 		ok := false
 		for _, c := range credentials {
@@ -354,12 +442,22 @@ func CheckConformance(credentials []map[string]any, profileID string) (map[strin
 		if ok {
 			satisfied++
 		}
-		results = append(results, map[string]any{
+		citation := requirement.Citation
+		if citation == "" {
+			citation = CitationUnverifiedSecondary
+		}
+		citations[citation] = citations[citation].(int) + 1
+		result := map[string]any{
 			"id":        requirement.ID,
 			"clause":    requirement.Clause,
 			"title":     requirement.Title,
 			"satisfied": ok,
-		})
+			"citation":  citation,
+		}
+		if requirement.CitationNote != "" {
+			result["citationNote"] = requirement.CitationNote
+		}
+		results = append(results, result)
 	}
 	total := len(prof.Requirements)
 	return map[string]any{
@@ -369,6 +467,7 @@ func CheckConformance(credentials []map[string]any, profileID string) (map[strin
 		"conforms":       satisfied == total,
 		"satisfiedCount": satisfied,
 		"totalCount":     total,
+		"citations":      citations,
 		"requirements":   results,
 	}, nil
 }
@@ -430,6 +529,7 @@ func BuildConformanceAttestation(s *signer.Signer, opts BuildConformanceAttestat
 		"conforms":       opts.Report["conforms"],
 		"satisfiedCount": opts.Report["satisfiedCount"],
 		"totalCount":     opts.Report["totalCount"],
+		"citations":      reportCitations(opts.Report),
 		"reportDigest":   digest,
 		"report":         opts.Report,
 	}
@@ -476,6 +576,15 @@ func VerifyConformanceAttestation(cred map[string]any, pub ed25519.PublicKey) (b
 		return false, nil
 	}
 	return true, subject
+}
+
+// reportCitations lifts the citation summary out of a report, tolerating a
+// report produced before citations were carried.
+func reportCitations(report map[string]any) any {
+	if citations, ok := report["citations"]; ok {
+		return citations
+	}
+	return map[string]any{}
 }
 
 // equalValues compares two JSON-decoded booleans, tolerating either concrete

--- a/go-sidecar/robotics/conformance_test.go
+++ b/go-sidecar/robotics/conformance_test.go
@@ -277,3 +277,59 @@ func TestUnknownProfile(t *testing.T) {
 		t.Fatal("expected an error for an unknown profile")
 	}
 }
+
+// TestConformanceCitationProvenance checks that every requirement declares
+// where its clause number came from, and that the report totals them, so
+// CONFORMS never reads as more authoritative about the regulation than its
+// sources are.
+func TestConformanceCitationProvenance(t *testing.T) {
+	for _, pid := range []string{
+		"iso-10218", "iso-ts-15066", "eu-machinery-2023-1230",
+		"eu-ai-act-high-risk", "ul-3300",
+	} {
+		report, err := CheckConformance(nil, pid)
+		if err != nil {
+			t.Fatal(err)
+		}
+		citations := report["citations"].(map[string]any)
+		if len(citations) != len(CitationStatuses) {
+			t.Fatalf("%s: want %d citation buckets, got %d", pid, len(CitationStatuses), len(citations))
+		}
+		counted := 0
+		for _, v := range citations {
+			counted += v.(int)
+		}
+		if counted != report["totalCount"].(int) {
+			t.Fatalf("%s: citation counts total %d, want %d", pid, counted, report["totalCount"])
+		}
+		for _, raw := range report["requirements"].([]any) {
+			got := raw.(map[string]any)["citation"].(string)
+			known := false
+			for _, status := range CitationStatuses {
+				if got == status {
+					known = true
+				}
+			}
+			if !known {
+				t.Fatalf("%s: unknown citation status %q", pid, got)
+			}
+		}
+	}
+}
+
+// TestUL3300CitationsAreDescriptive checks that the paywalled UL 3300 profile,
+// for which no clause numbering was available, never presents its topic names
+// as clauses an assessor can look up.
+func TestUL3300CitationsAreDescriptive(t *testing.T) {
+	report, err := CheckConformance(nil, "ul-3300")
+	if err != nil {
+		t.Fatal(err)
+	}
+	citations := report["citations"].(map[string]any)
+	if citations[CitationDescriptive].(int) != report["totalCount"].(int) {
+		t.Fatalf("want every ul-3300 clause descriptive, got %v", citations)
+	}
+	if citations[CitationVerifiedPrimary].(int) != 0 {
+		t.Fatalf("no ul-3300 clause was read from the standard, got %v", citations)
+	}
+}

--- a/packages/sdk-ts/examples/robotics-evidence-pack.ts
+++ b/packages/sdk-ts/examples/robotics-evidence-pack.ts
@@ -187,6 +187,24 @@ export async function signAttestations(
   return attestations;
 }
 
+/**
+ * Render the report's clause-citation provenance, worst first.
+ *
+ * CONFORMS answers "does the evidence cover the clauses this profile maps?",
+ * which is a different and weaker claim than "does the robot comply with the
+ * regulation". Printing the provenance beside the verdict keeps the two apart:
+ * a profile whose clause numbers came from secondary sources, or which only
+ * names topics, says so on the same line as the result.
+ */
+function citationSummary(report: ConformanceReport): string {
+  const counts = report.citations ?? ({} as Record<string, number>);
+  const order = ['descriptive', 'unverified-secondary', 'verified-primary'] as const;
+  return order
+    .filter((status) => counts[status])
+    .map((status) => `${counts[status]} ${status}`)
+    .join(', ');
+}
+
 function printSummary(reports: Record<string, ConformanceReport>): void {
   for (const [pid, report] of Object.entries(reports)) {
     const verdict = report.conforms ? 'CONFORMS' : 'GAPS';
@@ -194,6 +212,7 @@ function printSummary(reports: Record<string, ConformanceReport>): void {
       `  ${pid.padEnd(24)} ${verdict.padEnd(8)} ` +
         `(${report.satisfiedCount}/${report.totalCount})  ${report.regime}`
     );
+    console.log(`    citations: ${citationSummary(report)}`);
     for (const req of report.requirements) {
       if (!req.satisfied) console.log(`    gap: ${req.clause}: ${req.title}`);
     }

--- a/packages/sdk-ts/src/index.ts
+++ b/packages/sdk-ts/src/index.ts
@@ -329,6 +329,10 @@ export type { BuildSafetyEvidenceOptions } from './robotics/halos';
 // point-in-time attestation, byte-identical with the Python module.
 export {
   CONFORMANCE_ATTESTATION_TYPE,
+  CITATION_VERIFIED_PRIMARY,
+  CITATION_UNVERIFIED_SECONDARY,
+  CITATION_DESCRIPTIVE,
+  CITATION_STATUSES,
   PROFILES,
   profile,
   checkConformance,
@@ -337,6 +341,7 @@ export {
   verifyConformanceAttestation,
 } from './robotics/conformance';
 export type {
+  CitationStatus,
   Requirement,
   Profile,
   RequirementResult,

--- a/packages/sdk-ts/src/robotics/conformance.ts
+++ b/packages/sdk-ts/src/robotics/conformance.ts
@@ -46,6 +46,34 @@ function iso(d: Date): string {
 // subject). Profiles are plain data so every language reproduces them
 // identically.
 
+/**
+ * How well-sourced a requirement's clause citation is. A profile can be a
+ * useful crosswalk while its citations are only as good as the sources that
+ * were available, and a reader is entitled to know which. Every report and
+ * every signed attestation carries these, so a conformance result never
+ * implies more authority over the regulation than it has.
+ *
+ *   verified-primary       the clause text was read from the official
+ *                          published source.
+ *   unverified-secondary   the mapping is believed sound, but the clause
+ *                          number comes from secondary sources rather than the
+ *                          standard or official journal itself. The default,
+ *                          because it is the honest default.
+ *   descriptive            not a clause reference at all, only a description
+ *                          of the topic. An assessor cannot look it up.
+ */
+export const CITATION_VERIFIED_PRIMARY = 'verified-primary';
+export const CITATION_UNVERIFIED_SECONDARY = 'unverified-secondary';
+export const CITATION_DESCRIPTIVE = 'descriptive';
+
+export const CITATION_STATUSES = [
+  CITATION_VERIFIED_PRIMARY,
+  CITATION_UNVERIFIED_SECONDARY,
+  CITATION_DESCRIPTIVE,
+] as const;
+
+export type CitationStatus = (typeof CITATION_STATUSES)[number];
+
 export interface Requirement {
   id: string;
   clause: string;
@@ -58,6 +86,13 @@ export interface Requirement {
    * of having stayed inside the envelope.
    */
   expect: Record<string, unknown>;
+  /** Provenance of the clause reference above. */
+  citation: CitationStatus;
+  /**
+   * Anything a reader should know about the citation, such as a known conflict
+   * between sources.
+   */
+  citationNote?: string;
 }
 
 export interface Profile {
@@ -72,50 +107,93 @@ function req(
   title: string,
   credential: string,
   fields?: string[],
-  expect?: Record<string, unknown>
+  expect?: Record<string, unknown>,
+  citation: CitationStatus = CITATION_UNVERIFIED_SECONDARY,
+  citationNote?: string
 ): Requirement {
-  return {
+  if (!CITATION_STATUSES.includes(citation)) {
+    throw new RoboticsError(
+      `citation must be one of ${CITATION_STATUSES.join(', ')}, got ${citation}`
+    );
+  }
+  const requirement: Requirement = {
     id: rid,
     clause,
     title,
     credential,
     fields: fields ?? [],
     expect: expect ?? {},
+    citation,
   };
+  if (citationNote !== undefined) {
+    requirement.citationNote = citationNote;
+  }
+  return requirement;
 }
+
+const ISO_10218_EDITION_NOTE =
+  'ISO 10218-1/-2:2011 were superseded by the 2025 editions (in force ' +
+  '1 April 2025); this mapping still cites the 2011 clause numbering and has ' +
+  'not been migrated.';
+
+const ISO_PAYWALL_NOTE =
+  'Clause number taken from secondary sources; the standard is paywalled and ' +
+  'the text has not been read.';
+
+const OJ_NOTE =
+  'Article number taken from a third-party reproduction of the Official ' +
+  'Journal text, not from EUR-Lex itself.';
+
+const UL_NOTE =
+  'UL 3300 (now ANSI/CAN/UL 3300:2024) is paywalled and no clause numbering ' +
+  'was available; this names the topic only and cannot be looked up.';
+
+const ISO_10218_NOTE = `${ISO_PAYWALL_NOTE} ${ISO_10218_EDITION_NOTE}`;
 
 export const PROFILES: Record<string, Profile> = {
   'iso-10218': {
     regime: 'ISO 10218-1/-2 industrial robots',
-    version: '2011',
+    version: '2011 (superseded by the 2025 editions; mapping not yet migrated)',
     requirements: [
       req(
         'iso10218-identification',
         'ISO 10218-1:2011, 5.2',
         'Robot identification bound to its hardware',
         'RobotIdentityCredential',
-        ['hardwareRoot.kind', 'hardwareRoot.attestation']
+        ['hardwareRoot.kind', 'hardwareRoot.attestation'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        ISO_10218_NOTE
       ),
       req(
         'iso10218-software-integrity',
         'ISO 10218-1:2011, 5.3',
         'Control software and configuration integrity',
         'ModelProvenanceAttestation',
-        ['vla.weightsHash']
+        ['vla.weightsHash'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        ISO_10218_NOTE
       ),
       req(
         'iso10218-limits',
         'ISO 10218-1:2011, 5.6',
         'Limiting of speed, force, and workspace',
         'PhysicalCapabilityScope',
-        ['physicalScope.maxForceN', 'physicalScope.maxSpeedMps', 'physicalScope.allowedZones']
+        ['physicalScope.maxForceN', 'physicalScope.maxSpeedMps', 'physicalScope.allowedZones'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        ISO_10218_NOTE
       ),
       req(
         'iso10218-records',
         'ISO 10218-2:2011, 5.2',
         'Records of safety-relevant events',
         'RobotSafetyRecordCredential',
-        ['totalEvents', 'logHead']
+        ['totalEvents', 'logHead'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        ISO_10218_NOTE
       ),
     ],
   },
@@ -128,14 +206,23 @@ export const PROFILES: Record<string, Profile> = {
         'ISO/TS 15066:2016, 5.5.4',
         'Power and force limiting near humans',
         'PhysicalCapabilityScope',
-        ['physicalScope.maxSpeedNearHumansMps', 'physicalScope.maxForceN']
+        ['physicalScope.maxSpeedNearHumansMps', 'physicalScope.maxForceN'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        `${ISO_PAYWALL_NOTE} Secondary sources disagree on whether power and ` +
+          'force limiting is 5.5.4 or 5.5.2; confirm against the published ' +
+          'table of contents before relying on the number.'
       ),
       req(
         'iso15066-collaborative-workspace',
         'ISO/TS 15066:2016, 5.5.2',
         'Defined collaborative workspace',
         'PhysicalCapabilityScope',
-        ['physicalScope.allowedZones']
+        ['physicalScope.allowedZones'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        `${ISO_PAYWALL_NOTE} Shares the unresolved 5.5.2/5.5.4 numbering ` +
+          'conflict with iso15066-power-force-limiting.'
       ),
       req(
         'iso15066-monitoring',
@@ -143,7 +230,9 @@ export const PROFILES: Record<string, Profile> = {
         'Continuous monitoring of the collaborative operation',
         'RobotHeartbeatCredential',
         ['motionDigest'],
-        { 'motionDigest.withinEnvelope': true }
+        { 'motionDigest.withinEnvelope': true },
+        CITATION_UNVERIFIED_SECONDARY,
+        ISO_PAYWALL_NOTE
       ),
     ],
   },
@@ -156,28 +245,41 @@ export const PROFILES: Record<string, Profile> = {
         'Reg (EU) 2023/1230, Annex III 1.7.4',
         'Machinery identification and traceability',
         'RobotIdentityCredential',
-        ['make', 'model', 'serial']
+        ['make', 'model', 'serial'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        OJ_NOTE
       ),
       req(
         'eu-mr-software-integrity',
         'Reg (EU) 2023/1230, Annex III 1.1.9',
         'Protection against corruption of safety software',
         'ModelProvenanceAttestation',
-        ['vla.weightsHash', 'vla.safetyPolicy']
+        ['vla.weightsHash', 'vla.safetyPolicy'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        `${OJ_NOTE} The Annex III subclause for protection against corruption ` +
+          'has not been confirmed and may need to be re-pointed.'
       ),
       req(
         'eu-mr-safe-limits',
         'Reg (EU) 2023/1230, Annex III 1.2.1',
         'Safety and reliability of control systems and limits',
         'PhysicalCapabilityScope',
-        ['physicalScope.maxForceN']
+        ['physicalScope.maxForceN'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        OJ_NOTE
       ),
       req(
         'eu-mr-records',
         'Reg (EU) 2023/1230, Annex III 1.2.1',
         'Recording of safety-relevant data',
         'RobotSafetyRecordCredential',
-        ['totalEvents', 'logHead']
+        ['totalEvents', 'logHead'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        OJ_NOTE
       ),
     ],
   },
@@ -190,62 +292,88 @@ export const PROFILES: Record<string, Profile> = {
         'Reg (EU) 2024/1689, Art. 12',
         'Automatic recording of events (logging)',
         'RobotSafetyRecordCredential',
-        ['logHead']
+        ['logHead'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        OJ_NOTE
       ),
       req(
         'eu-aia-transparency',
         'Reg (EU) 2024/1689, Art. 13',
         'Model and configuration transparency',
         'ModelProvenanceAttestation',
-        ['vla.modelName', 'vla.configHash']
+        ['vla.modelName', 'vla.configHash'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        OJ_NOTE
       ),
       req(
         'eu-aia-human-oversight',
         'Reg (EU) 2024/1689, Art. 14',
         'Human oversight through enforced operating limits',
         'PhysicalCapabilityScope',
-        ['physicalScope.maxSpeedNearHumansMps']
+        ['physicalScope.maxSpeedNearHumansMps'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        `${OJ_NOTE} Art. 14 also requires a means for the overseer to ` +
+          'intervene or stop the system, which an operating-limit scope alone ' +
+          'does not evidence.'
       ),
       req(
         'eu-aia-accuracy-robustness',
         'Reg (EU) 2024/1689, Art. 15',
         'Accuracy and robustness traceable to a known build',
         'ModelProvenanceAttestation',
-        ['vla.weightsHash']
+        ['vla.weightsHash'],
+        undefined,
+        CITATION_UNVERIFIED_SECONDARY,
+        OJ_NOTE
       ),
     ],
   },
   'ul-3300': {
     regime: 'UL 3300 service, communication, and mobile robots',
-    version: '2022',
+    version: '2022 (see ANSI/CAN/UL 3300:2024)',
     requirements: [
       req(
         'ul3300-identity',
         'UL 3300, identification',
         'Robot identity bound to its hardware',
         'RobotIdentityCredential',
-        ['hardwareRoot.kind', 'hardwareRoot.attestation']
+        ['hardwareRoot.kind', 'hardwareRoot.attestation'],
+        undefined,
+        CITATION_DESCRIPTIVE,
+        UL_NOTE
       ),
       req(
         'ul3300-operating-limits',
         'UL 3300, operating limits',
         'Enforced speed and zone limits',
         'PhysicalCapabilityScope',
-        ['physicalScope.maxSpeedMps', 'physicalScope.allowedZones']
+        ['physicalScope.maxSpeedMps', 'physicalScope.allowedZones'],
+        undefined,
+        CITATION_DESCRIPTIVE,
+        UL_NOTE
       ),
       req(
         'ul3300-perception-integrity',
         'UL 3300, sensing integrity',
         'Integrity of perception used for safe operation',
         'PerceptionProvenanceCredential',
-        ['frameHash']
+        ['frameHash'],
+        undefined,
+        CITATION_DESCRIPTIVE,
+        UL_NOTE
       ),
       req(
         'ul3300-records',
         'UL 3300, incident records',
         'Records of safety-relevant incidents',
         'RobotSafetyRecordCredential',
-        ['totalEvents', 'logHead']
+        ['totalEvents', 'logHead'],
+        undefined,
+        CITATION_DESCRIPTIVE,
+        UL_NOTE
       ),
     ],
   },
@@ -269,6 +397,8 @@ export interface RequirementResult {
   clause: string;
   title: string;
   satisfied: boolean;
+  citation: CitationStatus;
+  citationNote?: string;
 }
 
 export interface ConformanceReport {
@@ -278,6 +408,8 @@ export interface ConformanceReport {
   conforms: boolean;
   satisfiedCount: number;
   totalCount: number;
+  /** How many requirements carry each citation provenance. */
+  citations: Record<CitationStatus, number>;
   requirements: RequirementResult[];
 }
 
@@ -330,6 +462,10 @@ function credentialSatisfies(
  * credential matches its type and has every required field. The caller is
  * expected to have verified the credentials' signatures first; this checks
  * structure and coverage, not proofs.
+ *
+ * Every requirement carries the provenance of its clause citation, and the
+ * report totals them, so a result never reads as more authoritative about the
+ * regulation than its sources are.
  */
 export function checkConformance(
   credentials: Array<Record<string, unknown>>,
@@ -338,15 +474,27 @@ export function checkConformance(
   const prof = profile(profileId);
   const results: RequirementResult[] = [];
   let satisfied = 0;
+  const citations = {
+    [CITATION_VERIFIED_PRIMARY]: 0,
+    [CITATION_UNVERIFIED_SECONDARY]: 0,
+    [CITATION_DESCRIPTIVE]: 0,
+  } as Record<CitationStatus, number>;
   for (const requirement of prof.requirements) {
     const ok = credentials.some((c) => credentialSatisfies(c, requirement));
     if (ok) satisfied += 1;
-    results.push({
+    const citation = requirement.citation ?? CITATION_UNVERIFIED_SECONDARY;
+    citations[citation] += 1;
+    const result: RequirementResult = {
       id: requirement.id,
       clause: requirement.clause,
       title: requirement.title,
       satisfied: ok,
-    });
+      citation,
+    };
+    if (requirement.citationNote !== undefined) {
+      result.citationNote = requirement.citationNote;
+    }
+    results.push(result);
   }
   const total = prof.requirements.length;
   return {
@@ -356,6 +504,7 @@ export function checkConformance(
     conforms: satisfied === total,
     satisfiedCount: satisfied,
     totalCount: total,
+    citations,
     requirements: results,
   };
 }
@@ -409,6 +558,7 @@ export async function buildConformanceAttestation(
     conforms: report.conforms,
     satisfiedCount: report.satisfiedCount,
     totalCount: report.totalCount,
+    citations: report.citations ?? {},
     reportDigest: reportDigest(report),
     report,
   };

--- a/packages/sdk-ts/tests/robotics-conformance.test.ts
+++ b/packages/sdk-ts/tests/robotics-conformance.test.ts
@@ -20,6 +20,9 @@ import {
   buildConformanceAttestation,
   verifyConformanceAttestation,
   CONFORMANCE_ATTESTATION_TYPE,
+  CITATION_STATUSES,
+  CITATION_DESCRIPTIVE,
+  PROFILES,
   type ConformanceReport,
 } from '../src';
 
@@ -175,5 +178,26 @@ describe('conformance attestation round-trip', () => {
     embedded.conforms = false;
     const res = verifyConformanceAttestation(cred, authority.pub);
     expect(res.ok).toBe(false);
+  });
+
+  it('carries the clause-citation provenance of every requirement', () => {
+    for (const profileId of Object.keys(PROFILES)) {
+      const report = checkConformance([], profileId);
+      const counted = Object.values(report.citations).reduce((a, b) => a + b, 0);
+      expect(counted).toBe(report.totalCount);
+      expect(Object.keys(report.citations).sort()).toEqual([...CITATION_STATUSES].sort());
+      for (const req of report.requirements) {
+        expect(CITATION_STATUSES).toContain(req.citation);
+      }
+    }
+  });
+
+  it('reports ul-3300 clauses as descriptive, not citable', () => {
+    // UL 3300 is paywalled and no clause numbering was available, so the
+    // profile must not present its topic names as clauses an assessor can
+    // look up -- even when the report says CONFORMS.
+    const report = checkConformance([], 'ul-3300');
+    expect(report.citations[CITATION_DESCRIPTIVE]).toBe(report.totalCount);
+    expect(report.citations['verified-primary']).toBe(0);
   });
 });

--- a/sdks/cpp/examples/robotics_example.c
+++ b/sdks/cpp/examples/robotics_example.c
@@ -280,6 +280,13 @@ int main(int argc, char **argv) {
     free(satisfied);
     free(total);
 
+    /* CONFORMS says the evidence covers the clauses this profile maps, which is
+     * a weaker claim than compliance with the regulation. Every report carries
+     * how well-sourced its clause numbers are, so the two never get conflated. */
+    char *citations = json_value(report, "citations");
+    printf("  citations: %s\n", citations);
+    free(citations);
+
     /* Sign a point-in-time attestation over that report, then verify it. */
     size_t att_len = strlen(report) + 512;
     char *att_params = malloc(att_len);

--- a/sdks/cpp/examples/robotics_verify_example.cpp
+++ b/sdks/cpp/examples/robotics_verify_example.cpp
@@ -154,10 +154,16 @@ int main(int argc, char** argv) {
   //    per profile, then one signed attestation per profile.
   std::printf("\nconformance across the five profiles:\n");
   int attested = 0;
+  int cited = 0;
   for (const char* pid : kAllProfileIds) {
     const std::string report = vouch::robotics::check_conformance(credentials, pid);
     const bool conforms = contains(report, "\"conforms\":true");
     std::printf("  %-24s %s\n", pid, conforms ? "CONFORMS" : "GAPS");
+
+    // CONFORMS says the evidence covers the clauses this profile maps, which
+    // is weaker than compliance with the regulation. Every report states how
+    // well-sourced its clause references are.
+    if (contains(report, "\"citations\":")) cited++;
 
     const std::string params =
         std::string("{\"issuerDid\":\"did:web:assessor.example.com\",") +
@@ -170,6 +176,7 @@ int main(int argc, char** argv) {
     if (att_subject != "null" && contains(att_subject, pid)) attested++;
   }
   std::printf("signed attestations verified: %d/5\n", attested);
+  std::printf("reports carrying clause-citation provenance: %d/5\n", cited);
 
   // 3. The VLA pre-actuation scope gate: allow the safe actions, deny the
   //    over-speed and out-of-zone ones.
@@ -202,7 +209,7 @@ int main(int argc, char** argv) {
     std::printf("  [%s] %s\n", ok ? "ALLOW" : "DENY ", c.task);
   }
 
-  const bool all_ok = identity_ok && proof_ok && attested == 5 && gate_ok;
+  const bool all_ok = identity_ok && proof_ok && attested == 5 && cited == 5 && gate_ok;
   std::printf("\n%s\n", all_ok ? "ALL ROBOTICS VERIFY EXAMPLE CHECKS PASSED"
                                : "SOME CHECKS FAILED");
   return all_ok ? 0 : 1;

--- a/sdks/cpp/test/test_robotics.cpp
+++ b/sdks/cpp/test/test_robotics.cpp
@@ -210,6 +210,28 @@ int main() {
     std::string report = vouch::robotics::check_conformance(credentials, "eu-ai-act-high-risk");
     check(report.find("\"conforms\":true") != std::string::npos, "profile conforms");
     check(report.find("\"totalCount\":4") != std::string::npos, "four requirements counted");
+    // CONFORMS says the evidence covers the clauses this profile maps, which
+    // is weaker than compliance with the regulation. Every report states how
+    // well-sourced its clause references are.
+    check(report.find("\"unverified-secondary\":4") != std::string::npos,
+          "clause-citation provenance reported");
+
+    // A heartbeat that reports an envelope breach is not evidence of having
+    // stayed inside the envelope: presence alone must not satisfy the
+    // continuous-monitoring requirement.
+    std::string breaching =
+        "[{\"type\":[\"VerifiableCredential\",\"RobotHeartbeatCredential\"],"
+        "\"credentialSubject\":{\"motionDigest\":{\"withinEnvelope\":false}}}]";
+    std::string breach_report =
+        vouch::robotics::check_conformance(breaching, "iso-ts-15066");
+    check(breach_report.find("\"conforms\":true") == std::string::npos,
+          "a breaching heartbeat does not evidence monitoring");
+
+    // UL 3300 is paywalled with no clause numbering available, so its entries
+    // must never present as clauses an assessor can look up.
+    std::string ul = vouch::robotics::check_conformance(credentials, "ul-3300");
+    check(ul.find("\"descriptive\":4") != std::string::npos,
+          "ul-3300 clauses are descriptive, not citable");
   }
 
   // The remaining checks drive the curated robotics C ABI against the shared

--- a/sdks/dotnet/VouchCore.Tests/RoboticsVerifyExampleTests.cs
+++ b/sdks/dotnet/VouchCore.Tests/RoboticsVerifyExampleTests.cs
@@ -108,7 +108,34 @@ public class RoboticsVerifyExampleTests
                 // profiles report the open clause.
                 Assert.False(conforms);
             }
+
+            // CONFORMS says the evidence covers the clauses this profile maps,
+            // which is weaker than compliance with the regulation. Every report
+            // states how well-sourced its clause references are, and the counts
+            // must add up to the number of requirements checked.
+            JsonElement citations = report.RootElement.GetProperty("citations");
+            int counted = 0;
+            foreach (JsonProperty bucket in citations.EnumerateObject())
+            {
+                counted += bucket.Value.GetInt32();
+            }
+            Assert.Equal(report.RootElement.GetProperty("totalCount").GetInt32(), counted);
         }
+    }
+
+    [Fact]
+    public void Ul3300ClausesAreDescriptiveNotCitable()
+    {
+        // UL 3300 is paywalled and no clause numbering was available, so the
+        // profile must never present its topic names as clauses an assessor
+        // can look up.
+        using var report = JsonDocument.Parse(
+            VouchRobotics.CheckConformance(CredentialsJson(), "ul-3300"));
+        JsonElement citations = report.RootElement.GetProperty("citations");
+        Assert.Equal(
+            report.RootElement.GetProperty("totalCount").GetInt32(),
+            citations.GetProperty("descriptive").GetInt32());
+        Assert.Equal(0, citations.GetProperty("verified-primary").GetInt32());
     }
 
     [Fact]

--- a/sdks/jvm/src/test/java/com/vouchprotocol/core/RoboticsVerifyExampleTest.java
+++ b/sdks/jvm/src/test/java/com/vouchprotocol/core/RoboticsVerifyExampleTest.java
@@ -3,6 +3,7 @@ package com.vouchprotocol.core;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.nio.charset.StandardCharsets;
@@ -112,7 +113,36 @@ class RoboticsVerifyExampleTest {
                 // attestation, so these profiles report the open clause.
                 assertFalse(conforms, pid + " should report gaps: " + report);
             }
+
+            // CONFORMS says the evidence covers the clauses this profile maps,
+            // which is weaker than compliance with the regulation. Every report
+            // states how well-sourced its clause references are, and the counts
+            // must add up to the number of requirements checked.
+            @SuppressWarnings("unchecked")
+            Map<String, Object> citations = (Map<String, Object>) report.get("citations");
+            assertNotNull(citations, pid + " must report its clause-citation provenance");
+            int counted = 0;
+            for (Object n : citations.values()) {
+                counted += ((Number) n).intValue();
+            }
+            assertEquals(((Number) report.get("totalCount")).intValue(), counted,
+                    pid + " citation counts must total its requirements: " + citations);
         }
+    }
+
+    @Test
+    void ul3300ClausesAreDescriptiveNotCitable() {
+        // UL 3300 is paywalled and no clause numbering was available, so the
+        // profile must never present its topic names as clauses an assessor
+        // can look up.
+        Map<String, Object> report = Json.parseObject(
+                VouchRobotics.checkConformance(credentialsJson(), "ul-3300"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> citations = (Map<String, Object>) report.get("citations");
+        assertEquals(((Number) report.get("totalCount")).intValue(),
+                ((Number) citations.get("descriptive")).intValue(), citations.toString());
+        assertEquals(0, ((Number) citations.get("verified-primary")).intValue(),
+                citations.toString());
     }
 
     @Test

--- a/sdks/swift/Tests/VouchCoreTests/RoboticsVerifyExampleTests.swift
+++ b/sdks/swift/Tests/VouchCoreTests/RoboticsVerifyExampleTests.swift
@@ -71,7 +71,26 @@ final class RoboticsVerifyExampleTests: XCTestCase {
             } else {
                 XCTAssertTrue(report.contains("\"conforms\":true"), "\(pid): \(report)")
             }
+
+            // CONFORMS says the evidence covers the clauses this profile maps,
+            // which is weaker than compliance with the regulation. Every report
+            // states how well-sourced its clause references are.
+            XCTAssertTrue(report.contains("\"citations\":"), "\(pid): \(report)")
         }
+    }
+
+    func testUl3300ClausesAreDescriptiveNotCitable() throws {
+        // UL 3300 is paywalled and no clause numbering was available, so the
+        // profile must never present its topic names as clauses an assessor
+        // can look up.
+        let v = try vector()
+        let credentials = try jsonString(v["conformance_credentials"]!)
+        let report = try VouchRobotics.checkConformance(
+            credentialsJson: credentials,
+            profileId: "ul-3300"
+        )
+        XCTAssertTrue(report.contains("\"descriptive\":4"), report)
+        XCTAssertTrue(report.contains("\"verified-primary\":0"), report)
     }
 
     func testSignsAndVerifiesOneAttestationPerProfile() throws {

--- a/test-vectors/robotics/vector.json
+++ b/test-vectors/robotics/vector.json
@@ -397,34 +397,47 @@
     "conforms": true,
     "satisfiedCount": 4,
     "totalCount": 4,
+    "citations": {
+      "verified-primary": 0,
+      "unverified-secondary": 4,
+      "descriptive": 0
+    },
     "requirements": [
       {
         "id": "eu-aia-record-keeping",
         "clause": "Reg (EU) 2024/1689, Art. 12",
         "title": "Automatic recording of events (logging)",
-        "satisfied": true
+        "satisfied": true,
+        "citation": "unverified-secondary",
+        "citationNote": "Article number taken from a third-party reproduction of the Official Journal text, not from EUR-Lex itself."
       },
       {
         "id": "eu-aia-transparency",
         "clause": "Reg (EU) 2024/1689, Art. 13",
         "title": "Model and configuration transparency",
-        "satisfied": true
+        "satisfied": true,
+        "citation": "unverified-secondary",
+        "citationNote": "Article number taken from a third-party reproduction of the Official Journal text, not from EUR-Lex itself."
       },
       {
         "id": "eu-aia-human-oversight",
         "clause": "Reg (EU) 2024/1689, Art. 14",
         "title": "Human oversight through enforced operating limits",
-        "satisfied": true
+        "satisfied": true,
+        "citation": "unverified-secondary",
+        "citationNote": "Article number taken from a third-party reproduction of the Official Journal text, not from EUR-Lex itself. Art. 14 also requires a means for the overseer to intervene or stop the system, which an operating-limit scope alone does not evidence."
       },
       {
         "id": "eu-aia-accuracy-robustness",
         "clause": "Reg (EU) 2024/1689, Art. 15",
         "title": "Accuracy and robustness traceable to a known build",
-        "satisfied": true
+        "satisfied": true,
+        "citation": "unverified-secondary",
+        "citationNote": "Article number taken from a third-party reproduction of the Official Journal text, not from EUR-Lex itself."
       }
     ]
   },
-  "expected_conformance_report_digest": "uMuWAsxwdw8uZVkWugGE5LTh6hHB0NVvqGm-fcXaO6zs",
+  "expected_conformance_report_digest": "u3UyS_2gIlWA89dQ7nQBYLBV2vV2ls3PQMM4jyhnVZu4",
   "pq_robot_identity_credential": {
     "@context": [
       "https://www.w3.org/ns/credentials/v2",

--- a/tests/test_robot_conformance.py
+++ b/tests/test_robot_conformance.py
@@ -15,7 +15,12 @@ from vouch.robotics import (
     report_digest,
     verify_conformance_attestation,
 )
-from vouch.robotics.conformance import _path_value
+from vouch.robotics.conformance import (
+    CITATION_DESCRIPTIVE,
+    CITATION_STATUSES,
+    _path_value,
+    _req,
+)
 from vouch.robotics.identity import RoboticsError, SoftwareRootOfTrust
 from vouch.robotics.safety_record import SafetyEventLog
 
@@ -64,9 +69,26 @@ class TestProfiles(unittest.TestCase):
                     self.assertIn(key, req)
 
     def test_profile_lookup_and_unknown(self):
-        self.assertEqual(profile("iso-10218")["version"], "2011")
+        self.assertTrue(profile("iso-10218")["version"].startswith("2011"))
         with self.assertRaises(RoboticsError):
             profile("does-not-exist")
+
+    def test_every_requirement_declares_its_citation_provenance(self):
+        # A crosswalk is only as authoritative as its sources, so every
+        # requirement says where its clause number came from.
+        for prof in PROFILES.values():
+            for req in prof["requirements"]:
+                self.assertIn(req["citation"], CITATION_STATUSES)
+
+    def test_ul_3300_citations_are_descriptive_not_clauses(self):
+        # UL 3300 is paywalled and no clause numbering was available, so the
+        # profile must not present its topic names as citable clauses.
+        for req in PROFILES["ul-3300"]["requirements"]:
+            self.assertEqual(req["citation"], CITATION_DESCRIPTIVE)
+
+    def test_unknown_citation_status_is_rejected(self):
+        with self.assertRaises(RoboticsError):
+            _req("x", "clause", "title", "SomeCredential", citation="looks-official")
 
 
 class TestChecker(unittest.TestCase):
@@ -117,6 +139,20 @@ class TestChecker(unittest.TestCase):
         b = check_conformance(self.creds, "iso-ts-15066")
         self.assertEqual(report_digest(a), report_digest(b))
 
+    def test_report_totals_the_citation_provenance_of_its_requirements(self):
+        report = check_conformance(self.creds, "eu-ai-act-high-risk")
+        self.assertEqual(sum(report["citations"].values()), report["totalCount"])
+        self.assertEqual(set(report["citations"]), set(CITATION_STATUSES))
+        for result in report["requirements"]:
+            self.assertIn(result["citation"], CITATION_STATUSES)
+
+    def test_a_conforming_ul_3300_report_still_says_its_clauses_are_descriptive(self):
+        # The point of the summary: a reader sees CONFORMS and, right beside
+        # it, that no clause in the profile can actually be looked up.
+        report = check_conformance(self.creds, "ul-3300")
+        self.assertEqual(report["citations"][CITATION_DESCRIPTIVE], report["totalCount"])
+        self.assertEqual(report["citations"]["verified-primary"], 0)
+
     def test_path_value_helper(self):
         subject = {"physicalScope": {"maxForceN": 80.0, "allowedZones": []}}
         self.assertEqual(_path_value(subject, "physicalScope.maxForceN"), 80.0)
@@ -140,6 +176,9 @@ class TestAttestation(unittest.TestCase):
         self.assertTrue(subject["conforms"])
         self.assertEqual(subject["profileId"], "iso-10218")
         self.assertEqual(subject["reportDigest"], report_digest(report))
+        # The citation summary travels with the signed attestation, so a
+        # consumer reading only the subject still sees how well-sourced it is.
+        self.assertEqual(subject["citations"], report["citations"])
 
     def test_wrong_key_rejected(self):
         report = check_conformance(self.creds, "iso-10218")

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -1069,8 +1069,8 @@ def robot_check_conformance(credentials_json: str, profile_id: str) -> str:
         profile_id: One of the built-in profile ids listed above.
 
     Returns:
-        'CONFORMS' or 'GAPS' with the satisfied count and one line per
-        requirement clause.
+        'CONFORMS' or 'GAPS' with the satisfied count, how well-sourced the
+        profile's clause references are, and one line per requirement clause.
     """
     from vouch.robotics import check_conformance
 
@@ -1091,6 +1091,17 @@ def robot_check_conformance(credentials_json: str, profile_id: str) -> str:
         f"{verdict}: {report['satisfiedCount']}/{report['totalCount']} requirements "
         f"of {report['regime']} ({report['profileId']})."
     ]
+    # CONFORMS means the evidence covers the clauses this profile maps, which is
+    # weaker than compliance with the regulation. Reporting how well-sourced the
+    # clause references are keeps a model from overstating the result.
+    citations = report.get("citations") or {}
+    summary = ", ".join(
+        f"{citations[status]} {status}"
+        for status in ("descriptive", "unverified-secondary", "verified-primary")
+        if citations.get(status)
+    )
+    if summary:
+        lines.append(f"Clause citations: {summary}.")
     for req in report["requirements"]:
         mark = "satisfied" if req["satisfied"] else "GAP"
         lines.append(f"  [{mark}] {req['clause']}: {req['title']}")

--- a/vouch/robotics/conformance.py
+++ b/vouch/robotics/conformance.py
@@ -47,6 +47,22 @@ CONFORMANCE_ATTESTATION_TYPE = "RobotConformanceAttestation"
 # Profiles are plain data so every language reproduces them identically.
 
 
+# How well-sourced a requirement's clause citation is. A profile can be a
+# useful crosswalk while its citations are only as good as the sources that
+# were available, and a reader is entitled to know which. Every report and
+# every signed attestation carries these, so a conformance result never implies
+# more authority over the regulation than it has.
+CITATION_VERIFIED_PRIMARY = "verified-primary"
+CITATION_UNVERIFIED_SECONDARY = "unverified-secondary"
+CITATION_DESCRIPTIVE = "descriptive"
+
+CITATION_STATUSES = (
+    CITATION_VERIFIED_PRIMARY,
+    CITATION_UNVERIFIED_SECONDARY,
+    CITATION_DESCRIPTIVE,
+)
+
+
 def _req(
     rid: str,
     clause: str,
@@ -54,27 +70,73 @@ def _req(
     credential: str,
     fields: Optional[List[str]] = None,
     expect: Optional[Dict[str, Any]] = None,
+    citation: str = CITATION_UNVERIFIED_SECONDARY,
+    citation_note: Optional[str] = None,
 ):
     """
-    One requirement. `fields` must all be present and non-empty; `expect` maps a
-    path to the exact value it must hold, for requirements where mere presence
-    is not evidence (a heartbeat that reports an envelope breach is not evidence
-    of staying inside the envelope).
+    One requirement.
+
+    `fields` must all be present and non-empty; `expect` maps a path to the
+    exact value it must hold, for requirements where mere presence is not
+    evidence (a heartbeat that reports an envelope breach is not evidence of
+    staying inside the envelope).
+
+    `citation` records how well-sourced the clause reference is:
+
+      verified-primary       the clause text was read from the official
+                             published source.
+      unverified-secondary   the mapping is believed sound, but the clause
+                             number comes from secondary sources rather than
+                             the standard or official journal itself. The
+                             default, because it is the honest default.
+      descriptive            not a clause reference at all, only a description
+                             of the topic. An assessor cannot look it up.
+
+    `citation_note` records anything a reader should know about the citation,
+    such as a known conflict between sources.
     """
-    return {
+    if citation not in CITATION_STATUSES:
+        raise RoboticsError(f"citation must be one of {CITATION_STATUSES}, got {citation!r}")
+    requirement = {
         "id": rid,
         "clause": clause,
         "title": title,
         "credential": credential,
         "fields": fields or [],
         "expect": expect or {},
+        "citation": citation,
     }
+    if citation_note is not None:
+        requirement["citationNote"] = citation_note
+    return requirement
+
+
+_ISO_10218_EDITION_NOTE = (
+    "ISO 10218-1/-2:2011 were superseded by the 2025 editions (in force "
+    "1 April 2025); this mapping still cites the 2011 clause numbering and has "
+    "not been migrated."
+)
+
+_ISO_PAYWALL_NOTE = (
+    "Clause number taken from secondary sources; the standard is paywalled and "
+    "the text has not been read."
+)
+
+_OJ_NOTE = (
+    "Article number taken from a third-party reproduction of the Official "
+    "Journal text, not from EUR-Lex itself."
+)
+
+_UL_NOTE = (
+    "UL 3300 (now ANSI/CAN/UL 3300:2024) is paywalled and no clause numbering "
+    "was available; this names the topic only and cannot be looked up."
+)
 
 
 PROFILES: Dict[str, Dict[str, Any]] = {
     "iso-10218": {
         "regime": "ISO 10218-1/-2 industrial robots",
-        "version": "2011",
+        "version": "2011 (superseded by the 2025 editions; mapping not yet migrated)",
         "requirements": [
             _req(
                 "iso10218-identification",
@@ -82,6 +144,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Robot identification bound to its hardware",
                 "RobotIdentityCredential",
                 ["hardwareRoot.kind", "hardwareRoot.attestation"],
+                citation_note=f"{_ISO_PAYWALL_NOTE} {_ISO_10218_EDITION_NOTE}",
             ),
             _req(
                 "iso10218-software-integrity",
@@ -89,6 +152,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Control software and configuration integrity",
                 "ModelProvenanceAttestation",
                 ["vla.weightsHash"],
+                citation_note=f"{_ISO_PAYWALL_NOTE} {_ISO_10218_EDITION_NOTE}",
             ),
             _req(
                 "iso10218-limits",
@@ -100,6 +164,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                     "physicalScope.maxSpeedMps",
                     "physicalScope.allowedZones",
                 ],
+                citation_note=f"{_ISO_PAYWALL_NOTE} {_ISO_10218_EDITION_NOTE}",
             ),
             _req(
                 "iso10218-records",
@@ -107,6 +172,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Records of safety-relevant events",
                 "RobotSafetyRecordCredential",
                 ["totalEvents", "logHead"],
+                citation_note=f"{_ISO_PAYWALL_NOTE} {_ISO_10218_EDITION_NOTE}",
             ),
         ],
     },
@@ -120,6 +186,11 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Power and force limiting near humans",
                 "PhysicalCapabilityScope",
                 ["physicalScope.maxSpeedNearHumansMps", "physicalScope.maxForceN"],
+                citation_note=(
+                    f"{_ISO_PAYWALL_NOTE} Secondary sources disagree on whether "
+                    "power and force limiting is 5.5.4 or 5.5.2; confirm against "
+                    "the published table of contents before relying on the number."
+                ),
             ),
             _req(
                 "iso15066-collaborative-workspace",
@@ -127,6 +198,10 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Defined collaborative workspace",
                 "PhysicalCapabilityScope",
                 ["physicalScope.allowedZones"],
+                citation_note=(
+                    f"{_ISO_PAYWALL_NOTE} Shares the unresolved 5.5.2/5.5.4 "
+                    "numbering conflict with iso15066-power-force-limiting."
+                ),
             ),
             _req(
                 "iso15066-monitoring",
@@ -135,6 +210,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "RobotHeartbeatCredential",
                 ["motionDigest"],
                 expect={"motionDigest.withinEnvelope": True},
+                citation_note=_ISO_PAYWALL_NOTE,
             ),
         ],
     },
@@ -148,6 +224,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Machinery identification and traceability",
                 "RobotIdentityCredential",
                 ["make", "model", "serial"],
+                citation_note=_OJ_NOTE,
             ),
             _req(
                 "eu-mr-software-integrity",
@@ -155,6 +232,11 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Protection against corruption of safety software",
                 "ModelProvenanceAttestation",
                 ["vla.weightsHash", "vla.safetyPolicy"],
+                citation_note=(
+                    f"{_OJ_NOTE} The Annex III subclause for protection against "
+                    "corruption has not been confirmed and may need to be "
+                    "re-pointed."
+                ),
             ),
             _req(
                 "eu-mr-safe-limits",
@@ -162,6 +244,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Safety and reliability of control systems and limits",
                 "PhysicalCapabilityScope",
                 ["physicalScope.maxForceN"],
+                citation_note=_OJ_NOTE,
             ),
             _req(
                 "eu-mr-records",
@@ -169,6 +252,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Recording of safety-relevant data",
                 "RobotSafetyRecordCredential",
                 ["totalEvents", "logHead"],
+                citation_note=_OJ_NOTE,
             ),
         ],
     },
@@ -182,6 +266,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Automatic recording of events (logging)",
                 "RobotSafetyRecordCredential",
                 ["logHead"],
+                citation_note=_OJ_NOTE,
             ),
             _req(
                 "eu-aia-transparency",
@@ -189,6 +274,7 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Model and configuration transparency",
                 "ModelProvenanceAttestation",
                 ["vla.modelName", "vla.configHash"],
+                citation_note=_OJ_NOTE,
             ),
             _req(
                 "eu-aia-human-oversight",
@@ -196,6 +282,11 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Human oversight through enforced operating limits",
                 "PhysicalCapabilityScope",
                 ["physicalScope.maxSpeedNearHumansMps"],
+                citation_note=(
+                    f"{_OJ_NOTE} Art. 14 also requires a means for the overseer "
+                    "to intervene or stop the system, which an operating-limit "
+                    "scope alone does not evidence."
+                ),
             ),
             _req(
                 "eu-aia-accuracy-robustness",
@@ -203,12 +294,13 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Accuracy and robustness traceable to a known build",
                 "ModelProvenanceAttestation",
                 ["vla.weightsHash"],
+                citation_note=_OJ_NOTE,
             ),
         ],
     },
     "ul-3300": {
         "regime": "UL 3300 service, communication, and mobile robots",
-        "version": "2022",
+        "version": "2022 (see ANSI/CAN/UL 3300:2024)",
         "requirements": [
             _req(
                 "ul3300-identity",
@@ -216,6 +308,8 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Robot identity bound to its hardware",
                 "RobotIdentityCredential",
                 ["hardwareRoot.kind", "hardwareRoot.attestation"],
+                citation=CITATION_DESCRIPTIVE,
+                citation_note=_UL_NOTE,
             ),
             _req(
                 "ul3300-operating-limits",
@@ -223,6 +317,8 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Enforced speed and zone limits",
                 "PhysicalCapabilityScope",
                 ["physicalScope.maxSpeedMps", "physicalScope.allowedZones"],
+                citation=CITATION_DESCRIPTIVE,
+                citation_note=_UL_NOTE,
             ),
             _req(
                 "ul3300-perception-integrity",
@@ -230,6 +326,8 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Integrity of perception used for safe operation",
                 "PerceptionProvenanceCredential",
                 ["frameHash"],
+                citation=CITATION_DESCRIPTIVE,
+                citation_note=_UL_NOTE,
             ),
             _req(
                 "ul3300-records",
@@ -237,6 +335,8 @@ PROFILES: Dict[str, Dict[str, Any]] = {
                 "Records of safety-relevant incidents",
                 "RobotSafetyRecordCredential",
                 ["totalEvents", "logHead"],
+                citation=CITATION_DESCRIPTIVE,
+                citation_note=_UL_NOTE,
             ),
         ],
     },
@@ -295,28 +395,40 @@ def check_conformance(
     expected to have verified the credentials' signatures first; this checks
     structure and coverage, not proofs.
 
+    Every requirement carries the provenance of its clause citation, and the
+    report totals them, so a result never reads as more authoritative about the
+    regulation than its sources are.
+
     The report is:
       {
         "profileId", "regime", "version",
         "conforms": bool, "satisfiedCount", "totalCount",
-        "requirements": [{"id", "clause", "title", "satisfied"}],
+        "citations": {"verified-primary", "unverified-secondary", "descriptive"},
+        "requirements": [
+          {"id", "clause", "title", "satisfied", "citation", "citationNote"?}
+        ],
       }
     """
     prof = profile(profile_id)
     results: List[Dict[str, Any]] = []
     satisfied = 0
+    citations = {status: 0 for status in CITATION_STATUSES}
     for requirement in prof["requirements"]:
         ok = any(_credential_satisfies(c, requirement) for c in credentials)
         if ok:
             satisfied += 1
-        results.append(
-            {
-                "id": requirement["id"],
-                "clause": requirement["clause"],
-                "title": requirement["title"],
-                "satisfied": ok,
-            }
-        )
+        citation = requirement.get("citation", CITATION_UNVERIFIED_SECONDARY)
+        citations[citation] += 1
+        result = {
+            "id": requirement["id"],
+            "clause": requirement["clause"],
+            "title": requirement["title"],
+            "satisfied": ok,
+            "citation": citation,
+        }
+        if requirement.get("citationNote") is not None:
+            result["citationNote"] = requirement["citationNote"]
+        results.append(result)
     total = len(prof["requirements"])
     return {
         "profileId": profile_id,
@@ -325,6 +437,7 @@ def check_conformance(
         "conforms": satisfied == total,
         "satisfiedCount": satisfied,
         "totalCount": total,
+        "citations": citations,
         "requirements": results,
     }
 
@@ -365,6 +478,7 @@ def build_conformance_attestation(
         "conforms": report["conforms"],
         "satisfiedCount": report["satisfiedCount"],
         "totalCount": report["totalCount"],
+        "citations": report.get("citations", {}),
         "reportDigest": report_digest(report),
         "report": report,
     }
@@ -418,6 +532,10 @@ def _iso(dt: datetime) -> str:
 
 __all__ = [
     "CONFORMANCE_ATTESTATION_TYPE",
+    "CITATION_VERIFIED_PRIMARY",
+    "CITATION_UNVERIFIED_SECONDARY",
+    "CITATION_DESCRIPTIVE",
+    "CITATION_STATUSES",
     "PROFILES",
     "profile",
     "check_conformance",


### PR DESCRIPTION
## Description

A conformance report said CONFORMS without saying how well-sourced the clauses it checked actually are. A `ul-3300 CONFORMS (4/4)` read exactly as authoritative as a result grounded in clause text somebody had actually read — and the signed attestation carried that appearance offline with it. The doubts were recorded only in `docs/robotics-conformance-crosswalk.md`, a document the consumer of a report never opens.

Provenance is now part of the report. Each requirement declares where its clause reference came from, the report totals them, and the attestation subject carries the summary so it cannot be dropped in transit.

| Status | Meaning |
|---|---|
| `verified-primary` | The clause text was read from the official published source. |
| `unverified-secondary` | The mapping is believed sound, but the clause number comes from secondary sources rather than the standard or Official Journal itself. The default. |
| `descriptive` | Not a clause reference at all, only a description of the topic. An assessor cannot look it up. |

As of this change **no built-in requirement is `verified-primary`.** Fifteen are `unverified-secondary`; the four UL 3300 entries are `descriptive`. An optional `citationNote` records the specifics — the unresolved ISO/TS 15066 5.5.2/5.5.4 conflict, the superseded ISO 10218 editions, the unconfirmed Machinery Annex III subclause, and that Art. 14 also requires a means to intervene that an operating-limit scope alone does not evidence. The two misleading `version` strings are now explicit rather than silently current.

The evidence pack prints it beside the verdict:

```
  ul-3300                  CONFORMS (4/4)  UL 3300 service, communication, and mobile robots
    citations: 4 descriptive
```

**This also completes a fix that shipped incomplete.** The Rust core carried the `expect_true` data added in #390 for the continuous-monitoring value assertion, but its checker never read it. The assertion held in Python, TypeScript and Go while Rust — and therefore the C ABI, WASM, Swift, JVM, .NET and C++ — still accepted a heartbeat reporting an envelope breach as evidence of having stayed inside the envelope. The Rust checker now enforces it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Completes the ISO/TS 15066, ISO 10218 edition and UL 3300 citation concerns raised in the crosswalk (P7, P8 and the 15066 numbering), by making them machine-readable rather than by asserting clause numbers that could not be checked.

## Changes Made

- Citation provenance on all 19 requirements, ported identically to Python, TypeScript, Go and the Rust core.
- `citations` summary in the report and in the signed attestation subject; per-requirement `citation` and optional `citationNote`.
- Rust checker enforces `expect_true`, closing the continuous-monitoring gap across the six surfaces built on it.
- `iso-10218` and `ul-3300` version strings state their edition situation.
- Citation summary surfaced in the Python, TypeScript, Go, Rust, WASM, C and C++ examples, and in the MCP `robot_check_conformance` tool.
- Crosswalk and assessor one-pager updated, including a correction: the crosswalk previously claimed P5 shipped in the Rust core.
- Interop vector updated in place, so the diff is the report shape alone rather than a full regeneration.

## Testing

- [x] Existing tests pass (`pytest tests/`) — 1377 passed, 6 skipped
- [x] New tests added for new functionality
- [x] Manual testing performed

All four implementations produce **identical report digests for all five profiles**, verified directly. Suites run locally: Python, TypeScript (406), Go, Rust core, JVM (`RoboticsVerifyExampleTest` 4 → 5 tests), C++ core tests, both C/C++ examples, and the WASM harness (12 passed). Regression coverage for the breaching-heartbeat gap in the Rust core and across the C ABI.

.NET and Swift assertions mirror the JVM ones but were **not executed locally** — no `dotnet` or `swift` toolchain in this environment. CI covers both, including the Swift job added in #392.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] I have added tests for new functionality
- [x] All tests pass locally
- [x] My commits are signed off (DCO)


---
_Generated by [Claude Code](https://claude.ai/code/session_019Se9bMrksZcQDect8FBRDd)_