### PR TITLE
feat(website): show clause-citation provenance beside every CONFORMS verdict

### DIFF
--- a/core/wasm/Cargo.lock
+++ b/core/wasm/Cargo.lock
@@ -905,7 +905,7 @@ dependencies = [
 
 [[package]]
 name = "vouch-core-wasm"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "base64",
  "getrandom",

--- a/core/wasm/Cargo.toml
+++ b/core/wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vouch-core-wasm"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 authors = ["Ramprasad Anandam Gaddam"]
 description = "Vouch Protocol core, WASM build (browser + Node): JCS canonicalization, Ed25519, did:key/multikey, Data Integrity (eddsa-jcs-2022), credentials, delegation, dual-proof ML-DSA-44, and BitstringStatusList revocation. Thin wasm-bindgen wrapper over the canonical vouch-core crate."

--- a/website/src/app/demos/robotics/RoboticsDemos.tsx
+++ b/website/src/app/demos/robotics/RoboticsDemos.tsx
@@ -652,14 +652,33 @@ const PACK_SCENARIOS: Array<{ id: PackScenario; label: string }> = [
   { id: 'noscope', label: 'Omit the physical capability scope' },
 ];
 
+/* How well-sourced a profile's clause references are, mirroring the `citations`
+ * summary every conformance report and signed attestation now carries. No
+ * built-in profile is verified-primary today: the ISO standards and UL 3300 are
+ * paywalled, and the EU texts were read from a third-party reproduction rather
+ * than EUR-Lex. Showing this beside CONFORMS keeps the demo from implying an
+ * authority over the regulation that the mapping does not have. */
+const CITATIONS: Record<string, { label: string; note: string }> = {
+  'unverified-secondary': {
+    label: 'unverified-secondary',
+    note: 'clause numbers from secondary sources, not the standard or Official Journal itself',
+  },
+  descriptive: {
+    label: 'descriptive',
+    note: 'topic names only; the standard is paywalled and no clause numbering was available',
+  },
+};
+
 const PACK_PROFILES: Array<{
   id: string;
   regime: string;
+  citation: keyof typeof CITATIONS;
   results: Record<PackScenario, { satisfied: number; total: number; gap?: string }>;
 }> = [
   {
     id: 'eu-ai-act-high-risk',
     regime: 'EU AI Act high-risk',
+    citation: 'unverified-secondary',
     results: {
       full: { satisfied: 4, total: 4 },
       base: { satisfied: 4, total: 4 },
@@ -669,6 +688,7 @@ const PACK_PROFILES: Array<{
   {
     id: 'iso-10218',
     regime: 'ISO 10218-1/-2',
+    citation: 'unverified-secondary',
     results: {
       full: { satisfied: 4, total: 4 },
       base: { satisfied: 4, total: 4 },
@@ -678,6 +698,7 @@ const PACK_PROFILES: Array<{
   {
     id: 'iso-ts-15066',
     regime: 'ISO/TS 15066 collaborative',
+    citation: 'unverified-secondary',
     results: {
       full: { satisfied: 3, total: 3 },
       base: { satisfied: 2, total: 3, gap: '5.2 continuous monitoring: no heartbeat motion digest' },
@@ -687,6 +708,7 @@ const PACK_PROFILES: Array<{
   {
     id: 'eu-machinery-2023-1230',
     regime: 'EU Machinery Regulation',
+    citation: 'unverified-secondary',
     results: {
       full: { satisfied: 4, total: 4 },
       base: { satisfied: 4, total: 4 },
@@ -696,6 +718,7 @@ const PACK_PROFILES: Array<{
   {
     id: 'ul-3300',
     regime: 'UL 3300 service robots',
+    citation: 'descriptive',
     results: {
       full: { satisfied: 4, total: 4 },
       base: { satisfied: 3, total: 4, gap: 'sensing integrity: no perception provenance' },
@@ -736,6 +759,7 @@ function EvidencePack() {
         {PACK_PROFILES.map((p) => {
           const r = p.results[scenario];
           const conforms = r.satisfied === r.total;
+          const cite = CITATIONS[p.citation];
           return (
             <div key={p.id} className={styles.card}>
               <div className={styles.cardLabel}>{p.regime}</div>
@@ -748,6 +772,11 @@ function EvidencePack() {
                 </span>
                 <span className={styles.reason}>{conforms ? 'every clause satisfied' : r.gap}</span>
               </div>
+              <div className={styles.mono}>
+                citations: {r.total} {cite.label}
+                <br />
+                {cite.note}
+              </div>
             </div>
           );
         })}
@@ -756,6 +785,14 @@ function EvidencePack() {
             {conformCount === 5
               ? 'All five attestations sign and verify offline; each binds the full report by digest.'
               : `${conformCount}/5 profiles conform; a signed attestation records the gaps for the rest.`}
+          </span>
+        </div>
+        <div className={styles.verdict}>
+          <span className={styles.reason}>
+            CONFORMS means the evidence covers the clauses this profile maps, which is a weaker claim than
+            compliance with the regulation. Every report and every signed attestation carries the provenance of
+            its clause references, so a result never implies an authority over the regulation that the mapping
+            does not have. No built-in profile is verified-primary today.
           </span>
         </div>
       </div>

--- a/website/src/app/faq/faq-data.ts
+++ b/website/src/app/faq/faq-data.ts
@@ -809,6 +809,16 @@ The four CLI commands are \`vouch root init\`, \`vouch root recognize\`, \`vouch
         a: `No. The profiles are a reference crosswalk to make conformance verifiable in the open. A deployment confirms each mapping against the current text of the regulation for its market before relying on it.`,
         meta: 'Shipped - vouch.robotics.conformance',
       },
+      {
+        q: 'How do I know the clause numbers in a profile are right?',
+        a: `The report tells you. Every requirement declares the provenance of its clause reference, and the report totals them under \`citations\`: \`verified-primary\` means the clause text was read from the official published source, \`unverified-secondary\` means the clause number comes from secondary sources rather than the standard or Official Journal itself, and \`descriptive\` means the entry names a topic an assessor cannot look up. No built-in requirement is verified-primary today, because the ISO standards and UL 3300 are paywalled and the EU texts were read from a third-party reproduction; the four UL 3300 entries are descriptive. The summary travels inside the signed attestation, so a CONFORMS result never implies more authority over the regulation than its sources give it.`,
+        meta: 'Shipped - vouch.robotics.conformance',
+      },
+      {
+        q: 'Does CONFORMS mean my robot is compliant?',
+        a: `No. CONFORMS means the evidence covers the clauses this profile maps, which is a weaker claim than compliance with the regulation. It is not a certification and does not authorise CE marking; it produces evidence a conformity-assessment process can consume. A notified body's reading of the regulation governs.`,
+        meta: 'Shipped - vouch.robotics.conformance',
+      },
     ],
   },
 

--- a/website/src/app/help/help-data.ts
+++ b/website/src/app/help/help-data.ts
@@ -2995,11 +2995,14 @@ The problem it closes: regulators and operators need to know a robot meets ISO 1
 
 How it works: \`check_conformance(credentials, profile_id)\` walks the named profile and reports, for each requirement, whether the presented credentials satisfy it, citing the clause. An assessing party then signs an attestation over that report.
 
+Each requirement also declares how well-sourced its clause reference is, and the report totals them under \`citations\`: \`verified-primary\` (the clause text was read from the official published source), \`unverified-secondary\` (the clause number comes from secondary sources), or \`descriptive\` (a topic name an assessor cannot look up). No built-in profile is verified-primary today; the four UL 3300 requirements are descriptive. The summary travels inside the signed attestation, so CONFORMS never reads as more authoritative about the regulation than its sources are.
+
 \`\`\`python
 from vouch.robotics import check_conformance, build_conformance_attestation
 
 report = check_conformance([identity, provenance, scope, safety_record], "eu-ai-act-high-risk")
 print(report["conforms"], report["satisfiedCount"], "/", report["totalCount"])
+print(report["citations"])   # {'verified-primary': 0, 'unverified-secondary': 4, 'descriptive': 0}
 
 attestation = build_conformance_attestation(assessor_signer, robot_did=robot, report=report)
 \`\`\`
@@ -3227,9 +3230,12 @@ from vouch.robotics import check_conformance, build_conformance_attestation, ver
 
 for pid in ["eu-ai-act-high-risk", "iso-10218", "iso-ts-15066", "eu-machinery-2023-1230", "ul-3300"]:
     report = check_conformance(credentials, pid)
+    print(pid, report["conforms"], report["citations"])
     att = build_conformance_attestation(assessor, robot_did=robot_did, report=report)
     ok, subject = verify_conformance_attestation(att, assessor_key)
 \`\`\`
+
+What CONFORMS does and does not say: it means the evidence covers the clauses this profile maps, which is a weaker claim than compliance with the regulation. Every report carries a \`citations\` summary of how well-sourced its clause references are, and so does the signed attestation. The ISO standards and UL 3300 are paywalled and the EU texts were read from a third-party reproduction, so no built-in requirement is \`verified-primary\` today; \`docs/robotics-conformance-crosswalk.md\` records the specific doubts, clause by clause.
 
 Security boundary: the open layer is the declarative profiles, the deterministic checker, and the signed point-in-time attestation, demonstrated end to end in \`examples/robotics_ai_act_evidence_pack.py\`. Hosted continuous monitoring, maintained and certified profiles, and auditor evidence portals are commercial.
 `,


### PR DESCRIPTION
## Description

#393 stopped the library overstating its conformance results. The website had not caught up, and was left asserting exactly what the code now refuses to.

The robotics demo printed bare clause numbers beside a CONFORMS badge — `UL 3300 CONFORMS 4/4`, with no way for a visitor to learn that none of those four entries is a clause an assessor can look up. The help and FAQ copy described the report shape without the `citations` summary it now carries.

The demo renders provenance under each verdict, matching what the checker actually reports:

```
UL 3300 service robots        ✓ CONFORMS 4/4    every clause satisfied
citations: 4 descriptive
topic names only; the standard is paywalled and no clause numbering was available
```

## Type of Change

- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update

## Related Issues

Follows #393, which added the citation provenance to the checker, the report and the signed attestation.

## Changes Made

- `demos/robotics` — per-profile citation provenance under each verdict, plus a line on what CONFORMS does and does not claim.
- `help-data.ts` — documents the three statuses and prints `report["citations"]` in the worked example; a new paragraph separating "the evidence covers the mapped clauses" from "the robot complies with the regulation".
- `faq-data.ts` — two entries: how to judge a profile's clause numbers, and why CONFORMS is not compliance.
- `core/wasm` bumped to **2.2.0** so the published npm package carries the #393 fixes.

## Testing

- [x] Existing tests pass (`pytest tests/`) — 1377 passed, 6 skipped
- [x] Manual testing performed

`npm run build` succeeds and the static export carries the new copy — verified in `out/demos/robotics/index.html` that all five profiles render (`4 unverified-secondary` ×3, `3 unverified-secondary`, `4 descriptive`). `tsc --noEmit` clean. WASM 2.2.0 rebuilt and re-run: `smoke.mjs` 31/31, `robotics-examples.mjs` 12/12. Rust core suite green.

## Notes for the maintainer

**Two corrections to what I told you earlier, both in the cautious direction.**

The robotics demo's conformance table is a hardcoded `PACK_PROFILES` array, and the two demos that do load WASM (halos, root-of-trust) call black-box and safety-evidence functions, never `roboticsCheckConformance`. So no live page was exercising the checker, and my earlier claim that the live demo still accepted a breaching heartbeat was wrong. The WASM republish matters for downstream npm consumers, not for site correctness.

**`website/package.json` is deliberately still on `core-wasm@2.1.0`.** The website pins the version and its lockfile, so bumping the dependency in this PR would fail the deploy build against a version not yet on the registry. Sequence: merge this → push tag `npm-v2.2.0` to publish → then a one-line follow-up bumps `website/package.json` and regenerates the lock, which is the edit that trips `deploy-website.yml`.

## Checklist

- [x] My code follows the project's code style
- [x] I have added/updated documentation as needed
- [x] All tests pass locally
- [x] My commits are signed off (DCO)


---
_Generated by [Claude Code](https://claude.ai/code/session_019Se9bMrksZcQDect8FBRDd)_