### PR TITLE
fix(pq): support both pqcrypto API generations for ML-DSA-44

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,11 @@ dependencies = [
     # credential. Bundled by default: pqcrypto ships
     # prebuilt wheels for all mainstream platforms (~80 KB, no compiler needed)
     # and the PQ story is core to Vouch, so we do not gate it behind an extra.
-    "pqcrypto>=0.4.0",
+    # 0.4.x and 1.0.x are both supported: they differ in the ML-DSA-44 entry
+    # point names and in how verify() reports a verdict, and
+    # vouch/data_integrity_hybrid.py handles both. The major version is capped
+    # so a future release cannot change those contracts underneath a verifier.
+    "pqcrypto>=0.4.0,<2.0.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_hybrid.py
+++ b/tests/test_hybrid.py
@@ -502,7 +502,9 @@ def test_composite_proof_value_is_over_the_legacy_digest():
     digest = data_integrity.legacy_proof_digest(cred, unsigned)
     assert len(digest) == 32
     ed_pub.verify(combined[: data_integrity_hybrid.ED25519_SIGNATURE_SIZE], digest)
-    assert pqcrypto.verify(ml_pub, digest, combined[data_integrity_hybrid.ED25519_SIGNATURE_SIZE :])
+    assert data_integrity_hybrid._mldsa44_verify(
+        pqcrypto, ml_pub, digest, combined[data_integrity_hybrid.ED25519_SIGNATURE_SIZE :]
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -599,3 +601,97 @@ def test_verify_dual_rejects_a_set_missing_the_classical_proof():
         )
         is False
     )
+
+
+# ---------------------------------------------------------------------------
+# pqcrypto API contracts: 0.4.x and 1.0.0 differ in how they report a verdict
+# ---------------------------------------------------------------------------
+
+
+class _BoolVerify:
+    """The pqcrypto 0.4.x contract: verify() returns a bool."""
+
+    def __init__(self, verdict):
+        self.verdict = verdict
+
+    def verify(self, public_key, message, signature):
+        return self.verdict
+
+
+class _RaisingVerify:
+    """The pqcrypto 1.0.0 contract: verify() returns None on success and
+    raises on failure."""
+
+    def __init__(self, error=None):
+        self.error = error
+
+    def verify(self, public_key, message, signature):
+        if self.error is not None:
+            raise self.error
+        return None
+
+
+def test_verify_reads_the_bool_returning_contract():
+    assert data_integrity_hybrid._mldsa44_verify(_BoolVerify(True), b"pub", b"msg", b"sig") is True
+    assert (
+        data_integrity_hybrid._mldsa44_verify(_BoolVerify(False), b"pub", b"msg", b"sig") is False
+    )
+
+
+def test_verify_reads_the_raising_contract():
+    """A None return means success under pqcrypto 1.0.0. Reading it as a bool
+    would reject every valid post-quantum proof."""
+    assert data_integrity_hybrid._mldsa44_verify(_RaisingVerify(), b"pub", b"msg", b"sig") is True
+
+
+def test_verify_rejects_when_the_library_raises():
+    for error in (
+        ValueError("signature verification failed"),
+        RuntimeError("truncated input"),
+        TypeError("wrong key type"),
+    ):
+        assert (
+            data_integrity_hybrid._mldsa44_verify(_RaisingVerify(error), b"pub", b"msg", b"sig")
+            is False
+        )
+
+
+def test_keygen_accepts_either_entry_point_name():
+    """pqcrypto 1.0.0 renamed generate_keypair() to keygen()."""
+
+    class _Keygen:
+        def keygen(self):
+            return b"pub-new", b"sec-new"
+
+    class _GenerateKeypair:
+        def generate_keypair(self):
+            return b"pub-old", b"sec-old"
+
+    class _Neither:
+        pass
+
+    assert data_integrity_hybrid._mldsa44_keygen(_Keygen()) == (b"pub-new", b"sec-new")
+    assert data_integrity_hybrid._mldsa44_keygen(_GenerateKeypair()) == (b"pub-old", b"sec-old")
+    with pytest.raises(RuntimeError):
+        data_integrity_hybrid._mldsa44_keygen(_Neither())
+
+
+def test_a_tampered_signature_is_rejected_under_the_installed_library():
+    """End-to-end against whichever pqcrypto is actually installed: a real
+    signature verifies and a flipped byte does not."""
+    ml_pub, ml_sec = data_integrity_hybrid.generate_mldsa44_keypair()
+    message = b"vouch protocol ml-dsa-44 contract check"
+    signature = pqcrypto.sign(ml_sec, message)
+
+    assert data_integrity_hybrid._mldsa44_verify(pqcrypto, ml_pub, message, signature) is True
+
+    tampered = bytearray(signature)
+    tampered[0] ^= 0x01
+    assert (
+        data_integrity_hybrid._mldsa44_verify(pqcrypto, ml_pub, message, bytes(tampered)) is False
+    )
+    assert (
+        data_integrity_hybrid._mldsa44_verify(pqcrypto, ml_pub, b"other message", signature)
+        is False
+    )
+    assert data_integrity_hybrid._mldsa44_verify(pqcrypto, ml_pub, message, b"short") is False

--- a/vouch/data_integrity_hybrid.py
+++ b/vouch/data_integrity_hybrid.py
@@ -89,7 +89,7 @@ def _import_pqcrypto():
 def generate_mldsa44_keypair() -> Tuple[bytes, bytes]:
     """Generate a fresh ML-DSA-44 keypair. Returns (public_key, secret_key)."""
     ml_dsa_44 = _import_pqcrypto()
-    return ml_dsa_44.generate_keypair()
+    return _mldsa44_keygen(ml_dsa_44)
 
 
 def build_dual_proof(
@@ -364,13 +364,41 @@ def _b64u_decode(body: str) -> bytes:
         raise ValueError(f"bad base64url proofValue: {exc}") from exc
 
 
+def _mldsa44_keygen(ml_dsa_44: Any) -> Tuple[bytes, bytes]:
+    """Generate an ML-DSA-44 keypair across pqcrypto's two entry point names.
+
+    pqcrypto 1.0.0 renamed `generate_keypair()` to `keygen()`. Both return
+    (public_key, secret_key) of the same FIPS 204 sizes, so either name gives
+    keys that the other release can use.
+    """
+    keygen = getattr(ml_dsa_44, "keygen", None)
+    if keygen is None:
+        keygen = getattr(ml_dsa_44, "generate_keypair", None)
+    if keygen is None:
+        raise RuntimeError(
+            "The installed pqcrypto exposes no ML-DSA-44 key generation entry point "
+            "(expected keygen or generate_keypair)"
+        )
+    public_key, secret_key = keygen()
+    return bytes(public_key), bytes(secret_key)
+
+
 def _mldsa44_verify(ml_dsa_44: Any, public_key: bytes, message: bytes, signature: bytes) -> bool:
-    # pqcrypto's verify raises on an invalid signature in some builds; treat
-    # any exception as a verification failure.
+    """Verify an ML-DSA-44 signature across pqcrypto's two verify contracts.
+
+    pqcrypto 0.4.x returns a bool. pqcrypto 1.0.0 returns None on success and
+    signals failure by raising. Reading the 1.0.0 return value as a bool would
+    call every valid signature invalid, so a None return is read as the success
+    that release defines it to be, and only an exception or a falsy bool is a
+    rejection.
+    """
     try:
-        return bool(ml_dsa_44.verify(public_key, message, signature))
+        result = ml_dsa_44.verify(public_key, message, signature)
     except Exception:
         return False
+    if result is None:
+        return True
+    return bool(result)
 
 
 def _format_iso8601(dt: datetime) -> str:


### PR DESCRIPTION
pqcrypto 1.0.0 landed on 2026-08-15 and changed the ML-DSA-44 surface the Python post-quantum path calls. Because the dependency was declared as `pqcrypto>=0.4.0`, every fresh install picks up the new release, including CI.

Two things moved:

- `generate_keypair()` is now `keygen()`.
- `verify()` used to return a bool. It now returns `None` on success and raises `pqcrypto.InvalidSignatureError` on failure.

`vouch/data_integrity_hybrid.py` now handles both shapes. Key generation resolves whichever entry point the installed release exposes. Verification reads a `None` return as the success that 1.0.0 defines it to be, keeps reading a bool as a bool for 0.4.x, and treats any exception as a rejection.

The wire format is untouched. Key and signature sizes are the same 1312 / 2560 / 2420 bytes in both releases, a signature produced under 0.4.0 verifies under 1.0.0, and one produced under 1.0.0 verifies under 0.4.0. The shared interop vector at `test-vectors/hybrid-eddsa-mldsa44/vector.json` is unchanged and still verifies, so the TypeScript, Go, and Rust sides need nothing. No credential already issued is affected.

Security boundary for the verify wrapper: it reports success only when the library affirms the signature, either by returning a truthy value or by returning without raising. It assumes the installed release signals a failed verification by raising rather than by returning `None`, which is the contract both supported releases follow. A test asserts against whichever pqcrypto is actually installed that a real signature verifies while a flipped signature byte, a substituted message, and a truncated signature are each refused, so that assumption is checked rather than trusted. The dependency is now capped below the next major version.

The rest of the added coverage pins both library contracts directly: a bool-returning verifier, a `None`-returning verifier, a raising verifier, and a module exposing neither key generation name.
