### PR TITLE
chore(funding): add the repository provenance file for the funding manifest

### DIFF
--- a/.well-known/funding-manifest-urls
+++ b/.well-known/funding-manifest-urls
@@ -1,0 +1,1 @@
+https://vouch-protocol.com/funding.json

--- a/funding.json
+++ b/funding.json
@@ -20,7 +20,8 @@
     "url": "https://vouch-protocol.com"
    },
    "repositoryUrl": {
-    "url": "https://github.com/vouch-protocol/vouch"
+    "url": "https://github.com/vouch-protocol/vouch",
+    "wellKnown": "https://github.com/vouch-protocol/vouch/blob/main/.well-known/funding-manifest-urls"
    },
    "licenses": [
     "spdx:Apache-2.0"


### PR DESCRIPTION
Groundwork for pointing the FLOSS/fund directory listing at https://vouch-protocol.com/funding.json instead of the copy in this repository.

The directory decides whether a link in the manifest is verified by comparing hostnames. Serving the manifest from the site root verifies both `entity.webpageUrl` and `projects[vouch-protocol].webpageUrl`, since they are the same host, and leaves `projects[vouch-protocol].repositoryUrl` pointing at github.com as the one cross-host link. That link is now backed by `.well-known/funding-manifest-urls` in this repository, which names the manifest URL that is allowed to reference it, and the manifest declares that file through `repositoryUrl.wellKnown`.

The rules the file satisfies, from the directory's own validator:

- The provenance URL is on the same host as the repository URL and under the same path.
- It ends in `/.well-known/funding-manifest-urls`.
- It contains the manifest URL as an exact line.

The manifest still validates against the v1.1.0 schema with the field added. The field is inert for the current listing, where the manifest and the repository share a host and no provenance check is called for, so this can land ahead of the listing change.
