### PR TITLE
fix(funding): drop the repository provenance link from the funding manifest

### DIFF
--- a/funding.json
+++ b/funding.json
@@ -20,8 +20,7 @@
     "url": "https://vouch-protocol.com"
    },
    "repositoryUrl": {
-    "url": "https://github.com/vouch-protocol/vouch",
-    "wellKnown": "https://github.com/vouch-protocol/vouch/blob/main/.well-known/funding-manifest-urls"
+    "url": "https://github.com/vouch-protocol/vouch"
    },
    "licenses": [
     "spdx:Apache-2.0"


### PR DESCRIPTION
Submitting the manifest to the FLOSS/fund directory fails while `projects[vouch-protocol].repositoryUrl.wellKnown` is declared, so the field comes back out.

The directory fetches a github.com provenance file by rewriting the URL to the `?raw=true` form. github.com answers that form with a 404 for non-browser clients, confirmed from two independent networks while the file itself resolves fine at its raw.githubusercontent.com address and through the API. The directory's own validator requires the provenance URL to sit on the same host as the repository URL, so raw.githubusercontent.com cannot stand in for it while the repository URL is the repository.

A provenance URL that cannot be fetched is a hard submission failure. Leaving the field out is accepted: it only means the repository link carries no provenance proof, while `entity.webpageUrl` and `projects[vouch-protocol].webpageUrl` verify on their own, because the manifest is served from that same domain. The manifest validates against the directory's validator with the field removed.

`.well-known/funding-manifest-urls` stays in the repository. It is correct, it names the manifest URL that is allowed to reference this repository, and the field can be declared again whenever the directory can fetch it.
