### PR TITLE
fix: four small correctness fixes in Shield and threshold signing

### DIFF
--- a/tests/test_threshold_loader.py
+++ b/tests/test_threshold_loader.py
@@ -1,0 +1,132 @@
+"""Tests for how vouch.threshold loads (or refuses) the native FROST library.
+
+These are deliberately separate from test_threshold.py. That module is gated on
+the native library being present, and the behaviour under test here is what
+happens when it is *absent or unusable* - which is exactly the case the gate
+skips.
+
+The regression these guard: a stale build of libvouch_core_uniffi loads fine and
+then raises AttributeError on the first symbol lookup. That escaped as an
+AttributeError instead of the documented ThresholdError, which broke pytest at
+collection time rather than skipping cleanly.
+"""
+
+import ctypes
+import ctypes.util
+
+import pytest
+
+import vouch.threshold as threshold
+
+
+@pytest.fixture(autouse=True)
+def _reset_loader_state():
+    """Keep loader caching from leaking between tests, in either direction."""
+    saved_lib = threshold._LIB
+    saved_attempted = threshold._LIB_LOAD_ATTEMPTED
+    threshold._LIB = None
+    threshold._LIB_LOAD_ATTEMPTED = False
+    yield
+    threshold._LIB = saved_lib
+    threshold._LIB_LOAD_ATTEMPTED = saved_attempted
+
+
+def _no_system_library(monkeypatch):
+    monkeypatch.setattr(ctypes.util, "find_library", lambda name: None)
+
+
+def test_missing_library_raises_threshold_error(monkeypatch):
+    """No library anywhere -> the documented ThresholdError."""
+    monkeypatch.setattr(threshold, "_candidate_paths", lambda: [])
+    _no_system_library(monkeypatch)
+
+    with pytest.raises(threshold.ThresholdError) as caught:
+        threshold.generate_key(2, 3)
+
+    assert "cargo build --release" in str(caught.value)
+
+
+def test_stale_library_raises_threshold_error_not_attribute_error(monkeypatch, tmp_path):
+    """A library missing a bound symbol must not leak AttributeError.
+
+    A stale shared object loads successfully and only fails when a symbol this
+    module binds is looked up. That must surface as ThresholdError so callers -
+    including the skip guard in test_threshold.py - can handle it.
+    """
+    fake = tmp_path / "libvouch_core_uniffi.so"
+    fake.write_bytes(b"")
+
+    class StaleLibrary:
+        """Loads, but exports nothing - like a build predating the symbol."""
+
+        _name = str(fake)
+
+        def __getattr__(self, name):
+            raise AttributeError(f"{fake}: undefined symbol: {name}")
+
+    monkeypatch.setattr(threshold, "_candidate_paths", lambda: [str(fake)])
+    monkeypatch.setattr(ctypes, "CDLL", lambda path: StaleLibrary())
+    _no_system_library(monkeypatch)
+
+    with pytest.raises(threshold.ThresholdError) as caught:
+        threshold.generate_key(2, 3)
+
+    message = str(caught.value)
+    assert "needs rebuilding" in message
+    assert "undefined symbol" in message
+    assert str(fake) in message
+
+
+def test_stale_candidate_does_not_shadow_a_usable_one(monkeypatch, tmp_path):
+    """A stale library earlier in the search order must not win.
+
+    The loader should treat it as unusable and keep looking, rather than
+    binding to it or giving up.
+    """
+    stale_path = tmp_path / "stale.so"
+    good_path = tmp_path / "good.so"
+    stale_path.write_bytes(b"")
+    good_path.write_bytes(b"")
+
+    class StaleLibrary:
+        def __getattr__(self, name):
+            raise AttributeError(f"{stale_path}: undefined symbol: {name}")
+
+    class GoodLibrary:
+        _name = str(good_path)
+
+        def __getattr__(self, name):
+            return type("Fn", (), {"argtypes": None, "restype": None})()
+
+    def fake_cdll(path):
+        return StaleLibrary() if path == str(stale_path) else GoodLibrary()
+
+    monkeypatch.setattr(threshold, "_candidate_paths", lambda: [str(stale_path), str(good_path)])
+    monkeypatch.setattr(ctypes, "CDLL", fake_cdll)
+    monkeypatch.setattr(threshold, "_configure_signatures", lambda lib: lib.probe)
+    _no_system_library(monkeypatch)
+
+    assert threshold._load_library()._name == str(good_path)
+
+
+def test_failed_configuration_is_not_cached(monkeypatch, tmp_path):
+    """A library that fails configuration must not be published to _LIB.
+
+    Caching a partially-configured handle would make the failure sticky: the
+    early return at the top of _load_library would hand it to every later call.
+    """
+    fake = tmp_path / "libvouch_core_uniffi.so"
+    fake.write_bytes(b"")
+
+    class StaleLibrary:
+        def __getattr__(self, name):
+            raise AttributeError(f"{fake}: undefined symbol: {name}")
+
+    monkeypatch.setattr(threshold, "_candidate_paths", lambda: [str(fake)])
+    monkeypatch.setattr(ctypes, "CDLL", lambda path: StaleLibrary())
+    _no_system_library(monkeypatch)
+
+    with pytest.raises(threshold.ThresholdError):
+        threshold._load_library()
+
+    assert threshold._LIB is None, "a library that failed configuration was cached"

--- a/vouch/shield/demo.py
+++ b/vouch/shield/demo.py
@@ -65,7 +65,7 @@ def main():
     print("🧪 Test 1: Signed call from TRUSTED DID")
     print("-" * 60)
 
-    token1 = trusted_signer.sign({"action": "read_file", "path": "/data/file.txt"})
+    token1 = trusted_signer.sign(action="read_file", target="filesystem", resource="/data/file.txt")
     result1 = shield.intercept(
         tool="read_file",
         args={"path": "/data/file.txt"},
@@ -102,7 +102,7 @@ def main():
 
     # Register the key for verification but don't trust the DID
     shield.register_key(malicious_did, malicious_keys.public_key_jwk)
-    token3 = malicious_signer.sign({"action": "run_command", "cmd": "rm -rf /"})
+    token3 = malicious_signer.sign(action="run_command", target="shell", resource="rm -rf /")
     result3 = shield.intercept(
         tool="run_command",
         args={"cmd": "rm -rf /"},
@@ -120,7 +120,7 @@ def main():
     print("🧪 Test 4: TRUSTED DID exceeding permissions")
     print("-" * 60)
 
-    token4 = trusted_signer.sign({"action": "run_command", "cmd": "sudo reboot"})
+    token4 = trusted_signer.sign(action="run_command", target="shell", resource="sudo reboot")
     result4 = shield.intercept(
         tool="run_command",
         args={"cmd": "sudo reboot"},
@@ -139,7 +139,7 @@ def main():
     print("-" * 60)
 
     shield.block_did(malicious_did, "Known malicious actor")
-    token5 = malicious_signer.sign({"action": "read_file", "path": "innocent.txt"})
+    token5 = malicious_signer.sign(action="read_file", target="filesystem", resource="innocent.txt")
     result5 = shield.intercept(
         tool="read_file",
         args={"path": "innocent.txt"},

--- a/vouch/shield/shield.py
+++ b/vouch/shield/shield.py
@@ -121,7 +121,7 @@ class Shield:
                 return InterceptResult(allowed=False, reason=reason)
 
             # Verify the token
-            is_valid, passport = self._verifier.check_vouch(token)
+            is_valid, passport = self._verifier.check_vouch_credential(token)
             if not is_valid or passport is None:
                 reason = "Invalid Vouch-Token signature"
                 self._flight_recorder.blocked("unknown", tool, reason, args)

--- a/vouch/shield/trust_registry.py
+++ b/vouch/shield/trust_registry.py
@@ -5,6 +5,7 @@ Manages trusted and blocked DIDs using the existing revocation infrastructure.
 Extends RevocationStoreInterface to support allowlist mode.
 """
 
+import asyncio
 import os
 import json
 import logging
@@ -20,6 +21,27 @@ from vouch.revocation import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _run(coro):
+    """Run a coroutine from synchronous code.
+
+    ``asyncio.get_event_loop()`` is deprecated and raises once anything in the
+    process has used ``asyncio.run()``, because that leaves no current loop set.
+    These calls are all short local revocation-store operations, so creating a
+    loop per call costs nothing worth optimising.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    # Already inside a running loop, which cannot be re-entered. Give the
+    # coroutine its own loop on a worker thread instead of failing.
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+        return pool.submit(asyncio.run, coro).result()
 
 
 class TrustStatus(Enum):
@@ -89,14 +111,10 @@ class TrustRegistry:
 
                     # Load blocked DIDs into revocation store
                     for did in config.get("blocked_dids", []):
-                        import asyncio
-
                         record = RevocationRecord(
                             did=did, revoked_at=0, reason="Loaded from config"
                         )
-                        asyncio.get_event_loop().run_until_complete(
-                            self._revocation_store.add_revocation(record)
-                        )
+                        _run(self._revocation_store.add_revocation(record))
 
                     logger.info(
                         f"Loaded trust config: {len(self._trusted_dids)} trusted, "
@@ -107,11 +125,7 @@ class TrustRegistry:
 
     def save_config(self) -> None:
         """Save trust config to file."""
-        import asyncio
-
-        blocked = asyncio.get_event_loop().run_until_complete(
-            self._revocation_store.list_revocations()
-        )
+        blocked = _run(self._revocation_store.list_revocations())
 
         config = {
             "trusted_dids": list(self._trusted_dids),
@@ -125,36 +139,27 @@ class TrustRegistry:
         """Add a DID to the trusted list."""
         self._trusted_dids.add(did)
         # Remove from blocked if present
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(self._revocation_store.remove_revocation(did))
+        _run(self._revocation_store.remove_revocation(did))
         logger.info(f"Trusted DID: {did}")
 
     def block(self, did: str, reason: str = "Manually blocked") -> None:
         """Add a DID to the blocked list."""
         self._trusted_dids.discard(did)
-        import asyncio
         import time
 
         record = RevocationRecord(did=did, revoked_at=int(time.time()), reason=reason)
-        asyncio.get_event_loop().run_until_complete(self._revocation_store.add_revocation(record))
+        _run(self._revocation_store.add_revocation(record))
         logger.info(f"Blocked DID: {did} - {reason}")
 
     def remove(self, did: str) -> None:
         """Remove a DID from all lists (reset to unknown)."""
         self._trusted_dids.discard(did)
-        import asyncio
-
-        asyncio.get_event_loop().run_until_complete(self._revocation_store.remove_revocation(did))
+        _run(self._revocation_store.remove_revocation(did))
 
     def get_status(self, did: str) -> TrustStatus:
         """Get the trust status of a DID."""
-        import asyncio
-
         # Check blocked first (revocation takes precedence)
-        is_blocked = asyncio.get_event_loop().run_until_complete(
-            self._revocation_store.is_revoked(did)
-        )
+        is_blocked = _run(self._revocation_store.is_revoked(did))
         if is_blocked:
             return TrustStatus.BLOCKED
 
@@ -182,9 +187,5 @@ class TrustRegistry:
 
     def get_blocked(self) -> List[str]:
         """Get all blocked DIDs."""
-        import asyncio
-
-        records = asyncio.get_event_loop().run_until_complete(
-            self._revocation_store.list_revocations()
-        )
+        records = _run(self._revocation_store.list_revocations())
         return [r.did for r in records]

--- a/vouch/threshold.py
+++ b/vouch/threshold.py
@@ -94,34 +94,59 @@ def _load_library() -> ctypes.CDLL:
         raise ThresholdError(_not_found_message())
     _LIB_LOAD_ATTEMPTED = True
 
+    # A candidate is only usable if it both loads *and* exports every symbol we
+    # bind. A stale build - one predating a symbol this module needs - loads
+    # fine and then fails on attribute lookup, so AttributeError is caught here
+    # alongside OSError and treated the same way: not usable, try the next one.
+    #
+    # _LIB is assigned only once configuration has succeeded. Publishing a
+    # partially-configured handle would make the failure sticky, because the
+    # early-return at the top of this function would hand it back to every
+    # later caller.
+    stale: List[str] = []
+
     for path in _candidate_paths():
         if path and os.path.exists(path):
             try:
-                _LIB = ctypes.CDLL(path)
-                _configure_signatures(_LIB)
-                return _LIB
+                candidate = ctypes.CDLL(path)
+                _configure_signatures(candidate)
             except OSError:
                 continue
+            except AttributeError as exc:
+                stale.append(f"{path} ({exc})")
+                continue
+            _LIB = candidate
+            return _LIB
 
     found = ctypes.util.find_library("vouch_core_uniffi")
     if found:
         try:
-            _LIB = ctypes.CDLL(found)
-            _configure_signatures(_LIB)
-            return _LIB
+            candidate = ctypes.CDLL(found)
+            _configure_signatures(candidate)
         except OSError:
             pass
+        except AttributeError as exc:
+            stale.append(f"{found} ({exc})")
+        else:
+            _LIB = candidate
+            return _LIB
 
-    raise ThresholdError(_not_found_message())
+    raise ThresholdError(_not_found_message(stale))
 
 
-def _not_found_message() -> str:
-    return (
+def _not_found_message(stale: Optional[List[str]] = None) -> str:
+    message = (
         "vouch.threshold requires the native vouch_core_uniffi library "
         "(the audited FROST-Ed25519 core shared with the Go/JVM/.NET/C++/Swift "
         "SDKs). Build it with `cargo build --release` in core/uniffi, or set "
         "VOUCH_CORE_LIB to the shared library path."
     )
+    if stale:
+        message += (
+            " A library was found but is missing symbols this module binds, "
+            "which means it predates them and needs rebuilding: " + "; ".join(stale)
+        )
+    return message
 
 
 def _configure_signatures(lib: ctypes.CDLL) -> None:


### PR DESCRIPTION
Four independent fixes, one per commit, kept separate from the feature work so the history stays readable.

**Shield.intercept called a verifier method that does not exist.** It reached for `Verifier.check_vouch`, which was removed when credentials moved to the W3C Verifiable Credential format. It now calls `check_vouch_credential`, which resolves the issuer key from trusted roots, from `did:key` offline, or via `did:web`.

**The trust registry assumed a preset event loop.** It used `asyncio.get_event_loop().run_until_complete(...)` in several places, which raises once anything in the process has used `asyncio.run()`. A small helper now runs those coroutines whether or not a loop is already running.

**The Shield demo signed incomplete intents.** A Vouch Credential binds an action, a target, and a resource, and the demo supplied only an action, so it raised on the first signature. Each demo credential now carries a complete intent, and `python -m vouch.shield.demo` runs end to end.

**Threshold signing now recognises a native library that predates a symbol it binds.** A shared library built before `vouch_threshold_generate_key` existed would load and then fail on attribute lookup, escaping as an `AttributeError` rather than the `ThresholdError` the module documents. Such a library is now detected, named in the error, and passed over in favour of a usable one. `tests/test_threshold_loader.py` covers the missing, stale, and shadowed cases.