### PR TITLE
feat(aat): interop adapter for attenuating authorization tokens

### DIFF
--- a/INTEROP-NOTES.md
+++ b/INTEROP-NOTES.md
@@ -1,0 +1,282 @@
+# Implementer notes on draft-niyikiza-oauth-attenuating-agent-tokens-01
+
+These notes came out of building an interop adapter between Attenuating
+Authorization Tokens and Vouch Protocol. The adapter verifies an AAT chain,
+maps the leaf's authority onto Vouch Shield rules, enforces them before an MCP
+tool call runs, and links the resulting Verifiable Credential to the AAT that
+authorised the action. The code is in
+[`integrations/aat/`](integrations/aat/) under Apache-2.0.
+
+Chain verification and token derivation were not reimplemented. Both are
+delegated to the reference implementation named in Appendix E.
+
+Everything below is a note from doing the work. It is offered as implementer
+feedback, not as a review of the design. Where I read something as ambiguous I
+say what I did instead, so the note is actionable. The draft was clear enough to
+build against on a first reading, which is not the usual experience.
+
+Version read: `-01`, published 15 June 2026.
+
+---
+
+## 1. Appendix E does not give the reference implementation's location or licence
+
+Appendix E.1 says Tenuo provides a reference implementation and describes what
+it covers, but gives no repository URL, package name, or licence.
+
+RFC 7942 Section 2 lists the implementation's name, a URL for information or
+source, and the licence among the details an Implementation Status section
+should carry. I found all three by searching: `github.com/tenuo-ai/tenuo`,
+Apache-2.0, published to PyPI as `tenuo` and to crates.io as `tenuo`.
+
+That search step is the kind of thing that stops an implementer who is deciding
+whether the dependency is usable at all. Adding the URL and the licence to
+E.1 would remove it.
+
+## 2. The normative wire format and the reference implementation's wire format differ
+
+The draft's normative envelope is JWT/JWS throughout: Section 3.2's claim table,
+the `cnf` object, the PoP JWT in Section 5, and `par_hash` in Section 6 step 7.
+
+The shipped reference implementation is CBOR/COSE-native. Its serialisation
+produces CBOR (`to_bytes()` begins `83 01 58 a6 aa`), and version 0.2.4 exposes
+no JWT encode or decode on its warrant type. Appendix E.1 is explicit that this
+representation is implementation-specific and does not define a fully
+interoperable CWT profile, with the profile deferred per Appendix D.
+
+The practical consequence is that there is currently no implementation of the
+draft's normative encoding to test against. An implementer who wants to consume
+draft-format AAT JWTs has to write both the encoder and the chain verifier,
+which is the work Appendix E would otherwise let them skip.
+
+This shaped my adapter directly. I built against the protocol model, which is
+what the reference implementation realises: the attenuation invariants of
+Section 4, the derivation rule of Section 6, and the verification algorithm of
+Section 7. I did not claim JWT-level interop, and the fixtures are labelled as
+CBOR warrant chains rather than AATs.
+
+Two things would help here, in rough order of value:
+
+- An interop test vector set carrying draft-encoded JWT AATs: a root, a valid
+  derived chain, and a set of chains that must fail, each with the invariant it
+  violates. Even a handful would pin the encoding.
+- A note in Appendix E stating plainly that the reference implementation
+  realises the protocol model rather than the JWT encoding, so implementers do
+  not assume otherwise.
+
+Section 6 step 7 also qualifies the `par_hash` input with "For JWT/JWS AATs, the
+parent token signing input is the JWS Signing Input." It does not define the
+signing input for other serialisations. If format independence is a goal of the
+model, defining "token signing input" once, per serialisation, would make the
+CBOR case well specified rather than implementation-defined.
+
+## 3. Section 7's expiry steps are not covered by the reference implementation's chain verification call
+
+Section 7 is unambiguous that expiry is part of chain verification. Step 2e
+requires `root.exp > now`, and step 4i requires `child.exp > now` under I3.
+
+In the reference implementation these checks are not performed by
+`Authorizer.verify_chain()`. They happen in `Authorizer.check_chain()` and
+`Authorizer.authorize_one()`. An expired warrant passes `verify_chain()` and is
+rejected only when an authorization call is made:
+
+```python
+authorizer.verify_chain([expired])          # returns normally
+authorizer.check_chain([expired], tool, args)  # raises ExpiredError
+```
+
+The naming is what makes this a trap. `verify_chain` is the obvious call to
+reach for when implementing Section 7, and on its own it does not implement
+Section 7. An implementer who builds a verification wrapper on it, and enforces
+authorization elsewhere, accepts expired authority.
+
+My adapter checks expiry explicitly for every token in the chain and routes
+enforcement through `check_chain`. There is a regression test for it
+(`test_expired_leaf_rejected`) that asserts the underlying behaviour first, so
+it will tell us if the reference implementation changes.
+
+This is a note about the implementation rather than the draft. It is here
+because Appendix E points implementers at that code, so the gap propagates.
+
+## 4. Section 6 does not state a producer obligation
+
+Section 6 specifies what a valid derived token looks like: the tool set MUST be
+a subset, constraints MUST be at least as restrictive, `exp` MUST be no later,
+and so on. It is written as a procedure a holder follows.
+
+What it does not say is whether a conforming implementation MUST refuse to emit
+a token that violates those rules, or whether the requirement lands purely on
+the verifier. Section 7 covers the verifier side thoroughly.
+
+The reference implementation takes the strict reading and refuses at derivation:
+adding a tool, loosening a pattern, and dropping a constraint each raise rather
+than minting a token. That is the safer behaviour, and I am not suggesting it
+change.
+
+It does have one practical effect worth knowing. A widening token cannot be
+produced through the supported API, so the natural negative test vector, a
+derived token that widens its parent, cannot be constructed by an implementer
+using the reference implementation. I had to build my negative fixture a
+different way: a token minted by an unrelated key claiming wider authority and
+spliced in behind a genuine root. That is rejected on I5 linkage rather than on
+I4 capability monotonicity, so it tests a different invariant than intended.
+
+If the draft ships interop vectors, widening chains are the ones implementers
+cannot easily make for themselves, and would be the most valuable to publish.
+Stating the producer obligation explicitly, either way, would also help.
+
+## 5. The duplicate-tool-identifier rule cannot be enforced with a stock JSON parser
+
+Section 3.3.1 says tool identifiers MUST be unique within a `tools` map, and
+that an entry containing duplicate keys is malformed and MUST be rejected.
+
+Standard JSON parsers do not surface duplicate object keys. Python's `json`
+keeps the last occurrence silently, and the common JavaScript, Go, and Rust
+parsers behave the same way by default:
+
+```python
+json.loads('{"read_file": {}, "read_file": {"path": 1}}')
+# {'read_file': {'path': 1}}   -- one key, no error
+```
+
+So an implementation that parses `authorization_details` with a normal JSON
+library cannot detect the condition, and will silently accept a token the draft
+says it must reject. Enforcing it requires a custom parse hook or a raw scan of
+the token before parsing, which is worth saying out loud.
+
+RFC 8785 does not help here either. JCS canonicalises a parsed value, so by the
+time canonicalisation runs the duplicate is already gone.
+
+A sentence in Section 3.3.1 noting that this check must happen at parse time,
+before the object is materialised, would save implementers finding it the hard
+way. Alternatively, if silently keeping one of the duplicates is acceptable, say
+which one.
+
+## 6. The core constraint set has no string-pattern or path type, which the motivating use case needs
+
+Section 3.4's nine core types are `exact`, `range`, `one_of`, `not_one_of`,
+`contains`, `subset`, `wildcard`, `all`, and `any`. The reasoning in the
+surrounding text is clear and I think correct: these are the types with simple,
+deterministic, format-independent `check` and `subsumes` rules.
+
+The difficulty is that the draft's own motivating examples are agent tool calls
+over files and URLs, and the first constraint anyone reaches for is a path or
+prefix pattern. Restricting `read_file` to `reports/*` cannot be expressed with
+the core nine. `one_of` requires enumerating every path in advance, which is not
+workable for a filesystem.
+
+Section 3.5.3 gives Path Containment as the worked example of an extension
+registration, which suggests this is anticipated. But no such type is registered
+yet, and Section 10.3.3's initial registry entries are the core types. So the
+first thing a real deployment does takes it outside the interoperable set, and
+two independent implementations of the draft cannot exchange the constraint that
+the draft's own examples motivate.
+
+The reference implementation ships `Pattern`, `Regex`, `Path`, `Subpath`,
+`Cidr`, `Url`, `UrlPattern`, `UrlSafe`, `Cmd`, `Shlex`, `CEL`, `Not`, and
+`AnyOf` beyond the core nine, which suggests the same pressure showed up in
+practice. My demo uses `Pattern("reports/*")`, and I flag in my own
+documentation that it is not a core AAT constraint type.
+
+Registering one path-containment type in the initial registry, with its
+`subsumes` procedure defined, would let a common case be interoperable at
+publication rather than after it.
+
+On a related point, Section 3.4's fail-closed rule for unrecognised
+`constraint_type` values is good and I implemented it. It does mean that
+adopting any extension type partitions deployments until the extension is widely
+implemented, which strengthens the argument for having the common one in the
+base registry.
+
+## 7. The PoP JWT carries argument values in the clear
+
+Section 5.2 defines `hta` as an object holding the tool arguments for the
+invocation, with argument names as keys and argument values as values. Not a
+digest of them.
+
+A JWS compact serialisation is signed, not encrypted, and the payload is
+base64url. So every PoP JWT exposes the full argument values of the call it
+authorises, to anything that handles it: proxies, gateways, request logs, error
+reporting. For the draft's own examples this can mean file paths, query strings,
+recipient addresses, and amounts.
+
+Two consequences worth a sentence in Section 9:
+
+- Privacy. Argument values are frequently the sensitive part of an agent tool
+  call, more so than the tool name.
+- Size. Arguments can be large. A tool taking a document body puts that body in
+  every PoP JWT, and header-carried tokens meet size limits in practice.
+
+A digest form would address both. `hta` could carry
+`base64url(SHA-256(JCS(args)))` instead of the arguments, since the enforcement
+point already has the arguments from the invocation itself and only needs to
+confirm they match. The current design does not appear to need the values
+themselves to be present. If there is a reason it does, saying so would help,
+because the digest form is what an implementer will reach for.
+
+The naming is also worth a look. `hta` sits close to DPoP's `htm` and `htu`
+(RFC 9449), which are short strings describing an HTTP request. `hta` is an
+object with different semantics. Something like `args` or `aat_args` would
+signal the difference, and would match the `aat_`-prefixed claims alongside it.
+
+## 8. Audience binding is optional by default
+
+`aat_aud` is OPTIONAL in Table 4. Deployments that require audience binding MUST
+require the claim and enforce it, which puts the choice with the deployment.
+
+The default posture is then that a PoP JWT is valid at any enforcement point
+that trusts the chain, within the clock tolerance of Section 5.3. Where one leaf
+token is presented to several enforcement points, a PoP captured by one can be
+replayed to another for the same tool and arguments. Section 8.5 covers replay
+and notes that detecting `jti` reuse depends on stateful tracking being
+deployed, which is a separate control and is also optional.
+
+Making `aat_aud` REQUIRED, or stating a default in Section 5.3 for what an
+enforcement point should do when it is absent, would make the safer
+configuration the one implementers get without thinking about it.
+
+---
+
+## Things that were straightforward to implement
+
+Worth recording, since feedback documents tend to list only friction.
+
+- The five invariants I1 to I5 map cleanly to code and are easy to test
+  individually. Naming them and referring to them by number throughout is a real
+  help when writing tests, because a failure can be attributed to a specific
+  invariant.
+- Offline derivation works exactly as described. No network access is needed and
+  none is attempted.
+- The narrow-only rule needed no adaptation to sit alongside Vouch's own
+  delegation model, which enforces the same non-expansion invariant over a
+  different dimension set. That the two composed without either side changing
+  its semantics is the main result of this exercise.
+- Exact-string tool matching with no normalization is the right call and made
+  the mapping to our Shield rules trivial. The explicit "MUST NOT apply Unicode
+  normalization, URI normalization, case folding, percent decoding, or alias
+  resolution" is the kind of sentence that prevents divergent implementations.
+- The fail-closed rule for unknown constraint types, paired with the requirement
+  to ignore unrecognised top-level claims, draws the line in the right place.
+
+## What was mapped, and what was lossy
+
+Recorded in [`integrations/aat/DESIGN.md`](integrations/aat/DESIGN.md). The
+short version, from the AAT side:
+
+- Tool names, the narrow-only invariant, `jti`, and `exp` map cleanly onto Vouch
+  concepts.
+- AAT's per-argument constraints have no equivalent in Vouch Shield's rule
+  model, which is per-DID capability levels and never sees call arguments. I did
+  not flatten them, because doing so would widen authority. Argument evaluation
+  stays with the reference implementation and runs in the same pre-execution
+  step.
+- Going the other way, Vouch's `rate` and `policy` delegation dimensions have no
+  equivalent in AAT's core constraint set and would need registered extension
+  types.
+- `del_max_depth` has no counterpart in Vouch, which sets no fixed depth limit.
+  AAT to Vouch is safe; the reverse would mean inventing a ceiling.
+- A derived token's `iss` is a JWK Thumbprint URI while Vouch uses DIDs. Neither
+  specification defines a conversion. `did:key` is the closest analogue.
+
+Happy to supply the adapter, its tests, or the fixtures if any of this is useful
+in preparing `-02`.

--- a/integrations/aat/DEMO.md
+++ b/integrations/aat/DEMO.md
@@ -1,0 +1,202 @@
+# Scene 4 - AAT narrowed offline, enforced by Vouch
+
+A 20-second scene to add to the existing demo. Every command below has been run
+as written.
+
+**The line to say on camera:**
+
+> "OAuth-world delegation, narrowed offline; VC-world accountability on top;
+> enforced before the call ran."
+
+---
+
+## Before recording
+
+```bash
+cd /path/to/vouch-protocol
+pip install tenuo
+```
+
+Clear any stale demo directory so the scene starts from nothing:
+
+```bash
+rm -rf /tmp/aat-demo
+```
+
+---
+
+## 1. Show the root AAT
+
+`read_file` **and** `write_file` on `reports/*`.
+
+```bash
+python3 integrations/aat/demo_setup.py --out /tmp/aat-demo
+```
+
+Expected output:
+
+```
+Demo directory: /tmp/aat-demo
+  root AAT grants : read_file, write_file on reports/*
+  leaf AAT grants : read_file on reports/*
+  leaf jti        : tnu_wrt_...
+  chain root      : tnu_wrt_...
+  leaf depth      : 1
+
+Narrowed offline. No authorization server was contacted.
+```
+
+## 2. The narrowing was offline
+
+That single command already did it: the leaf was derived from the root by a
+local signing operation, with no authorization-server round trip. To show it is
+genuinely disconnected, re-run it with the network off:
+
+```bash
+# optional, for the camera
+unshare -rn python3 integrations/aat/demo_setup.py --out /tmp/aat-demo-offline
+```
+
+Point at the two lines: root grants `read_file, write_file`; leaf grants
+`read_file`. The narrowing is the whole scene.
+
+## 3. Start `vouch-mcp` with the leaf
+
+```bash
+VOUCH_DID=did:web:demo-agent.example.com \
+VOUCH_PRIVATE_KEY="$(cat your-key.jwk)" \
+vouch-mcp --aat-chain /tmp/aat-demo/leaf.json \
+          --aat-holder-key /tmp/aat-demo/holder.pem
+```
+
+For Claude Desktop, use this in `claude_desktop_config.json` instead:
+
+```json
+{
+  "mcpServers": {
+    "vouch": {
+      "command": "vouch-mcp",
+      "args": [
+        "--aat-chain", "/tmp/aat-demo/leaf.json",
+        "--aat-holder-key", "/tmp/aat-demo/holder.pem"
+      ],
+      "env": {
+        "VOUCH_DID": "did:web:your-agent.example.com",
+        "VOUCH_PRIVATE_KEY": "PASTE_YOUR_PRIVATE_KEY_JWK_JSON_STRING",
+        "PYTHONPATH": "/path/to/vouch-protocol"
+      }
+    }
+  }
+}
+```
+
+`PYTHONPATH` matters: the adapter lives in `integrations/`, which is not part of
+the installed `vouch` package. Without it the AAT tool fails closed and denies.
+
+## 4. In Claude Desktop: the allowed call
+
+Ask:
+
+> Use the vouch tool `check_action_aat` to check `read_file` with
+> `{"path": "reports/q3.txt"}`.
+
+Expected:
+
+```
+ALLOW: 'read_file' is permitted by AAT leaf tnu_wrt_... (chain root tnu_wrt_...).
+```
+
+To show the credential carrying the AAT `jti`, run in the terminal:
+
+```bash
+python3 integrations/aat/demo_call.py \
+  --chain /tmp/aat-demo/leaf.json \
+  --holder-key /tmp/aat-demo/holder.pem \
+  --tool read_file --path reports/q3.txt
+```
+
+The frame worth holding is inside `credentialSubject.intent`:
+
+```json
+"authorizedBy": {
+  "scheme": "aat",
+  "jti": "tnu_wrt_...",
+  "chainRoot": "tnu_wrt_...",
+  "depth": 1
+}
+```
+
+That is the Vouch credential recording *which delegation authorised this action*.
+
+## 5. The blocked call
+
+`write_file` was in the root and narrowed out of the leaf.
+
+> Use the vouch tool `check_action_aat` to check `write_file` with
+> `{"path": "reports/q3.txt"}`.
+
+Expected:
+
+```
+DENY: Tool 'write_file' is not in the AAT leaf's authority (leaf permits: read_file)
+```
+
+Then in the terminal, to show the tool never ran:
+
+```bash
+python3 integrations/aat/demo_call.py \
+  --chain /tmp/aat-demo/leaf.json \
+  --holder-key /tmp/aat-demo/holder.pem \
+  --tool write_file --path reports/q3.txt
+```
+
+```
+BLOCKED before execution: Tool 'write_file' is not in the AAT leaf's authority (leaf permits: read_file)
+tool invocations: 0  <- the tool never ran
+```
+
+And the file is untouched:
+
+```bash
+ls -l /tmp/aat-demo/reports/ && cat /tmp/aat-demo/reports/q3.txt
+```
+
+```
+Q3 revenue: up and to the right.
+```
+
+## 6. Optional closer - the argument constraint
+
+If there is time, this is the sharpest beat: the tool is allowed, the *argument*
+is not.
+
+```bash
+python3 integrations/aat/demo_call.py \
+  --chain /tmp/aat-demo/leaf.json \
+  --holder-key /tmp/aat-demo/holder.pem \
+  --tool read_file --path /etc/passwd
+```
+
+```
+BLOCKED before execution: ConstraintViolation: Constraint 'path' not satisfied: value does not match constraint
+tool invocations: 0  <- the tool never ran
+```
+
+Same tool that succeeded a moment ago. Different argument. Still blocked, still
+before execution.
+
+---
+
+## If something goes wrong on the day
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `DENY: AAT authority is not available (VOUCH_AAT_CHAIN is not set)` | The flag did not reach the server. | Check `--aat-chain`, or set `VOUCH_AAT_CHAIN` in `env`. |
+| `DENY: AAT authority is not available (AAT adapter unavailable ...)` | `integrations/` is not importable. | Set `PYTHONPATH` to the repo root. |
+| `AAT chain did not verify: AatExpired` | The demo chain aged out. | Re-run `demo_setup.py`; it mints a fresh hour-long chain. |
+| Everything denies, including `read_file` | No holder key, so no proof-of-possession. | Pass `--aat-holder-key /tmp/aat-demo/holder.pem`. |
+
+One honesty note for the recording: `--aat-holder-key` lets the server mint the
+proof-of-possession itself, which keeps the demo to one terminal. In a real
+deployment the PoP is produced by the caller that holds the key and passed in
+with the call.

--- a/integrations/aat/DESIGN.md
+++ b/integrations/aat/DESIGN.md
@@ -1,0 +1,397 @@
+# AAT ↔ Vouch interop - design
+
+Status: **accepted and implemented.** Scoping decisions recorded in Section 9.
+
+This document is Step 0 of the AAT interop work: what the AAT draft says, what
+the reference implementation actually ships, and how AAT concepts map onto Vouch
+Shield rules and the Vouch Signer's per-action credential.
+
+The claim this work is meant to make true:
+
+> AAT and Vouch's delegation model enforce the same narrow-only invariant - AAT
+> in OAuth/RAR form, Vouch as a VC - and they compose.
+
+Nothing here asserts precedence, origin, or priority for either project. This is
+an interop exercise.
+
+---
+
+## 1. Source documents
+
+| Thing | Where | Notes |
+|---|---|---|
+| The draft | `draft-niyikiza-oauth-attenuating-agent-tokens-01` | Published 15 June 2026, expires 17 December 2026. 3,696 lines. Author: Niki Aimable Niyikiza (Tenuo). |
+| Text used | `https://www.ietf.org/archive/id/draft-niyikiza-oauth-attenuating-agent-tokens-01.txt` | Read in full. |
+| Reference implementation | `https://github.com/tenuo-ai/tenuo` | **Apache-2.0.** Rust core, Python bindings. |
+| Python distribution | PyPI `tenuo`, version 0.2.4 | `License: Apache-2.0`, `Requires-Python: >=3.9`. Prebuilt `abi3` wheels for linux/macOS/Windows. |
+
+Both licence and language check out: Apache-2.0 matches Vouch's own licence, and
+the Python bindings are directly callable. **The stop-and-report condition in the
+brief does not trigger.** We depend on the reference implementation for
+derivation and chain verification and do not reimplement either.
+
+---
+
+## 2. What the draft specifies
+
+### 2.1 Claim set (§3.2, Table 1)
+
+Common claims on every AAT:
+
+| Claim | Presence | Meaning |
+|---|---|---|
+| `jti` | REQUIRED | Unique token identifier. UUIDv7 RECOMMENDED. |
+| `iss` | REQUIRED | Root tokens: issuer URI. Derived tokens: `urn:ietf:params:oauth:jwk-thumbprint:sha-256:<thumbprint>` of the parent holder key. |
+| `iat`, `exp` | REQUIRED | Issuance and expiry. |
+| `cnf` | REQUIRED | Confirmation object carrying the holder's public key (`jwk`). |
+| `del_depth` | REQUIRED | Position in the chain. Root is 0; each derivation adds exactly 1. |
+| `del_max_depth` | REQUIRED | Absolute ceiling. Monotonically non-increasing down the chain. |
+| `par_hash` | Root: MUST be absent. Derived: MUST be present. | Base64url SHA-256 of the parent's JWS Signing Input. |
+| `authorization_details` | REQUIRED | RFC 9396 array carrying the tool capability claims. |
+
+Ed25519 signing MUST be supported. JCS (RFC 8785) is used for canonicalization.
+
+### 2.2 Tools and argument constraints (§3.3, §3.4)
+
+`authorization_details` entries are typed `attenuating_agent_token` and carry a
+`tools` object:
+
+```json
+{
+  "type": "attenuating_agent_token",
+  "tools": {
+    "read_file": { "path": { "constraint_type": "exact", "value": "reports/q3.txt" } }
+  }
+}
+```
+
+Tool identifiers match by **exact string**, with no normalization (§3.3.1).
+
+Nine core constraint types are normative (§3.4, Table 2). Both the `check`
+predicate and the `subsumes` relation are normative - two implementations MUST
+agree:
+
+`exact`, `range` (with `min`/`max` and inclusivity flags), `one_of`,
+`not_one_of`, `contains`, `subset`, `wildcard`, `all` (AND), `any` (OR).
+
+Two fail-closed rules matter for us:
+
+- An enforcement point **MUST deny** if it meets a `constraint_type` it does not
+  recognize.
+- An enforcement point **MUST ignore** unrecognized *top-level JWT claims* - a
+  token must not be rejected merely for carrying extra claims.
+
+Anything richer than the core nine (path containment, URI normalization, policy
+expressions) MUST be a **registered extension constraint type** (§3.5). §3.5.3
+gives "Path Containment" as the worked example of such a registration.
+
+### 2.3 Derivation: "equal or narrower" (§6)
+
+A derived token MUST satisfy all of:
+
+- **Tools**: a subset of the parent's tool set.
+- **Per-tool constraints**: same argument keys as the parent where the parent's
+  set is non-empty; each constraint subsumed by the parent's per §4.5.
+- **`exp`**: less than or equal to the parent's.
+- **`iat`**: greater than or equal to the parent's.
+- **`del_depth`**: exactly parent + 1.
+- **`del_max_depth`**: at least the child's own depth, at most the parent's ceiling.
+
+Derivation is entirely offline. No authorization-server round trip.
+
+### 2.4 Chain verification (§7)
+
+Seven steps, root anchor down to leaf:
+
+1. Chain size and cycle checks.
+2. Root token validation: algorithm, signature, claims, exactly one AAT entry.
+3. Adjacent-pair checks against the five invariants - **I1** delegation
+   authority, **I2** depth monotonicity, **I3** TTL monotonicity, **I4**
+   capability monotonicity, **I5** `par_hash` cryptographic linkage.
+4. Chain length consistency.
+5. Leaf: tool present, constraints evaluated in closed-world mode.
+6. PoP JWT verification.
+
+All offline.
+
+### 2.5 Proof of possession (§5)
+
+A separate PoP JWT per invocation, signed by the key matching the leaf's
+`cnf.jwk`, carrying: fresh `jti`, `iat`, `aat_id` (the leaf's `jti`), `aat_tool`
+(exact tool name), optional `aat_aud`, and `hta` (the tool arguments,
+JCS-canonicalized). This is invariant **I6**.
+
+### 2.6 Implementation Status (Appendix E)
+
+Quoted in relevant part:
+
+> Tenuo provides a reference implementation of this protocol. The chain
+> verification algorithm (Section 7) and token derivation procedure (Section 6)
+> are both implemented. Tenuo also includes an implementation-specific CBOR/COSE
+> wire representation, with Ed25519 signatures carried in COSE_Sign1 structures.
+> That implementation experience supports the format independence of the core
+> protocol model, but does not define a fully interoperable CWT profile; the CWT
+> profile is deferred as described in Appendix D.
+
+Appendix E gives **no repository URL and no licence**. Both were found by search
+and confirmed against PyPI and the repository's `LICENSE` file. That gap is
+logged in `INTEROP-NOTES.md`.
+
+---
+
+## 3. The finding that shapes this work: two wire formats
+
+The draft's normative envelope is **JWT/JWS**. The shipped reference
+implementation is **CBOR/COSE-native**.
+
+Verified directly against `tenuo` 0.2.4:
+
+```
+Warrant.to_bytes()[:5] == b'\x83\x01\x58\xa6\xaa'   # CBOR: array(3), uint(1), bytes(0xa6), map(6)
+```
+
+There is no `Warrant.from_jwt` / `to_jwt` on the 0.2.4 Python surface. The
+vocabulary differs too: the library says *warrant*, *capability*, *holder*; the
+draft says *AAT*, `authorization_details`, `cnf`.
+
+Appendix E is candid that the CBOR/COSE representation is implementation-specific
+and does not constitute an interoperable profile. So there is no shipping
+implementation of the draft's JWT wire format to test against - the author's own
+implementation realises the draft's *protocol model*, not its *encoding*.
+
+This forces an explicit scoping choice, because the brief forbids reimplementing
+chain verification:
+
+- **What we can do**: verify chains, derive narrower tokens offline, and extract
+  leaf authority using the reference implementation - i.e. exercise the exact
+  normative model of §4, §6 and §7 through the author's code.
+- **What we cannot do without reimplementing the spec**: produce or verify
+  draft-conformant JWT AATs. Writing a JWT AAT encoder plus verifier *is* the
+  thing the brief rules out.
+
+**Recommended resolution.** Build the adapter against the reference
+implementation's protocol model. Fixtures under `test-vectors/aat/` are then
+tenuo CBOR warrant chains, and we say so plainly in the README rather than
+implying they are draft-encoded JWTs. The interop claim stays true and precise:
+*the attenuation invariant composes*, demonstrated through the draft author's own
+implementation. The claim we must **not** make is "Vouch consumes draft-format
+AAT JWTs" - that would be false today, for anyone.
+
+Optionally we can render a verified leaf's effective authority into the draft's
+`authorization_details` JSON shape for display and for the credential link. That
+is a presentation mapping only, with no cryptographic meaning, and it must be
+labelled as such wherever it appears.
+
+---
+
+## 4. The Vouch side
+
+### 4.1 Shield
+
+`vouch/shield/shield.py`. The pre-execution gate is:
+
+```python
+Shield.intercept(tool: str, args: dict, token: str|None, did: str|None) -> InterceptResult
+```
+
+Four steps: signature check → trust status → `PermissionManager.check_permission(did, tool)` → allow.
+
+The rule model (`vouch/shield/permissions.py`) is **coarse and per-DID**:
+`Capabilities(filesystem, network, shell, custom)` at levels
+`none < read < write < full`, plus a module-level `TOOL_REQUIREMENTS` map from
+tool name to required levels.
+
+The consequence that drives the design: **Shield's permission check takes `tool`
+but never `args`.** It cannot express a per-argument constraint. AAT's whole
+expressive core is per-argument constraints.
+
+### 4.2 Vouch's own delegation attenuation
+
+`vouch/attenuation.py` - `non_expansion(parent, child)` over six dimensions:
+`action`, `target`, `resource` (sub-resource containment), `time` (window
+nesting), `rate` (events/sec), `policy` (no-weaker). Default-deny on any
+malformed or ambiguous input. This is the same narrow-only invariant as AAT's
+I4/I3, over a different dimension set.
+
+### 4.3 The Signer
+
+`Signer.sign(intent=..., action=, target=, resource=, ...) -> dict`.
+
+`intent` is validated only for the presence of `action`, `target`, `resource`
+(`vouch/vc.py::_validate_intent`) and is then placed **verbatim** into
+`credentialSubject.intent`. Extra keys survive into the credential and are
+covered by the Data Integrity proof.
+
+That is our extension point for the credential link. No new required field, no
+change to the credential format, no change to the cryptosuite.
+
+---
+
+## 5. Mapping table
+
+| AAT concept | Vouch concept | Mapping | Lossy? |
+|---|---|---|---|
+| Tool name (`tools` key, exact-match) | Shield `action` / the `tool` argument to `intercept` | Direct 1:1, byte-exact string. Both sides already match tool names exactly with no normalization. | **No** |
+| Argument constraints (`{arg: {constraint_type, …}}`) | Shield `target` / `resource` constraints | **No native home.** Shield's `check_permission(did, tool)` never sees `args`. Enforced instead by delegating the argument decision back to the reference implementation's `Authorizer.check_chain(chain, tool, args, signature)`, in the same pre-execution step. | **Yes - see 5.1** |
+| Chain parent reference (`par_hash`) | Delegation parent `id` | Both bind a child to exactly one parent instance. AAT binds by SHA-256 of the parent's signing input; Vouch binds by parent credential `id` plus proof binding. Provenance-equivalent, not byte-equivalent. | **Yes - representation only** |
+| Narrow-only derivation (§6, I4) | Attenuation MUST-rule (`non_expansion`) | Identical invariant: a child may only narrow. Different dimension sets (AAT: tools + per-arg constraints + exp + depth; Vouch: action/target/resource/time/rate/policy). | **No** (invariant), **yes** (dimensions - see 5.1) |
+| `jti` | External authorisation reference on the credential | Carried as `intent.authorizedBy` - an extra key inside the existing `intent` dict, covered by the proof. Records *which delegation authorised this action*. | **No** |
+| `exp` / TTL monotonicity (I3) | Credential validity window (`validFrom`/`validUntil`) | Leaf `exp` clamps the issued credential's validity so the credential never outlives the authority that justified it. | **No** |
+| `cnf` / PoP (I6) | Holder binding | AAT binds per-invocation via a PoP signature over (leaf id, tool, JCS args). Vouch binds the credential to the issuer DID's key. Related but not the same object: PoP proves *this call*, the VC proves *this issuer*. | **Yes - see 5.1** |
+| `del_depth` / `del_max_depth` | Chain depth | Vouch imposes no fixed depth limit; AAT requires an explicit ceiling. Mapping AAT→Vouch is safe (a bound maps into the unbounded case); Vouch→AAT would need a ceiling invented. | **Yes - one direction only** |
+| `iss` (JWK-thumbprint URN on derived tokens) | Issuer DID | Different identifier schemes. A thumbprint URN is not a DID; `did:key` is the closest analogue and the conversion is not defined by either spec. | **Yes** |
+
+### 5.1 Lossy rows, stated plainly
+
+This list is a deliverable in its own right.
+
+1. **Shield cannot express AAT argument constraints.** Shield's rule model is
+   per-DID capability *levels*, not per-argument predicates. Nothing in
+   `Capabilities` can say "`path` must match `reports/*`". We therefore do not
+   flatten AAT constraints into Shield rules - that would silently widen
+   authority, allowing `read_file /etc/passwd` under a rule meant for
+   `reports/*`. Instead the argument decision stays with the reference
+   implementation and is composed with Shield's decision **before execution**.
+   Both must allow.
+
+2. **The reverse direction is lossy too.** Vouch's `rate` and `policy`
+   dimensions have no AAT equivalent in the core constraint set. AAT would need
+   registered extension constraint types (§3.5) to carry them.
+
+3. **`Pattern("reports/*")` is not a core AAT constraint type.** The demo's
+   natural constraint is path-globbing, which the draft explicitly excludes from
+   the core nine and defers to a registered extension (§3.5.3, "Path
+   Containment"). So the demo exercises a constraint that is real in the
+   reference implementation but not yet registered in the draft. Worth flagging
+   to the author.
+
+4. **PoP and VC holder binding are not the same guarantee.** AAT's PoP is
+   per-invocation and covers the arguments. A Vouch credential attests an issued
+   action by a DID. The adapter records the PoP-verified `jti` in the credential;
+   it does not claim the VC itself is a PoP.
+
+5. **Depth ceilings do not round-trip.** See the table row above.
+
+6. **Wire format.** Per §3, the fixtures are CBOR/COSE warrants from the
+   reference implementation, not draft JWT AATs. No round-trip to the draft's
+   normative encoding is possible with any shipping code today.
+
+---
+
+## 6. Behavioural findings from the reference implementation
+
+Verified by direct experiment against `tenuo` 0.2.4. These change the adapter's
+shape, so they are recorded here rather than discovered later.
+
+1. **`Authorizer.verify_chain()` does not enforce expiry.** An expired warrant
+   passes `verify_chain()` and is rejected only by `check_chain()` /
+   `authorize_one()` with `ExpiredError`. A verifier built on `verify_chain()`
+   alone would accept expired authority. The adapter therefore checks expiry
+   explicitly **and** routes enforcement through `check_chain()`. Logged in
+   `INTEROP-NOTES.md`: §7 step 3 lists TTL monotonicity as part of chain
+   verification, so which layer owns leaf expiry is ambiguous.
+
+2. **Widening is refused at derivation time, not just at verification.**
+   `attenuate()` raises rather than minting a widened child. Good default; it
+   means the "widening chain" fixture must be constructed deliberately.
+
+3. **`Warrant.allows()` and `check_constraints()` are documented
+   "DIAGNOSTIC USE ONLY".** The enforcement path is `Authorizer.check_chain`.
+   The adapter uses only the latter for decisions.
+
+4. **Tool-scope denial precedes PoP.** A narrowed-out tool returns
+   `ToolNotAuthorized` even with no PoP signature supplied, so the block in
+   Scene 4 is decisive and does not depend on PoP setup.
+
+5. **Tampering is caught at decode.** A single flipped byte fails with
+   `DeserializationError` before signature checking.
+
+---
+
+## 7. Proposed shape
+
+```
+integrations/aat/
+  aat_chain.py       # load chain, call the reference verifier, return
+                     # VerifiedChain | typed failure (bad signature, broken
+                     # chain, widened scope, expired, PoP mismatch)
+  aat_to_shield.py   # leaf effective authority -> Shield rules (tool scope) +
+                     # a bound argument-check callable (constraints)
+  credential_link.py # pass leaf jti + root identifier to the Signer via intent
+  README.md
+  DEMO.md
+  tests/
+test-vectors/aat/    # valid narrowing chain; widening chain; + generation README
+```
+
+Enforcement composition, all strictly before execution:
+
+```
+intercept(tool, args)
+  → Shield.intercept(...)            # trust, DID, tool-level capability
+  → Authorizer.check_chain(...)      # AAT chain + tool scope + arg constraints + PoP
+  → both allow?  execute, then Signer.sign(intent with authorizedBy=jti)
+  → either denies? return blocked. The tool is never called.
+```
+
+Fail-closed everywhere: any verification failure yields **no** rules and no
+execution.
+
+`vouch-mcp` wiring: `VOUCH_AAT_CHAIN` env var (the server is env-configured
+today; `main()` has no argparse) plus an optional `--aat-chain` flag.
+**Precedence**: when an AAT chain is present, it is applied *in addition to* the
+static allow-list, never instead of it. Both must allow. That direction is the
+only one that cannot widen authority relative to today's behaviour.
+
+---
+
+## 8. Boundaries this design holds
+
+- No change to the credential format, cryptosuite, or Shield semantics. AAT is
+  an input to the gate, not a modification of it.
+- Vouch's outputs stay byte-identical. Baseline recorded below.
+- No priority claims in any artefact.
+- No new required credential field - the link rides in the existing `intent`.
+- Apache-2.0 throughout; the dependency is Apache-2.0.
+
+### Test baseline (recorded before any change)
+
+```
+python3 -m pytest tests/ -q --ignore=tests/test_threshold.py
+→ 1447 passed, 1 skipped
+```
+
+`tests/test_threshold.py` fails at **collection** on this machine, before any of
+this work: the prebuilt `core/uniffi/target/release/libvouch_core_uniffi.so` is
+stale and missing the symbol `vouch_threshold_generate_key`. Pre-existing and
+unrelated; noted so it is not mistaken for fallout later. Everything else runs
+clean and must stay that way.
+
+---
+
+## 9. Scoping decisions
+
+Both questions below were put to the maintainer and answered before any code was
+written. The answers are recorded here as the decisions the implementation
+follows.
+
+**Decision 1: Python only.** Not Python + TypeScript.
+
+**Decision 2: build against the protocol model, labelled honestly.** Fixtures
+are CBOR warrant chains and are described as such; no claim is made anywhere
+that this adapter consumes draft-format AAT JWTs. The optional
+presentation-only RAR view described in Section 3 was not built.
+
+The reasoning behind each, as it was put at the time:
+
+**Scope: Python-only adapter for the demo (default), or Python + TypeScript?**
+
+Python-only is the recommendation. It covers Shield, the Signer, `vouch-mcp` and
+the whole of Scene 4, and the reference implementation's Python bindings are the
+mature surface. Tenuo does publish `@tenuo/core@beta` for TypeScript, so a TS
+adapter is possible, but "beta" on the dependency side would put the weakest link
+in the demo path.
+
+There is also the §3 question to confirm: proceed against the reference
+implementation's protocol model, with fixtures honestly labelled as CBOR warrant
+chains rather than draft JWT AATs.

--- a/integrations/aat/README.md
+++ b/integrations/aat/README.md
@@ -1,0 +1,159 @@
+# AAT ↔ Vouch Protocol interop
+
+**Attenuating Authorization Tokens** ([`draft-niyikiza-oauth-attenuating-agent-tokens-01`](https://datatracker.ietf.org/doc/html/draft-niyikiza-oauth-attenuating-agent-tokens-01))
+are JWT-based delegation tokens for AI agents, profiling RFC 9396 Rich
+Authorization Requests. An AAT names the tools an agent may invoke and the
+argument constraints on those invocations; any holder can derive a narrower
+token offline, with no authorization-server round trip, and the resulting chain
+verifies against its root trust anchor. This adapter verifies such a chain,
+turns the leaf's authority into Vouch Shield rules, enforces them **before** an
+MCP tool call runs, and links the resulting Vouch credential back to the AAT
+that authorised the action.
+
+**Same invariant, two envelopes.** AAT and Vouch's delegation model both enforce
+that authority may only narrow - never widen - as it is handed on. AAT expresses
+that in OAuth/RAR form as a signed token chain; Vouch expresses it as a
+Verifiable Credential chain over six dimensions (action, target, resource, time,
+rate, policy). Neither had to change to work with the other: AAT is an *input*
+to the gate, and Vouch's credential format, cryptosuite and Shield semantics are
+untouched. The two compose - OAuth-world delegation underneath, VC-world
+accountability on top.
+
+Chain verification and token derivation are **not** reimplemented here. Both are
+delegated to the AAT reference implementation
+([`tenuo`](https://github.com/tenuo-ai/tenuo), Apache-2.0), which the draft's
+Implementation Status appendix names. This adapter is the layer between that and
+Vouch.
+
+## Install and run
+
+```bash
+pip install tenuo
+python3 -m pytest integrations/aat/tests/ -q
+```
+
+Run from the repository root. `integrations/` is not part of the installed
+`vouch` package (the same is true of `integrations/ros2/`), so set
+`PYTHONPATH=/path/to/vouch-protocol` when invoking it from elsewhere.
+
+Try it:
+
+```python
+from integrations.aat import AatGate, verify_chain_file
+
+chain = verify_chain_file("test-vectors/aat/valid-narrowing-chain.json")
+gate = AatGate(chain, holder_key=holder_key)
+
+decision = gate.check("read_file", {"path": "reports/q3.txt"})
+if decision.allowed:
+    run_the_tool()          # only ever reached on an allowed decision
+```
+
+With `vouch-mcp`:
+
+```bash
+vouch-mcp --aat-chain leaf.json --aat-holder-key holder.pem
+```
+
+That exposes a `check_action_aat` tool which sources its rules from the chain's
+leaf. **Precedence:** when a static allow-list is also in force, both must allow.
+An AAT chain narrows what the server will do; it never widens it. If the chain
+is missing or fails to verify, the tool denies - there is no lax fallback.
+
+**Where enforcement actually binds.** `AatGate.check` is the enforcement API:
+it returns a decision and never executes anything, so a caller that runs a tool
+only on `decision.allowed` cannot execute an unauthorised call. That is the
+in-process path, and it is what the tests assert against with a mock tool.
+
+`check_action_aat` is a *decision* tool in the same shape as the existing
+`check_action`: it answers ALLOW or DENY and does not itself run the gated tool.
+Over MCP the decision therefore binds only as far as the client honours it,
+exactly as `check_action` does today. This adapter deliberately did not change
+that, since Shield semantics were out of scope. If you need enforcement that
+cannot be bypassed by a client, put `AatGate` in front of the tool in-process
+rather than relying on the MCP decision tool.
+
+See [`DEMO.md`](DEMO.md) for the recordable walkthrough and
+[`DESIGN.md`](DESIGN.md) for the full mapping.
+
+## What maps cleanly
+
+| AAT | Vouch | |
+|---|---|---|
+| Tool name | Shield `action` | Exact string match on both sides, no normalization |
+| Narrow-only derivation | Attenuation MUST-rule | The same invariant |
+| `jti` | `intent.authorizedBy` on the credential | Records which delegation authorised the action |
+| Leaf `exp` | Credential validity window | Clamped, so a credential never outlives its authority |
+
+## What does not map cleanly
+
+This list is a deliverable, not a caveat section. Full detail in
+[`DESIGN.md`](DESIGN.md) §5.1.
+
+1. **Shield cannot express AAT argument constraints.** Its permission check is
+   `check_permission(did, tool)` - it never sees the call's arguments, and its
+   rule model is per-DID capability *levels*, not per-argument predicates.
+   Flattening AAT constraints into those levels would silently widen authority:
+   a leaf limited to `reports/*` would become a blanket filesystem-read grant
+   and `read_file /etc/passwd` would pass. So this adapter does not flatten
+   them. Tool scope becomes Shield rules; argument constraints stay with the
+   reference implementation and are evaluated in the same pre-execution step.
+   Both must allow.
+
+2. **Vouch's `rate` and `policy` dimensions have no AAT equivalent** in the core
+   constraint set. Carrying them would need registered extension constraint
+   types (draft §3.5).
+
+3. **The demo's own constraint is not a core AAT type.** Path globbing
+   (`reports/*`) is explicitly excluded from the draft's core nine and deferred
+   to a registered extension - §3.5.3 uses "Path Containment" as its worked
+   example. It is real in the reference implementation, not yet registered in
+   the draft.
+
+4. **PoP and VC holder binding are different guarantees.** AAT's
+   proof-of-possession is per-invocation and covers the arguments; a Vouch
+   credential attests an action issued by a DID. The adapter records the
+   PoP-verified `jti` on the credential; it does not claim the credential is
+   itself a proof of possession.
+
+5. **Depth ceilings do not round-trip.** AAT requires an explicit
+   `del_max_depth`; Vouch imposes no fixed depth limit. AAT → Vouch is safe;
+   the reverse would mean inventing a ceiling.
+
+6. **Identifier schemes differ.** A derived AAT's `iss` is a JWK-thumbprint URN;
+   Vouch uses DIDs. `did:key` is the nearest analogue and neither spec defines
+   the conversion.
+
+7. **Wire format.** The draft's normative envelope is JWT/JWS. The reference
+   implementation is CBOR/COSE-native and its Appendix E says so plainly
+   ("implementation-specific ... does not define a fully interoperable CWT
+   profile"). There is therefore no shipping implementation of the draft's
+   encoding to test against. This adapter works against the *protocol model* -
+   the attenuation invariants and chain verification of §4, §6 and §7 - through
+   the author's own implementation. The fixtures in `test-vectors/aat/` are CBOR
+   warrant chains, and are labelled as such. **This adapter does not consume
+   draft-format AAT JWTs**, and nothing here should be read as claiming it does.
+
+## Layout
+
+| File | Purpose |
+|---|---|
+| `aat_chain.py` | Load a chain, verify it against its root anchor, return a verified chain or a typed failure |
+| `aat_to_shield.py` | Leaf authority → Shield rules; the pre-execution gate |
+| `credential_link.py` | Record the authorising AAT on the issued credential |
+| `demo_setup.py`, `demo_call.py` | Scene 4 |
+| `tests/` | 17 tests, each named for what it proves |
+| `../../test-vectors/aat/` | Chain fixtures and their generator |
+
+Failures are typed so a caller can branch on them: `AatMalformedChain`,
+`AatBadSignature`, `AatBrokenChain`, `AatWidenedScope`, `AatExpired`,
+`AatUntrustedRoot`, `AatPopMismatch`, all under `AatError`. Every path is
+fail-closed - a failure yields no rules and nothing executes.
+
+Implementer feedback on the draft is in
+[`../../INTEROP-NOTES.md`](../../INTEROP-NOTES.md).
+
+## Licence
+
+Apache-2.0, matching the rest of the repository and the reference
+implementation.

--- a/integrations/aat/__init__.py
+++ b/integrations/aat/__init__.py
@@ -1,0 +1,59 @@
+"""AAT <-> Vouch interop adapter.
+
+Verifies an Attenuating Authorization Token chain against its root trust
+anchor using the AAT reference implementation, turns the leaf's authority into
+Vouch Shield rules, enforces them before a tool call runs, and links the
+resulting Vouch credential back to the AAT that authorised the action.
+
+See ``README.md`` for what AAT is and ``DESIGN.md`` for the mapping and its
+lossy rows.
+"""
+
+from .aat_chain import (
+    AatBadSignature,
+    AatBrokenChain,
+    AatError,
+    AatExpired,
+    AatMalformedChain,
+    AatPopMismatch,
+    AatUntrustedRoot,
+    AatWidenedScope,
+    ChainDocument,
+    VerifiedChain,
+    load_chain_document,
+    verify_chain,
+    verify_chain_file,
+)
+from .aat_to_shield import AatDecision, AatGate, ShieldRules, leaf_to_shield_rules
+from .credential_link import (
+    AAT_LINK_KEY,
+    attach_aat_link,
+    build_aat_link,
+    extract_aat_link,
+    sign_with_aat_link,
+)
+
+__all__ = [
+    "AatBadSignature",
+    "AatBrokenChain",
+    "AatError",
+    "AatExpired",
+    "AatMalformedChain",
+    "AatPopMismatch",
+    "AatUntrustedRoot",
+    "AatWidenedScope",
+    "ChainDocument",
+    "VerifiedChain",
+    "load_chain_document",
+    "verify_chain",
+    "verify_chain_file",
+    "AatDecision",
+    "AatGate",
+    "ShieldRules",
+    "leaf_to_shield_rules",
+    "AAT_LINK_KEY",
+    "attach_aat_link",
+    "build_aat_link",
+    "extract_aat_link",
+    "sign_with_aat_link",
+]

--- a/integrations/aat/aat_chain.py
+++ b/integrations/aat/aat_chain.py
@@ -1,0 +1,327 @@
+"""Load and verify an AAT delegation chain.
+
+This module is a thin wrapper around the AAT reference implementation
+(``tenuo``, Apache-2.0, https://github.com/tenuo-ai/tenuo). Chain verification
+and token derivation are the reference implementation's job -- see
+``draft-niyikiza-oauth-attenuating-agent-tokens-01`` Section 6 (derivation) and
+Section 7 (the seven-step verification algorithm). Nothing here reimplements
+either. What this module adds is:
+
+- a file format for carrying a chain plus its root trust anchor;
+- typed, fail-closed failures a caller can branch on;
+- an explicit expiry check, because the reference implementation's
+  ``Authorizer.verify_chain()`` does not enforce expiry on its own (see
+  ``INTEROP-NOTES.md``).
+
+Wire format note: the reference implementation serialises warrants as CBOR, not
+as the draft's JWT/JWS encoding. See ``DESIGN.md`` Section 3.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+try:
+    from tenuo import Authorizer, PublicKey, Warrant
+    from tenuo import exceptions as _tex
+except ImportError as exc:  # pragma: no cover - exercised only without the dep
+    raise ImportError(
+        "The AAT adapter needs the AAT reference implementation. Install it with: pip install tenuo"
+    ) from exc
+
+
+CHAIN_FORMAT_VERSION = 1
+
+__all__ = [
+    "AatError",
+    "AatMalformedChain",
+    "AatBadSignature",
+    "AatBrokenChain",
+    "AatWidenedScope",
+    "AatExpired",
+    "AatUntrustedRoot",
+    "AatPopMismatch",
+    "ChainDocument",
+    "VerifiedChain",
+    "load_chain_document",
+    "verify_chain",
+    "verify_chain_file",
+]
+
+
+# ---------------------------------------------------------------------------
+# Typed failures
+# ---------------------------------------------------------------------------
+
+
+class AatError(Exception):
+    """Base class for every AAT adapter failure.
+
+    Callers that only care 'did this fail' should catch this. Every failure
+    path is fail-closed: no rules are produced and no tool runs.
+    """
+
+
+class AatMalformedChain(AatError):
+    """The chain file itself is unusable -- missing, bad JSON, wrong shape."""
+
+
+class AatBadSignature(AatError):
+    """A token in the chain is not authentic.
+
+    Covers both a failed signature check and a payload that will not decode.
+    The reference implementation rejects a tampered token at CBOR decode,
+    before signature verification, so a single flipped byte surfaces here as a
+    deserialization failure rather than a signature failure. Both mean the same
+    thing to a caller -- these bytes are not the bytes that were signed -- so
+    they share one type.
+    """
+
+
+class AatBrokenChain(AatError):
+    """Chain structure is invalid: linkage, depth, cycle, or ordering."""
+
+
+class AatWidenedScope(AatError):
+    """A derived token broadens its parent. The narrow-only invariant failed."""
+
+
+class AatExpired(AatError):
+    """A token in the chain has expired."""
+
+
+class AatUntrustedRoot(AatError):
+    """The chain does not anchor to the expected root trust anchor."""
+
+
+class AatPopMismatch(AatError):
+    """Proof-of-possession missing or not valid for this call."""
+
+
+def _classify(exc: Exception) -> AatError:
+    """Translate a reference-implementation exception into a typed failure.
+
+    Ordered most specific first. Anything unrecognised becomes a generic
+    ``AatError`` rather than being allowed through -- unknown means deny.
+    """
+    if isinstance(exc, _tex.UntrustedRoot):
+        return AatUntrustedRoot(str(exc))
+    if isinstance(exc, _tex.ExpiredError):
+        return AatExpired(str(exc))
+    if isinstance(exc, _tex.MonotonicityError):
+        return AatWidenedScope(str(exc))
+    if isinstance(exc, _tex.PopError):
+        return AatPopMismatch(str(exc))
+    if isinstance(exc, _tex.MissingSignature):
+        return AatPopMismatch(str(exc))
+    if isinstance(exc, (_tex.SerializationError, _tex.CryptoError)):
+        return AatBadSignature(str(exc))
+    if isinstance(exc, _tex.ChainError):
+        return AatBrokenChain(str(exc))
+    return AatError(f"{type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Chain document
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ChainDocument:
+    """An AAT chain as it is carried on disk.
+
+    Public material only. The holder's private key is never part of this file;
+    it is supplied separately at invocation time to produce proof-of-possession.
+    """
+
+    root_public_key_pem: str
+    warrants_b64: List[str]
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "aat_chain_version": CHAIN_FORMAT_VERSION,
+            "root_public_key_pem": self.root_public_key_pem,
+            "warrants": list(self.warrants_b64),
+        }
+
+    def write(self, path: Union[str, Path]) -> None:
+        Path(path).write_text(json.dumps(self.to_dict(), indent=2) + "\n")
+
+
+def load_chain_document(path: Union[str, Path]) -> ChainDocument:
+    """Read a chain file. Raises ``AatMalformedChain`` on anything unusable."""
+    p = Path(path)
+    try:
+        raw = json.loads(p.read_text())
+    except FileNotFoundError as exc:
+        raise AatMalformedChain(f"AAT chain file not found: {p}") from exc
+    except json.JSONDecodeError as exc:
+        raise AatMalformedChain(f"AAT chain file is not valid JSON: {p}: {exc}") from exc
+
+    if not isinstance(raw, dict):
+        raise AatMalformedChain(f"AAT chain file must contain a JSON object: {p}")
+
+    version = raw.get("aat_chain_version")
+    if version != CHAIN_FORMAT_VERSION:
+        raise AatMalformedChain(
+            f"Unsupported aat_chain_version {version!r} in {p} "
+            f"(this adapter reads version {CHAIN_FORMAT_VERSION})"
+        )
+
+    root_pem = raw.get("root_public_key_pem")
+    if not isinstance(root_pem, str) or not root_pem.strip():
+        raise AatMalformedChain(f"root_public_key_pem is missing or empty in {p}")
+
+    warrants = raw.get("warrants")
+    if not isinstance(warrants, list) or not warrants:
+        raise AatMalformedChain(f"warrants must be a non-empty array in {p}")
+    if not all(isinstance(w, str) and w for w in warrants):
+        raise AatMalformedChain(f"every entry in warrants must be a non-empty string in {p}")
+
+    return ChainDocument(root_public_key_pem=root_pem, warrants_b64=list(warrants))
+
+
+# ---------------------------------------------------------------------------
+# Verified chain
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerifiedChain:
+    """A chain that passed verification, ordered root -> leaf.
+
+    Only ``leaf`` carries the authority that may be exercised. The rest of the
+    chain is retained for provenance, not summed: per the draft, a derived
+    token's authority is what it says, already narrowed. See ``DESIGN.md``.
+    """
+
+    warrants: List[Any]
+    root_public_key: Any
+    _authorizer: Any
+
+    @property
+    def leaf(self) -> Any:
+        return self.warrants[-1]
+
+    @property
+    def root(self) -> Any:
+        return self.warrants[0]
+
+    @property
+    def leaf_jti(self) -> str:
+        """The leaf token identifier -- the AAT that authorises a given call."""
+        return str(self.leaf.id)
+
+    @property
+    def root_jti(self) -> str:
+        """The chain root identifier."""
+        return str(self.root.id)
+
+    @property
+    def depth(self) -> int:
+        return int(self.leaf.depth)
+
+    @property
+    def tools(self) -> List[str]:
+        """Tool names the leaf authorises, sorted for stable output."""
+        return sorted(str(t) for t in self.leaf.tools)
+
+    @property
+    def expires_at(self) -> str:
+        """Leaf expiry as an RFC 3339 string."""
+        return str(self.leaf.expires_at())
+
+    def capabilities(self) -> Dict[str, Any]:
+        """Leaf capabilities as ``{tool: {arg: constraint}}``."""
+        return dict(self.leaf.capabilities)
+
+
+def _parse_rfc3339(value: str) -> datetime:
+    text = str(value).strip()
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    return datetime.fromisoformat(text).astimezone(timezone.utc)
+
+
+def _assert_not_expired(warrants: Sequence[Any], as_of: Optional[datetime]) -> None:
+    """Reject any expired token in the chain.
+
+    Done explicitly because ``Authorizer.verify_chain()`` in the reference
+    implementation returns success for an expired warrant; expiry is enforced
+    only on the authorization call. Relying on ``verify_chain`` alone would
+    accept expired authority. Recorded in ``INTEROP-NOTES.md``.
+    """
+    now = (as_of or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    for index, warrant in enumerate(warrants):
+        try:
+            expiry = _parse_rfc3339(warrant.expires_at())
+        except Exception as exc:
+            raise AatMalformedChain(
+                f"token at position {index} has an unreadable expiry: {exc}"
+            ) from exc
+        if expiry <= now:
+            raise AatExpired(
+                f"token at position {index} ({warrant.id}) expired at {warrant.expires_at()}"
+            )
+
+
+def verify_chain(
+    document: ChainDocument,
+    *,
+    as_of: Optional[datetime] = None,
+) -> VerifiedChain:
+    """Verify a chain against its root trust anchor.
+
+    Returns a :class:`VerifiedChain` ordered root -> leaf, or raises one of the
+    typed failures in this module. There is no partial success: a chain either
+    verifies whole or yields nothing.
+    """
+    try:
+        root_key = PublicKey.from_pem(document.root_public_key_pem)
+    except Exception as exc:
+        raise AatMalformedChain(f"root_public_key_pem is not a usable key: {exc}") from exc
+
+    warrants: List[Any] = []
+    for index, encoded in enumerate(document.warrants_b64):
+        try:
+            warrants.append(Warrant.from_base64(encoded))
+        except _tex.TenuoError as exc:
+            raise _classify(exc) from exc
+        except Exception as exc:
+            raise AatMalformedChain(
+                f"token at position {index} could not be decoded: {exc}"
+            ) from exc
+
+    authorizer = Authorizer()
+    try:
+        authorizer.add_trusted_root(root_key)
+    except Exception as exc:
+        raise AatMalformedChain(f"root trust anchor rejected: {exc}") from exc
+
+    try:
+        authorizer.verify_chain(warrants)
+    except _tex.TenuoError as exc:
+        raise _classify(exc) from exc
+    except Exception as exc:
+        raise AatError(f"chain verification failed: {exc}") from exc
+
+    _assert_not_expired(warrants, as_of)
+
+    return VerifiedChain(
+        warrants=warrants,
+        root_public_key=root_key,
+        _authorizer=authorizer,
+    )
+
+
+def verify_chain_file(
+    path: Union[str, Path],
+    *,
+    as_of: Optional[datetime] = None,
+) -> VerifiedChain:
+    """Load and verify a chain file in one call."""
+    return verify_chain(load_chain_document(path), as_of=as_of)

--- a/integrations/aat/aat_to_shield.py
+++ b/integrations/aat/aat_to_shield.py
@@ -1,0 +1,247 @@
+"""Translate a verified AAT leaf into Vouch Shield rules, and enforce them.
+
+Only the **leaf** matters for enforcement. A derived AAT already states its own
+narrowed authority, so there is nothing to intersect: the chain is verified for
+provenance, the leaf is what is enforced. See ``DESIGN.md``.
+
+The mapping is deliberately partial, and the partiality is the interesting part.
+Shield's permission check has the signature ``check_permission(did, tool)`` --
+it never sees the call's arguments, so it structurally cannot express an AAT
+argument constraint such as ``path`` matching ``reports/*``. Flattening those
+constraints into Shield's capability levels would silently widen authority: a
+leaf restricted to ``reports/*`` would become a blanket filesystem-read grant,
+and ``read_file /etc/passwd`` would pass. So this module does not flatten them.
+
+Instead:
+
+- **Tool scope** becomes Shield rules -- an explicit allowlist plus the least
+  capability set that admits exactly those tools.
+- **Argument constraints** stay with the AAT reference implementation, and are
+  evaluated by ``Authorizer.check_chain`` in the same pre-execution step.
+
+Both must allow. Either refusing means the tool does not run.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from vouch.shield.permissions import (
+    TOOL_REQUIREMENTS,
+    Capabilities,
+    NetworkLevel,
+    PermissionLevel,
+    ShellLevel,
+)
+
+from .aat_chain import VerifiedChain
+
+try:
+    from tenuo import exceptions as _tex
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "The AAT adapter needs the AAT reference implementation. Install it with: pip install tenuo"
+    ) from exc
+
+
+__all__ = ["ShieldRules", "AatDecision", "AatGate", "leaf_to_shield_rules"]
+
+
+# Ordered weakest -> strongest, matching vouch.shield.permissions.
+_LEVELS = {
+    "filesystem": (["none", "read", "write", "full"], PermissionLevel),
+    "network": (["none", "internal", "outbound", "full"], NetworkLevel),
+    "shell": (["none", "sandboxed", "full"], ShellLevel),
+}
+
+
+@dataclass(frozen=True)
+class ShieldRules:
+    """Shield rules sourced from an AAT leaf.
+
+    ``allowed_tools`` is authoritative. ``capabilities`` alone would be too
+    permissive: Shield's capability levels are per-resource, not per-tool, so a
+    leaf granting ``read_file`` yields ``filesystem=read``, which would also
+    admit ``list_directory``. The allowlist is what pins enforcement to exactly
+    the tools the leaf names.
+    """
+
+    allowed_tools: frozenset
+    capabilities: Capabilities
+    unmapped_tools: tuple = ()
+    leaf_jti: str = ""
+    root_jti: str = ""
+
+    def permits_tool(self, tool: str) -> bool:
+        """Exact-string match, per draft Section 3.3.1 -- no normalization."""
+        return tool in self.allowed_tools
+
+
+def leaf_to_shield_rules(chain: VerifiedChain) -> ShieldRules:
+    """Derive Shield rules from a verified chain's leaf.
+
+    The capability set is the least one that admits exactly the leaf's tools:
+    the per-resource maximum over each tool's entry in ``TOOL_REQUIREMENTS``.
+    Tools with no entry are reported in ``unmapped_tools`` -- Shield denies
+    unknown tools by default, which is the fail-closed behaviour we want, so
+    they are surfaced rather than silently granted a capability.
+    """
+    tools = list(chain.tools)
+
+    levels: Dict[str, str] = {"filesystem": "none", "network": "none", "shell": "none"}
+    unmapped: List[str] = []
+
+    for tool in tools:
+        requirements = TOOL_REQUIREMENTS.get(tool.lower())
+        if requirements is None:
+            unmapped.append(tool)
+            continue
+        for resource, required in requirements.items():
+            order, _ = _LEVELS.get(resource, (None, None))
+            if order is None:
+                # An unrecognised resource dimension. Do not guess -- treat the
+                # tool as unmapped so it shows up rather than being waved through.
+                unmapped.append(tool)
+                continue
+            if order.index(required) > order.index(levels[resource]):
+                levels[resource] = required
+
+    capabilities = Capabilities(
+        filesystem=PermissionLevel(levels["filesystem"]),
+        network=NetworkLevel(levels["network"]),
+        shell=ShellLevel(levels["shell"]),
+    )
+
+    return ShieldRules(
+        allowed_tools=frozenset(tools),
+        capabilities=capabilities,
+        unmapped_tools=tuple(sorted(set(unmapped))),
+        leaf_jti=chain.leaf_jti,
+        root_jti=chain.root_jti,
+    )
+
+
+@dataclass(frozen=True)
+class AatDecision:
+    """The outcome of a pre-execution check. ``allowed`` is the whole answer."""
+
+    allowed: bool
+    tool: str
+    reason: Optional[str] = None
+    leaf_jti: str = ""
+    root_jti: str = ""
+    failure: Optional[str] = None
+
+    def __bool__(self) -> bool:
+        return self.allowed
+
+
+class AatGate:
+    """Pre-execution gate combining AAT authority with Vouch Shield.
+
+    Every decision happens before the tool runs. There is no path through this
+    class that executes a tool and then checks it.
+
+    Usage::
+
+        chain = verify_chain_file("leaf.json")
+        gate = AatGate(chain, holder_key=key)
+        decision = gate.check("read_file", {"path": "reports/q3.txt"})
+        if decision.allowed:
+            run_tool()
+    """
+
+    def __init__(
+        self,
+        chain: VerifiedChain,
+        *,
+        holder_key: Any = None,
+        shield: Any = None,
+        did: Optional[str] = None,
+    ) -> None:
+        """
+        Args:
+            chain: A chain already verified by ``aat_chain.verify_chain``.
+            holder_key: Optional signing key matching the leaf's authorized
+                holder. Supplied, the gate mints the proof-of-possession for
+                each call itself. That is a convenience for local and demo use:
+                in a real deployment the PoP is produced by the caller holding
+                the key and passed to ``check`` as ``signature``.
+            shield: Optional ``vouch.shield.Shield``. When given, its verdict is
+                combined with the AAT verdict and both must allow.
+            did: DID to check Shield permissions against, when ``shield`` is set.
+        """
+        self._chain = chain
+        self._holder_key = holder_key
+        self._shield = shield
+        self._did = did
+        self.rules = leaf_to_shield_rules(chain)
+
+    @property
+    def chain(self) -> VerifiedChain:
+        return self._chain
+
+    def check(
+        self,
+        tool: str,
+        args: Optional[Dict[str, Any]] = None,
+        *,
+        signature: Optional[bytes] = None,
+        as_of: Optional[datetime] = None,
+    ) -> AatDecision:
+        """Decide whether a call may proceed. Never executes anything.
+
+        Order: tool scope, then Shield, then the AAT reference implementation
+        (which re-checks tool scope, evaluates argument constraints, enforces
+        expiry, and verifies proof-of-possession). Any failure is fail-closed.
+        """
+        args = dict(args or {})
+
+        def deny(reason: str, failure: Optional[str] = None) -> AatDecision:
+            return AatDecision(
+                allowed=False,
+                tool=tool,
+                reason=reason,
+                leaf_jti=self.rules.leaf_jti,
+                root_jti=self.rules.root_jti,
+                failure=failure,
+            )
+
+        # 1. Tool scope from the leaf.
+        if not self.rules.permits_tool(tool):
+            return deny(
+                f"Tool '{tool}' is not in the AAT leaf's authority "
+                f"(leaf permits: {', '.join(sorted(self.rules.allowed_tools)) or 'nothing'})",
+                failure="ToolNotAuthorized",
+            )
+
+        # 2. Shield, when configured. Both layers must allow.
+        if self._shield is not None:
+            result = self._shield.intercept(tool=tool, args=args, did=self._did)
+            if not result.allowed:
+                return deny(f"Shield denied: {result.reason}", failure="ShieldDenied")
+
+        # 3. The AAT reference implementation: argument constraints, expiry, PoP.
+        pop = signature
+        if pop is None and self._holder_key is not None:
+            try:
+                pop = self._chain.leaf.sign(self._holder_key, tool, args, int(time.time()))
+            except Exception as exc:
+                return deny(f"Could not produce proof-of-possession: {exc}", failure="PopError")
+
+        try:
+            self._chain._authorizer.check_chain(self._chain.warrants, tool, args, signature=pop)
+        except _tex.TenuoError as exc:
+            return deny(f"{type(exc).__name__}: {exc}", failure=type(exc).__name__)
+        except Exception as exc:  # unknown means deny
+            return deny(f"AAT check failed: {exc}", failure=type(exc).__name__)
+
+        return AatDecision(
+            allowed=True,
+            tool=tool,
+            leaf_jti=self.rules.leaf_jti,
+            root_jti=self.rules.root_jti,
+        )

--- a/integrations/aat/credential_link.py
+++ b/integrations/aat/credential_link.py
@@ -1,0 +1,121 @@
+"""Record which AAT authorised an action on the Vouch credential it produced.
+
+The link rides inside the credential's existing ``intent`` object. ``intent`` is
+validated only for the presence of ``action``, ``target`` and ``resource``
+(``vouch/vc.py::_validate_intent``) and is then placed verbatim into
+``credentialSubject.intent``, so extra keys survive into the credential and are
+covered by the Data Integrity proof.
+
+That means no new required field, no change to the credential format, and no
+change to the cryptosuite. A verifier that knows nothing about AAT still
+verifies these credentials byte-for-byte as before.
+"""
+
+from __future__ import annotations
+
+import math
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .aat_chain import VerifiedChain, _parse_rfc3339
+
+__all__ = [
+    "AAT_LINK_KEY",
+    "build_aat_link",
+    "attach_aat_link",
+    "extract_aat_link",
+    "sign_with_aat_link",
+]
+
+
+#: Key used inside ``intent`` to carry the authorising delegation.
+AAT_LINK_KEY = "authorizedBy"
+
+
+def build_aat_link(chain: VerifiedChain) -> Dict[str, Any]:
+    """Build the link object for a verified chain.
+
+    ``jti`` is the leaf -- the token that actually authorised the call.
+    ``chainRoot`` identifies the delegation the leaf descends from, so an
+    auditor can tell two chains apart that happen to grant the same tool.
+    """
+    return {
+        "scheme": "aat",
+        "jti": chain.leaf_jti,
+        "chainRoot": chain.root_jti,
+        "depth": chain.depth,
+    }
+
+
+def attach_aat_link(intent: Dict[str, Any], chain: VerifiedChain) -> Dict[str, Any]:
+    """Return a copy of ``intent`` carrying the AAT link. Never mutates input."""
+    enriched = dict(intent)
+    enriched[AAT_LINK_KEY] = build_aat_link(chain)
+    return enriched
+
+
+def extract_aat_link(credential: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Pull the AAT link back out of an issued credential, or ``None``."""
+    subject = credential.get("credentialSubject")
+    if not isinstance(subject, dict):
+        return None
+    intent = subject.get("intent")
+    if not isinstance(intent, dict):
+        return None
+    link = intent.get(AAT_LINK_KEY)
+    return link if isinstance(link, dict) else None
+
+
+def _seconds_until_leaf_expiry(chain: VerifiedChain, now: Optional[datetime] = None) -> int:
+    moment = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    remaining = (_parse_rfc3339(chain.expires_at) - moment).total_seconds()
+    return int(math.floor(remaining))
+
+
+def sign_with_aat_link(
+    signer: Any,
+    chain: VerifiedChain,
+    *,
+    action: str,
+    target: str,
+    resource: str,
+    valid_seconds: Optional[int] = None,
+    clamp_to_leaf_expiry: bool = True,
+    **sign_kwargs: Any,
+) -> Dict[str, Any]:
+    """Issue a Vouch credential that records the AAT which authorised the action.
+
+    The credential's validity is clamped so it never outlives the authority that
+    justified it: a credential asserting 'this was authorised' should not remain
+    valid after that authorisation has expired.
+
+    Args:
+        signer: A ``vouch.signer.Signer``.
+        chain: The verified chain whose leaf authorised this action.
+        action, target, resource: The required Vouch intent fields.
+        valid_seconds: Requested validity. Defaults to the Signer's own default.
+        clamp_to_leaf_expiry: Cap validity at the leaf's remaining lifetime.
+        **sign_kwargs: Passed through to ``Signer.sign`` unchanged.
+
+    Raises:
+        ValueError: if the leaf has already expired, so no valid window exists.
+    """
+    intent = attach_aat_link({"action": action, "target": target, "resource": resource}, chain)
+
+    requested = (
+        valid_seconds if valid_seconds is not None else getattr(signer, "default_expiry", None)
+    )
+
+    if clamp_to_leaf_expiry:
+        remaining = _seconds_until_leaf_expiry(chain)
+        if remaining <= 0:
+            raise ValueError(
+                f"AAT leaf {chain.leaf_jti} expired at {chain.expires_at}; "
+                "refusing to issue a credential for expired authority"
+            )
+        requested = remaining if requested is None else min(int(requested), remaining)
+
+    if requested is not None:
+        sign_kwargs["valid_seconds"] = int(requested)
+
+    return signer.sign(intent=intent, **sign_kwargs)

--- a/integrations/aat/demo_call.py
+++ b/integrations/aat/demo_call.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Make one gated tool call against an AAT chain. Scene 4's working part.
+
+    python3 integrations/aat/demo_call.py --chain /tmp/aat-demo/leaf.json \
+        --holder-key /tmp/aat-demo/holder.pem \
+        --tool read_file --path reports/q3.txt
+
+Allowed calls run the tool and print the Vouch credential that records which
+AAT authorised the action. Blocked calls print why, and the tool is never
+invoked -- the counter at the end says so.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations.aat import (  # noqa: E402
+    AatError,
+    AatGate,
+    extract_aat_link,
+    sign_with_aat_link,
+    verify_chain_file,
+)
+
+INVOCATIONS: list = []
+
+
+def read_file(base: Path, path: str) -> str:
+    INVOCATIONS.append(("read_file", path))
+    return (base / path).read_text()
+
+
+def write_file(base: Path, path: str, content: str = "OVERWRITTEN\n") -> str:
+    INVOCATIONS.append(("write_file", path))
+    (base / path).write_text(content)
+    return "written"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--chain", required=True)
+    parser.add_argument("--holder-key", required=True)
+    parser.add_argument("--tool", required=True)
+    parser.add_argument("--path", required=True)
+    parser.add_argument("--base", default=None, help="defaults to the chain's directory")
+    args = parser.parse_args()
+
+    base = Path(args.base) if args.base else Path(args.chain).resolve().parent
+
+    try:
+        chain = verify_chain_file(args.chain)
+    except AatError as exc:
+        print(f"BLOCKED: the AAT chain did not verify -- {type(exc).__name__}: {exc}")
+        return 1
+
+    from tenuo import SigningKey
+
+    holder_key = SigningKey.from_pem(Path(args.holder_key).read_text())
+    gate = AatGate(chain, holder_key=holder_key)
+
+    print(f"AAT leaf     : {chain.leaf_jti}")
+    print(f"leaf permits : {', '.join(chain.tools)} on reports/*")
+    print(f"requested    : {args.tool} {args.path}")
+    print()
+
+    decision = gate.check(args.tool, {"path": args.path})
+
+    if not decision.allowed:
+        print(f"BLOCKED before execution: {decision.reason}")
+        print(f"tool invocations: {len(INVOCATIONS)}  <- the tool never ran")
+        return 1
+
+    tool = {"read_file": read_file, "write_file": write_file}.get(args.tool)
+    if tool is None:
+        print(f"BLOCKED: no such demo tool: {args.tool}")
+        return 1
+
+    result = tool(base, args.path)
+    print(f"ALLOWED. Tool ran, returned: {result.strip()[:60]!r}")
+
+    from vouch.keys import generate_identity
+    from vouch.signer import Signer
+
+    identity = generate_identity(domain="demo-agent.example.com")
+    signer = Signer(private_key=identity.private_key_jwk, did=identity.did)
+
+    credential = sign_with_aat_link(
+        signer,
+        chain,
+        action=args.tool,
+        target=args.path,
+        resource=f"file://{args.path}",
+    )
+
+    print("\nVouch credential issued for this action:")
+    print(json.dumps(credential, indent=2))
+    print(f"\nAAT link on the credential: {json.dumps(extract_aat_link(credential))}")
+    print(f"tool invocations: {len(INVOCATIONS)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/aat/demo_setup.py
+++ b/integrations/aat/demo_setup.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Set up Scene 4 of the demo: an AAT chain narrowed offline.
+
+Writes a demo directory containing the root AAT, a leaf derived offline from it,
+the holder key, and a sample file for the agent to read.
+
+    python3 integrations/aat/demo_setup.py --out /tmp/aat-demo
+
+Everything here uses the AAT reference implementation
+(https://github.com/tenuo-ai/tenuo, Apache-2.0). The derivation step contacts
+nothing: narrowing an AAT is a local signing operation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from tenuo import Pattern, SigningKey, Warrant
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from integrations.aat import ChainDocument, verify_chain_file  # noqa: E402
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", default="/tmp/aat-demo", help="demo directory")
+    parser.add_argument("--ttl", type=int, default=3600, help="root TTL in seconds")
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    (out / "reports").mkdir(parents=True, exist_ok=True)
+
+    root_key = SigningKey.generate()
+    holder_key = SigningKey.generate()
+
+    # 1. The root AAT: read_file AND write_file over reports/*.
+    root = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("reports/*"))
+        .capability("write_file", path=Pattern("reports/*"))
+        .ttl(args.ttl)
+        .holder(holder_key.public_key)
+        .mint(root_key)
+    )
+
+    # 2. Narrowed offline by the holder: read_file only. No server contacted.
+    leaf = root.attenuate(
+        capabilities={"read_file": {"path": Pattern("reports/*")}},
+        signing_key=holder_key,
+    )
+
+    ChainDocument(
+        root_public_key_pem=root_key.public_key.to_pem(),
+        warrants_b64=[root.to_base64()],
+    ).write(out / "root.json")
+
+    ChainDocument(
+        root_public_key_pem=root_key.public_key.to_pem(),
+        warrants_b64=[root.to_base64(), leaf.to_base64()],
+    ).write(out / "leaf.json")
+
+    (out / "holder.pem").write_text(holder_key.to_pem())
+    (out / "reports" / "q3.txt").write_text("Q3 revenue: up and to the right.\n")
+
+    # Prove the written chain verifies before anyone points a camera at it.
+    chain = verify_chain_file(out / "leaf.json")
+
+    summary = {
+        "root_tools": sorted(str(t) for t in root.tools),
+        "leaf_tools": chain.tools,
+        "leaf_jti": chain.leaf_jti,
+        "chain_root": chain.root_jti,
+        "leaf_depth": chain.depth,
+        "leaf_expires_at": chain.expires_at,
+    }
+    (out / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
+
+    print(f"Demo directory: {out}")
+    print(f"  root AAT grants : {', '.join(summary['root_tools'])} on reports/*")
+    print(f"  leaf AAT grants : {', '.join(summary['leaf_tools'])} on reports/*")
+    print(f"  leaf jti        : {summary['leaf_jti']}")
+    print(f"  chain root      : {summary['chain_root']}")
+    print(f"  leaf depth      : {summary['leaf_depth']}")
+    print("\nNarrowed offline. No authorization server was contacted.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/integrations/aat/tests/test_aat_interop.py
+++ b/integrations/aat/tests/test_aat_interop.py
@@ -1,0 +1,461 @@
+"""AAT <-> Vouch interop tests.
+
+Each test is named for what it proves. The invariant under test throughout is
+that authority can only narrow, and that every decision happens *before* a tool
+runs.
+
+Chains are built in-process rather than read from ``test-vectors/aat/`` for the
+behavioural tests, because a warrant carries a wall-clock expiry and committed
+fixtures would eventually expire and turn these into false failures. The
+committed fixtures are exercised separately at the bottom of this file.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import pytest
+
+tenuo = pytest.importorskip("tenuo", reason="AAT reference implementation not installed")
+
+from tenuo import Pattern, SigningKey, Warrant  # noqa: E402
+
+from vouch.keys import generate_identity  # noqa: E402
+from vouch.signer import Signer  # noqa: E402
+
+from integrations.aat import (  # noqa: E402
+    AatBadSignature,
+    AatBrokenChain,
+    AatError,
+    AatExpired,
+    AatGate,
+    ChainDocument,
+    extract_aat_link,
+    leaf_to_shield_rules,
+    sign_with_aat_link,
+    verify_chain,
+    verify_chain_file,
+)
+
+VECTORS = Path(__file__).resolve().parents[3] / "test-vectors" / "aat"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def keys():
+    return SigningKey.generate(), SigningKey.generate()
+
+
+def make_root(root_key, holder_key, ttl=3600):
+    """Root authority: read_file + write_file over reports/*."""
+    return (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("reports/*"))
+        .capability("write_file", path=Pattern("reports/*"))
+        .ttl(ttl)
+        .holder(holder_key.public_key)
+        .mint(root_key)
+    )
+
+
+def narrow_to_read_only(root, holder_key):
+    """Offline derivation. No authorization-server round trip."""
+    return root.attenuate(
+        capabilities={"read_file": {"path": Pattern("reports/*")}},
+        signing_key=holder_key,
+    )
+
+
+def document(root_key, warrants):
+    return ChainDocument(
+        root_public_key_pem=root_key.public_key.to_pem(),
+        warrants_b64=[w.to_base64() for w in warrants],
+    )
+
+
+@pytest.fixture
+def verified_chain(keys):
+    root_key, holder_key = keys
+    root = make_root(root_key, holder_key)
+    leaf = narrow_to_read_only(root, holder_key)
+    return verify_chain(document(root_key, [root, leaf])), holder_key
+
+
+# ---------------------------------------------------------------------------
+# Chain verification
+# ---------------------------------------------------------------------------
+
+
+def test_valid_chain_leaf_rules_extracted(keys):
+    """Root -> one derivation. Shield rules match the leaf, not the root."""
+    root_key, holder_key = keys
+    root = make_root(root_key, holder_key)
+    leaf = narrow_to_read_only(root, holder_key)
+
+    chain = verify_chain(document(root_key, [root, leaf]))
+
+    assert chain.depth == 1
+    assert chain.tools == ["read_file"]
+    assert chain.leaf_jti == str(leaf.id)
+    assert chain.root_jti == str(root.id)
+
+    rules = leaf_to_shield_rules(chain)
+
+    # The leaf's authority, not the root's: write_file was narrowed away.
+    assert rules.allowed_tools == frozenset({"read_file"})
+    assert not rules.permits_tool("write_file")
+
+    # The least capability set admitting exactly read_file.
+    assert rules.capabilities.to_dict() == {
+        "filesystem": "read",
+        "network": "none",
+        "shell": "none",
+    }
+    assert rules.unmapped_tools == ()
+
+
+def test_widened_scope_rejected(keys):
+    """A token that widens authority fails. Shield gets no rules."""
+    root_key, holder_key = keys
+    root = make_root(root_key, holder_key)
+
+    # The reference implementation refuses to derive a widened token at all:
+    # adding a tool, loosening a pattern, and dropping a constraint are each
+    # refused at derivation rather than at verification.
+    for _label, capabilities in [
+        ("adds a tool", {"read_file": {"path": Pattern("reports/*")}, "delete_file": {}}),
+        ("loosens the pattern", {"read_file": {"path": Pattern("*")}}),
+        ("drops the constraint", {"read_file": {}}),
+    ]:
+        with pytest.raises(tenuo.exceptions.MonotonicityError):
+            root.attenuate(capabilities=capabilities, signing_key=holder_key)
+
+    # What an attacker can actually build is a token of their own claiming wider
+    # authority, spliced in behind a genuine root. That must fail verification,
+    # and no rules may be produced from it.
+    attacker_key = SigningKey.generate()
+    forged = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("reports/*"))
+        .capability("delete_file", path=Pattern("*"))
+        .ttl(3600)
+        .holder(holder_key.public_key)
+        .mint(attacker_key)
+    )
+
+    with pytest.raises(AatError) as caught:
+        verify_chain(document(root_key, [root, forged]))
+
+    # Fail closed: the failure is typed, and nothing usable came back.
+    assert isinstance(caught.value, AatError)
+    assert "delete_file" not in str(caught.value)
+
+
+def test_broken_signature_rejected(keys):
+    """Tamper one byte. Fail closed."""
+    root_key, holder_key = keys
+    root = make_root(root_key, holder_key)
+    leaf = narrow_to_read_only(root, holder_key)
+
+    raw = bytearray(leaf.to_bytes())
+    raw[len(raw) // 2] ^= 0x01
+    import base64
+
+    tampered_b64 = base64.b64encode(bytes(raw)).decode()
+
+    doc = ChainDocument(
+        root_public_key_pem=root_key.public_key.to_pem(),
+        warrants_b64=[root.to_base64(), tampered_b64],
+    )
+
+    with pytest.raises(AatError) as caught:
+        verify_chain(doc)
+    assert isinstance(caught.value, (AatBadSignature, AatBrokenChain))
+
+
+def test_untrusted_root_rejected(keys):
+    """A chain anchored to a different root is not accepted."""
+    root_key, holder_key = keys
+    root = make_root(root_key, holder_key)
+    leaf = narrow_to_read_only(root, holder_key)
+
+    stranger = SigningKey.generate()
+    doc = ChainDocument(
+        root_public_key_pem=stranger.public_key.to_pem(),
+        warrants_b64=[root.to_base64(), leaf.to_base64()],
+    )
+
+    with pytest.raises(AatError):
+        verify_chain(doc)
+
+
+def test_expired_leaf_rejected(keys):
+    """An expired leaf fails closed.
+
+    This is the case the reference implementation's ``verify_chain()`` lets
+    through on its own -- expiry is enforced only on the authorization call --
+    so the adapter checks it explicitly. See INTEROP-NOTES.md.
+    """
+    root_key, holder_key = keys
+    root = make_root(root_key, holder_key, ttl=1)
+    time.sleep(2)
+
+    # Precondition: the underlying verifier does not catch this by itself.
+    from tenuo import Authorizer
+
+    authorizer = Authorizer()
+    authorizer.add_trusted_root(root_key.public_key)
+    authorizer.verify_chain([root])  # does not raise
+
+    with pytest.raises(AatExpired):
+        verify_chain(document(root_key, [root]))
+
+
+# ---------------------------------------------------------------------------
+# Enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_in_scope_call_allowed_and_credential_links_jti(verified_chain):
+    """An in-scope call is allowed and its credential carries the AAT jti."""
+    chain, holder_key = verified_chain
+    gate = AatGate(chain, holder_key=holder_key)
+
+    decision = gate.check("read_file", {"path": "reports/q3.txt"})
+    assert decision.allowed, decision.reason
+
+    identity = generate_identity(domain="test-agent.example.com")
+    signer = Signer(private_key=identity.private_key_jwk, did=identity.did)
+
+    credential = sign_with_aat_link(
+        signer,
+        chain,
+        action="read",
+        target="reports/q3.txt",
+        resource="file://reports/q3.txt",
+    )
+
+    link = extract_aat_link(credential)
+    assert link is not None
+    assert link["scheme"] == "aat"
+    assert link["jti"] == chain.leaf_jti
+    assert link["chainRoot"] == chain.root_jti
+    assert link["depth"] == 1
+
+    # The link rides inside the existing intent object, so the credential is an
+    # ordinary Vouch credential: same format, same cryptosuite, still verifies.
+    assert credential["credentialSubject"]["intent"]["action"] == "read"
+    assert credential["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+    from vouch.verifier import Verifier
+
+    is_valid, _ = Verifier.verify(credential, signer.get_public_key_multikey())
+    assert is_valid
+
+
+def test_out_of_scope_call_blocked_before_execution(verified_chain):
+    """delete_file never reaches the tool."""
+    chain, holder_key = verified_chain
+    gate = AatGate(chain, holder_key=holder_key)
+
+    invoked = []
+
+    def delete_file(path):  # the tool that must never run
+        invoked.append(path)
+        return "deleted"
+
+    decision = gate.check("delete_file", {"path": "reports/q3.txt"})
+    if decision.allowed:  # pragma: no cover - would be the bug this guards
+        delete_file("reports/q3.txt")
+
+    assert not decision.allowed
+    assert decision.failure == "ToolNotAuthorized"
+    assert invoked == [], "the tool was executed despite being out of scope"
+
+
+def test_narrowed_out_tool_blocked_before_execution(verified_chain):
+    """write_file was in the root but narrowed out of the leaf. It is blocked."""
+    chain, holder_key = verified_chain
+    gate = AatGate(chain, holder_key=holder_key)
+
+    invoked = []
+
+    def write_file(path, content):  # pragma: no cover - must never run
+        invoked.append(path)
+
+    decision = gate.check("write_file", {"path": "reports/q3.txt"})
+    if decision.allowed:  # pragma: no cover
+        write_file("reports/q3.txt", "x")
+
+    assert not decision.allowed
+    assert decision.failure == "ToolNotAuthorized"
+    assert invoked == []
+
+
+def test_argument_constraint_enforced(verified_chain):
+    """Allowed tool, disallowed argument value -> blocked."""
+    chain, holder_key = verified_chain
+    gate = AatGate(chain, holder_key=holder_key)
+
+    invoked = []
+
+    def read_file(path):
+        invoked.append(path)
+        return "contents"
+
+    allowed = gate.check("read_file", {"path": "reports/q3.txt"})
+    assert allowed.allowed
+
+    blocked = gate.check("read_file", {"path": "/etc/passwd"})
+    if blocked.allowed:  # pragma: no cover
+        read_file("/etc/passwd")
+
+    assert not blocked.allowed
+    assert blocked.failure == "ConstraintViolation"
+    assert invoked == [], "a constraint-violating call reached the tool"
+
+
+def test_missing_proof_of_possession_is_denied(verified_chain):
+    """Without a PoP signature, an otherwise in-scope call does not proceed."""
+    chain, _ = verified_chain
+    gate = AatGate(chain)  # no holder key, so no PoP can be minted
+
+    decision = gate.check("read_file", {"path": "reports/q3.txt"})
+    assert not decision.allowed
+    assert decision.failure in {"MissingSignature", "SignatureMismatch"}
+
+
+def test_shield_and_aat_must_both_allow(verified_chain):
+    """Shield's verdict is combined with the AAT verdict, not replaced by it."""
+    from vouch.shield import Shield, ShieldConfig
+    from vouch.shield.permissions import Capabilities, PermissionLevel
+
+    chain, holder_key = verified_chain
+    did = "did:vouch:test-agent"
+
+    shield = Shield(ShieldConfig(require_signature=False, strict_mode=True))
+    shield.trust_did(did)
+    # Shield grants nothing, so it must veto even though the AAT permits.
+    shield.set_capabilities(did, Capabilities(filesystem=PermissionLevel.NONE))
+
+    gate = AatGate(chain, holder_key=holder_key, shield=shield, did=did)
+    decision = gate.check("read_file", {"path": "reports/q3.txt"})
+
+    assert not decision.allowed
+    assert decision.failure == "ShieldDenied"
+
+
+# ---------------------------------------------------------------------------
+# Committed fixtures
+# ---------------------------------------------------------------------------
+
+
+def _fixture_expired(path):
+    from integrations.aat import AatExpired as _Expired
+
+    try:
+        verify_chain_file(path)
+        return False
+    except _Expired:
+        return True
+    except AatError:
+        return False
+
+
+def test_valid_fixture_verifies():
+    """The committed narrowing fixture verifies and yields read_file only."""
+    path = VECTORS / "valid-narrowing-chain.json"
+    if _fixture_expired(path):
+        pytest.skip(
+            "test-vectors/aat/valid-narrowing-chain.json has expired; "
+            "regenerate with: python3 test-vectors/aat/generate.py"
+        )
+
+    chain = verify_chain_file(path)
+    assert chain.tools == ["read_file"]
+    assert leaf_to_shield_rules(chain).allowed_tools == frozenset({"read_file"})
+
+
+def test_widening_fixture_is_rejected():
+    """The committed widening fixture must never verify.
+
+    Chain structure is checked before expiry, so this holds whether or not the
+    fixture has aged out.
+    """
+    with pytest.raises(AatError):
+        verify_chain_file(VECTORS / "widening-chain.json")
+
+
+def test_fixture_files_carry_no_private_material():
+    """Chain fixtures are public material only."""
+    for name in ("valid-narrowing-chain.json", "widening-chain.json"):
+        raw = json.loads((VECTORS / name).read_text())
+        assert "PRIVATE KEY" not in json.dumps(raw)
+        assert set(raw) >= {"aat_chain_version", "root_public_key_pem", "warrants"}
+
+
+# ---------------------------------------------------------------------------
+# vouch-mcp wiring
+# ---------------------------------------------------------------------------
+
+
+def _mcp_server():
+    return pytest.importorskip("vouch.integrations.mcp.server", reason="MCP SDK not installed")
+
+
+def test_mcp_denies_when_no_aat_chain_configured(monkeypatch):
+    """With no chain configured the AAT tool denies. There is no lax fallback."""
+    server = _mcp_server()
+    monkeypatch.setattr(server, "_AAT_CHAIN", None)
+    server._aat_gate_cache.clear()
+
+    out = server.check_action_aat("read_file", '{"path": "reports/q3.txt"}')
+    assert out.startswith("DENY")
+    server._aat_gate_cache.clear()
+
+
+def test_mcp_sources_rules_from_aat_leaf(tmp_path, monkeypatch, keys):
+    """--aat-chain makes the MCP gate enforce the leaf's authority."""
+    server = _mcp_server()
+    root_key, holder_key = keys
+
+    root = make_root(root_key, holder_key)
+    leaf = narrow_to_read_only(root, holder_key)
+
+    chain_path = tmp_path / "leaf.json"
+    document(root_key, [root, leaf]).write(chain_path)
+    key_path = tmp_path / "holder.pem"
+    key_path.write_text(holder_key.to_pem())
+
+    monkeypatch.setattr(server, "_AAT_CHAIN", str(chain_path))
+    monkeypatch.setattr(server, "_AAT_HOLDER_KEY", str(key_path))
+    server._aat_gate_cache.clear()
+
+    allowed = server.check_action_aat("read_file", '{"path": "reports/q3.txt"}')
+    assert allowed.startswith("ALLOW"), allowed
+    assert str(leaf.id) in allowed
+
+    # Narrowed out of the leaf, even though the root granted it.
+    assert server.check_action_aat("write_file", '{"path": "reports/q3.txt"}').startswith("DENY")
+    # Allowed tool, disallowed argument.
+    assert server.check_action_aat("read_file", '{"path": "/etc/passwd"}').startswith("DENY")
+
+    server._aat_gate_cache.clear()
+
+
+def test_mcp_denies_when_chain_does_not_verify(tmp_path, monkeypatch):
+    """A chain that fails verification yields no authority at all."""
+    server = _mcp_server()
+    monkeypatch.setattr(server, "_AAT_CHAIN", str(VECTORS / "widening-chain.json"))
+    monkeypatch.setattr(server, "_AAT_HOLDER_KEY", None)
+    server._aat_gate_cache.clear()
+
+    out = server.check_action_aat("read_file", '{"path": "reports/q3.txt"}')
+    assert out.startswith("DENY")
+    server._aat_gate_cache.clear()

--- a/test-vectors/aat/README.md
+++ b/test-vectors/aat/README.md
@@ -1,0 +1,66 @@
+# AAT chain fixtures
+
+Delegation-chain fixtures for the AAT ↔ Vouch adapter in
+[`integrations/aat/`](../../integrations/aat/).
+
+## How they were generated
+
+Both fixtures were produced by [`generate.py`](generate.py) using the AAT
+reference implementation ([`tenuo`](https://github.com/tenuo-ai/tenuo),
+Apache-2.0), which the draft's Implementation Status appendix names as the
+reference implementation of `draft-niyikiza-oauth-attenuating-agent-tokens-01`.
+Nothing here is hand-built: the root is minted and the leaf is derived through
+that implementation's own API, so the fixtures are exactly what it emits.
+
+```bash
+pip install tenuo
+python3 test-vectors/aat/generate.py
+```
+
+| File | What it is |
+|---|---|
+| `valid-narrowing-chain.json` | Root grants `read_file` + `write_file` over `reports/*`. The leaf is derived offline by the holder and grants `read_file` only. Must verify. |
+| `widening-chain.json` | A token minted by a third key claiming `delete_file`, spliced in behind a genuine root. Must fail verification. |
+| `keys.json` | The test-only Ed25519 seeds used above, published deliberately - they protect nothing. The holder seed mints the proof-of-possession for a call against the valid chain. |
+
+## Two things to know before relying on these
+
+**They are not byte-reproducible.** Unlike `jcs/` or
+`data-integrity-eddsa-jcs-2022/`, these are not a deterministic interop
+contract. Warrant identifiers are UUIDv7-style and expiry is wall-clock, so
+every run of `generate.py` produces different bytes. They are illustrative chain
+fixtures.
+
+**They expire.** The reference implementation caps a warrant's TTL at 90 days,
+so a committed chain ages out. `_generated_at` in each file records when it was
+made. The behavioural tests build their chains in-process for exactly this
+reason; the fixture-backed test skips with a regeneration hint once the valid
+chain has expired. The widening fixture stays meaningful either way, because
+chain structure is checked before expiry.
+
+## Why the widening fixture is a spliced token rather than a derived one
+
+The obvious fixture would be a derived token that adds a tool or loosens a
+constraint. The reference implementation will not produce one: `attenuate()`
+raises `MonotonicityError` rather than minting a widened child, and the same
+goes for loosening a pattern or dropping a constraint entirely. Refusing at
+derivation is the stronger behaviour, but it means a widened *derived* token
+cannot be created through the supported API.
+
+So the fixture captures what an attacker can actually build - a token of their
+own, claiming authority the root never granted, presented as though it descended
+from that root. It is rejected on the draft's I5 cryptographic-linkage invariant:
+the spliced token carries no `parent_hash` binding it to the root.
+
+Derivation-time refusal is covered separately, in
+`test_widened_scope_rejected`.
+
+## Wire format
+
+These are CBOR warrants from the reference implementation, **not** the draft's
+JWT/JWS encoding. The draft's normative envelope is JWT; the reference
+implementation is CBOR/COSE-native, which its Appendix E states plainly
+("implementation-specific ... does not define a fully interoperable CWT
+profile"). See [`integrations/aat/DESIGN.md`](../../integrations/aat/DESIGN.md)
+§3 for why the adapter is built against the protocol model rather than the
+encoding.

--- a/test-vectors/aat/generate.py
+++ b/test-vectors/aat/generate.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Regenerate the AAT chain fixtures.
+
+Run from the repository root::
+
+    python3 test-vectors/aat/generate.py
+
+These fixtures are produced with the AAT reference implementation
+(``tenuo``, Apache-2.0, https://github.com/tenuo-ai/tenuo). Nothing here builds
+a token by hand: the root is minted and the leaf is derived through the
+reference implementation's own API, so the fixtures are exactly what that
+implementation emits.
+
+Unlike the cryptographic vectors elsewhere in ``test-vectors/``, these are not
+byte-reproducible. Warrant identifiers are UUIDv7-style and expiry is wall-clock,
+so every run produces different bytes. They are illustrative chain fixtures, not
+a deterministic interop contract -- see README.md.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from tenuo import Pattern, SigningKey, Warrant
+
+HERE = Path(__file__).resolve().parent
+
+# Fixed test seeds so the fixtures' keys are stable across regenerations.
+# These are test-only keys published deliberately, matching the convention of
+# the other vectors in this directory. They protect nothing.
+ROOT_SEED = bytes([0x01] * 32)
+HOLDER_SEED = bytes([0x02] * 32)
+ATTACKER_SEED = bytes([0x03] * 32)
+
+# 90 days, the reference implementation's maximum warrant TTL.
+FIXTURE_TTL_SECONDS = 7_776_000
+
+
+def _document(root_public_key_pem: str, warrants) -> dict:
+    return {
+        "aat_chain_version": 1,
+        "root_public_key_pem": root_public_key_pem,
+        "warrants": [w.to_base64() for w in warrants],
+    }
+
+
+def main() -> int:
+    root_key = SigningKey.from_bytes(ROOT_SEED)
+    holder_key = SigningKey.from_bytes(HOLDER_SEED)
+    attacker_key = SigningKey.from_bytes(ATTACKER_SEED)
+
+    # --- valid narrowing chain -------------------------------------------
+    # Root grants read_file and write_file over reports/*.
+    root = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("reports/*"))
+        .capability("write_file", path=Pattern("reports/*"))
+        .ttl(FIXTURE_TTL_SECONDS)
+        .holder(holder_key.public_key)
+        .mint(root_key)
+    )
+    # Derived offline by the holder: read_file only. No authorization server.
+    leaf = root.attenuate(
+        capabilities={"read_file": {"path": Pattern("reports/*")}},
+        signing_key=holder_key,
+    )
+
+    valid = _document(root_key.public_key.to_pem(), [root, leaf])
+
+    # --- widening chain ---------------------------------------------------
+    # The reference implementation refuses to *derive* a widened token at all:
+    # attenuate() raises MonotonicityError rather than minting one. So a
+    # widening fixture cannot be produced through derivation. What an attacker
+    # can actually do is mint their own token claiming wider authority and
+    # splice it in behind a genuine root -- which is what this fixture is.
+    #
+    # It is rejected on the I5 cryptographic-linkage invariant: the spliced
+    # token carries no parent_hash binding it to the root.
+    forged = (
+        Warrant.mint_builder()
+        .capability("read_file", path=Pattern("reports/*"))
+        .capability("write_file", path=Pattern("reports/*"))
+        .capability("delete_file", path=Pattern("*"))
+        .ttl(FIXTURE_TTL_SECONDS)
+        .holder(holder_key.public_key)
+        .mint(attacker_key)
+    )
+    widening = _document(root_key.public_key.to_pem(), [root, forged])
+
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for name, doc, note in [
+        (
+            "valid-narrowing-chain.json",
+            valid,
+            "Root grants read_file + write_file on reports/*; the leaf is derived "
+            "offline by the holder and grants read_file only.",
+        ),
+        (
+            "widening-chain.json",
+            widening,
+            "A token minted by a third key claiming delete_file, spliced in behind "
+            "a genuine root. MUST fail verification.",
+        ),
+    ]:
+        payload = dict(doc)
+        payload["_comment"] = note
+        payload["_generated_at"] = generated_at
+        payload["_generated_by"] = "test-vectors/aat/generate.py"
+        (HERE / name).write_text(json.dumps(payload, indent=2) + "\n")
+        print(f"wrote {name}")
+
+    keys = {
+        "_comment": (
+            "Test-only Ed25519 seeds for the AAT fixtures. Published deliberately; "
+            "they protect nothing. The holder seed is needed to mint the "
+            "proof-of-possession for a call against the valid chain."
+        ),
+        "root_seed_hex": ROOT_SEED.hex(),
+        "holder_seed_hex": HOLDER_SEED.hex(),
+        "attacker_seed_hex": ATTACKER_SEED.hex(),
+    }
+    (HERE / "keys.json").write_text(json.dumps(keys, indent=2) + "\n")
+    print("wrote keys.json")
+
+    expiry = root.expires_at()
+    print(f"\nFixtures expire at {expiry}. Re-run this script to refresh them.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/test-vectors/aat/keys.json
+++ b/test-vectors/aat/keys.json
@@ -1,0 +1,6 @@
+{
+  "_comment": "Test-only Ed25519 seeds for the AAT fixtures. Published deliberately; they protect nothing. The holder seed is needed to mint the proof-of-possession for a call against the valid chain.",
+  "root_seed_hex": "0101010101010101010101010101010101010101010101010101010101010101",
+  "holder_seed_hex": "0202020202020202020202020202020202020202020202020202020202020202",
+  "attacker_seed_hex": "0303030303030303030303030303030303030303030303030303030303030303"
+}

--- a/test-vectors/aat/valid-narrowing-chain.json
+++ b/test-vectors/aat/valid-narrowing-chain.json
@@ -1,0 +1,11 @@
+{
+  "aat_chain_version": 1,
+  "root_public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w=\n-----END PUBLIC KEY-----\n",
+  "warrants": [
+    "gwFY2aoAAQFQAaB33eMBfQO58kSKhBslbwIAA6JpcmVhZF9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKmp3cml0ZV9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKgSCAVgggTl3Dqh9F19Wo1Rmw0x-zMuNipG07jeiXfYPW4_Js5QFggFYIIqI4910CfGV_VLbLTy6XXLKZwm_HZQSG_N0iAG0D29cBhpqnalxBxprFFBxCBhAEgCCAVhA9Rzs25rTPsf9xoWwbyb9bA5UVYyPTTwA9MoR1Acpjy-EsC7aaEaqLnSJ4uTsrrBtWzzP44EsjdwAhdX2vYyMDQ",
+    "gwFY5KsAAQFQAaB33eMBfQO58kSWp2D7kAIAA6FpcmVhZF9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKgSCAVgggTl3Dqh9F19Wo1Rmw0x-zMuNipG07jeiXfYPW4_Js5QFggFYIIE5dw6ofRdfVqNUZsNMfszLjYqRtO43ol32D1uPybOUBhpqnalxBxprFFBxCBhACZggGMMYawcY2hhvGDQYlBhxGOkYWBgnGN0YHBiZDxjVGNcEAhjoGPkY6higGLEY0hhQGNsSGMIYQhhVGHUSAYIBWEDTPZfOJfM97hEK7XgljUI6Pwtk8MVc-MjoBUOGF32c_iBw-IBKLd3RsZhxyeLfFB54vzERQouCyeDrgZCxKpIM"
+  ],
+  "_comment": "Root grants read_file + write_file on reports/*; the leaf is derived offline by the holder and grants read_file only.",
+  "_generated_at": "2026-09-06T17:57:05Z",
+  "_generated_by": "test-vectors/aat/generate.py"
+}

--- a/test-vectors/aat/widening-chain.json
+++ b/test-vectors/aat/widening-chain.json
@@ -1,0 +1,11 @@
+{
+  "aat_chain_version": 1,
+  "root_public_key_pem": "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAiojj3XQJ8ZX9UtstPLpdcspnCb8dlBIb83SIAbQPb1w=\n-----END PUBLIC KEY-----\n",
+  "warrants": [
+    "gwFY2aoAAQFQAaB33eMBfQO58kSKhBslbwIAA6JpcmVhZF9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKmp3cml0ZV9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKgSCAVgggTl3Dqh9F19Wo1Rmw0x-zMuNipG07jeiXfYPW4_Js5QFggFYIIqI4910CfGV_VLbLTy6XXLKZwm_HZQSG_N0iAG0D29cBhpqnalxBxprFFBxCBhAEgCCAVhA9Rzs25rTPsf9xoWwbyb9bA5UVYyPTTwA9MoR1Acpjy-EsC7aaEaqLnSJ4uTsrrBtWzzP44EsjdwAhdX2vYyMDQ",
+    "gwFZAQWqAAEBUAGgd93jAX0DufJEoDinuxYCAAOja2RlbGV0ZV9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuYSppcmVhZF9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKmp3cml0ZV9maWxloWtjb25zdHJhaW50c6FkcGF0aIICoWdwYXR0ZXJuaXJlcG9ydHMvKgSCAVgggTl3Dqh9F19Wo1Rmw0x-zMuNipG07jeiXfYPW4_Js5QFggFYIO1JKMYo0cLG6ukDOJBZlWEpWSc6XGP5NjbBRhSshzfRBhpqnalxBxprFFBxCBhAEgCCAVhACmKj45DegIKRf7H-WSQO7cVl0hQ4g_T3zV7oUoK1HtXKQCKfBRaGjmmiksU7lxlAe6US-m_HehDBNTb0qPs0Bw"
+  ],
+  "_comment": "A token minted by a third key claiming delete_file, spliced in behind a genuine root. MUST fail verification.",
+  "_generated_at": "2026-09-06T17:57:05Z",
+  "_generated_by": "test-vectors/aat/generate.py"
+}

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -33,6 +33,7 @@ Tools:
     decode_did         Decode a DID key / Multikey and report its algorithm.
     delegate           Issue a narrowed sub-delegation grant to another agent.
     check_action       Decide if an agent's capabilities permit a tool (Shield).
+    check_action_aat   Decide if an AAT delegation chain permits a tool call.
     check_trust        Recompute a session voucher's decayed trust vs a threshold.
     disclose_ai_origin Sign a disclosure that content is AI-generated.
     create_authority_state    Publish this authority's signed epoch and status.
@@ -47,6 +48,9 @@ Run (stdio, for Claude Desktop / Cursor):
 Run (Streamable HTTP, for remote / hosted use):
     VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
         VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
+
+Run (sourcing authority from an AAT delegation chain):
+    VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp --aat-chain leaf.json
 """
 
 from __future__ import annotations
@@ -83,6 +87,14 @@ from vouch.autosign import resolve_signer, sign_intent
 
 _HOST = os.getenv("VOUCH_MCP_HOST", "127.0.0.1")
 _PORT = int(os.getenv("VOUCH_MCP_PORT", "8080"))
+
+# Optional AAT delegation source. When VOUCH_AAT_CHAIN points at a verified
+# Attenuating Authorization Token chain, ``check_action_aat`` sources its rules
+# from that chain's leaf. See integrations/aat/README.md.
+_AAT_CHAIN = os.getenv("VOUCH_AAT_CHAIN")
+_AAT_HOLDER_KEY = os.getenv("VOUCH_AAT_HOLDER_KEY")
+_aat_gate_cache: dict = {}
+
 
 if _MCP_SDK_V2:
     # mcp>=2.0 takes host/port per transport at run() time, not here.
@@ -658,6 +670,98 @@ def check_action(
     return f"DENY: {reason}"
 
 
+def _load_aat_gate():
+    """Build the AAT gate from VOUCH_AAT_CHAIN, or return a reason it is off.
+
+    Returns ``(gate, None)`` on success or ``(None, reason)`` on failure.
+    Any failure is fail-closed: no gate means no AAT-sourced authority, and
+    ``check_action_aat`` denies rather than falling back to something laxer.
+    """
+    if "result" in _aat_gate_cache:
+        return _aat_gate_cache["result"]
+
+    if not _AAT_CHAIN:
+        result = (None, "VOUCH_AAT_CHAIN is not set")
+        _aat_gate_cache["result"] = result
+        return result
+
+    try:
+        from integrations.aat import AatGate, verify_chain_file
+    except ImportError as exc:
+        result = (None, f"AAT adapter unavailable ({exc})")
+        _aat_gate_cache["result"] = result
+        return result
+
+    try:
+        chain = verify_chain_file(_AAT_CHAIN)
+    except Exception as exc:
+        result = (None, f"AAT chain did not verify: {type(exc).__name__}: {exc}")
+        _aat_gate_cache["result"] = result
+        return result
+
+    holder_key = None
+    if _AAT_HOLDER_KEY:
+        try:
+            from tenuo import SigningKey
+
+            holder_key = SigningKey.from_pem(open(_AAT_HOLDER_KEY).read())
+        except Exception as exc:
+            result = (None, f"AAT holder key could not be loaded: {exc}")
+            _aat_gate_cache["result"] = result
+            return result
+
+    result = (AatGate(chain, holder_key=holder_key), None)
+    _aat_gate_cache["result"] = result
+    return result
+
+
+@mcp.tool()
+def check_action_aat(tool: str, args_json: str = "{}") -> str:
+    """Decide whether an AAT delegation chain permits a tool call (Shield).
+
+    The counterpart to ``check_action`` for deployments that carry authority as
+    an Attenuating Authorization Token chain. Rules come from the verified
+    chain's **leaf** -- the authority after all narrowing -- rather than from a
+    static capability grant.
+
+    Unlike ``check_action``, this evaluates the call's *arguments* too: an AAT
+    leaf can restrict ``path`` to ``reports/*``, and a call outside that is
+    denied even though the tool itself is permitted.
+
+    Requires ``VOUCH_AAT_CHAIN`` to point at a chain file. Denies if it is
+    unset or if the chain does not verify -- there is no lax fallback.
+
+    Precedence: when a static allow-list is also in force, both must allow.
+    An AAT chain narrows what this server will do; it never widens it.
+
+    Args:
+        tool: The tool name being gated, e.g. 'read_file'.
+        args_json: The call's arguments as a JSON object, e.g.
+            '{"path": "reports/q3.txt"}'.
+
+    Returns:
+        'ALLOW' or 'DENY' with the reason.
+    """
+    gate, reason = _load_aat_gate()
+    if gate is None:
+        return f"DENY: AAT authority is not available ({reason})."
+
+    try:
+        args = json.loads(args_json) if args_json else {}
+    except json.JSONDecodeError as e:
+        return f"Error: args_json is not valid JSON ({e})"
+    if not isinstance(args, dict):
+        return "Error: args_json must be a JSON object"
+
+    decision = gate.check(tool, args)
+    if decision.allowed:
+        return (
+            f"ALLOW: '{tool}' is permitted by AAT leaf {decision.leaf_jti} "
+            f"(chain root {decision.root_jti})."
+        )
+    return f"DENY: {decision.reason}"
+
+
 # Trust-over-time and transparency tools.
 
 
@@ -1202,7 +1306,41 @@ def main() -> None:
     - 'sse': the HTTP+SSE transport, deprecated by the MCP specification;
       kept for existing clients during the deprecation window. Use
       Streamable HTTP for anything new.
+
+    ``--aat-chain`` (or VOUCH_AAT_CHAIN) points at an AAT delegation chain;
+    ``check_action_aat`` then sources its rules from that chain's leaf.
     """
+    global _AAT_CHAIN, _AAT_HOLDER_KEY
+
+    import argparse
+
+    parser = argparse.ArgumentParser(prog="vouch-mcp", description="Vouch Protocol MCP server.")
+    parser.add_argument(
+        "--aat-chain",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to an AAT delegation chain. Shield rules are then sourced "
+            "from the chain's leaf. Overrides VOUCH_AAT_CHAIN."
+        ),
+    )
+    parser.add_argument(
+        "--aat-holder-key",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Path to the PEM holder key matching the AAT leaf, used to mint "
+            "proof-of-possession locally. Overrides VOUCH_AAT_HOLDER_KEY."
+        ),
+    )
+    args, _ = parser.parse_known_args()
+
+    if args.aat_chain:
+        _AAT_CHAIN = args.aat_chain
+    if args.aat_holder_key:
+        _AAT_HOLDER_KEY = args.aat_holder_key
+    _aat_gate_cache.clear()
+
     transport = os.getenv("VOUCH_MCP_TRANSPORT", "stdio").lower().replace("_", "-")
     if transport in ("http", "streamable-http"):
         if _MCP_SDK_V2:


### PR DESCRIPTION
An adapter that lets a Vouch Protocol deployment accept delegation expressed as an Attenuating Authorization Token chain.

AATs are an IETF draft (`draft-niyikiza-oauth-attenuating-agent-tokens-01`) for OAuth-world agent delegation: a token names the tools an agent may invoke and the argument constraints on them, and any holder can derive a narrower token offline with no authorization server involved. Vouch Protocol enforces the same narrow-only invariant through credential chains. The two express the same idea in different envelopes, and this adapter is the seam between them.

**What it does.** `aat_chain.py` loads a chain and verifies it against its root trust anchor, returning either a verified chain or a typed failure. `aat_to_shield.py` takes the leaf, which is the authority after all narrowing, and turns its tool scope into Shield rules. `credential_link.py` records which delegation authorised an action on the credential that action produces, carried inside the existing intent object so no new credential field is needed. `vouch-mcp` gains an optional `--aat-chain` flag.

**Security boundary.** Chain verification and token derivation are delegated to the reference implementation named in the draft, not reimplemented here. The adapter adds a file format for carrying a chain with its trust anchor, typed failures a caller can branch on, and an explicit expiry check on every token in the chain. Every failure path yields no rules and runs nothing: a chain either verifies whole or produces nothing usable. Only the leaf grants authority; the rest of the chain is verified for provenance and never summed.

**What it deliberately does not do.** It does not claim to consume draft-encoded JWTs. The draft specifies a JWT envelope and the reference implementation is CBOR-native, so this works against the protocol model rather than the encoding, and the fixtures under `test-vectors/aat/` are labelled as what they are. Those fixtures carry a wall-clock expiry and need regenerating after 2026-12-05; the behavioural tests build their chains in-process for that reason.

`INTEROP-NOTES.md` records implementer feedback on the draft, written to be useful to its author.