### PR TITLE
feat(vouch-mcp): refuse to sign an intent the rules forbid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The `vouch-mcp` server consults Shield before it signs. An intent your rules
+  forbid never becomes a credential; the caller gets a structured refusal
+  instead, so a denied action is distinguishable from a signing error. Its
+  `check_action` tool now takes an action, a target, a resource, and a DID, and
+  reports the reason behind its decision. Rules come from `VOUCH_RULES`.
 - Vouch Shield rules now match `action`, `target`, and `resource`, the same
   three fields a credential binds in `credentialSubject.intent`, so the policy
   asks the question the evidence answers. `Shield.check(did, action, target,

--- a/tests/test_mcp_server_shield.py
+++ b/tests/test_mcp_server_shield.py
@@ -1,0 +1,139 @@
+"""vouch-mcp consults Shield before it signs.
+
+A credential is a statement that this agent authorised an action. If policy says
+it may not, there is nothing to attest, so no credential is issued. That makes
+the signer the first of two refusal points, the second being the tool server
+that receives the credential.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+pytest.importorskip("mcp", reason="MCP SDK not installed")
+
+from vouch import multikey  # noqa: E402
+from vouch.integrations.mcp import server as notary  # noqa: E402
+from vouch.autosign import reset_default_signer  # noqa: E402
+from vouch.keys import generate_identity  # noqa: E402
+
+TARGET = "files"
+
+
+@pytest.fixture
+def notary_env(tmp_path, monkeypatch):
+    keypair = generate_identity()
+    raw = base64.urlsafe_b64decode(json.loads(keypair.public_key_jwk)["x"] + "==")
+    did = "did:key:" + multikey.encode_ed25519_public(raw)
+
+    rules = tmp_path / "rules.json"
+    rules.write_text(
+        json.dumps(
+            {
+                "version": 2,
+                "rules": [
+                    {
+                        "did": did,
+                        "allow": [
+                            {
+                                "id": "read-reports",
+                                "action": "read_file",
+                                "target": TARGET,
+                                "resource": "reports/**",
+                            }
+                        ],
+                    }
+                ],
+                "deny_default": True,
+            }
+        )
+    )
+
+    monkeypatch.setenv("VOUCH_DID", did)
+    monkeypatch.setenv("VOUCH_PRIVATE_KEY", keypair.private_key_jwk)
+    monkeypatch.setattr(notary, "_RULES_PATH", str(rules))
+    notary._shield_cache.clear()
+    # resolve_signer() memoises the process-wide default signer, so a stale one
+    # from an earlier test would sign under the wrong DID.
+    reset_default_signer()
+    yield {"did": did}
+    notary._shield_cache.clear()
+    reset_default_signer()
+
+
+def test_sign_issues_a_credential_for_a_permitted_intent(notary_env):
+    out = json.loads(notary.sign(action="read_file", target=TARGET, resource="reports/q3.txt"))
+
+    assert out.get("error") is None
+    assert out["credentialSubject"]["intent"]["resource"] == "reports/q3.txt"
+    assert out["proof"]["cryptosuite"] == "eddsa-jcs-2022"
+
+
+def test_sign_refuses_a_denied_action_with_a_structured_refusal(notary_env):
+    """Nothing to present: the notary will not stamp it."""
+    out = json.loads(notary.sign(action="delete_file", target=TARGET, resource="reports/q3.txt"))
+
+    assert out["error"] == "refused"
+    assert out["reason"] == "no matching rule"
+    assert out["action"] == "delete_file"
+    assert "proof" not in out
+
+
+def test_sign_refuses_a_resource_outside_scope(notary_env):
+    out = json.loads(notary.sign(action="read_file", target=TARGET, resource="secrets/keys.txt"))
+
+    assert out["error"] == "refused"
+    assert out["reason"] == "resource outside scope"
+
+
+def test_sign_refuses_traversal(notary_env):
+    out = json.loads(
+        notary.sign(action="read_file", target=TARGET, resource="reports/../secrets/keys.txt")
+    )
+    assert out["error"] == "refused"
+    assert out["reason"] == "resource outside scope"
+
+
+def test_sign_refuses_everything_without_a_rules_file(monkeypatch, tmp_path):
+    keypair = generate_identity()
+    raw = base64.urlsafe_b64decode(json.loads(keypair.public_key_jwk)["x"] + "==")
+    did = "did:key:" + multikey.encode_ed25519_public(raw)
+    monkeypatch.setenv("VOUCH_DID", did)
+    monkeypatch.setenv("VOUCH_PRIVATE_KEY", keypair.private_key_jwk)
+    monkeypatch.setattr(notary, "_RULES_PATH", None)
+    notary._shield_cache.clear()
+    reset_default_signer()
+
+    out = json.loads(notary.sign(action="read_file", target=TARGET, resource="reports/q3.txt"))
+    assert out["error"] == "refused"
+    assert out["reason"] == "unknown did"
+    notary._shield_cache.clear()
+    reset_default_signer()
+
+
+def test_check_action_reports_the_decision_and_its_reason(notary_env):
+    did = notary_env["did"]
+
+    allowed = notary.check_action(
+        action="read_file", target=TARGET, resource="reports/q3.txt", did=did
+    )
+    assert allowed.startswith("ALLOW")
+    assert "read-reports" in allowed
+
+    outside = notary.check_action(
+        action="read_file", target=TARGET, resource="secrets/keys.txt", did=did
+    )
+    assert outside == "DENY: resource outside scope"
+
+    wrong_action = notary.check_action(
+        action="delete_file", target=TARGET, resource="reports/q3.txt", did=did
+    )
+    assert wrong_action == "DENY: no matching rule"
+
+    stranger = notary.check_action(
+        action="read_file", target=TARGET, resource="reports/q3.txt", did="did:key:z6MkStranger"
+    )
+    assert stranger == "DENY: unknown did"

--- a/vouch/integrations/mcp/server.py
+++ b/vouch/integrations/mcp/server.py
@@ -49,6 +49,9 @@ Run (Streamable HTTP, for remote / hosted use):
     VOUCH_MCP_TRANSPORT=http VOUCH_MCP_HOST=0.0.0.0 VOUCH_MCP_PORT=8080 \
         VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
 
+Run (with Shield rules, so the server refuses to sign what policy forbids):
+    VOUCH_RULES=rules.yaml VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp
+
 Run (sourcing authority from an AAT delegation chain):
     VOUCH_PRIVATE_KEY=... VOUCH_DID=... vouch-mcp --aat-chain leaf.json
 """
@@ -149,6 +152,26 @@ def sign(
             "VOUCH_DID, or run 'vouch init'."
         )
     resolved_resource = resource or target
+
+    # Consult Shield before signing. A credential is a statement this agent
+    # authorised the action; if policy says it may not, there is nothing to
+    # attest and no credential is issued. The refusal is structured so a caller
+    # can tell it apart from a signing error.
+    decision = _shield().check(
+        signer.get_did(), action=action, target=target, resource=resolved_resource
+    )
+    if not decision.allow:
+        return json.dumps(
+            {
+                "error": "refused",
+                "reason": decision.reason,
+                "action": action,
+                "target": target,
+                "resource": resolved_resource,
+            },
+            separators=(",", ":"),
+        )
+
     try:
         if post_quantum:
             credential = signer.sign_hybrid(


### PR DESCRIPTION
The `vouch-mcp` server consults Shield before it signs.

A Vouch Credential is a statement that this agent authorised an action. If policy says it may not, there is nothing to attest, so no credential is issued and the caller gets a structured refusal naming the reason instead. That is distinguishable from a signing error, so a client can tell "policy said no" apart from "something went wrong".

Rules come from `VOUCH_RULES`. Without a rules file the server holds no authority and refuses to sign anything, which is the safe direction for a component whose whole job is handing out authority.

**Security boundary.** This makes the signer the first of two refusal points, and it is the weaker of the two. A signer can decline to mint a credential, but it cannot stop a client from calling some other tool server, and it does not see what the client eventually does. It is a useful constraint on what this agent will put its name to, not a substitute for the receiving side checking the credential it is handed. The change that adds that receiving side comes later in this series.

`check_action` reports the reason behind its decision, so a caller can distinguish an action that is not permitted at all from one that is permitted somewhere else.