### PR TITLE
feat(aat): derive resource globs from a leaf's path constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The AAT interop adapter maps a leaf's path constraints onto Shield resource
+  globs, so Shield refuses an out-of-scope path itself rather than leaving every
+  argument decision to the token's own evaluator. The two glob languages differ,
+  so patterns are translated rather than copied, and a test asserts the derived
+  Shield rule is never wider than the constraint it came from. Constraint forms
+  Shield cannot express fall back to the evaluator, and both must allow.
 - The `vouch-mcp` server consults Shield before it signs. An intent your rules
   forbid never becomes a credential; the caller gets a structured refusal
   instead, so a denied action is distinguishable from a signing error. Its

--- a/integrations/aat/DESIGN.md
+++ b/integrations/aat/DESIGN.md
@@ -232,7 +232,7 @@ change to the credential format, no change to the cryptosuite.
 | AAT concept | Vouch concept | Mapping | Lossy? |
 |---|---|---|---|
 | Tool name (`tools` key, exact-match) | Shield `action` / the `tool` argument to `intercept` | Direct 1:1, byte-exact string. Both sides already match tool names exactly with no normalization. | **No** |
-| Argument constraints (`{arg: {constraint_type, …}}`) | Shield `target` / `resource` constraints | **No native home.** Shield's `check_permission(did, tool)` never sees `args`. Enforced instead by delegating the argument decision back to the reference implementation's `Authorizer.check_chain(chain, tool, args, signature)`, in the same pre-execution step. | **Yes - see 5.1** |
+| Argument constraints (`{arg: {constraint_type, …}}`) | Shield `resource` glob | **Exact for path-shaped constraints.** Shield v2 matches `action`/`target`/`resource` with globs, so `Pattern`, `Exact` and `OneOf` over paths become real Shield rules and Shield refuses an out-of-scope path itself. Non-path forms (`Range`, `Regex`, `CEL`, `Cidr`, `Not`, …) have no Shield equivalent and stay with the reference implementation's evaluator. Both gates must allow either way. | **No** for path-shaped; **yes** otherwise - see 5.1 |
 | Chain parent reference (`par_hash`) | Delegation parent `id` | Both bind a child to exactly one parent instance. AAT binds by SHA-256 of the parent's signing input; Vouch binds by parent credential `id` plus proof binding. Provenance-equivalent, not byte-equivalent. | **Yes - representation only** |
 | Narrow-only derivation (§6, I4) | Attenuation MUST-rule (`non_expansion`) | Identical invariant: a child may only narrow. Different dimension sets (AAT: tools + per-arg constraints + exp + depth; Vouch: action/target/resource/time/rate/policy). | **No** (invariant), **yes** (dimensions - see 5.1) |
 | `jti` | External authorisation reference on the credential | Carried as `intent.authorizedBy` - an extra key inside the existing `intent` dict, covered by the proof. Records *which delegation authorised this action*. | **No** |
@@ -245,14 +245,22 @@ change to the credential format, no change to the cryptosuite.
 
 This list is a deliverable in its own right.
 
-1. **Shield cannot express AAT argument constraints.** Shield's rule model is
-   per-DID capability *levels*, not per-argument predicates. Nothing in
-   `Capabilities` can say "`path` must match `reports/*`". We therefore do not
-   flatten AAT constraints into Shield rules - that would silently widen
-   authority, allowing `read_file /etc/passwd` under a rule meant for
-   `reports/*`. Instead the argument decision stays with the reference
-   implementation and is composed with Shield's decision **before execution**.
-   Both must allow.
+1. **Path-shaped argument constraints now map exactly; other shapes do not.**
+   This row used to read "Shield cannot express AAT argument constraints",
+   because Shield's rule model was per-DID capability *levels* and its check
+   never saw a call's arguments. Shield v2 matches `action`/`target`/`resource`
+   with globs on `resource`, so a leaf's `Pattern("reports/*")` becomes a real
+   Shield rule and Shield refuses `read_file /etc/passwd` on its own.
+
+   Two cautions remain. First, the two glob languages differ: Tenuo's `*`
+   crosses `/` and Shield's does not, so patterns are **translated**, not
+   copied, and a differential test asserts the Shield rule is never wider than
+   the constraint it came from. Second, constraint forms with no faithful
+   translation (`Range`, `Regex`, `CEL`, `Cidr`, `Not`, `NotOneOf`, mid-string
+   `*`) fall back to `resource: "**"` and remain the reference implementation's
+   responsibility alone. Shield never *replaces* that evaluator; it adds a
+   second, independent refusal point for the subset it can express. Both must
+   allow.
 
 2. **The reverse direction is lossy too.** Vouch's `rate` and `policy`
    dimensions have no AAT equivalent in the core constraint set. AAT would need

--- a/integrations/aat/README.md
+++ b/integrations/aat/README.md
@@ -65,13 +65,14 @@ it returns a decision and never executes anything, so a caller that runs a tool
 only on `decision.allowed` cannot execute an unauthorised call. That is the
 in-process path, and it is what the tests assert against with a mock tool.
 
-`check_action_aat` is a *decision* tool in the same shape as the existing
-`check_action`: it answers ALLOW or DENY and does not itself run the gated tool.
-Over MCP the decision therefore binds only as far as the client honours it,
-exactly as `check_action` does today. This adapter deliberately did not change
-that, since Shield semantics were out of scope. If you need enforcement that
-cannot be bypassed by a client, put `AatGate` in front of the tool in-process
-rather than relying on the MCP decision tool.
+`check_action_aat` is a *decision* tool in the same shape as `check_action`: it
+answers ALLOW or DENY and does not itself run the gated tool, so over MCP it
+binds only as far as the client honours it.
+
+For enforcement a client cannot bypass, put the check on the receiving side:
+either `AatGate` in front of the tool in-process, or build the tool server on
+[`vouch.mcp.FastMCP`](../../vouch/mcp/), which refuses to run any tool without a
+credential Shield permits.
 
 See [`DEMO.md`](DEMO.md) for the recordable walkthrough and
 [`DESIGN.md`](DESIGN.md) for the full mapping.
@@ -90,15 +91,20 @@ See [`DEMO.md`](DEMO.md) for the recordable walkthrough and
 This list is a deliverable, not a caveat section. Full detail in
 [`DESIGN.md`](DESIGN.md) §5.1.
 
-1. **Shield cannot express AAT argument constraints.** Its permission check is
-   `check_permission(did, tool)` - it never sees the call's arguments, and its
-   rule model is per-DID capability *levels*, not per-argument predicates.
-   Flattening AAT constraints into those levels would silently widen authority:
-   a leaf limited to `reports/*` would become a blanket filesystem-read grant
-   and `read_file /etc/passwd` would pass. So this adapter does not flatten
-   them. Tool scope becomes Shield rules; argument constraints stay with the
-   reference implementation and are evaluated in the same pre-execution step.
-   Both must allow.
+1. **Path constraints map exactly; other constraint shapes do not.** Shield
+   matches `action`/`target`/`resource` with globs on `resource`, so a leaf's
+   `Pattern("reports/*")` becomes a real Shield rule and Shield refuses
+   `read_file /etc/passwd` on its own, without consulting the reference
+   implementation.
+
+   The two glob languages are not the same, though: Tenuo's `*` crosses `/` and
+   Shield's does not. Patterns are therefore translated rather than copied
+   (`reports/*` becomes `reports/*/**`), and a differential test asserts the
+   Shield rule is never wider than the constraint it came from. Constraint forms
+   with no faithful translation - `Range`, `Regex`, `CEL`, `Cidr`, `Not`,
+   `NotOneOf`, and any mid-string `*` - fall back to `resource: "**"` and stay
+   with the reference implementation's evaluator alone. Shield never replaces
+   that evaluator; both must allow.
 
 2. **Vouch's `rate` and `policy` dimensions have no AAT equivalent** in the core
    constraint set. Carrying them would need registered extension constraint
@@ -142,7 +148,7 @@ This list is a deliverable, not a caveat section. Full detail in
 | `aat_to_shield.py` | Leaf authority → Shield rules; the pre-execution gate |
 | `credential_link.py` | Record the authorising AAT on the issued credential |
 | `demo_setup.py`, `demo_call.py` | Scene 4 |
-| `tests/` | 17 tests, each named for what it proves |
+| `tests/` | 22 tests, each named for what it proves |
 | `../../test-vectors/aat/` | Chain fixtures and their generator |
 
 Failures are typed so a caller can branch on them: `AatMalformedChain`,

--- a/integrations/aat/aat_to_shield.py
+++ b/integrations/aat/aat_to_shield.py
@@ -4,15 +4,20 @@ Only the **leaf** matters for enforcement. A derived AAT already states its own
 narrowed authority, so there is nothing to intersect: the chain is verified for
 provenance, the leaf is what is enforced. See ``DESIGN.md``.
 
-The mapping is deliberately partial, and the partiality is the interesting part.
+Shield v2 matches on ``action`` / ``target`` / ``resource`` with globs on
+``resource``, so a leaf's path constraint now has a home in Shield itself. Tool
+scope becomes the rule's ``action``; a path-shaped argument constraint becomes
+its ``resource`` glob.
 
-- **Tool scope** becomes Shield rules: one allow rule per tool the leaf names.
-- **Argument constraints** stay with the AAT reference implementation, and are
-  evaluated by ``Authorizer.check_chain`` in the same pre-execution step. Every
-  derived rule therefore carries ``resource: "**"``; Shield does not yet claim
-  to express what the token says about a call's arguments.
+Two properties this module holds to:
 
-Both must allow. Either refusing means the tool does not run.
+1. **A Shield rule is never wider than the Tenuo constraint it came from.**
+   Where an exact translation is not possible the rule falls back to ``**`` and
+   the constraint stays with Tenuo's evaluator alone. Narrower is safe here,
+   because both gates must allow; wider would not be.
+2. **Shield never replaces Tenuo.** The reference implementation still evaluates
+   every constraint on every call. Shield is a second, independent refusal
+   point for the subset it can express, not a substitute for the first.
 """
 
 from __future__ import annotations
@@ -20,9 +25,14 @@ from __future__ import annotations
 import time
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
-from vouch.shield.rules import Rule, RuleSet, normalize_pattern
+from vouch.shield.rules import (
+    Decision,
+    Rule,
+    RuleSet,
+    normalize_pattern,
+)
 
 from .aat_chain import VerifiedChain
 
@@ -34,70 +44,249 @@ except ImportError as exc:  # pragma: no cover
     ) from exc
 
 
-__all__ = ["ShieldRules", "AatDecision", "AatGate", "leaf_to_shield_rules"]
-
+__all__ = [
+    "ShieldRules",
+    "AatDecision",
+    "AatGate",
+    "leaf_to_shield_rules",
+    "tenuo_glob_to_shield",
+    "DEFAULT_TARGET",
+    "RESOURCE_ARG_NAMES",
+]
 
 #: Rule ``target`` used for AAT-derived rules unless the caller says otherwise.
 DEFAULT_TARGET = "filesystem"
 
+#: Argument names treated as carrying the call's resource, most specific first.
+#: Used when a tool constrains several arguments and we must choose which one
+#: Shield's ``resource`` represents.
+RESOURCE_ARG_NAMES = ("path", "file", "filename", "resource", "url", "uri", "table")
+
+
+# ---------------------------------------------------------------------------
+# Constraint translation
+# ---------------------------------------------------------------------------
+
+
+def tenuo_glob_to_shield(pattern: str) -> Optional[str]:
+    """Translate a Tenuo glob into an equal-or-narrower Shield glob.
+
+    The two do not share semantics. Tenuo's ``*`` is a plain glob whose ``*``
+    crosses ``/``; Shield's ``*`` is one path segment and never crosses ``/``.
+    So ``reports/*`` means different things to each, and copying the string
+    across would produce a Shield rule that wrongly denies ``reports/2026/q3.txt``.
+
+    Translatable shapes, verified against the reference implementation by the
+    differential test in ``tests/``:
+
+    ============================  ==========================
+    Tenuo                         Shield
+    ============================  ==========================
+    ``reports/q3.txt`` (literal)  ``reports/q3.txt``
+    ``reports/*``                 ``reports/*/**``
+    ``reports/**``                ``reports/*/**``
+    ``*`` / ``**``                ``**``
+    ============================  ==========================
+
+    Anything else returns None, meaning "no faithful Shield rule exists for
+    this"; the caller then falls back to ``**`` and leaves the constraint to
+    Tenuo. A mid-string ``*`` such as ``rep*ts`` is the common example: Tenuo
+    matches ``rep/or/ts`` through it, and Shield has no way to say that.
+    """
+    if not isinstance(pattern, str) or not pattern:
+        return None
+
+    if pattern in ("*", "**"):
+        return "**"
+
+    if "*" not in pattern:
+        # A literal. Reject '.'/'..' segments rather than resolving them,
+        # matching normalize_pattern's stance.
+        segments = [s for s in pattern.split("/") if s]
+        if not segments or any(s in (".", "..") for s in segments):
+            return None
+        return "/".join(segments)
+
+    # Only a single trailing '/*' or '/**' is translatable.
+    for suffix in ("/**", "/*"):
+        if pattern.endswith(suffix):
+            prefix = pattern[: -len(suffix)]
+            if "*" in prefix:
+                return None
+            segments = [s for s in prefix.split("/") if s]
+            if not segments or any(s in (".", "..") for s in segments):
+                return None
+            # '*/**' is "one or more segments below the prefix", which is what
+            # Tenuo's trailing '*' means. A bare '**' here would also match the
+            # prefix itself, which would be wider than Tenuo.
+            return "/".join(segments) + "/*/**"
+
+    return None
+
+
+def _constraint_to_globs(constraint: Any) -> Optional[List[str]]:
+    """Shield globs equivalent to one Tenuo constraint, or None if untranslatable."""
+    name = type(constraint).__name__
+
+    if name == "Pattern":
+        translated = tenuo_glob_to_shield(str(constraint.pattern))
+        return [translated] if translated else None
+
+    if name == "Exact":
+        value = constraint.value
+        if not isinstance(value, str) or "*" in value:
+            return None
+        translated = tenuo_glob_to_shield(value)
+        return [translated] if translated else None
+
+    if name == "OneOf":
+        globs: List[str] = []
+        for value in constraint.values:
+            text = getattr(value, "value", value)
+            if not isinstance(text, str) or "*" in text:
+                return None
+            translated = tenuo_glob_to_shield(text)
+            if translated is None:
+                return None
+            globs.append(translated)
+        return globs or None
+
+    # Wildcard, Range, Regex, CEL, Cidr, Url*, Cmd, Shlex, Not, NotOneOf, ...
+    return None
+
+
+def _pick_resource_arg(constraints: Dict[str, Any]) -> Optional[str]:
+    """Choose which constrained argument Shield's ``resource`` stands for."""
+    if not constraints:
+        return None
+    if len(constraints) == 1:
+        return next(iter(constraints))
+    for candidate in RESOURCE_ARG_NAMES:
+        if candidate in constraints:
+            return candidate
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
 
 @dataclass(frozen=True)
 class ShieldRules:
-    """Shield rules sourced from an AAT leaf.
-
-    Tool scope maps directly: each tool the leaf authorises becomes one allow
-    rule. Argument constraints do not map yet, so every rule carries
-    ``resource: "**"`` and the reference implementation's evaluator remains the
-    only gate on a call's arguments. Both must allow.
-    """
+    """Shield v2 rules derived from an AAT leaf."""
 
     did: str
     target: str
-    rules: tuple
+    rules: Tuple[Rule, ...]
     allowed_tools: frozenset
-    unmapped_tools: tuple = ()
+    #: Tools whose argument constraint became a real resource glob.
+    mapped_tools: Tuple[str, ...] = ()
+    #: Tools whose constraints Shield cannot express; Tenuo alone gates their
+    #: arguments, and their rule is ``resource: "**"``.
+    unmapped_tools: Tuple[str, ...] = ()
+    #: The argument each mapped tool's resource was taken from.
+    resource_args: Optional[Dict[str, str]] = None
     leaf_jti: str = ""
     root_jti: str = ""
 
     def permits_tool(self, tool: str) -> bool:
-        """Exact-string match, per draft Section 3.3.1 -- no normalization."""
+        """Exact-string match, per draft Section 3.3.1 - no normalization."""
         return tool in self.allowed_tools
 
     def as_rule_set(self) -> RuleSet:
-        return RuleSet(by_did={self.did: list(self.rules)})
+        by_did: Dict[str, List[Rule]] = {self.did: list(self.rules)}
+        return RuleSet(by_did=by_did)
+
+    def as_document(self) -> Dict[str, Any]:
+        """The rules as a v2 rules document, for writing to a file."""
+        return {
+            "version": 2,
+            "rules": [
+                {
+                    "did": self.did,
+                    "allow": [
+                        {
+                            "id": r.id,
+                            "action": r.action,
+                            "target": r.target,
+                            "resource": r.resource,
+                        }
+                        for r in self.rules
+                    ],
+                }
+            ],
+            "deny_default": True,
+        }
 
 
 def leaf_to_shield_rules(
     chain: VerifiedChain,
     *,
-    did: str = "did:vouch:aat-holder",
+    did: str,
     target: str = DEFAULT_TARGET,
+    resource_arg: Optional[str] = None,
 ) -> ShieldRules:
-    """Derive Shield rules from a verified chain's leaf.
+    """Derive Shield v2 rules from a verified chain's leaf.
 
-    Each authorised tool becomes one allow rule. The resource is ``**``, because
-    Shield cannot yet express the leaf's argument constraints; those stay with
-    the reference implementation.
+    Each tool the leaf authorises becomes one or more allow rules: the tool name
+    is the ``action``, and its path-shaped argument constraint becomes the
+    ``resource`` glob. Constraints Shield cannot express fall back to ``**`` and
+    are reported in ``unmapped_tools``; Tenuo still gates them.
+
+    Args:
+        chain: A verified chain. Only its leaf is used.
+        did: The DID these rules apply to.
+        target: Rule ``target``. AAT has no target concept, so it is supplied.
+        resource_arg: Force which argument carries the resource. By default it
+            is inferred (see :data:`RESOURCE_ARG_NAMES`).
     """
-    tools = sorted(chain.capabilities())
-    rules = tuple(
-        Rule(
-            action=tool,
-            target=target,
-            resource=normalize_pattern("**"),
-            id=f"aat:{chain.leaf_jti}:{tool}",
-        )
-        for tool in tools
-    )
+    capabilities = chain.capabilities()
+    rules: List[Rule] = []
+    mapped: List[str] = []
+    unmapped: List[str] = []
+    chosen_args: Dict[str, str] = {}
+
+    for tool in sorted(capabilities):
+        constraints = capabilities[tool] or {}
+        arg = resource_arg or _pick_resource_arg(constraints)
+        globs = _constraint_to_globs(constraints[arg]) if arg in constraints else None
+
+        if globs:
+            mapped.append(tool)
+            chosen_args[tool] = arg
+        else:
+            # No faithful translation. Shield allows the tool at any resource
+            # and Tenuo remains the only gate on its arguments.
+            globs = ["**"]
+            unmapped.append(tool)
+
+        for index, glob in enumerate(globs):
+            rules.append(
+                Rule(
+                    action=tool,
+                    target=target,
+                    resource=normalize_pattern(glob),
+                    id=f"aat:{chain.leaf_jti}:{tool}:{index}",
+                )
+            )
+
     return ShieldRules(
         did=did,
         target=target,
-        rules=rules,
-        allowed_tools=frozenset(tools),
-        unmapped_tools=tuple(tools),
+        rules=tuple(rules),
+        allowed_tools=frozenset(capabilities),
+        mapped_tools=tuple(mapped),
+        unmapped_tools=tuple(unmapped),
+        resource_args=chosen_args,
         leaf_jti=chain.leaf_jti,
         root_jti=chain.root_jti,
     )
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
 
 
 @dataclass(frozen=True)
@@ -110,6 +299,8 @@ class AatDecision:
     leaf_jti: str = ""
     root_jti: str = ""
     failure: Optional[str] = None
+    #: Which layer refused: "shield" or "tenuo". None when allowed.
+    refused_by: Optional[str] = None
 
     def __bool__(self) -> bool:
         return self.allowed
@@ -124,11 +315,15 @@ class AatGate:
     Usage::
 
         chain = verify_chain_file("leaf.json")
-        gate = AatGate(chain, holder_key=key)
+        gate = AatGate(chain, holder_key=key, did="did:web:agent.example.com")
         decision = gate.check("read_file", {"path": "reports/q3.txt"})
         if decision.allowed:
             run_tool()
     """
+
+    #: DID used for AAT-derived rules when the caller does not supply one. The
+    #: rules are scoped to this leaf, so the identifier only has to be stable.
+    DEFAULT_DID = "did:vouch:aat-holder"
 
     def __init__(
         self,
@@ -137,6 +332,8 @@ class AatGate:
         holder_key: Any = None,
         shield: Any = None,
         did: Optional[str] = None,
+        target: str = DEFAULT_TARGET,
+        resource_arg: Optional[str] = None,
     ) -> None:
         """
         Args:
@@ -146,19 +343,45 @@ class AatGate:
                 each call itself. That is a convenience for local and demo use:
                 in a real deployment the PoP is produced by the caller holding
                 the key and passed to ``check`` as ``signature``.
-            shield: Optional ``vouch.shield.Shield``. When given, its verdict is
-                combined with the AAT verdict and both must allow.
-            did: DID to check Shield permissions against, when ``shield`` is set.
+            shield: Optional external ``vouch.shield.Shield``. When given, its
+                verdict is combined with the others and all must allow.
+            did: DID the AAT-derived rules are written for.
+            target: Rule ``target`` for the derived rules.
+            resource_arg: Force which argument carries the resource.
         """
         self._chain = chain
         self._holder_key = holder_key
         self._shield = shield
-        self._did = did or "did:vouch:aat-holder"
-        self.rules = leaf_to_shield_rules(chain, did=self._did)
+        self._did = did or self.DEFAULT_DID
+        self.rules = leaf_to_shield_rules(
+            chain, did=self._did, target=target, resource_arg=resource_arg
+        )
+        self._rule_set = self.rules.as_rule_set()
 
     @property
     def chain(self) -> VerifiedChain:
         return self._chain
+
+    def shield_check(self, tool: str, args: Dict[str, Any]) -> Decision:
+        """Shield's verdict alone, using the AAT-derived rules."""
+        return self._rule_set.check(
+            self._did,
+            action=tool,
+            target=self.rules.target,
+            resource=self._resource_for(tool, args),
+        )
+
+    def _resource_for(self, tool: str, args: Dict[str, Any]) -> str:
+        """The resource string Shield matches for this call."""
+        arg = (self.rules.resource_args or {}).get(tool)
+        if arg is None:
+            arg = _pick_resource_arg(args) or ""
+        value = args.get(arg)
+        if isinstance(value, str) and value:
+            return value
+        # Nothing resource-shaped to match on. Tools in this position are
+        # unmapped and carry a '**' rule, so Shield defers to Tenuo.
+        return "\x00" if tool in self.rules.mapped_tools else "unspecified"
 
     def check(
         self,
@@ -170,13 +393,16 @@ class AatGate:
     ) -> AatDecision:
         """Decide whether a call may proceed. Never executes anything.
 
-        Order: tool scope, then Shield, then the AAT reference implementation
-        (which re-checks tool scope, evaluates argument constraints, enforces
-        expiry, and verifies proof-of-possession). Any failure is fail-closed.
+        Order: tool scope, then Shield against the AAT-derived rules, then any
+        external Shield, then the AAT reference implementation (which re-checks
+        tool scope, evaluates every argument constraint, enforces expiry, and
+        verifies proof-of-possession). Any failure is fail-closed.
         """
         args = dict(args or {})
 
-        def deny(reason: str, failure: Optional[str] = None) -> AatDecision:
+        def deny(
+            reason: str, failure: Optional[str] = None, by: Optional[str] = None
+        ) -> AatDecision:
             return AatDecision(
                 allowed=False,
                 tool=tool,
@@ -184,6 +410,7 @@ class AatGate:
                 leaf_jti=self.rules.leaf_jti,
                 root_jti=self.rules.root_jti,
                 failure=failure,
+                refused_by=by,
             )
 
         # 1. Tool scope from the leaf.
@@ -192,28 +419,52 @@ class AatGate:
                 f"Tool '{tool}' is not in the AAT leaf's authority "
                 f"(leaf permits: {', '.join(sorted(self.rules.allowed_tools)) or 'nothing'})",
                 failure="ToolNotAuthorized",
+                by="shield",
             )
 
-        # 2. Shield, when configured. Both layers must allow.
-        if self._shield is not None:
-            result = self._shield.intercept(tool=tool, args=args, did=self._did)
-            if not result.allowed:
-                return deny(f"Shield denied: {result.reason}", failure="ShieldDenied")
+        # 2. Shield, using rules derived from the leaf's own constraints. For a
+        #    path-shaped constraint this is a real, independent refusal point:
+        #    it denies 'read_file /etc/passwd' under a 'reports/*' leaf without
+        #    consulting Tenuo at all.
+        shield_decision = self.shield_check(tool, args)
+        if not shield_decision.allow:
+            return deny(
+                f"Shield denied: {shield_decision.reason}",
+                failure="ShieldDenied",
+                by="shield",
+            )
 
-        # 3. The AAT reference implementation: argument constraints, expiry, PoP.
+        # 3. An externally supplied Shield, when configured. All layers must allow.
+        if self._shield is not None:
+            result = self._shield.intercept(
+                tool=tool,
+                args=args,
+                did=self._did,
+                target=self.rules.target,
+                resource=self._resource_for(tool, args),
+            )
+            if not result.allowed:
+                return deny(f"Shield denied: {result.reason}", failure="ShieldDenied", by="shield")
+
+        # 4. The AAT reference implementation: every argument constraint,
+        #    expiry, and proof-of-possession. Shield never replaces this.
         pop = signature
         if pop is None and self._holder_key is not None:
             try:
                 pop = self._chain.leaf.sign(self._holder_key, tool, args, int(time.time()))
             except Exception as exc:
-                return deny(f"Could not produce proof-of-possession: {exc}", failure="PopError")
+                return deny(
+                    f"Could not produce proof-of-possession: {exc}",
+                    failure="PopError",
+                    by="tenuo",
+                )
 
         try:
             self._chain._authorizer.check_chain(self._chain.warrants, tool, args, signature=pop)
         except _tex.TenuoError as exc:
-            return deny(f"{type(exc).__name__}: {exc}", failure=type(exc).__name__)
+            return deny(f"{type(exc).__name__}: {exc}", failure=type(exc).__name__, by="tenuo")
         except Exception as exc:  # unknown means deny
-            return deny(f"AAT check failed: {exc}", failure=type(exc).__name__)
+            return deny(f"AAT check failed: {exc}", failure=type(exc).__name__, by="tenuo")
 
         return AatDecision(
             allowed=True,

--- a/integrations/aat/tests/test_aat_interop.py
+++ b/integrations/aat/tests/test_aat_interop.py
@@ -41,6 +41,8 @@ from integrations.aat import (  # noqa: E402
 
 VECTORS = Path(__file__).resolve().parents[3] / "test-vectors" / "aat"
 
+DID = "did:web:agent.example.com"
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -105,17 +107,18 @@ def test_valid_chain_leaf_rules_extracted(keys):
     assert chain.leaf_jti == str(leaf.id)
     assert chain.root_jti == str(root.id)
 
-    rules = leaf_to_shield_rules(chain)
+    rules = leaf_to_shield_rules(chain, did=DID)
 
     # The leaf's authority, not the root's: write_file was narrowed away.
     assert rules.allowed_tools == frozenset({"read_file"})
     assert not rules.permits_tool("write_file")
 
-    # Tool scope maps; the leaf's argument constraint does not yet, so the
-    # rule is deliberately wide and the reference implementation still gates it.
+    # The leaf's path constraint became a real Shield resource glob, so the
+    # rule is as fine-grained as the token it came from.
     assert [r.action for r in rules.rules] == ["read_file"]
-    assert rules.rules[0].resource == "**"
-    assert rules.unmapped_tools == ("read_file",)
+    assert rules.rules[0].resource == "reports/*/**"
+    assert rules.mapped_tools == ("read_file",)
+    assert rules.unmapped_tools == ()
 
 
 def test_widened_scope_rejected(keys):
@@ -315,7 +318,9 @@ def test_argument_constraint_enforced(verified_chain):
         read_file("/etc/passwd")
 
     assert not blocked.allowed
-    assert blocked.failure == "ConstraintViolation"
+    # Shield now expresses the leaf's path constraint itself, so it refuses
+    # first. Tenuo would also refuse; it simply never gets asked.
+    assert blocked.refused_by == "shield"
     assert invoked == [], "a constraint-violating call reached the tool"
 
 
@@ -329,8 +334,8 @@ def test_missing_proof_of_possession_is_denied(verified_chain):
     assert decision.failure in {"MissingSignature", "SignatureMismatch"}
 
 
-def test_shield_and_aat_must_both_allow(verified_chain):
-    """Shield's verdict is combined with the AAT verdict, not replaced by it."""
+def test_external_shield_and_aat_must_both_allow(verified_chain):
+    """An external Shield's verdict is combined with the AAT verdict."""
     from vouch.shield import Shield, ShieldConfig
 
     chain, holder_key = verified_chain
@@ -338,7 +343,8 @@ def test_shield_and_aat_must_both_allow(verified_chain):
 
     shield = Shield(ShieldConfig(require_signature=False, strict_mode=True))
     shield.trust_did(did)
-    # Shield holds no rules, so it must veto even though the AAT permits.
+    # The external Shield grants nothing, so it must veto even though both the
+    # AAT and the AAT-derived rules permit the call.
     gate = AatGate(chain, holder_key=holder_key, shield=shield, did=did)
     decision = gate.check("read_file", {"path": "reports/q3.txt"})
 
@@ -374,7 +380,7 @@ def test_valid_fixture_verifies():
 
     chain = verify_chain_file(path)
     assert chain.tools == ["read_file"]
-    assert leaf_to_shield_rules(chain).allowed_tools == frozenset({"read_file"})
+    assert leaf_to_shield_rules(chain, did=DID).allowed_tools == frozenset({"read_file"})
 
 
 def test_widening_fixture_is_rejected():
@@ -454,3 +460,136 @@ def test_mcp_denies_when_chain_does_not_verify(tmp_path, monkeypatch):
     out = server.check_action_aat("read_file", '{"path": "reports/q3.txt"}')
     assert out.startswith("DENY")
     server._aat_gate_cache.clear()
+
+
+# ---------------------------------------------------------------------------
+# Shield v2 mapping (Step 2 follow-through)
+# ---------------------------------------------------------------------------
+
+
+def test_aat_path_constraint_enforced_by_shield(verified_chain):
+    """`read_file /etc/passwd` is denied by Shield, not only by Tenuo.
+
+    The leaf constrains `path` to `reports/*`. Shield v2 can express that as a
+    resource glob, so it refuses on its own. This asserts against Shield's
+    verdict directly, with Tenuo's evaluator out of the picture entirely.
+    """
+    chain, _ = verified_chain
+    gate = AatGate(chain, did=DID)
+
+    assert gate.shield_check("read_file", {"path": "reports/q3.txt"}).allow
+
+    denied = gate.shield_check("read_file", {"path": "/etc/passwd"})
+    assert not denied.allow
+    assert denied.reason == "resource outside scope"
+
+    # Narrowed out of the leaf entirely: not a resource question.
+    assert gate.shield_check("write_file", {"path": "reports/q3.txt"}).reason == (
+        "no matching rule"
+    )
+
+    # And traversal cannot sneak back in.
+    assert not gate.shield_check("read_file", {"path": "reports/../etc/passwd"}).allow
+
+
+def test_shield_glob_is_never_wider_than_the_tenuo_constraint(verified_chain):
+    """Differential check: Shield must not allow what Tenuo would refuse.
+
+    Tenuo's `*` crosses `/`; Shield's does not. The translation has to account
+    for that. Narrower is safe here because both gates must allow; wider would
+    silently widen authority.
+    """
+    from tenuo import Pattern
+
+    from integrations.aat.aat_to_shield import tenuo_glob_to_shield
+    from vouch.shield.rules import normalize_pattern, normalize_resource, resource_matches
+
+    resources = [
+        "reports",
+        "reports/q3.txt",
+        "reports/2026/q3.txt",
+        "reports/a/b/c",
+        "secrets/keys.txt",
+        "reportsX/a",
+        "etc/passwd",
+    ]
+
+    for tenuo_pattern in ["reports/*", "reports/**", "reports/q3.txt"]:
+        shield_glob = tenuo_glob_to_shield(tenuo_pattern)
+        assert shield_glob is not None, tenuo_pattern
+        matcher = Pattern(tenuo_pattern)
+        for resource in resources:
+            normalised = normalize_resource(resource)
+            shield_allows = normalised is not None and resource_matches(
+                normalize_pattern(shield_glob), normalised
+            )
+            if shield_allows:
+                assert matcher.matches(resource), (
+                    f"Shield glob {shield_glob!r} allows {resource!r} but "
+                    f"Tenuo pattern {tenuo_pattern!r} does not - that is a widening"
+                )
+
+
+def test_untranslatable_constraints_fall_back_and_stay_with_tenuo(keys):
+    """A constraint Shield cannot express yields '**' and is reported."""
+    from tenuo import Range
+
+    from integrations.aat.aat_to_shield import tenuo_glob_to_shield
+
+    # Mid-string '*' has no faithful Shield equivalent: Tenuo matches across
+    # '/' through it, and Shield has no way to say that.
+    assert tenuo_glob_to_shield("rep*ts") is None
+    assert tenuo_glob_to_shield("a/*/b") is None
+
+    root_key, holder_key = keys
+    root = (
+        Warrant.mint_builder()
+        .capability("charge", amount=Range.max_value(100))
+        .ttl(3600)
+        .holder(holder_key.public_key)
+        .mint(root_key)
+    )
+    chain = verify_chain(document(root_key, [root]))
+    rules = leaf_to_shield_rules(chain, did=DID, target="payments")
+
+    assert rules.unmapped_tools == ("charge",)
+    assert rules.mapped_tools == ()
+    assert [r.resource for r in rules.rules] == ["**"]
+
+
+def test_numeric_constraint_still_enforced_by_tenuo(keys):
+    """Shield's fallback must not become a hole: Tenuo still refuses."""
+    from tenuo import Range
+
+    root_key, holder_key = keys
+    root = (
+        Warrant.mint_builder()
+        .capability("charge", amount=Range.max_value(100))
+        .ttl(3600)
+        .holder(holder_key.public_key)
+        .mint(root_key)
+    )
+    chain = verify_chain(document(root_key, [root]))
+    gate = AatGate(chain, holder_key=holder_key, did=DID, target="payments")
+
+    # Shield allows it (its rule is '**'), so the refusal must come from Tenuo.
+    assert gate.shield_check("charge", {"amount": 500}).allow
+
+    decision = gate.check("charge", {"amount": 500})
+    assert not decision.allowed
+    assert decision.refused_by == "tenuo"
+
+    assert gate.check("charge", {"amount": 50}).allowed
+
+
+def test_rules_render_as_a_v2_document(verified_chain):
+    """The derived rules load back through Shield's own loader."""
+    from vouch.shield.rules import load_rules
+
+    chain, _ = verified_chain
+    rules = leaf_to_shield_rules(chain, did=DID)
+
+    rule_set = load_rules(rules.as_document(), source="<aat>")
+    assert rule_set.ok
+    assert rule_set.check(DID, "read_file", "filesystem", "reports/q3.txt").allow
+    assert not rule_set.check(DID, "read_file", "filesystem", "/etc/passwd").allow


### PR DESCRIPTION
With Shield matching on a resource, an AAT leaf that constrains a path now has somewhere to land. A leaf restricting `path` to `reports/*` becomes a Shield rule, and Shield refuses `read_file /etc/passwd` on its own rather than leaving every argument decision to the tokens own evaluator.

**The two glob languages are not the same.** In an AAT the `*` in `reports/*` crosses `/`, so it matches `reports/2026/q3.txt`. In a Shield rule `*` is one path segment and does not. Copying the pattern string across would produce a rule that wrongly refuses a path the token actually permits. Patterns are therefore translated rather than copied, and `reports/*` becomes `reports/*/**`.

**Security boundary.** A derived Shield rule is never wider than the constraint it came from. That direction is the one that matters: because both gates must allow, a rule that is narrower than the token only ever refuses something the token would have permitted, while a wider one would grant authority the token withheld. A test checks this as a property across a matrix of patterns and resources rather than asserting it in prose. Constraint forms with no faithful translation, including numeric ranges, regular expressions, network ranges, and negations, fall back to a rule that matches anything and remain the responsibility of the reference implementation alone. Shield never replaces that evaluator; it adds a second, independent refusal point for the subset it can express.

A decision now records which layer refused, so it is clear whether Shield or the token evaluator turned a call away.