### PR TITLE
test(shield): shared cross-language decision vectors

### DIFF
--- a/test-vectors/shield/README.md
+++ b/test-vectors/shield/README.md
@@ -1,0 +1,83 @@
+# Vouch Shield decision vectors
+
+The cross-language contract for Shield rules. Every implementation loads
+`rules.yaml`, runs the calls in `cases.json`, and must produce the same verdict,
+the same reason string, and the same rule id.
+
+| File | What it is |
+|---|---|
+| `rules.yaml` | The shared rule set. Actions are named after the glob behaviour they exercise, so a failing case names its own cause. |
+| `cases.json` | 77 calls with their expected decisions. |
+
+## Running them
+
+| Language | Command |
+|---|---|
+| Python | `pytest tests/test_shield_vectors.py` |
+| TypeScript | `cd packages/sdk-ts && npm test` |
+
+Both run in CI wherever the other shared vectors run.
+
+## The shape of a case
+
+```json
+{
+  "name": "deep: two segments below",
+  "action": "deep",
+  "target": "files",
+  "resource": "reports/2026/q3.txt",
+  "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" }
+}
+```
+
+`did` defaults to the top-level `did` in the file and is stated per case only
+when a case is about a different one. `rule_id` is checked only when the case
+states it, so a case can assert a verdict without pinning which rule produced
+it. A case carrying its own `rules` object uses that document instead of
+`rules.yaml`, which is how load-time behaviour is covered without a file per
+case.
+
+## What the cases cover
+
+- **Glob depth.** `*` is exactly one segment and never crosses a `/`; `**` is
+  any number including zero; a trailing `/**` also matches the bare prefix.
+- **Non-path resources.** A string with no `/` is a single segment, so
+  `public.*` matches `public.customers` and `public.a.b`. `.` is literal.
+- **Normalisation.** Leading slash, duplicate slashes, `.` segments, trailing
+  slash, and interior `..` all resolve before matching.
+- **Traversal.** `reports/../etc/passwd` normalises to `etc/passwd` and falls
+  outside a `reports/**` rule. A resource that climbs above its own root is
+  refused outright rather than clamped, and reports `invalid resource` rather
+  than `resource outside scope`.
+- **Unusable resources.** Empty, slashes only, dot segments only, NUL, a C0
+  control character, a newline, and a C1 control character.
+- **Exact matching.** Action, target, and DID are compared exactly and are case
+  sensitive. A DID is never matched by prefix.
+- **Load failures.** A missing or wrong `version`, `deny_default: false`, an
+  unknown key on a rule or a block, a missing or empty required field, a
+  malformed resource pattern. Each denies everything with `malformed rules`
+  rather than admitting anything.
+- **Empty authority.** No rules, no `rules` key, or a DID with an empty allow
+  list all permit nothing.
+
+All six reason strings appear at least once, so no implementation can pass by
+stubbing one out. A test asserts that, and that the allow and deny cases are
+both well represented, so a port cannot pass by being uniformly strict or
+uniformly permissive.
+
+## Precedence when a case surprises you
+
+The order of checks is observable and is part of the contract. A resource that
+cannot be normalised reports `invalid resource` even when the DID is unknown,
+because the resource is checked first. A rule that matches action and target but
+not the resource reports `resource outside scope`, while no action and target
+match at all reports `no matching rule`. That distinction is the difference
+between "you may not do this" and "you may do this, but not there".
+
+## Changing these
+
+These are a contract between implementations, so a change to an expectation is
+a change to Shield's behaviour and needs the same scrutiny as a change to the
+code. Adding cases is cheap and welcome. Editing an expectation to make a
+failing implementation pass is the wrong direction; work out which side is
+wrong first.

--- a/test-vectors/shield/cases.json
+++ b/test-vectors/shield/cases.json
@@ -1,0 +1,98 @@
+{
+  "description": "Shared Vouch Shield decision vectors. Every implementation loads rules.yaml and must produce these verdicts exactly, including the reason string. A case carrying its own `rules` object uses that document instead of rules.yaml, which is how load-time behaviour is covered. `rule_id` is only checked when the case states it.",
+  "default_rules": "rules.yaml",
+  "did": "did:web:agent.example.com",
+  "cases": [
+    { "name": "deep: bare prefix matches a trailing /**", "action": "deep", "target": "files", "resource": "reports", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "deep: one segment below", "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "deep: two segments below", "action": "deep", "target": "files", "resource": "reports/2026/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "deep: four segments below", "action": "deep", "target": "files", "resource": "reports/a/b/c/d", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "deep: a sibling directory is outside", "action": "deep", "target": "files", "resource": "secrets/keys.txt", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "deep: a prefix must match a whole segment, not a substring", "action": "deep", "target": "files", "resource": "reportsX/a", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "deep: a longer segment name is not the prefix", "action": "deep", "target": "files", "resource": "reports2", "expect": { "allow": false, "reason": "resource outside scope" } },
+
+    { "name": "shallow: * matches exactly one segment", "action": "shallow", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "shallow" } },
+    { "name": "shallow: * does not cross a slash", "action": "shallow", "target": "files", "resource": "reports/2026/q3.txt", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "shallow: * requires a segment to be present", "action": "shallow", "target": "files", "resource": "reports", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "shallow: unrelated prefix", "action": "shallow", "target": "files", "resource": "logs/a.txt", "expect": { "allow": false, "reason": "resource outside scope" } },
+
+    { "name": "mid: ** matches zero segments", "action": "mid", "target": "files", "resource": "a/b", "expect": { "allow": true, "reason": "allowed", "rule_id": "mid" } },
+    { "name": "mid: ** matches one segment", "action": "mid", "target": "files", "resource": "a/x/b", "expect": { "allow": true, "reason": "allowed", "rule_id": "mid" } },
+    { "name": "mid: ** matches several segments", "action": "mid", "target": "files", "resource": "a/x/y/z/b", "expect": { "allow": true, "reason": "allowed", "rule_id": "mid" } },
+    { "name": "mid: the suffix must still match", "action": "mid", "target": "files", "resource": "a/x/c", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "mid: the prefix must still match", "action": "mid", "target": "files", "resource": "z/x/b", "expect": { "allow": false, "reason": "resource outside scope" } },
+
+    { "name": "everything: a single segment", "action": "everything", "target": "files", "resource": "anything", "expect": { "allow": true, "reason": "allowed", "rule_id": "everything" } },
+    { "name": "everything: a deep path", "action": "everything", "target": "files", "resource": "a/b/c/d/e", "expect": { "allow": true, "reason": "allowed", "rule_id": "everything" } },
+    { "name": "everything: still refuses an unusable resource", "action": "everything", "target": "files", "resource": "../escape", "expect": { "allow": false, "reason": "invalid resource" } },
+
+    { "name": "dotted: * covers the rest of a single segment", "action": "dotted", "target": "db", "resource": "public.customers", "expect": { "allow": true, "reason": "allowed", "rule_id": "dotted" } },
+    { "name": "dotted: a different prefix does not match", "action": "dotted", "target": "db", "resource": "internal.salaries", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "dotted: * spans further dots inside one segment", "action": "dotted", "target": "db", "resource": "public.a.b", "expect": { "allow": true, "reason": "allowed", "rule_id": "dotted" } },
+    { "name": "dotted: the literal prefix must be present", "action": "dotted", "target": "db", "resource": "publicX.customers", "expect": { "allow": false, "reason": "resource outside scope" } },
+
+    { "name": "literal: . is not a wildcard", "action": "literal", "target": "files", "resource": "axb", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "literal: the exact string matches", "action": "literal", "target": "files", "resource": "a.b", "expect": { "allow": true, "reason": "allowed", "rule_id": "literal" } },
+
+    { "name": "exact: the exact resource matches", "action": "exact", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "exact" } },
+    { "name": "exact: a sibling file does not", "action": "exact", "target": "files", "resource": "reports/q4.txt", "expect": { "allow": false, "reason": "resource outside scope" } },
+
+    { "name": "normalisation: a leading slash is stripped", "action": "deep", "target": "files", "resource": "/reports/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "normalisation: duplicate slashes collapse", "action": "deep", "target": "files", "resource": "reports//q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "normalisation: a single dot segment is dropped", "action": "deep", "target": "files", "resource": "reports/./q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "normalisation: a trailing slash is stripped", "action": "deep", "target": "files", "resource": "reports/", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "normalisation: an interior .. resolves", "action": "deep", "target": "files", "resource": "reports/2026/../q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep" } },
+    { "name": "normalisation: a pattern's leading slash normalises away too", "action": "leadingslash", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "leading-slash" } },
+
+    { "name": "traversal: .. cannot escape the rule's prefix", "action": "deep", "target": "files", "resource": "reports/../etc/passwd", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "traversal: .. cannot escape via a deeper path", "action": "deep", "target": "files", "resource": "reports/a/../../etc/passwd", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "traversal: climbing above the root is refused outright", "action": "deep", "target": "files", "resource": "../etc/passwd", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "traversal: a bare .. is refused", "action": "deep", "target": "files", "resource": "..", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "traversal: climbing past the root is refused, not clamped", "action": "deep", "target": "files", "resource": "reports/../..", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "traversal: a leading slash does not permit a climb", "action": "deep", "target": "files", "resource": "/../etc/passwd", "expect": { "allow": false, "reason": "invalid resource" } },
+
+    { "name": "invalid: an empty resource", "action": "deep", "target": "files", "resource": "", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "invalid: a resource that is only slashes", "action": "deep", "target": "files", "resource": "///", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "invalid: a resource that is only dot segments", "action": "deep", "target": "files", "resource": "./.", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "invalid: a NUL byte", "action": "deep", "target": "files", "resource": "reports/\u0000etc", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "invalid: a C0 control character", "action": "deep", "target": "files", "resource": "reports/\u001fetc", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "invalid: a newline", "action": "deep", "target": "files", "resource": "reports/\netc", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "invalid: a C1 control character", "action": "deep", "target": "files", "resource": "reports/\u009fetc", "expect": { "allow": false, "reason": "invalid resource" } },
+
+    { "name": "action: an action with no rule at all", "action": "nosuchaction", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "no matching rule" } },
+    { "name": "action: matching is case sensitive", "action": "DEEP", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "no matching rule" } },
+    { "name": "target: a target with no rule", "action": "deep", "target": "network", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "no matching rule" } },
+    { "name": "target: matching is case sensitive", "action": "deep", "target": "Files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "no matching rule" } },
+    { "name": "target: the same action on a second target is a separate rule", "action": "deep", "target": "db", "resource": "reports/q3.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "deep-other-target" } },
+    { "name": "target: that second rule does not widen the first", "action": "shallow", "target": "db", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "no matching rule" } },
+
+    { "name": "did: an unknown DID is refused before anything else", "did": "did:web:stranger.example.com", "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "unknown did" } },
+    { "name": "did: an unknown DID is refused even for an invalid resource", "did": "did:web:stranger.example.com", "action": "deep", "target": "files", "resource": "../escape", "expect": { "allow": false, "reason": "invalid resource" } },
+    { "name": "did: DID matching is exact, not prefix", "did": "did:web:agent.example.com.evil.com", "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "unknown did" } },
+    { "name": "did: a second DID has its own rules", "did": "did:key:z6MkfrQ1example", "action": "deep", "target": "files", "resource": "logs/today.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "second-did" } },
+    { "name": "did: the second DID does not inherit the first's scope", "did": "did:key:z6MkfrQ1example", "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "resource outside scope" } },
+    { "name": "did: the first DID does not inherit the second's scope", "action": "deep", "target": "files", "resource": "logs/today.txt", "expect": { "allow": false, "reason": "resource outside scope" } },
+
+    { "name": "load: an empty rule list permits nothing", "rules": { "version": 2, "rules": [], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "unknown did" } },
+    { "name": "load: a missing rules key permits nothing", "rules": { "version": 2, "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "unknown did" } },
+    { "name": "load: a DID with an empty allow list permits nothing", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "unknown did" } },
+
+    { "name": "load: no version is rejected", "rules": { "rules": [], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: version 1 is rejected", "rules": { "version": 1, "rules": [], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: deny_default false is rejected", "rules": { "version": 2, "rules": [], "deny_default": false }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: an unknown key inside a rule is rejected, not ignored", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files", "resourse": "reports/**" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: an unknown key on a rule block is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [], "deny": [] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: a rule missing resource is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: a rule with an empty action is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "", "target": "files", "resource": "reports/**" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: a block missing did is rejected", "rules": { "version": 2, "rules": [ { "allow": [] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: rules as a mapping is rejected", "rules": { "version": 2, "rules": {}, "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: a pattern with ** inside a segment is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files", "resource": "a/**b" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "a/xb", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: a pattern containing .. is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files", "resource": "a/../b" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "b", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: a pattern containing a single dot segment is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files", "resource": "a/./b" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "a/b", "expect": { "allow": false, "reason": "malformed rules" } },
+    { "name": "load: an empty resource pattern is rejected", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files", "resource": "" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "a", "expect": { "allow": false, "reason": "malformed rules" } },
+
+    { "name": "load: a rule id is optional and a generated one is still returned", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "action": "deep", "target": "files", "resource": "reports/**" } ] } ], "deny_default": true }, "action": "deep", "target": "files", "resource": "reports/q3.txt", "expect": { "allow": true, "reason": "allowed" } },
+    { "name": "load: several rules for one DID are all considered", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "id": "one", "action": "deep", "target": "files", "resource": "reports/**" }, { "id": "two", "action": "shallow", "target": "files", "resource": "logs/*" } ] } ], "deny_default": true }, "action": "shallow", "target": "files", "resource": "logs/today.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "two" } },
+    { "name": "load: two blocks for the same DID accumulate", "rules": { "version": 2, "rules": [ { "did": "did:web:agent.example.com", "allow": [ { "id": "first", "action": "deep", "target": "files", "resource": "reports/**" } ] }, { "did": "did:web:agent.example.com", "allow": [ { "id": "second", "action": "shallow", "target": "files", "resource": "logs/*" } ] } ], "deny_default": true }, "action": "shallow", "target": "files", "resource": "logs/today.txt", "expect": { "allow": true, "reason": "allowed", "rule_id": "second" } }
+  ]
+}

--- a/test-vectors/shield/rules.yaml
+++ b/test-vectors/shield/rules.yaml
@@ -1,0 +1,75 @@
+# Shared Vouch Shield rule set for the cross-language vectors.
+#
+# Every implementation must load this file and produce the verdicts in
+# cases.json. Actions are deliberately named after the glob behaviour they
+# exercise so a failing case names its own cause.
+
+version: 2
+rules:
+  - did: did:web:agent.example.com
+    allow:
+      # '**' matches any depth, including zero segments, so a trailing '/**'
+      # also matches the bare prefix.
+      - id: deep
+        action: deep
+        target: files
+        resource: "reports/**"
+
+      # '*' matches exactly one segment and never crosses a '/'.
+      - id: shallow
+        action: shallow
+        target: files
+        resource: "reports/*"
+
+      # '**' in the middle of a pattern.
+      - id: mid
+        action: mid
+        target: files
+        resource: "a/**/b"
+
+      # Matches anything that normalises.
+      - id: everything
+        action: everything
+        target: files
+        resource: "**"
+
+      # A resource with no '/' is a single segment, so '*' covers the rest of
+      # it. This is what makes a non-path resource such as a table name work.
+      - id: dotted
+        action: dotted
+        target: db
+        resource: "public.*"
+
+      # '.' is a literal character, not a wildcard.
+      - id: literal
+        action: literal
+        target: files
+        resource: "a.b"
+
+      # A pattern with no wildcard at all.
+      - id: exact
+        action: exact
+        target: files
+        resource: "reports/q3.txt"
+
+      # A leading '/' in a pattern normalises away, so this is the same rule as
+      # writing it without one.
+      - id: leading-slash
+        action: leadingslash
+        target: files
+        resource: "/reports/**"
+
+      # The same action on a second target, to prove target is matched exactly.
+      - id: deep-other-target
+        action: deep
+        target: db
+        resource: "reports/**"
+
+  - did: did:key:z6MkfrQ1example
+    allow:
+      - id: second-did
+        action: deep
+        target: files
+        resource: "logs/**"
+
+deny_default: true

--- a/tests/test_shield_vectors.py
+++ b/tests/test_shield_vectors.py
@@ -1,0 +1,90 @@
+"""Vouch Shield decisions against the shared cross-language vectors.
+
+`test-vectors/shield/` is the contract every implementation must meet: the same
+rules file, the same calls, the same verdicts, and the same reason strings
+character for character. Python is the reference, so it has to pass them first.
+
+The expectations in `cases.json` were written from the documented semantics
+rather than generated from this implementation, so a disagreement means one of
+the two is wrong and both are worth looking at.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vouch.shield.rules import load_rules, load_rules_file
+
+VECTORS = Path(__file__).resolve().parents[1] / "test-vectors" / "shield"
+CASES_PATH = VECTORS / "cases.json"
+
+_doc = json.loads(CASES_PATH.read_text(encoding="utf-8"))
+CASES = _doc["cases"]
+DEFAULT_DID = _doc["did"]
+
+
+def _ids():
+    return [c["name"] for c in CASES]
+
+
+@pytest.fixture(scope="module")
+def default_rules():
+    pytest.importorskip("yaml", reason="the shared rules file is YAML")
+    return load_rules_file(VECTORS / _doc["default_rules"])
+
+
+@pytest.mark.parametrize("case", CASES, ids=_ids())
+def test_shield_vector(case, default_rules):
+    rules = (
+        load_rules(case["rules"], source=f"<case:{case['name']}>")
+        if "rules" in case
+        else default_rules
+    )
+
+    decision = rules.check(
+        case.get("did", DEFAULT_DID),
+        action=case["action"],
+        target=case["target"],
+        resource=case["resource"],
+    )
+
+    expected = case["expect"]
+    assert decision.allow is expected["allow"], (
+        f"{case['name']}: expected allow={expected['allow']}, "
+        f"got {decision.allow} with reason {decision.reason!r}"
+    )
+    assert decision.reason == expected["reason"], (
+        f"{case['name']}: expected reason {expected['reason']!r}, got {decision.reason!r}"
+    )
+    if "rule_id" in expected:
+        assert decision.rule_id == expected["rule_id"], (
+            f"{case['name']}: expected rule_id {expected['rule_id']!r}, got {decision.rule_id!r}"
+        )
+
+
+def test_vector_file_is_substantial():
+    """A thin vector set would pass everywhere and prove nothing."""
+    assert len(CASES) >= 60
+
+
+def test_every_reason_string_is_exercised():
+    """All six verdict reasons appear, so no implementation can stub one out."""
+    reasons = {c["expect"]["reason"] for c in CASES}
+    assert reasons == {
+        "allowed",
+        "unknown did",
+        "no matching rule",
+        "resource outside scope",
+        "invalid resource",
+        "malformed rules",
+    }
+
+
+def test_allow_and_deny_are_both_well_represented():
+    allowed = sum(1 for c in CASES if c["expect"]["allow"])
+    denied = len(CASES) - allowed
+    assert allowed >= 15, "too few allow cases to catch an over-strict port"
+    assert denied >= 30, "too few deny cases to catch an over-permissive port"


### PR DESCRIPTION
A contract for Shield rules that every implementation has to meet, ahead of the TypeScript port.

`test-vectors/shield/rules.yaml` is a shared rule set whose actions are named after the glob behaviour each one exercises, so a failing case names its own cause. `test-vectors/shield/cases.json` holds 77 calls with their expected verdict, reason string, and rule id.

The expectations were written from the documented semantics rather than generated from the Python implementation. Generating them would have made the vectors agree with whatever the code already did, including any mistake, and would prove nothing about a second implementation. Python passes all 77 unchanged.

**What they pin down.** Glob depth, where `*` is exactly one segment and never crosses a `/` and `**` is any number including zero, with a trailing `/**` also matching the bare prefix. Non-path resources, where a string with no `/` is a single segment, which is what makes `public.*` match a table name, and where `.` is literal. Normalisation of leading and duplicate slashes, `.` segments, trailing slashes, and interior `..`. Traversal, where a path climbing above its own root is refused outright rather than clamped. Unusable resources including NUL, C0 and C1 control characters, and a newline. Exact case-sensitive matching of action, target, and DID, with no prefix matching on a DID. Load failures, each denying everything rather than admitting anything. And empty authority, where no rules at all permits nothing.

**Why the reason strings are part of the contract.** They are what an operator greps and alerts on, so two implementations disagreeing about wording is a real interoperability problem even when both reach the same allow or deny. The vectors check them character for character.

Three guard tests keep the set honest: all six reason strings must appear, so no implementation can pass by stubbing one out; the case count has a floor; and both allow and deny cases have minimums, so a port cannot pass by being uniformly strict or uniformly permissive.

**Observable ordering.** The order of checks is part of the contract and the cases pin it. A resource that cannot be normalised reports `invalid resource` even when the DID is unknown. A rule matching action and target but not resource reports `resource outside scope`, while nothing matching at all reports `no matching rule`.