### PR TITLE
feat(mcp): Vouch-protected MCP servers in TypeScript

### DIFF
--- a/.github/workflows/sdk-tests.yml
+++ b/.github/workflows/sdk-tests.yml
@@ -77,6 +77,25 @@ jobs:
           npm install --no-save --legacy-peer-deps ../../core/wasm/pkg
           npm test
 
+  vouch-mcp-ts:
+    name: MCP server wrapper (TypeScript)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - name: Install the SDK it builds on
+        working-directory: packages/sdk-ts
+        run: npm install --legacy-peer-deps
+      - name: Install and test
+        working-directory: packages/vouch-mcp-ts
+        run: |
+          # The SDK is a peer dependency, so npm does not fetch it here. Tests
+          # resolve it from the sibling source via the vitest alias.
+          npm install --legacy-peer-deps
+          npm test
+
   wasm:
     name: WASM core
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,6 @@ agent-trust-index/data/results.json
 
 # Build-time copy of the root funding manifest (website/scripts/copy-funding.mjs)
 website/public/funding.json
+
+# Local builds of the TypeScript example
+examples/mcp_server_ts/dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `@vouch-protocol-official/mcp`, the TypeScript counterpart of
+  `vouch.mcp.FastMCP`. `McpServer` is a drop-in replacement for the MCP SDK's
+  own, in which every registered tool is protected by default: a call must
+  arrive with a Vouch Credential that verifies, comes from a trusted issuer,
+  authorises that exact call, and passes Shield, before the tool body runs. A
+  tool opts out with `unprotected: true`, and a server missing `VOUCH_RULES` or
+  `VOUCH_TRUSTED_ISSUERS` refuses to start. `examples/mcp_server_ts/` is a
+  working filesystem server built on it.
+- Vouch Shield rules in the TypeScript SDK: `RuleSet`, `loadRules`,
+  `parseRules`, and the normalisation and glob primitives, with reason strings
+  identical to the Python reference.
+- `test-vectors/shield/`, 77 shared decision vectors that both the Python and
+  TypeScript implementations run, covering glob depth, normalisation,
+  traversal, unusable resources, exact matching, and every load failure.
+
 - `vouch.mcp.FastMCP`, a drop-in replacement for the MCP SDK's `FastMCP` in
   which every registered tool is protected by default. Changing one import makes
   a server refuse to run any tool unless the call arrives with a Vouch
@@ -389,6 +404,11 @@ standards-aligned alignment with backward-compatible coexistence of the legacy v
 - Setuptools config excludes `vouch.pro` from published packages
 
 ### Fixed
+
+- The TypeScript SDK's `Verifier.checkVouchCredential` now resolves a `did:key`
+  issuer offline, as the Python reference and this SDK's own `verify()` already
+  did. It previously accepted only issuers pinned as trusted roots, so a
+  self-certifying `did:key` credential was rejected as an unknown issuer.
 - Legacy single-layer fallback preserved for backwards compatibility in watermark detection
 
 ## [1.4.0] - 2026-01-05

--- a/examples/mcp_server_ts/README.md
+++ b/examples/mcp_server_ts/README.md
@@ -1,0 +1,63 @@
+# A Vouch-protected MCP server (TypeScript)
+
+The TypeScript counterpart of [`examples/mcp_server/`](../mcp_server/). Same
+four tools, same rules, same behaviour; the only difference is the language.
+
+The one line that protects everything:
+
+```ts
+import { McpServer } from '@vouch-protocol-official/mcp';
+// was: import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+```
+
+## 30-second setup
+
+```bash
+# Mint an identity, write rules, create files to act on. The Python example's
+# setup script does this and prints the environment both servers need.
+python3 examples/mcp_server/setup_demo.py --out /tmp/vouch-demo
+
+cd examples/mcp_server_ts
+npm install
+npm run build
+
+export VOUCH_FS_ROOT="/tmp/vouch-demo"
+export VOUCH_RULES="/tmp/vouch-demo/rules.yaml"
+export VOUCH_TRUSTED_ISSUERS="did:key:z6Mk..."   # from the setup output
+export VOUCH_TARGET="files"
+
+npm start
+```
+
+A credential minted by `vouch-mcp` works against this server unchanged, because
+both sides speak the same credential format and the same rules. That is the
+point of running the same scene twice.
+
+## Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "files-ts": {
+      "command": "node",
+      "args": ["/path/to/vouch-protocol/examples/mcp_server_ts/dist/server.js"],
+      "env": {
+        "VOUCH_FS_ROOT": "/tmp/vouch-demo",
+        "VOUCH_RULES": "/tmp/vouch-demo/rules.yaml",
+        "VOUCH_TRUSTED_ISSUERS": "did:key:z6Mk...",
+        "VOUCH_TARGET": "files"
+      }
+    }
+  }
+}
+```
+
+## Two checks, not one
+
+Shield rejects `..` traversal in the policy string. That matching is lexical, so
+it cannot see a symlink pointing out of the directory. This server therefore
+also resolves every path and confines it to `VOUCH_FS_ROOT`. Policy matching and
+filesystem confinement are different jobs and neither substitutes for the other.
+
+See the package [README](../../packages/vouch-mcp-ts/README.md) for
+configuration, resource binding, and refusal reasons.

--- a/examples/mcp_server_ts/package.json
+++ b/examples/mcp_server_ts/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "vouch-example-mcp-server-ts",
+  "private": true,
+  "version": "2.2.0",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@vouch-protocol-official/mcp": "^2.2.0",
+    "zod": "^4.0.0"
+  },
+  "devDependencies": { "@types/node": "^20.11.0", "typescript": "^5.4.0" }
+}

--- a/examples/mcp_server_ts/src/server.ts
+++ b/examples/mcp_server_ts/src/server.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * A Vouch-protected MCP server, in TypeScript.
+ *
+ * The TypeScript counterpart of examples/mcp_server/. An ordinary filesystem
+ * MCP server; the only thing that makes it Vouch-protected is the import on the
+ * next line. Every tool registered on this server refuses to run unless the
+ * call arrives with a Vouch Credential that verifies, comes from a trusted
+ * issuer, authorises that exact call, and passes Shield.
+ *
+ * Run:
+ *   VOUCH_FS_ROOT=/tmp/vouch-demo \
+ *   VOUCH_RULES=/tmp/vouch-demo/rules.yaml \
+ *   VOUCH_TRUSTED_ISSUERS=did:key:z6Mk... \
+ *   VOUCH_TARGET=files \
+ *   npm start
+ */
+
+import { readFileSync, readdirSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+
+import { McpServer } from '@vouch-protocol-official/mcp';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+const ROOT = resolve(process.env.VOUCH_FS_ROOT ?? '');
+
+/**
+ * Resolve a relative path inside the configured root, or refuse.
+ *
+ * Shield already rejects `..` traversal in the policy string. This is the
+ * second half of the job: policy matching is lexical, so it cannot see a
+ * symlink pointing out of the root. Both checks are needed, and neither
+ * replaces the other.
+ */
+function resolveInRoot(path: string): string {
+  const candidate = resolve(ROOT, path);
+  if (candidate !== ROOT && !candidate.startsWith(ROOT + sep)) {
+    throw new Error(`path escapes VOUCH_FS_ROOT: ${path}`);
+  }
+  return candidate;
+}
+
+const server = new McpServer({ name: 'files', version: '2.2.0' });
+
+const byPath = (args: Record<string, unknown>) => args.path as string;
+
+server.registerTool(
+  'read_file',
+  {
+    description: "Read a file inside the server's root.",
+    inputSchema: { path: z.string().describe("Path relative to the root, e.g. 'reports/q3.txt'") },
+    resource: byPath,
+  },
+  async ({ path }: { path: string }) => ({
+    content: [{ type: 'text' as const, text: readFileSync(resolveInRoot(path), 'utf8') }],
+  }),
+);
+
+server.registerTool(
+  'write_file',
+  {
+    description: "Write a file inside the server's root.",
+    inputSchema: { path: z.string(), content: z.string() },
+    resource: byPath,
+  },
+  async ({ path, content }: { path: string; content: string }) => {
+    const target = resolveInRoot(path);
+    mkdirSync(dirname(target), { recursive: true });
+    writeFileSync(target, content);
+    return { content: [{ type: 'text' as const, text: `wrote ${content.length} bytes to ${path}` }] };
+  },
+);
+
+server.registerTool(
+  'delete_file',
+  {
+    description: "Delete a file inside the server's root.",
+    inputSchema: { path: z.string() },
+    resource: byPath,
+  },
+  async ({ path }: { path: string }) => {
+    unlinkSync(resolveInRoot(path));
+    return { content: [{ type: 'text' as const, text: `deleted ${path}` }] };
+  },
+);
+
+server.registerTool(
+  'list_dir',
+  {
+    description: "List a directory inside the server's root.",
+    inputSchema: { path: z.string() },
+    resource: byPath,
+  },
+  async ({ path }: { path: string }) => ({
+    content: [
+      { type: 'text' as const, text: readdirSync(resolveInRoot(path)).sort().join('\n') },
+    ],
+  }),
+);
+
+async function main(): Promise<void> {
+  if (!process.env.VOUCH_FS_ROOT) {
+    console.error(
+      'VOUCH_FS_ROOT is not set. This server refuses to run without a root directory to confine itself to.',
+    );
+    process.exit(1);
+  }
+  await server.connect(new StdioServerTransport());
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/examples/mcp_server_ts/tsconfig.json
+++ b/examples/mcp_server_ts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "module": "ESNext", "moduleResolution": "bundler",
+    "lib": ["ES2022"], "types": ["node"], "strict": true,
+    "esModuleInterop": true, "skipLibCheck": true, "outDir": "dist"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/sdk-ts/src/verifier.ts
+++ b/packages/sdk-ts/src/verifier.ts
@@ -236,7 +236,20 @@ export class Verifier {
         };
       }
 
-      const rawKey = this.trustedRootsRaw.get(issuer);
+      // A trusted root wins, so a deployment can pin a key for an issuer.
+      // Verifier.verify accepts a KeyObject or a Multikey string, which is what
+      // lets the did:key branch below hand it the key straight from the DID.
+      let rawKey: crypto.KeyObject | string | undefined =
+        this.trustedRootsRaw.get(issuer);
+
+      // did:key is self-certifying: the multikey after the prefix is the key,
+      // so it resolves offline with no document to fetch and no root to pin.
+      // This mirrors the Python reference, whose check_vouch_credential does
+      // the same, and the module-level verify() in this file.
+      if (!rawKey && issuer.startsWith('did:key:')) {
+        rawKey = issuer.slice('did:key:'.length);
+      }
+
       if (!rawKey) {
         return {
           isValid: false,

--- a/packages/vouch-mcp-ts/README.md
+++ b/packages/vouch-mcp-ts/README.md
@@ -1,0 +1,141 @@
+# @vouch-protocol-official/mcp
+
+A Vouch-protected MCP server. Change one import and every tool checks a
+credential before it acts.
+
+```ts
+import { McpServer } from '@vouch-protocol-official/mcp';
+// was: import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+```
+
+Every tool registered on that server is protected. Before a tool body runs, the
+call must arrive with a Vouch Credential that verifies, comes from a trusted
+issuer, authorises *this exact call*, and passes your Shield rules. Any failure
+is refused through the protocol's error path and the body is never entered.
+
+This is the receiving side. A signer can decline to mint a credential, but it
+cannot stop a client calling some other server. The check has to live where the
+work happens.
+
+## Install
+
+```bash
+npm install @vouch-protocol-official/mcp @modelcontextprotocol/sdk zod
+```
+
+## Use
+
+```ts
+import { McpServer } from '@vouch-protocol-official/mcp';
+import { z } from 'zod';
+
+const server = new McpServer({ name: 'files', version: '1.0.0' });
+
+server.registerTool(
+  'read_file',
+  {
+    inputSchema: { path: z.string() },
+    resource: (args) => args.path as string,
+  },
+  async ({ path }: { path: string }) => ({
+    content: [{ type: 'text', text: read(path) }],
+  }),
+);
+```
+
+The wrapper adds a required `credential` argument to each tool's schema and
+consumes it before your function runs, so your function body is unchanged.
+
+## Configuration
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `VOUCH_RULES` | yes | Path to the Shield rules file |
+| `VOUCH_TRUSTED_ISSUERS` | yes | Comma-separated DIDs whose credentials are accepted |
+| `VOUCH_TARGET` | no | `intent.target` to require. Defaults to the server name |
+
+All three can be passed to the constructor instead. A server missing what it
+needs **refuses to start**. It never starts unprotected.
+
+## Rules
+
+Rules match the same three fields a credential binds: `action`, `target`, and
+`resource`.
+
+```yaml
+version: 2
+rules:
+  - did: did:web:agent.example.com
+    allow:
+      - { action: read_file, target: files, resource: "reports/**" }
+deny_default: true
+```
+
+A segment is the text between `/` separators. `*` matches exactly one segment
+and never crosses a `/`; `**` matches any number. Resources are normalised
+first, so `reports/../etc/passwd` cannot slip through a `reports/**` rule.
+
+That normalisation is lexical and cannot see a symlink, so a server mapping a
+resource onto a real path must also confine that path itself.
+
+## Resource binding
+
+By default a credential authorises one call with one exact set of arguments:
+`intent.resource` is the JCS canonicalisation of the argument object, so
+changing any argument changes what the credential is for.
+
+`resource` loosens that to a chosen value, which is what lets a rule glob over
+paths or table names. Treat it as a policy decision worth making on purpose.
+
+## Opting out
+
+```ts
+server.registerTool('health', { unprotected: true }, async () => ({
+  content: [{ type: 'text', text: 'ok' }],
+}));
+```
+
+Logs a warning at registration and on every call. Anything reachable without a
+credential should be something you are happy for anyone to call.
+
+## Refusals
+
+A refused call throws `VouchRefusedError`, which the MCP protocol reports to the
+client with `isError` set. A refusal is never returned as an ordinary value: a
+returned object looks like a result, which a model can read straight past, and
+an error cannot be mistaken for data.
+
+Reasons are stable strings you can alert on: `no credential`,
+`credential did not verify`, `untrusted issuer`,
+`credential does not match request`, `no matching rule`,
+`resource outside scope`, `unknown did`, `invalid resource`, `malformed rules`.
+
+One structured line goes to stderr per decision:
+
+```
+ALLOW  did:key:z6Mk...  read_file  reports/q3.txt
+DENY   did:key:z6Mk...  read_file  secrets/keys.txt  resource outside scope
+```
+
+## A note on typing
+
+The SDK's `registerTool` is overloaded and generic, so an override that narrowed
+it would not be assignable to the base class. The config object is typed by
+`VouchToolConfig`, and tool callbacks take their argument type from an
+annotation, as the example shows. Everything else passes through to the SDK
+unchanged.
+
+## Not using `McpServer`?
+
+`protect(server)` applies the same checks to a server this package did not
+construct. It cannot add a `credential` parameter to a schema it does not own,
+so the tool has to accept one already. Prefer `McpServer` where you can: a
+wrapper someone has to remember to apply is a wrapper someone will forget.
+
+## Related
+
+- `examples/mcp_server_ts/` in the repository, a working filesystem server.
+- The Python equivalent is `vouch.mcp.FastMCP` in `vouch-protocol`.
+- `test-vectors/shield/` is the cross-language contract both implementations meet.
+
+Apache-2.0.

--- a/packages/vouch-mcp-ts/package.json
+++ b/packages/vouch-mcp-ts/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@vouch-protocol-official/mcp",
+  "version": "2.2.0",
+  "description": "Vouch-protected MCP servers. Change one import and every tool checks a credential before it acts.",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/vouch-protocol/vouch.git",
+    "directory": "packages/vouch-mcp-ts"
+  },
+  "homepage": "https://vouch-protocol.com",
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "authorization",
+    "verifiable-credentials",
+    "ai-agents",
+    "vouch-protocol"
+  ],
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "prepublishOnly": "npm run build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "yaml": "^2.4.0"
+  },
+  "peerDependencies": {
+    "@modelcontextprotocol/sdk": ">=1.10.0",
+    "@vouch-protocol-official/sdk": ">=2.2.0",
+    "zod": "^3.23.0 || ^4.0.0"
+  },
+  "devDependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
+    "@noble/post-quantum": "^0.4.0",
+    "@types/node": "^20.11.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0",
+    "zod": "^4.0.0"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/packages/vouch-mcp-ts/src/guard.ts
+++ b/packages/vouch-mcp-ts/src/guard.ts
@@ -1,0 +1,303 @@
+/**
+ * The protection behind `McpServer` and `protect`.
+ *
+ * One place decides whether a tool call may run. Everything else in this
+ * package is plumbing that routes calls through here.
+ *
+ * Faithful port of vouch/mcp/_guard.py. The five steps, in order, all before
+ * the tool body:
+ *
+ * 1. Locate the credential.
+ * 2. Verify it (proof, issuer binding, purpose, validity window).
+ * 3. Confirm the issuer is trusted.
+ * 4. Confirm the credential's intent is *this* call, not a similar one.
+ * 5. Ask Shield.
+ *
+ * Any failure refuses. No exception reaches the tool body, and no partial
+ * success lets it run.
+ */
+
+import { readFileSync } from 'node:fs';
+
+import {
+  RuleSet,
+  Verifier,
+  canonicalizeToString,
+  parseRules,
+} from '@vouch-protocol-official/sdk';
+import { parse as parseYaml } from 'yaml';
+
+/** The tool argument carrying the credential. */
+export const CREDENTIAL_ARG = 'credential';
+
+/** Raised when a protected server is not configured to protect anything. */
+export class VouchMcpConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'VouchMcpConfigError';
+  }
+}
+
+/** A structured refusal. Carried on the error a refused call throws. */
+export interface Refusal {
+  reason: string;
+  tool: string;
+  detail?: string;
+}
+
+export function refusalPayload(refusal: Refusal): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    error: 'refused',
+    reason: refusal.reason,
+    tool: refusal.tool,
+  };
+  if (refusal.detail) out.detail = refusal.detail;
+  return out;
+}
+
+/** Configuration for a protected server. Read from the environment. */
+export interface GuardConfig {
+  rulesPath: string;
+  trustedIssuers: Set<string>;
+  target: string;
+}
+
+export interface GuardOptions {
+  rulesPath?: string;
+  trustedIssuers?: string[] | string;
+  target?: string;
+  env?: Record<string, string | undefined>;
+}
+
+/** Build configuration from the environment. Throws rather than starting unprotected. */
+export function guardConfigFrom(serverName: string, options: GuardOptions = {}): GuardConfig {
+  const env = options.env ?? process.env;
+
+  const rulesPath = options.rulesPath ?? env.VOUCH_RULES;
+  if (!rulesPath) {
+    throw new VouchMcpConfigError(
+      'VOUCH_RULES is not set. A Vouch-protected MCP server needs a Shield rules ' +
+        'file to know what it may do. Point VOUCH_RULES at one, or pass rulesPath. ' +
+        'Refusing to start unprotected.',
+    );
+  }
+
+  const rawIssuers = options.trustedIssuers ?? env.VOUCH_TRUSTED_ISSUERS ?? '';
+  const list = Array.isArray(rawIssuers) ? rawIssuers : rawIssuers.split(',');
+  const trustedIssuers = new Set(list.map((d) => d.trim()).filter((d) => d.length > 0));
+  if (trustedIssuers.size === 0) {
+    throw new VouchMcpConfigError(
+      'VOUCH_TRUSTED_ISSUERS is not set. Without it no credential can be accepted, ' +
+        'so every call would be refused. Set it to a comma-separated list of DIDs. ' +
+        'Refusing to start unprotected.',
+    );
+  }
+
+  return {
+    rulesPath,
+    trustedIssuers,
+    target: options.target ?? env.VOUCH_TARGET ?? serverName,
+  };
+}
+
+/**
+ * The resource string this call binds to.
+ *
+ * Default is the JCS canonicalisation of the whole argument object, so a
+ * credential authorises exactly one call with exactly these arguments. A tool
+ * that opts into `resource` is deliberately loosening that.
+ */
+export function computeResource(
+  args: Record<string, unknown>,
+  resourceFn?: (args: Record<string, unknown>) => string,
+): string {
+  const payload: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(args)) {
+    if (key !== CREDENTIAL_ARG) payload[key] = value;
+  }
+  if (resourceFn) {
+    const value = resourceFn(payload);
+    if (typeof value !== 'string' || value.length === 0) {
+      throw new Error('the resource callback must return a non-empty string');
+    }
+    return value;
+  }
+  return canonicalizeToString(payload);
+}
+
+/** Decides whether one tool call may run. */
+export class ToolGuard {
+  readonly config: GuardConfig;
+  readonly rules: RuleSet;
+  private readonly verifier: Verifier;
+
+  constructor(config: GuardConfig, rules?: RuleSet) {
+    this.config = config;
+    this.rules = rules ?? loadRulesFromFile(config.rulesPath);
+    this.verifier = new Verifier();
+
+    if (!this.rules.ok) {
+      // Loud, but still deny-all rather than a crash: a running server that
+      // refuses everything is easier to diagnose than one that will not start,
+      // and it cannot be mistaken for a permissive one.
+      // eslint-disable-next-line no-console
+      console.error(
+        `Vouch: rules did not load (${this.rules.malformedReason}). Every call will be refused.`,
+      );
+    }
+  }
+
+  /**
+   * Return undefined if the call may run, or a Refusal if it may not.
+   *
+   * Emits exactly one structured decision line, whichever way it goes, so an
+   * operator can read the server's behaviour from stderr.
+   */
+  async check(
+    toolName: string,
+    args: Record<string, unknown>,
+    resourceFn?: (args: Record<string, unknown>) => string,
+  ): Promise<Refusal | undefined> {
+    const { refusal, did, resource } = await this.decide(toolName, args, resourceFn);
+    const verdict = refusal ? 'DENY ' : 'ALLOW';
+    const detail = refusal ? `${refusal.reason}${refusal.detail ? ` (${refusal.detail})` : ''}` : '';
+    // eslint-disable-next-line no-console
+    console.error(`${verdict}  ${did}  ${toolName}  ${resource}  ${detail}`.trimEnd());
+    return refusal;
+  }
+
+  private async decide(
+    toolName: string,
+    args: Record<string, unknown>,
+    resourceFn?: (args: Record<string, unknown>) => string,
+  ): Promise<{ refusal?: Refusal; did: string; resource: string }> {
+    let did = '-';
+    let resource = '-';
+    try {
+      resource = computeResource(args, resourceFn);
+    } catch {
+      resource = '-';
+    }
+
+    // 1. Locate and parse the credential.
+    const raw = args[CREDENTIAL_ARG];
+    if (raw === undefined || raw === null || raw === '') {
+      return { refusal: { reason: 'no credential', tool: toolName }, did, resource };
+    }
+    let credential: Record<string, unknown>;
+    if (typeof raw === 'string') {
+      try {
+        credential = JSON.parse(raw) as Record<string, unknown>;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          refusal: { reason: 'no credential', tool: toolName, detail: `not valid JSON: ${message}` },
+          did,
+          resource,
+        };
+      }
+    } else if (typeof raw === 'object') {
+      credential = raw as Record<string, unknown>;
+    } else {
+      return {
+        refusal: {
+          reason: 'no credential',
+          tool: toolName,
+          detail: 'credential must be a JSON object',
+        },
+        did,
+        resource,
+      };
+    }
+
+    // 2. Verify it: proof, issuer binding, proof purpose, validity window.
+    const result = await this.verifier.checkVouchCredential(credential);
+    if (!result.isValid || !result.passport) {
+      return {
+        refusal: {
+          reason: 'credential did not verify',
+          tool: toolName,
+          detail: result.error ?? 'signature, issuer binding, or validity window failed',
+        },
+        did,
+        resource,
+      };
+    }
+    const passport = result.passport as { issuer?: string; intent?: Record<string, unknown> };
+    did = passport.issuer ?? '-';
+
+    // 3. Trusted issuer.
+    if (!this.config.trustedIssuers.has(did)) {
+      return { refusal: { reason: 'untrusted issuer', tool: toolName, detail: did }, did, resource };
+    }
+
+    // 4. The credential must be for *this* call. A credential for
+    //    read_file reports/q3.txt must not authorise reports/q4.txt.
+    let expectedResource: string;
+    try {
+      expectedResource = computeResource(args, resourceFn);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return {
+        refusal: { reason: 'credential does not match request', tool: toolName, detail: message },
+        did,
+        resource,
+      };
+    }
+
+    const intent = passport.intent ?? {};
+    if (intent.action !== toolName) {
+      return {
+        refusal: {
+          reason: 'credential does not match request',
+          tool: toolName,
+          detail: `intent.action is ${JSON.stringify(intent.action)}, called ${JSON.stringify(toolName)}`,
+        },
+        did,
+        resource,
+      };
+    }
+    if (intent.target !== this.config.target) {
+      return {
+        refusal: {
+          reason: 'credential does not match request',
+          tool: toolName,
+          detail: `intent.target is ${JSON.stringify(intent.target)}, this server is ${JSON.stringify(this.config.target)}`,
+        },
+        did,
+        resource,
+      };
+    }
+    if (intent.resource !== expectedResource) {
+      return {
+        refusal: {
+          reason: 'credential does not match request',
+          tool: toolName,
+          detail: 'intent.resource does not match these arguments',
+        },
+        did,
+        resource,
+      };
+    }
+
+    // 5. Shield.
+    const decision = this.rules.check(did, toolName, this.config.target, expectedResource);
+    if (!decision.allow) {
+      return { refusal: { reason: decision.reason, tool: toolName }, did, resource };
+    }
+
+    return { did, resource };
+  }
+}
+
+/** Read a rules file from disk. Node only; a bad file denies everything. */
+export function loadRulesFromFile(path: string): RuleSet {
+  let text: string;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return parseRules('', `rules file could not be read: ${path}: ${message}`);
+  }
+  return parseRules(text, path, parseYaml);
+}

--- a/packages/vouch-mcp-ts/src/index.test.ts
+++ b/packages/vouch-mcp-ts/src/index.test.ts
@@ -1,0 +1,436 @@
+/**
+ * Every tool protected by default, checked before it runs.
+ *
+ * Ported from tests/test_vouch_mcp.py. The property under test is that the tool
+ * body is not entered unless a verified credential authorises exactly that call
+ * and Shield permits it, so most tests assert on a spy rather than only on the
+ * returned value: a refusal that still ran the tool would be worthless.
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import * as crypto from 'node:crypto';
+
+import { Signer, encodeEd25519Public } from '@vouch-protocol-official/sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+
+import { McpServer, VouchMcpConfigError, VouchRefusedError } from './index.js';
+
+const TARGET = 'files';
+
+interface Fixture {
+  did: string;
+  signer: Signer;
+  rulesPath: string;
+}
+
+function writeRules(dir: string, did: string, allow?: unknown[]): string {
+  const rules = allow ?? [{ action: 'read_file', target: TARGET, resource: 'reports/**' }];
+  const path = join(dir, 'rules.json');
+  writeFileSync(
+    path,
+    JSON.stringify({ version: 2, rules: [{ did, allow: rules }], deny_default: true }),
+  );
+  return path;
+}
+
+// Node needs DER-wrapped keys; a raw Ed25519 seed gets this fixed PKCS8 prefix.
+const PKCS8_ED25519_PREFIX = Buffer.from('302e020100300506032b657004220420', 'hex');
+
+/** A did:key identity, which resolves offline with no document to host. */
+function makeIdentity(): { did: string; signer: Signer } {
+  const seed = crypto.randomBytes(32);
+  const priv = crypto.createPrivateKey({
+    key: Buffer.concat([PKCS8_ED25519_PREFIX, seed]),
+    format: 'der',
+    type: 'pkcs8',
+  });
+  const pubJwk = crypto.createPublicKey(priv).export({ format: 'jwk' }) as { x: string };
+  const xRaw = new Uint8Array(Buffer.from(pubJwk.x, 'base64url'));
+  const did = 'did:key:' + encodeEd25519Public(xRaw);
+  const privateKey = JSON.stringify({
+    kty: 'OKP',
+    crv: 'Ed25519',
+    x: pubJwk.x,
+    d: seed.toString('base64url'),
+  });
+  return { did, signer: new Signer({ privateKey, did }) };
+}
+
+async function makeFixture(allow?: unknown[]): Promise<Fixture> {
+  const { did, signer } = makeIdentity();
+  const dir = mkdtempSync(join(tmpdir(), 'vouch-mcp-'));
+  return { did, signer, rulesPath: writeRules(dir, did, allow) };
+}
+
+function server(fx: Fixture, register: (s: McpServer, spy: string[]) => void) {
+  const spy: string[] = [];
+  const s = new McpServer(
+    { name: 'files', version: '1.0.0' },
+    { rulesPath: fx.rulesPath, trustedIssuers: [fx.did], target: TARGET },
+  );
+  register(s, spy);
+  return { server: s, spy };
+}
+
+/** Invoke a registered tool the way the SDK would, returning ok or refused. */
+async function call(
+  s: McpServer,
+  name: string,
+  args: Record<string, unknown>,
+): Promise<{ status: 'ok' | 'refused'; payload?: Record<string, unknown> }> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const registered = (s as any)._registeredTools[name];
+  try {
+    await registered.handler(args, {});
+    return { status: 'ok' };
+  } catch (error) {
+    if (error instanceof VouchRefusedError) {
+      return { status: 'refused', payload: error.refusal as unknown as Record<string, unknown> };
+    }
+    throw error;
+  }
+}
+
+async function credentialFor(
+  fx: Fixture,
+  resource: string,
+  overrides: { action?: string; target?: string } = {},
+): Promise<string> {
+  const credential = await fx.signer.sign({
+    action: overrides.action ?? 'read_file',
+    target: overrides.target ?? TARGET,
+    resource,
+  });
+  return JSON.stringify(credential);
+}
+
+function registerReadFile(s: McpServer, spy: string[]) {
+  s.registerTool(
+    'read_file',
+    {
+      inputSchema: { path: z.string() },
+      resource: (args: Record<string, unknown>) => args.path as string,
+    },
+    async ({ path }: { path: string }) => {
+      spy.push(path);
+      return { content: [{ type: 'text', text: `contents of ${path}` }] };
+    },
+  );
+}
+
+describe('the default is protected', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => undefined));
+
+  it('refuses a call with no credential, without asking', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', { path: 'reports/q3.txt' });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('no credential');
+    expect(spy).toEqual([]);
+  });
+
+  it('declares credential as a required argument', async () => {
+    const fx = await makeFixture();
+    const { server: s } = server(fx, registerReadFile);
+    // The SDK compiles inputSchema into a Zod object, so read the shape back
+    // out rather than the raw config we handed it.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const registered = (s as any)._registeredTools.read_file;
+    const shape = registered.inputSchema?.shape ?? registered.inputSchema?._def?.shape?.();
+    expect(Object.keys(shape ?? {})).toContain('credential');
+  });
+
+  it('lets an unprotected tool through and says so', async () => {
+    const fx = await makeFixture();
+    const spy: string[] = [];
+    const s = new McpServer(
+      { name: 'files', version: '1.0.0' },
+      { rulesPath: fx.rulesPath, trustedIssuers: [fx.did], target: TARGET },
+    );
+    s.registerTool('health', { unprotected: true }, async () => {
+      spy.push('health');
+      return { content: [{ type: 'text', text: 'ok' }] };
+    });
+
+    const result = await call(s, 'health', {});
+    expect(result.status).toBe('ok');
+    expect(spy).toEqual(['health']);
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining('UNPROTECTED'));
+  });
+
+  it('rejects a resource callback on an unprotected tool', async () => {
+    const fx = await makeFixture();
+    const { server: s } = server(fx, () => undefined);
+    expect(() =>
+      s.registerTool('x', { unprotected: true, resource: () => 'a' }, async () => ({
+        content: [],
+      })),
+    ).toThrow();
+  });
+});
+
+describe('verification', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => undefined));
+
+  it('runs an in-scope call', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', {
+      path: 'reports/q3.txt',
+      credential: await credentialFor(fx, 'reports/q3.txt'),
+    });
+    expect(result.status).toBe('ok');
+    expect(spy).toEqual(['reports/q3.txt']);
+  });
+
+  it('refuses a forged signature', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const credential = JSON.parse(await credentialFor(fx, 'reports/q3.txt'));
+    const proof = credential.proof.proofValue as string;
+    credential.proof.proofValue = proof.slice(0, -1) + (proof.endsWith('A') ? 'B' : 'A');
+
+    const result = await call(s, 'read_file', {
+      path: 'reports/q3.txt',
+      credential: JSON.stringify(credential),
+    });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('credential did not verify');
+    expect(spy).toEqual([]);
+  });
+
+  it('refuses an untrusted issuer', async () => {
+    const fx = await makeFixture();
+    const stranger = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', {
+      path: 'reports/q3.txt',
+      credential: await credentialFor(stranger, 'reports/q3.txt'),
+    });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('untrusted issuer');
+    expect(spy).toEqual([]);
+  });
+
+  it('refuses an unparseable credential', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', { path: 'reports/q3.txt', credential: 'not json' });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('no credential');
+    expect(spy).toEqual([]);
+  });
+});
+
+describe('the credential must be for this call', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => undefined));
+
+  it('refuses a credential minted for a different file', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', {
+      path: 'reports/q4.txt',
+      credential: await credentialFor(fx, 'reports/q3.txt'),
+    });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('credential does not match request');
+    expect(spy).toEqual([]);
+  });
+
+  it('refuses a credential minted for a different action', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', {
+      path: 'reports/q3.txt',
+      credential: await credentialFor(fx, 'reports/q3.txt', { action: 'write_file' }),
+    });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('credential does not match request');
+    expect(spy).toEqual([]);
+  });
+
+  it('refuses a credential minted for a different target', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', {
+      path: 'reports/q3.txt',
+      credential: await credentialFor(fx, 'reports/q3.txt', { target: 'somewhere-else' }),
+    });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('credential does not match request');
+    expect(spy).toEqual([]);
+  });
+});
+
+describe('Shield', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => undefined));
+
+  it('never reaches the tool for an out-of-scope resource', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const result = await call(s, 'read_file', {
+      path: 'secrets/keys.txt',
+      credential: await credentialFor(fx, 'secrets/keys.txt'),
+    });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('resource outside scope');
+    expect(spy).toEqual([]);
+  });
+
+  it('refuses a traversal', async () => {
+    const fx = await makeFixture();
+    const { server: s, spy } = server(fx, registerReadFile);
+
+    const path = 'reports/../secrets/keys.txt';
+    const result = await call(s, 'read_file', { path, credential: await credentialFor(fx, path) });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('resource outside scope');
+    expect(spy).toEqual([]);
+  });
+});
+
+describe('resource binding', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => undefined));
+
+  it('binds a credential to exact arguments by default', async () => {
+    const fx = await makeFixture([{ action: 'run_query', target: TARGET, resource: '**' }]);
+    const spy: string[] = [];
+    const s = new McpServer(
+      { name: 'files', version: '1.0.0' },
+      { rulesPath: fx.rulesPath, trustedIssuers: [fx.did], target: TARGET },
+    );
+    s.registerTool(
+      'run_query',
+      { inputSchema: { table: z.string(), where: z.string() } },
+      async ({ table, where }: { table: string; where: string }) => {
+        spy.push(`${table}|${where}`);
+        return { content: [] };
+      },
+    );
+
+    const { canonicalizeToString } = await import('@vouch-protocol-official/sdk');
+    const resource = canonicalizeToString({ table: 'a', where: 'x' });
+    const credential = JSON.stringify(
+      await fx.signer.sign({ action: 'run_query', target: TARGET, resource }),
+    );
+
+    expect((await call(s, 'run_query', { table: 'a', where: 'x', credential })).status).toBe('ok');
+    const changed = await call(s, 'run_query', { table: 'a', where: 'y', credential });
+    expect(changed.status).toBe('refused');
+    expect(changed.payload?.reason).toBe('credential does not match request');
+    expect(spy).toEqual(['a|x']);
+  });
+
+  it('lets a resource callback widen the unit to a glob', async () => {
+    const fx = await makeFixture([{ action: 'run_query', target: TARGET, resource: 'public.*' }]);
+    const spy: string[] = [];
+    const s = new McpServer(
+      { name: 'files', version: '1.0.0' },
+      { rulesPath: fx.rulesPath, trustedIssuers: [fx.did], target: TARGET },
+    );
+    s.registerTool(
+      'run_query',
+      {
+        inputSchema: { table: z.string() },
+        resource: (args: Record<string, unknown>) => args.table as string,
+      },
+      async ({ table }: { table: string }) => {
+        spy.push(table);
+        return { content: [] };
+      },
+    );
+
+    const ok = JSON.stringify(
+      await fx.signer.sign({ action: 'run_query', target: TARGET, resource: 'public.customers' }),
+    );
+    expect((await call(s, 'run_query', { table: 'public.customers', credential: ok })).status).toBe(
+      'ok',
+    );
+
+    const denied = JSON.stringify(
+      await fx.signer.sign({ action: 'run_query', target: TARGET, resource: 'internal.salaries' }),
+    );
+    const blocked = await call(s, 'run_query', { table: 'internal.salaries', credential: denied });
+    expect(blocked.status).toBe('refused');
+    expect(blocked.payload?.reason).toBe('resource outside scope');
+    expect(spy).toEqual(['public.customers']);
+  });
+});
+
+describe('configuration', () => {
+  beforeEach(() => vi.spyOn(console, 'error').mockImplementation(() => undefined));
+
+  it('refuses to start without rules', async () => {
+    expect(
+      () =>
+        new McpServer(
+          { name: 'files', version: '1.0.0' },
+          { trustedIssuers: ['did:key:z6Mk'], env: {} },
+        ),
+    ).toThrow(VouchMcpConfigError);
+  });
+
+  it('refuses to start without trusted issuers', async () => {
+    const fx = await makeFixture();
+    expect(
+      () =>
+        new McpServer({ name: 'files', version: '1.0.0' }, { rulesPath: fx.rulesPath, env: {} }),
+    ).toThrow(VouchMcpConfigError);
+  });
+
+  it('defaults the target to the server name', async () => {
+    const fx = await makeFixture();
+    const s = new McpServer(
+      { name: 'crm-tools', version: '1.0.0' },
+      { rulesPath: fx.rulesPath, trustedIssuers: [fx.did], env: {} },
+    );
+    expect(s.vouchGuard.config.target).toBe('crm-tools');
+  });
+
+  it('refuses everything when the rules will not load', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'vouch-mcp-bad-'));
+    const rulesPath = join(dir, 'rules.json');
+    writeFileSync(rulesPath, JSON.stringify({ version: 1, rules: [] }));
+    const identity = makeIdentity();
+
+    const spy: string[] = [];
+    const s = new McpServer(
+      { name: 'files', version: '1.0.0' },
+      { rulesPath, trustedIssuers: [identity.did], target: TARGET },
+    );
+    s.registerTool(
+      'read_file',
+      { inputSchema: { path: z.string() }, resource: (a: Record<string, unknown>) => a.path as string },
+      async ({ path }: { path: string }) => {
+        spy.push(path);
+        return { content: [] };
+      },
+    );
+
+    const credential = JSON.stringify(
+      await identity.signer.sign({
+        action: 'read_file',
+        target: TARGET,
+        resource: 'reports/q3.txt',
+      }),
+    );
+    const result = await call(s, 'read_file', { path: 'reports/q3.txt', credential });
+    expect(result.status).toBe('refused');
+    expect(result.payload?.reason).toBe('malformed rules');
+    expect(spy).toEqual([]);
+  });
+});

--- a/packages/vouch-mcp-ts/src/index.ts
+++ b/packages/vouch-mcp-ts/src/index.ts
@@ -1,0 +1,261 @@
+/**
+ * Vouch-protected MCP servers: change one import, every tool checks first.
+ *
+ * `McpServer` is a drop-in replacement for the MCP SDK's `McpServer` in which
+ * every registered tool is protected by default:
+ *
+ * ```ts
+ * import { McpServer } from '@vouch-protocol-official/mcp';
+ * // was: import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+ *
+ * const server = new McpServer({ name: 'files', version: '1.0.0' });
+ *
+ * server.registerTool(
+ *   'read_file',
+ *   { inputSchema: { path: z.string() }, resource: (args) => args.path as string },
+ *   async ({ path }) => ({ content: [{ type: 'text', text: read(path) }] }),
+ * );
+ * ```
+ *
+ * A protected tool gains a required `credential` argument. Before its body
+ * runs, the credential is verified, checked against the trusted issuer list,
+ * confirmed to authorise *this exact call*, and put to Shield. Any failure
+ * refuses and the body never runs.
+ *
+ * Configuration comes from the environment and is required: `VOUCH_RULES`,
+ * `VOUCH_TRUSTED_ISSUERS`, and optionally `VOUCH_TARGET` (default: the server
+ * name). A server missing what it needs refuses to start. It never starts
+ * unprotected.
+ *
+ * This is the receiving side. The signing side lives in the Vouch Protocol SDK.
+ */
+
+import { McpServer as BaseMcpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+
+import {
+  CREDENTIAL_ARG,
+  type GuardConfig,
+  type GuardOptions,
+  type Refusal,
+  ToolGuard,
+  VouchMcpConfigError,
+  computeResource,
+  guardConfigFrom,
+  loadRulesFromFile,
+  refusalPayload,
+} from './guard.js';
+
+export {
+  CREDENTIAL_ARG,
+  ToolGuard,
+  VouchMcpConfigError,
+  computeResource,
+  guardConfigFrom,
+  loadRulesFromFile,
+};
+export type { GuardConfig, GuardOptions, Refusal };
+
+/** Thrown when a call is refused. Carries the structured reason. */
+export class VouchRefusedError extends Error {
+  readonly refusal: Refusal;
+
+  constructor(refusal: Refusal) {
+    super(JSON.stringify(refusalPayload(refusal)));
+    this.name = 'VouchRefusedError';
+    this.refusal = refusal;
+  }
+}
+
+/** Extra options a Vouch-protected tool accepts, on top of the SDK's config. */
+export interface VouchToolOptions {
+  /**
+   * Skip protection entirely. Logs a warning at registration and on every call,
+   * because an unprotected tool on a protected server is a decision someone
+   * should be able to see in the logs.
+   */
+  unprotected?: boolean;
+  /**
+   * Map the argument object to the resource string. Without it the resource is
+   * the JCS canonicalisation of all arguments, so a credential authorises
+   * exactly one call with exactly those arguments. Supplying this is a
+   * deliberate loosening, and a policy decision the tool author is making.
+   */
+  resource?: (args: Record<string, unknown>) => string;
+}
+
+/** The config object a Vouch-protected tool takes: the SDK's, plus ours. */
+export type VouchToolConfig<InputArgs> = VouchToolOptions & {
+  title?: string;
+  description?: string;
+  inputSchema?: InputArgs;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  outputSchema?: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  annotations?: any;
+  _meta?: Record<string, unknown>;
+};
+
+export interface VouchServerOptions extends GuardOptions {
+  /** A preconfigured guard, mainly for tests. */
+  guard?: ToolGuard;
+}
+
+/**
+ * An MCP server whose tools are protected by default.
+ *
+ * A thin subclass. The constructor takes everything the SDK's `McpServer`
+ * takes; `registerTool` and `tool` take everything theirs take plus
+ * `unprotected` and `resource`. Registration, schema generation, and dispatch
+ * all stay with the SDK.
+ */
+export class McpServer extends BaseMcpServer {
+  readonly vouchGuard: ToolGuard;
+
+  constructor(serverInfo: ConstructorParameters<typeof BaseMcpServer>[0], options: VouchServerOptions = {}, ...rest: unknown[]) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    super(serverInfo as any, ...(rest as []));
+
+    const name = (serverInfo as { name?: string })?.name ?? 'mcp';
+    this.vouchGuard = options.guard ?? new ToolGuard(guardConfigFrom(name, options));
+
+    // eslint-disable-next-line no-console
+    console.error(
+      `Vouch: protecting '${name}' (target=${this.vouchGuard.config.target}, ` +
+        `rules=${this.vouchGuard.config.rulesPath}, issuers=${this.vouchGuard.config.trustedIssuers.size})`,
+    );
+  }
+
+  /**
+   * Register a tool. Protected unless `unprotected: true` is set in the config.
+   *
+   * The generics mirror the SDK's own, so a tool body still gets its arguments
+   * typed from `inputSchema`. The Vouch options are added to the config object
+   * rather than the positional signature, so the call shape is unchanged.
+   */
+  // The base method is overloaded and generic, so an override that narrows it
+  // would not be assignable. The config is documented by VouchToolConfig and
+  // the example annotates its callbacks; see the README.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  registerTool(name: string, config: VouchToolConfig<any>, cb: any): any {
+    const { unprotected, resource, ...sdkConfig } = (config ?? {}) as VouchToolOptions &
+      Record<string, unknown>;
+
+    if (unprotected && resource) {
+      throw new Error('the resource callback has no meaning on an unprotected tool');
+    }
+
+    if (unprotected) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `Vouch: tool '${name}' is registered UNPROTECTED; calls to it are not checked`,
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const warned = async (...callArgs: any[]) => {
+        // eslint-disable-next-line no-console
+        console.error(`Vouch: UNPROTECTED call to '${name}'`);
+        return cb(...callArgs);
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return (super.registerTool as any)(name, sdkConfig, warned);
+    }
+
+    // Add `credential` to the tool's declared schema so a client that knows
+    // nothing about Vouch Protocol fails loudly on a required argument rather
+    // than silently omitting it.
+    const inputSchema = {
+      ...((sdkConfig.inputSchema as Record<string, unknown>) ?? {}),
+      [CREDENTIAL_ARG]: z
+        .string()
+        .describe('A Vouch Credential authorising exactly this call, as JSON.'),
+    };
+
+    const guard = this.vouchGuard;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const guarded = async (args: any, extra: any) => {
+      const supplied = (args ?? {}) as Record<string, unknown>;
+      const refusal = await guard.check(name, supplied, resource);
+      if (refusal) throw new VouchRefusedError(refusal);
+
+      const forwarded: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(supplied)) {
+        if (key !== CREDENTIAL_ARG) forwarded[key] = value;
+      }
+      return cb(forwarded, extra);
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (super.registerTool as any)(name, { ...sdkConfig, inputSchema }, guarded);
+  }
+
+  /**
+   * The SDK's older `tool()` entry point, kept working and protected.
+   *
+   * The SDK deprecates it in favour of `registerTool`, and its overloads make
+   * the argument positions ambiguous, so this normalises the common shapes and
+   * hands them to `registerTool`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tool(name: string, ...rest: any[]): any {
+    const cb = rest[rest.length - 1];
+    const middle = rest.slice(0, -1);
+
+    let description: string | undefined;
+    let schemaOrOptions: Record<string, unknown> = {};
+    for (const part of middle) {
+      if (typeof part === 'string') description = part;
+      else if (part && typeof part === 'object') schemaOrOptions = part as Record<string, unknown>;
+    }
+
+    const { unprotected, resource, ...maybeSchema } = schemaOrOptions as VouchToolOptions &
+      Record<string, unknown>;
+
+    const config: Record<string, unknown> = {};
+    if (description) config.description = description;
+    if (unprotected !== undefined) config.unprotected = unprotected;
+    if (resource !== undefined) config.resource = resource;
+    if (Object.keys(maybeSchema).length > 0) config.inputSchema = maybeSchema;
+
+    return this.registerTool(name, config, cb);
+  }
+}
+
+/**
+ * Protect an already-built server's tool dispatch.
+ *
+ * The secondary API, for a server this package did not construct. Same checks
+ * and the same refusals; the difference is that it cannot add a `credential`
+ * parameter to a schema it does not own, so the credential is read from the
+ * call's arguments if the tool already accepts one.
+ *
+ * Prefer `McpServer` where you can: a wrapper someone has to remember to apply
+ * is a wrapper someone will forget.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function protect<T extends { callTool?: any; name?: string }>(
+  server: T,
+  options: VouchServerOptions = {},
+): T {
+  const guard = options.guard ?? new ToolGuard(guardConfigFrom(server.name ?? 'mcp', options));
+  const original = server.callTool;
+  if (typeof original !== 'function') {
+    throw new TypeError(
+      `${server.constructor?.name ?? 'server'} has no callTool to wrap; use McpServer instead`,
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).callTool = async (name: string, args: Record<string, unknown>, ...more: any[]) => {
+    const supplied = args ?? {};
+    const refusal = await guard.check(name, supplied);
+    if (refusal) throw new VouchRefusedError(refusal);
+    const forwarded: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(supplied)) {
+      if (key !== CREDENTIAL_ARG) forwarded[key] = value;
+    }
+    return original.call(server, name, forwarded, ...more);
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (server as any).vouchGuard = guard;
+  return server;
+}

--- a/packages/vouch-mcp-ts/tsconfig.json
+++ b/packages/vouch-mcp-ts/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/vouch-mcp-ts/vitest.config.ts
+++ b/packages/vouch-mcp-ts/vitest.config.ts
@@ -1,0 +1,15 @@
+import { resolve } from 'node:path';
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      // Point at the SDK's source rather than its build. Tests then exercise
+      // the current source, and they sidestep a dynamic require of the
+      // optional post-quantum module in the SDK's bundled ESM output.
+      '@vouch-protocol-official/sdk': resolve(__dirname, '../sdk-ts/src/index.ts'),
+    },
+  },
+  test: { globals: true, environment: 'node', include: ['src/**/*.test.ts'] },
+});


### PR DESCRIPTION
The TypeScript counterpart of `vouch.mcp.FastMCP`, so the same one-line integration is available in both languages.

`@vouch-protocol-official/mcp` exports an `McpServer` that is a drop-in replacement for the MCP SDK's own. Every tool registered on it is protected by default: a call must arrive with a Vouch Credential that verifies, comes from a trusted issuer, authorises that exact call, and passes Shield, before the tool body runs. Same five steps in the same order as Python. `examples/mcp_server_ts/` is a working filesystem server built on it, mirroring `examples/mcp_server/`.

**Package naming.** The npm scope on this project is `@vouch-protocol-official`, which is where the SDK, the WASM core, and the API client already live. `@vouch-protocol` has nothing published under it, so the package is `@vouch-protocol-official/mcp` rather than starting a second scope.

**Refusals go through the protocol error path**, as `VouchRefusedError`, which MCP reports with `isError` set. Not returned as a value: a returned object looks like a result, which a model can read straight past, and an error cannot be mistaken for data. The tool body is still never entered, and 19 tests assert that against a spy on each body, ported from the Python suite.

**A fix in the SDK this depends on.** `Verifier.checkVouchCredential` accepted only issuers pinned as trusted roots, so a self-certifying `did:key` credential came back as an unknown issuer. The Python reference resolves `did:key` offline in the same method, and this SDK's own module-level `verify()` already did, so the class method was the odd one out. It now resolves it too, with a pinned trusted root still taking precedence.

**Security boundary.** Identical to the Python side. A credential for one call does not authorise another, because `intent.resource` defaults to the canonical form of the whole argument object; the `resource` callback loosens that to a chosen value when a coarser policy unit such as a path or a table name is wanted, and that is a policy decision the tool author is making. A server missing `VOUCH_RULES` or `VOUCH_TRUSTED_ISSUERS` refuses to start rather than starting unprotected. Rule matching is lexical, so a server that maps a resource onto a real path must still confine that path itself, which the example does.

**One deliberate limitation.** The SDK's `registerTool` is overloaded and generic, so an override that narrowed it would not be assignable to the base class. The config object is typed by `VouchToolConfig` and tool callbacks take their argument type from an annotation, which the example shows. Everything else passes through unchanged, so if the SDK changes shape this breaks loudly rather than drifting.

A CI job builds the SDK and runs this package's tests alongside the other SDK suites.