### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -43,3 +43,10 @@ jobs:
         run: |
           npm install
           npm publish --access public || echo "api-client: version may already be published, continuing"
+      - name: Publish mcp
+        working-directory: packages/vouch-mcp-ts
+        run: |
+          # The SDK is a peer dependency and is resolved from the sibling
+          # source by the tsconfig path mapping, so it is not fetched here.
+          npm install --legacy-peer-deps
+          npm publish --access public || echo "mcp: version may already be published, continuing"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-08
+
 ### BREAKING
 
 - Vouch Shield's capability-level rules are removed. `check_permission`,
@@ -73,6 +75,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   normalised before matching, so a path that climbs above its root is refused
   rather than resolved. Anything that does not match a rule is denied, and so
   is a missing or malformed rules file.
+
+### Removed
+
+- The AAT interop adapter's dependence on the removed capability model. It now
+  derives Shield rules directly, so nothing in it refers to capability levels.
+
+### Fixed
+
+- `Shield.intercept` called a `Verifier.check_vouch` method that does not exist,
+  so signature-checked interception always raised. It now calls
+  `check_vouch_credential`.
+- `vouch.threshold` raised `AttributeError` instead of `ThresholdError` when the
+  native library was present but too old to export a symbol it binds, which
+  aborted test collection rather than skipping cleanly. A stale library is now
+  detected, reported by name, and skipped in favour of a usable one.
+- The trust registry no longer assumes a preset event loop, so it works once
+  anything in the process has used `asyncio.run()`, and it leaves the loop as it
+  found it.
+- The Shield demo signed intents missing `target` and `resource`, so it raised on
+  its first credential. It now runs end to end.
+- The TypeScript SDK's `Verifier.checkVouchCredential` now resolves a `did:key`
+  issuer offline, as the Python reference and this SDK's own `verify()` already
+  did. It previously accepted only issuers pinned as trusted roots, so a
+  self-certifying `did:key` credential was rejected as an unknown issuer.
 
 ## [2.1.0] - 2026-08-02
 

--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vouch-protocol-official/sdk",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "Official TypeScript SDK for Vouch Protocol. Verifiable Credentials with Data Integrity proofs (eddsa-jcs-2022), Multikey verification methods, optional hybrid post-quantum profile (Ed25519 + ML-DSA-44), plus a daemon client for delegating signing operations.",
   "keywords": [
     "vouch",

--- a/packages/vouch-mcp-ts/tsconfig.json
+++ b/packages/vouch-mcp-ts/tsconfig.json
@@ -3,14 +3,26 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
-    "lib": ["ES2022"],
-    "types": ["node"],
+    "lib": [
+      "ES2022"
+    ],
+    "types": [
+      "node"
+    ],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "declaration": true,
     "outDir": "dist",
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "baseUrl": ".",
+    "paths": {
+      "@vouch-protocol-official/sdk": [
+        "../sdk-ts/src/index.ts"
+      ]
+    }
   },
-  "include": ["src/**/*.ts"]
+  "include": [
+    "src/**/*.ts"
+  ]
 }

--- a/packages/vouch-mcp/pyproject.toml
+++ b/packages/vouch-mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-mcp"
-version = "2.0.1"
+version = "2.2.0"
 description = "Model Context Protocol server that issues and verifies Vouch Credentials to authorize AI agent tool calls."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/packages/vouch-mcp/server.json
+++ b/packages/vouch-mcp/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/vouch-protocol/vouch",
     "source": "github"
   },
-  "version": "2.0.1",
+  "version": "2.2.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "vouch-mcp",
-      "version": "2.0.1",
+      "version": "2.2.0",
       "transport": { "type": "stdio" },
       "environmentVariables": [
         {

--- a/packages/vouch-mcp/src/vouch_mcp/__init__.py
+++ b/packages/vouch-mcp/src/vouch_mcp/__init__.py
@@ -13,4 +13,4 @@ Run:
 from vouch.integrations.mcp.server import main, mcp
 
 __all__ = ["main", "mcp"]
-__version__ = "2.0.1"
+__version__ = "2.2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "2.1.0"
+version = "2.2.0"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/sdks/clients/typescript/package.json
+++ b/sdks/clients/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vouch-protocol-official/api-client",
-  "version": "2.0.0",
+  "version": "2.2.0",
   "description": "Typed HTTP client for the Vouch Protocol Bridge API (sign, verify, audio), generated from its OpenAPI spec.",
   "author": "Ramprasad Anandam Gaddam",
   "license": "Apache-2.0",

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -5,7 +5,7 @@ This package provides cryptographic identity binding for autonomous AI agents,
 enabling verifiable proof of intent and non-repudiation.
 """
 
-__version__ = "2.1.0"
+__version__ = "2.2.0"
 
 # Core signing/verification
 from .signer import Signer, sign


### PR DESCRIPTION
Version bumps and the changelog entry for 2.2.0.

`vouch-protocol` and `vouch-mcp` go to 2.2.0 on PyPI. `@vouch-protocol-official/sdk` and `@vouch-protocol-official/api-client` go to 2.2.0 on npm, and `@vouch-protocol-official/mcp` publishes for the first time at the same version, so a Python and a TypeScript install of the same release carry the same Shield and the same protected-server behaviour. The MCP Registry manifest for `vouch-mcp` is regenerated to match.

The npm publish workflow gains a step for the new package. It resolves the SDK from the sibling source through a tsconfig path mapping rather than the registry, since the SDK is a peer dependency and the version being published does not exist yet at build time.

**Headline of the release, and it is breaking.** Vouch Shield now matches an action, a target, and a resource, with globs on the resource, replacing per-DID capability levels. `check_permission`, `Capabilities`, `PermissionManager`, `TOOL_REQUIREMENTS`, and `vouch/shield/permissions.py` are gone, and rules files need rewriting. The changelog leads with that and points at the schema.

Alongside it: Vouch-protected MCP servers in both languages, where changing one import makes every tool on a server refuse to run without a credential that authorises the call; the AAT interop adapter; 77 shared decision vectors that both implementations run; and five fixes, four of which predate this work.