### PR TITLE
fix(mcp): support both lines of the MCP Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-09-08
+
+### Fixed
+
+- `vouch.mcp` works against both lines of the MCP Python SDK. It imported only
+  `FastMCP`, which mcp 2.x renamed to `MCPServer`, so a fresh
+  `pip install 'vouch-protocol[mcp]'` that resolved to mcp 2.x could not import
+  it at all. The base class is now chosen from whichever SDK is installed, and
+  `vouch.mcp.MCPServer` is exported alongside `vouch.mcp.FastMCP` as the name
+  the newer SDK uses. Both refer to the same protected server.
+
 ## [2.2.0] - 2026-09-08
 
 ### BREAKING

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "vouch-protocol"
-version = "2.2.0"
+version = "2.2.1"
 description = "The Identity & Reputation Standard for AI Agents"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_vouch_mcp.py
+++ b/tests/test_vouch_mcp.py
@@ -441,3 +441,28 @@ def test_every_decision_is_logged_once(server, env, caplog):
     deny_lines = [r for r in caplog.records if r.getMessage().startswith("DENY")]
     assert len(deny_lines) == 1
     assert "credential does not match request" in deny_lines[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# SDK compatibility
+# ---------------------------------------------------------------------------
+
+
+def test_works_against_whichever_mcp_sdk_is_installed():
+    """The SDK renamed its server class; both names reach the same subclass.
+
+    mcp 1.x ships `FastMCP`, mcp 2.x renamed it to `MCPServer`. Importing only
+    one of them made this module fail outright on the other line, so the base
+    class is chosen at import time and both names are exported.
+    """
+    import vouch.mcp as module
+
+    assert module.MCPServer is module.FastMCP
+    assert isinstance(module._MCP_SDK_V2, bool)
+
+    # Whichever line is installed, the subclass really extends that SDK's class.
+    base = type(module.FastMCP).__mro__[0]
+    assert base is type
+    parents = [c.__name__ for c in module.FastMCP.__mro__]
+    assert parents[0] == "FastMCP"
+    assert any(name in parents for name in ("FastMCP", "MCPServer"))

--- a/vouch/__init__.py
+++ b/vouch/__init__.py
@@ -5,7 +5,7 @@ This package provides cryptographic identity binding for autonomous AI agents,
 enabling verifiable proof of intent and non-repudiation.
 """
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 # Core signing/verification
 from .signer import Signer, sign

--- a/vouch/mcp/__init__.py
+++ b/vouch/mcp/__init__.py
@@ -53,20 +53,33 @@ from ._guard import (
 
 logger = logging.getLogger(__name__)
 
+# The official MCP Python SDK renamed its high-level server class for the
+# 2026-07-28 protocol revision: mcp>=2.0 ships ``mcp.server.MCPServer`` while
+# mcp 1.x ships ``mcp.server.fastmcp.FastMCP``. Their ``tool()`` decorators take
+# the same shape, so one subclass covers both and the installed SDK decides
+# which protocol revisions are spoken on the wire.
 try:
-    from mcp.server.fastmcp import FastMCP as _BaseFastMCP
-except ImportError as exc:  # pragma: no cover
-    raise ImportError(
-        "vouch.mcp needs the MCP SDK. Install it with:\n"
-        "    pip install 'vouch-protocol[mcp]'\n"
-        "or\n"
-        "    pip install mcp\n"
-        f"(import error: {exc})"
-    ) from exc
+    from mcp.server import MCPServer as _BaseServer  # mcp >= 2.0
+
+    _MCP_SDK_V2 = True
+except ImportError:
+    try:
+        from mcp.server.fastmcp import FastMCP as _BaseServer  # mcp 1.x
+
+        _MCP_SDK_V2 = False
+    except ImportError as exc:  # pragma: no cover
+        raise ImportError(
+            "vouch.mcp needs the MCP SDK. Install it with:\n"
+            "    pip install 'vouch-protocol[mcp]'\n"
+            "or\n"
+            "    pip install mcp\n"
+            f"(import error: {exc})"
+        ) from exc
 
 
 __all__ = [
     "FastMCP",
+    "MCPServer",
     "protect",
     "GuardConfig",
     "Refusal",
@@ -77,7 +90,7 @@ __all__ = [
 ]
 
 
-class FastMCP(_BaseFastMCP):
+class FastMCP(_BaseServer):
     """An MCP server whose tools are protected by default.
 
     A thin subclass. The constructor takes everything the SDK's ``FastMCP``
@@ -249,3 +262,8 @@ def protect(server: Any, *, guard: Optional[ToolGuard] = None, **config: Any) ->
     server.call_tool = guarded_call_tool  # type: ignore[assignment]
     server.vouch_guard = guard  # type: ignore[attr-defined]
     return server
+
+
+#: The name the 2026-07-28 SDK uses for the same class. Both names refer to the
+#: one subclass; which base it extends depends on the installed SDK.
+MCPServer = FastMCP


### PR DESCRIPTION
A fresh `pip install "vouch-protocol[mcp]"` today resolves to mcp 2.x, and `vouch.mcp` could not import at all against it.

The SDK renamed its high-level server class for the 2026-07-28 protocol revision: mcp 1.x ships `FastMCP`, mcp 2.x ships `MCPServer`. `vouch.mcp` imported only the former, so it raised on import for anyone on the newer line. The `vouch-mcp` server in this repository already handled both; the new module did not.

The base class is now chosen from whichever SDK is installed, and `vouch.mcp.MCPServer` is exported alongside `vouch.mcp.FastMCP` as the name the newer SDK uses. Both names refer to the same protected server, so either import works and existing code is unaffected.

Verified against mcp 2.2.0 end to end: an in-scope call runs, a credential minted for a different file is refused, and a resource outside the rules is refused, with the tool body entered only for the call that was authorised. A regression test asserts both names resolve to the same class whichever line is installed.

This missed the 2.2.0 release because the development environment had mcp 1.x pinned, so the failure only appeared on a clean install. Releasing as 2.2.1.