### PR TITLE
fix(mcp): expose package.json through the exports map

### DIFF
--- a/packages/vouch-mcp-ts/package.json
+++ b/packages/vouch-mcp-ts/package.json
@@ -31,7 +31,8 @@
         "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
-    }
+    },
+    "./package.json": "./package.json"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Tooling that reads a package version at runtime does so with `require("@vouch-protocol-official/mcp/package.json")`, and the exports map did not list that subpath, so Node refused it with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

Adding `"./package.json": "./package.json"` is the conventional entry for this and does not widen the public surface in any other way.

Found while installing the published package from the registry and reading its version back. It does not affect importing or using the package, so it can ride along with the next npm release rather than warranting one of its own.