### PR TITLE
chore(release): npm 2.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it at all. The base class is now chosen from whichever SDK is installed, and
   `vouch.mcp.MCPServer` is exported alongside `vouch.mcp.FastMCP` as the name
   the newer SDK uses. Both refer to the same protected server.
+- `@vouch-protocol-official/mcp` exposes `package.json` through its exports map,
+  so tooling that reads the package version at runtime no longer fails with
+  `ERR_PACKAGE_PATH_NOT_EXPORTED`. Published as npm 2.2.1.
 
 ## [2.2.0] - 2026-09-08
 

--- a/packages/vouch-mcp-ts/package.json
+++ b/packages/vouch-mcp-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vouch-protocol-official/mcp",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "Vouch-protected MCP servers. Change one import and every tool checks a credential before it acts.",
   "license": "Apache-2.0",
   "repository": {


### PR DESCRIPTION
Ships the exports-map fix from #424 to npm.

Only `@vouch-protocol-official/mcp` moves, from 2.2.0 to 2.2.1, because that is the only package the fix touches. Bumping the SDK, the API client, and the WASM core to a version with no changes in them would make the changelog claim something untrue, so npm will show `mcp` at 2.2.1 alongside the others at 2.2.0.

No Python release. The version constants stay where 2.2.1 left them, and the `npm-v*` tag only triggers the npm workflow; the PyPI one listens on `py-v*`.

One changelog line under the existing 2.2.1 heading, next to the Python entry it shares a version number with.

Verified before opening: packed the exact artifact and installed it clean, where `require("@vouch-protocol-official/mcp/package.json").version` returns 2.2.1 and the package still imports with `McpServer` intact. The tarball is six files and byte-identical to what npm receives.